### PR TITLE
add "service_name" label to scraping metrics that contains backend service's product name

### DIFF
--- a/docs/operators/metrics.md
+++ b/docs/operators/metrics.md
@@ -20,12 +20,17 @@ The collector service exposes the following metrics by default:
 
 | Type | Metric | Labels |
 | --- | --- | --- |
-| Counter | `limes_successful_scrapes` | `os_cluster`, `service` (counts projects) |
-| Counter | `limes_failed_scrapes` | `os_cluster`, `service` (counts projects) |
+| Counter | `limes_successful_scrapes` | `os_cluster`, `service`, `service_name` (counts projects) |
+| Counter | `limes_failed_scrapes` | `os_cluster`, `service`, `service_name` (counts projects) |
 
 The `limes_failed_scrapes` metric is particularly useful for assessing the continued operation of backend services
 (specifically their API parts). If you can do only one alert on Limes metrics, alert on `limes_failed_scrapes`.
+
 `os_cluster` represents the OpenStack cluster configured in the [clusters configuration section](config.md#section-clusters)
+
+For both metrics, the `service` label contains the type of the backend service in question (as stated in the Keystone
+service catalog), and the `service_name` label contains the product name (in lower case) of the reference implementation
+of this service, for instance, `service_name="nova"` for `service="compute"`.
 
 ## Data metrics
 

--- a/pkg/collector/metrics.go
+++ b/pkg/collector/metrics.go
@@ -35,7 +35,7 @@ var scrapeSuccessCounter = prometheus.NewCounterVec(
 		Name: "limes_successful_scrapes",
 		Help: "Counter for successful scrape operations per Keystone project.",
 	},
-	[]string{"os_cluster", "service"},
+	[]string{"os_cluster", "service", "service_name"},
 )
 
 var scrapeFailedCounter = prometheus.NewCounterVec(
@@ -43,7 +43,7 @@ var scrapeFailedCounter = prometheus.NewCounterVec(
 		Name: "limes_failed_scrapes",
 		Help: "Counter for failed scrape operations per Keystone project.",
 	},
-	[]string{"os_cluster", "service"},
+	[]string{"os_cluster", "service", "service_name"},
 )
 
 func init() {

--- a/pkg/collector/scrape.go
+++ b/pkg/collector/scrape.go
@@ -60,10 +60,15 @@ var findProjectQuery = `
 //Errors are logged instead of returned. The function will not return unless
 //startup fails.
 func (c *Collector) Scrape() {
-	serviceType := c.Plugin.ServiceInfo().Type
+	serviceInfo := c.Plugin.ServiceInfo()
+	serviceType := serviceInfo.Type
 
 	//make sure that the counters are reported
-	labels := prometheus.Labels{"os_cluster": c.Cluster.ID, "service": serviceType}
+	labels := prometheus.Labels{
+		"os_cluster":   c.Cluster.ID,
+		"service":      serviceType,
+		"service_name": serviceInfo.ProductName,
+	}
 	scrapeSuccessCounter.With(labels).Add(0)
 	scrapeFailedCounter.With(labels).Add(0)
 

--- a/pkg/limes/plugin.go
+++ b/pkg/limes/plugin.go
@@ -127,6 +127,10 @@ type ServiceInfo struct {
 	//plugin implements. This string must be identical to the type string from
 	//the Keystone service catalog.
 	Type string `json:"type"`
+	//ProductName returns the name of the product that is the reference
+	//implementation for this service. For example, ProductName = "nova" for
+	//Type = "compute".
+	ProductName string `json:"-"`
 	//Area is a hint that UIs can use to group similar services.
 	Area string `json:"area"`
 }

--- a/pkg/plugins/cinder.go
+++ b/pkg/plugins/cinder.go
@@ -53,8 +53,9 @@ func init() {
 //ServiceInfo implements the limes.QuotaPlugin interface.
 func (p *cinderPlugin) ServiceInfo() limes.ServiceInfo {
 	return limes.ServiceInfo{
-		Type: "volumev2",
-		Area: "storage",
+		Type:        "volumev2",
+		ProductName: "cinder",
+		Area:        "storage",
 	}
 }
 

--- a/pkg/plugins/designate.go
+++ b/pkg/plugins/designate.go
@@ -50,8 +50,9 @@ func init() {
 //ServiceInfo implements the limes.QuotaPlugin interface.
 func (p *designatePlugin) ServiceInfo() limes.ServiceInfo {
 	return limes.ServiceInfo{
-		Type: "dns",
-		Area: "dns",
+		Type:        "dns",
+		ProductName: "designate",
+		Area:        "dns",
 	}
 }
 

--- a/pkg/plugins/manila.go
+++ b/pkg/plugins/manila.go
@@ -66,8 +66,9 @@ func init() {
 //ServiceInfo implements the limes.QuotaPlugin interface.
 func (p *manilaPlugin) ServiceInfo() limes.ServiceInfo {
 	return limes.ServiceInfo{
-		Type: "sharev2",
-		Area: "storage",
+		Type:        "sharev2",
+		ProductName: "manila",
+		Area:        "storage",
 	}
 }
 

--- a/pkg/plugins/neutron.go
+++ b/pkg/plugins/neutron.go
@@ -120,8 +120,9 @@ func init() {
 //ServiceInfo implements the limes.QuotaPlugin interface.
 func (p *neutronPlugin) ServiceInfo() limes.ServiceInfo {
 	return limes.ServiceInfo{
-		Type: "network",
-		Area: "network",
+		Type:        "network",
+		ProductName: "neutron",
+		Area:        "network",
 	}
 }
 

--- a/pkg/plugins/nova.go
+++ b/pkg/plugins/nova.go
@@ -63,8 +63,9 @@ func init() {
 //ServiceInfo implements the limes.QuotaPlugin interface.
 func (p *novaPlugin) ServiceInfo() limes.ServiceInfo {
 	return limes.ServiceInfo{
-		Type: "compute",
-		Area: "compute",
+		Type:        "compute",
+		ProductName: "nova",
+		Area:        "compute",
 	}
 }
 

--- a/pkg/plugins/swift.go
+++ b/pkg/plugins/swift.go
@@ -54,8 +54,9 @@ func init() {
 //ServiceInfo implements the limes.QuotaPlugin interface.
 func (p *swiftPlugin) ServiceInfo() limes.ServiceInfo {
 	return limes.ServiceInfo{
-		Type: "object-store",
-		Area: "storage",
+		Type:        "object-store",
+		ProductName: "swift",
+		Area:        "storage",
 	}
 }
 


### PR DESCRIPTION
This is useful for our internal alerting which groups alerts by product name, e.g. "nova" instead of "compute".

Checklist:

- [ ] ~If this PR is about a plugin, I tested the plugin against an OpenStack cluster.~
- [X] I updated the documentation to describe the semantical or interface changes I introduced.
