### PR TITLE
Resolving flavors for compute instance subresource

### DIFF
--- a/docs/operators/config.md
+++ b/docs/operators/config.md
@@ -150,9 +150,9 @@ The `instances` resource supports subresource scraping. Subresources bear the fo
 | `id` | string | nova server UUID |
 | `name` | string | nova server name |
 | `status` | string | https://wiki.openstack.org/wiki/VMState |
-| `ram` | string | ram configured in flavor |
-| `vcpu` | string | vcpu configured in flavor |
-| `disk` | string | root disk size configured in flavor |
+| `ram` | int | ram configured in flavor |
+| `vcpu` | int | vcpu configured in flavor |
+| `disk` | int | root disk size configured in flavor |
 
 ## `dns`: Designate v2
 

--- a/docs/operators/config.md
+++ b/docs/operators/config.md
@@ -147,10 +147,12 @@ The `instances` resource supports subresource scraping. Subresources bear the fo
 
 | Attribute | Type | Comment |
 | --- | --- | --- |
-| `id` | string ||
-| `name` | string ||
-| `status` | string ||
-| `flavor_id` | string | provisional; will be replaced by `cores` and `ram` attributes soon |
+| `id` | string | nova server UUID |
+| `name` | string | nova server name |
+| `status` | string | https://wiki.openstack.org/wiki/VMState |
+| `ram` | string | ram configured in flavor |
+| `vcpu` | string | vcpu configured in flavor |
+| `disk` | string | root disk size configured in flavor |
 
 ## `dns`: Designate v2
 

--- a/docs/operators/config.md
+++ b/docs/operators/config.md
@@ -150,9 +150,9 @@ The `instances` resource supports subresource scraping. Subresources bear the fo
 | `id` | string | nova server UUID |
 | `name` | string | nova server name |
 | `status` | string | https://wiki.openstack.org/wiki/VMState |
-| `ram` | int | ram configured in flavor |
+| `ram` | int | ram in MB configured in flavor |
 | `vcpu` | int | vcpu configured in flavor |
-| `disk` | int | root disk size configured in flavor |
+| `disk` | int | root disk size in GB configured in flavor |
 
 ## `dns`: Designate v2
 

--- a/pkg/plugins/nova.go
+++ b/pkg/plugins/nova.go
@@ -33,7 +33,7 @@ import (
 type novaPlugin struct {
 	cfg             limes.ServiceConfiguration
 	scrapeInstances bool
-	flavors 	map[string]*flavors.Flavor
+	flavors         map[string]*flavors.Flavor
 }
 
 var novaResources = []limes.ResourceInfo{
@@ -117,7 +117,7 @@ func (p *novaPlugin) Scrape(provider *gophercloud.ProviderClient, domainUUID, pr
 				}
 				flavor, err := p.getFlavor(client, instance.Flavor["id"].(string))
 				if err == nil {
-					subResource["ram"]  = flavor.RAM
+					subResource["ram"] = flavor.RAM
 					subResource["vcpu"] = flavor.VCPUs
 					subResource["disk"] = flavor.Disk
 				}

--- a/pkg/plugins/nova.go
+++ b/pkg/plugins/nova.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/limits"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/quotasets"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 	"github.com/gophercloud/gophercloud/pagination"
 	"github.com/sapcc/limes/pkg/limes"
@@ -32,6 +33,7 @@ import (
 type novaPlugin struct {
 	cfg             limes.ServiceConfiguration
 	scrapeInstances bool
+	flavors 	map[string]*flavors.Flavor
 }
 
 var novaResources = []limes.ResourceInfo{
@@ -108,13 +110,18 @@ func (p *novaPlugin) Scrape(provider *gophercloud.ProviderClient, domainUUID, pr
 			}
 
 			for _, instance := range instances {
-				instanceData = append(instanceData, map[string]interface{}{
+				subResource := map[string]interface{}{
 					"id":     instance.ID,
 					"name":   instance.Name,
 					"status": instance.Status,
-					//TODO: get flavor object and report "cores"/"ram" instead of "flavor_id" (but cache the flavors!)
-					"flavor_id": instance.Flavor["id"],
-				})
+				}
+				flavor, err := p.getFlavor(client, instance.Flavor["id"].(string))
+				if err == nil {
+					subResource["ram"]  = flavor.RAM
+					subResource["vcpu"] = flavor.VCPUs
+					subResource["disk"] = flavor.Disk
+				}
+				instanceData = append(instanceData, subResource)
 			}
 			return true, nil
 		})
@@ -152,6 +159,25 @@ func (p *novaPlugin) SetQuota(provider *gophercloud.ProviderClient, domainUUID, 
 		Instances: makeIntPointer(int(quotas["instances"])),
 		Ram:       makeIntPointer(int(quotas["ram"])),
 	}).Err
+}
+
+//Getting and caching flavor details
+//Changing a flavor is not supported from OpenStack, so no invalidating of the cache needed
+//Acces to the map is not thread safe
+func (p *novaPlugin) getFlavor(client *gophercloud.ServiceClient, flavorID string) (*flavors.Flavor, error) {
+	if p.flavors == nil {
+		p.flavors = make(map[string]*flavors.Flavor)
+	}
+
+	if flavor, ok := p.flavors[flavorID]; ok {
+		return flavor, nil
+	}
+
+	flavor, err := flavors.Get(client, flavorID).Extract()
+	if err == nil {
+		p.flavors[flavorID] = flavor
+	}
+	return flavor, err
 }
 
 func makeIntPointer(value int) *int {


### PR DESCRIPTION
Basicly we need to discuss 2 things: 
* Flavors are cached and not invalidated, as changing **should** not be possible
* Access to cache is not thread safe as the current assumption is that the nova plugin will only scrape on project at once

Checklist:

- [X] If this PR is about a plugin, I tested the plugin against an OpenStack cluster.
- [X] I updated the documentation to describe the semantical or interface changes I introduced.
