### PR TITLE
Relabel metrics from `cluster` to `os_cluster`

### DIFF
--- a/docs/operators/metrics.md
+++ b/docs/operators/metrics.md
@@ -20,11 +20,12 @@ The collector service exposes the following metrics by default:
 
 | Type | Metric | Labels |
 | --- | --- | --- |
-| Counter | `limes_successful_scrapes` | `cluster`, `service` (counts projects) |
-| Counter | `limes_failed_scrapes` | `cluster`, `service` (counts projects) |
+| Counter | `limes_successful_scrapes` | `os_cluster`, `service` (counts projects) |
+| Counter | `limes_failed_scrapes` | `os_cluster`, `service` (counts projects) |
 
 The `limes_failed_scrapes` metric is particularly useful for assessing the continued operation of backend services
 (specifically their API parts). If you can do only one alert on Limes metrics, alert on `limes_failed_scrapes`.
+`os_cluster` represents the OpenStack cluster configured in the [clusters configuration section](config.md#section-clusters)
 
 ## Data metrics
 
@@ -33,8 +34,10 @@ additional metrics:
 
 | Type | Metric | Labels |
 | --- | --- | --- |
-| Gauge | `limes_cluster_capacity` | `cluster`, `service`, `resource` |
-| Gauge | `limes_domain_quota` | `cluster`, `service`, `resource`, `domain`, `domain_id` |
-| Gauge | `limes_project_backendquota` | `cluster`, `service`, `resource`, `domain`, `domain_id`, `project`, `project_id` |
-| Gauge | `limes_project_quota` | `cluster`, `service`, `resource`, `domain`, `domain_id`, `project`, `project_id` |
-| Gauge | `limes_project_usage` | `cluster`, `service`, `resource`, `domain`, `domain_id`, `project`, `project_id` |
+| Gauge | `limes_cluster_capacity` | `os_cluster`, `service`, `resource` |
+| Gauge | `limes_domain_quota` | `os_cluster`, `service`, `resource`, `domain`, `domain_id` |
+| Gauge | `limes_project_backendquota` | `os_cluster`, `service`, `resource`, `domain`, `domain_id`, `project`, `project_id` |
+| Gauge | `limes_project_quota` | `os_cluster`, `service`, `resource`, `domain`, `domain_id`, `project`, `project_id` |
+| Gauge | `limes_project_usage` | `os_cluster`, `service`, `resource`, `domain`, `domain_id`, `project`, `project_id` |
+
+`os_cluster` represents the OpenStack cluster configured in the [clusters configuration section](config.md#section-clusters)

--- a/pkg/collector/fixtures/scrape_metrics.json
+++ b/pkg/collector/fixtures/scrape_metrics.json
@@ -1,12 +1,12 @@
 # HELP limes_project_backendquota Actual quota of a Limes resource for an OpenStack project.
 # TYPE limes_project_backendquota gauge
-limes_project_backendquota{cluster="west",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest"} 20
-limes_project_backendquota{cluster="west",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest"} 13
+limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest"} 20
+limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest"} 13
 # HELP limes_project_quota Assigned quota of a Limes resource for an OpenStack project.
 # TYPE limes_project_quota gauge
-limes_project_quota{cluster="west",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest"} 20
-limes_project_quota{cluster="west",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest"} 13
+limes_project_quota{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest"} 20
+limes_project_quota{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest"} 13
 # HELP limes_project_usage Actual usage of a Limes resource for an OpenStack project.
 # TYPE limes_project_usage gauge
-limes_project_usage{cluster="west",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest"} 0
-limes_project_usage{cluster="west",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest"} 5
+limes_project_usage{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest"} 0
+limes_project_usage{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest"} 5

--- a/pkg/collector/metrics.go
+++ b/pkg/collector/metrics.go
@@ -35,7 +35,7 @@ var scrapeSuccessCounter = prometheus.NewCounterVec(
 		Name: "limes_successful_scrapes",
 		Help: "Counter for successful scrape operations per Keystone project.",
 	},
-	[]string{"cluster", "service"},
+	[]string{"os_cluster", "service"},
 )
 
 var scrapeFailedCounter = prometheus.NewCounterVec(
@@ -43,7 +43,7 @@ var scrapeFailedCounter = prometheus.NewCounterVec(
 		Name: "limes_failed_scrapes",
 		Help: "Counter for failed scrape operations per Keystone project.",
 	},
-	[]string{"cluster", "service"},
+	[]string{"os_cluster", "service"},
 )
 
 func init() {
@@ -59,7 +59,7 @@ var clusterCapacityGauge = prometheus.NewGaugeVec(
 		Name: "limes_cluster_capacity",
 		Help: "Reported capacity of a Limes resource for an OpenStack cluster.",
 	},
-	[]string{"cluster", "service", "resource"},
+	[]string{"os_cluster", "service", "resource"},
 )
 
 var domainQuotaGauge = prometheus.NewGaugeVec(
@@ -67,7 +67,7 @@ var domainQuotaGauge = prometheus.NewGaugeVec(
 		Name: "limes_domain_quota",
 		Help: "Assigned quota of a Limes resource for an OpenStack domain.",
 	},
-	[]string{"cluster", "domain", "domain_id", "service", "resource"},
+	[]string{"os_cluster", "domain", "domain_id", "service", "resource"},
 )
 
 var projectQuotaGauge = prometheus.NewGaugeVec(
@@ -75,7 +75,7 @@ var projectQuotaGauge = prometheus.NewGaugeVec(
 		Name: "limes_project_quota",
 		Help: "Assigned quota of a Limes resource for an OpenStack project.",
 	},
-	[]string{"cluster", "domain", "domain_id", "project", "project_id", "service", "resource"},
+	[]string{"os_cluster", "domain", "domain_id", "project", "project_id", "service", "resource"},
 )
 
 var projectUsageGauge = prometheus.NewGaugeVec(
@@ -83,7 +83,7 @@ var projectUsageGauge = prometheus.NewGaugeVec(
 		Name: "limes_project_usage",
 		Help: "Actual usage of a Limes resource for an OpenStack project.",
 	},
-	[]string{"cluster", "domain", "domain_id", "project", "project_id", "service", "resource"},
+	[]string{"os_cluster", "domain", "domain_id", "project", "project_id", "service", "resource"},
 )
 
 var projectBackendQuotaGauge = prometheus.NewGaugeVec(
@@ -91,7 +91,7 @@ var projectBackendQuotaGauge = prometheus.NewGaugeVec(
 		Name: "limes_project_backendquota",
 		Help: "Actual quota of a Limes resource for an OpenStack project.",
 	},
-	[]string{"cluster", "domain", "domain_id", "project", "project_id", "service", "resource"},
+	[]string{"os_cluster", "domain", "domain_id", "project", "project_id", "service", "resource"},
 )
 
 //DataMetricsCollector is a prometheus.Collector that submits

--- a/pkg/collector/scrape.go
+++ b/pkg/collector/scrape.go
@@ -63,7 +63,7 @@ func (c *Collector) Scrape() {
 	serviceType := c.Plugin.ServiceInfo().Type
 
 	//make sure that the counters are reported
-	labels := prometheus.Labels{"cluster": c.Cluster.ID, "service": serviceType}
+	labels := prometheus.Labels{"os_cluster": c.Cluster.ID, "service": serviceType}
 	scrapeSuccessCounter.With(labels).Add(0)
 	scrapeFailedCounter.With(labels).Add(0)
 


### PR DESCRIPTION
It turned out that cluster is too generic for the configured OpenStack
clusters. E.g Prometheus federation might add the same label as well.
To avoid further confusions rename the label to os_cluster.

Checklist:

~~- [ ] If this PR is about a plugin, I tested the plugin against an OpenStack cluster.~~
- [X] I updated the documentation to describe the semantical or interface changes I introduced.
