### PR TITLE
Prevent nil pointer access in config validate

### DIFF
--- a/pkg/limes/config.go
+++ b/pkg/limes/config.go
@@ -191,7 +191,10 @@ func (cfg configurationInFile) validate() (success bool) {
 			util.LogError("missing clusters[%s].%s configuration value", clusterID, key)
 			success = false
 		}
-
+		if cluster.Auth == nil {
+			//Avoid nil pointer access if section cluster.auth not provided but still alert on the missing values
+			cluster.Auth = new(AuthParameters)
+		}
 		//gophercloud is very strict about requiring a trailing slash here
 		if cluster.Auth.AuthURL != "" && !strings.HasSuffix(cluster.Auth.AuthURL, "/") {
 			cluster.Auth.AuthURL += "/"


### PR DESCRIPTION
If cluster.auth section is not provided in config.yaml, the validation fails
because of nil pointer when accessing cluster.Auth.AuthURl. To avoid segfault
and still inform user about missing values just create an empty struct.