### PR TITLE
add sapcc-ironic capacity plugin

### DIFF
--- a/docs/operators/config.md
+++ b/docs/operators/config.md
@@ -409,6 +409,16 @@ capacitors:
           capacity: min(swift_cluster_storage_capacity_bytes < inf) / 3
 ```
 
+## `sapcc-ironic`
+
+```yaml
+capacitors:
+  - id: sapcc-ironic
+```
+
+This capacity plugin reports capacity for the special `compute/instances_<flavorname>` resources that exist on SAP
+Converged Cloud ([see above](#compute-nova-v2)). For each such flavor, it counts the number of Ironic nodes whose RAM
+size, disk size, number of cores, and capabilities match those in the flavor.
 
 [yaml]:   http://yaml.org/
 [pq-uri]: https://www.postgresql.org/docs/9.6/static/libpq-connect.html#LIBPQ-CONNSTRING

--- a/pkg/plugins/capacity_sapcc_ironic.go
+++ b/pkg/plugins/capacity_sapcc_ironic.go
@@ -90,6 +90,11 @@ func (p *capacitySapccIronicPlugin) Scrape(provider *gophercloud.ProviderClient)
 
 	unmatchedCounter := 0
 	for _, node := range nodes {
+		//do not consider nodes that have not been made available for provisioning yet
+		if !isAvailableProvisionState[node.StableProvisionState()] {
+			continue
+		}
+
 		matched := false
 		for _, flavor := range flavors {
 			if node.Matches(flavor) {

--- a/pkg/plugins/capacity_sapcc_ironic.go
+++ b/pkg/plugins/capacity_sapcc_ironic.go
@@ -1,0 +1,237 @@
+/*******************************************************************************
+*
+* Copyright 2018 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package plugins
+
+import (
+	"strings"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack"
+	flavorsmodule "github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
+	"github.com/gophercloud/gophercloud/pagination"
+	"github.com/sapcc/limes/pkg/limes"
+	"github.com/sapcc/limes/pkg/util"
+)
+
+type capacitySapccIronicPlugin struct {
+	cfg limes.CapacitorConfiguration
+}
+
+func init() {
+	limes.RegisterCapacityPlugin(func(c limes.CapacitorConfiguration) limes.CapacityPlugin {
+		return &capacitySapccIronicPlugin{c}
+	})
+}
+
+func (p *capacitySapccIronicPlugin) NovaClient(provider *gophercloud.ProviderClient) (*gophercloud.ServiceClient, error) {
+	return openstack.NewComputeV2(provider,
+		gophercloud.EndpointOpts{Availability: gophercloud.AvailabilityPublic},
+	)
+}
+
+//ID implements the limes.CapacityPlugin interface.
+func (p *capacitySapccIronicPlugin) ID() string {
+	return "sapcc-ironic"
+}
+
+type ironicFlavorInfo struct {
+	ID           string
+	Name         string
+	Cores        uint64
+	MemoryMiB    uint64
+	DiskGiB      uint64
+	Capabilities map[string]string
+}
+
+//Scrape implements the limes.CapacityPlugin interface.
+func (p *capacitySapccIronicPlugin) Scrape(provider *gophercloud.ProviderClient) (map[string]map[string]uint64, error) {
+	//collect info about flavors with separate instance quota
+	novaClient, err := p.NovaClient(provider)
+	if err != nil {
+		return nil, err
+	}
+	flavors, err := collectIronicFlavorInfo(novaClient)
+	if err != nil {
+		return nil, err
+	}
+
+	//we are going to report capacity for all per-flavor instance quotas
+	result := make(map[string]uint64)
+	for _, flavor := range flavors {
+		result["instances_"+flavor.Name] = 0
+	}
+
+	//count Ironic nodes
+	ironicClient, err := newIronicClient(provider)
+	if err != nil {
+		return nil, err
+	}
+	nodes, err := ironicClient.GetNodes()
+	if err != nil {
+		return nil, err
+	}
+
+	unmatchedCounter := 0
+	for _, node := range nodes {
+		matched := false
+		for _, flavor := range flavors {
+			if node.Matches(flavor) {
+				util.LogDebug("Ironic node %q (%s) matches flavor %s", node.Name, node.ID, flavor.Name)
+				result["instances_"+flavor.Name]++
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			util.LogDebug("Ironic node %q (%s) does not match any flavor", node.Name, node.ID)
+			unmatchedCounter++
+		}
+	}
+
+	if unmatchedCounter > 0 {
+		util.LogError("%d Ironic nodes do not match any baremetal flavors", unmatchedCounter)
+	}
+
+	return map[string]map[string]uint64{"compute": result}, nil
+}
+
+//NOTE: This method is shared with the Nova quota plugin.
+func listPerFlavorInstanceResources(novaClient *gophercloud.ServiceClient) ([]string, error) {
+	//look at quota class "default" to determine which quotas exist
+	url := novaClient.ServiceURL("os-quota-class-sets", "default")
+	var result gophercloud.Result
+	_, err := novaClient.Get(url, &result.Body, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	//At SAP Converged Cloud, we use per-flavor instance quotas for baremetal
+	//(Ironic) flavors, to control precisely how many baremetal machines can be
+	//used by each domain/project. Each such quota has the resource name
+	//"instances_${FLAVOR_NAME}".
+	var body struct {
+		//NOTE: cannot use map[string]int64 here because this object contains the
+		//field "id": "default" (curse you, untyped JSON)
+		QuotaClassSet map[string]interface{} `json:"quota_class_set"`
+	}
+	err = result.ExtractInto(&body)
+	if err != nil {
+		return nil, err
+	}
+
+	var resources []string
+	for key := range body.QuotaClassSet {
+		if strings.HasPrefix(key, "instances_") {
+			resources = append(resources, key)
+		}
+	}
+
+	return resources, nil
+}
+
+func collectIronicFlavorInfo(novaClient *gophercloud.ServiceClient) ([]ironicFlavorInfo, error) {
+	//which flavors have separate instance quota?
+	resources, err := listPerFlavorInstanceResources(novaClient)
+	if err != nil {
+		return nil, err
+	}
+	isRelevantFlavorName := make(map[string]bool, len(resources))
+	for _, resourceName := range resources {
+		flavorName := strings.TrimPrefix(resourceName, "instances_")
+		isRelevantFlavorName[flavorName] = true
+	}
+
+	//collect basic attributes for flavors
+	var result []ironicFlavorInfo
+	err = flavorsmodule.ListDetail(novaClient, nil).EachPage(func(page pagination.Page) (bool, error) {
+		flavors, err := flavorsmodule.ExtractFlavors(page)
+		if err != nil {
+			return false, err
+		}
+
+		for _, flavor := range flavors {
+			if isRelevantFlavorName[flavor.Name] {
+				result = append(result, ironicFlavorInfo{
+					ID:           flavor.ID,
+					Name:         flavor.Name,
+					Cores:        uint64(flavor.VCPUs),
+					MemoryMiB:    uint64(flavor.RAM),
+					DiskGiB:      uint64(flavor.Disk),
+					Capabilities: make(map[string]string),
+				})
+			}
+		}
+		return true, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	//retrieve extra specs - the ones in the "capabilities" namespace are
+	//relevant for Ironic node selection
+	for _, flavor := range result {
+		extraSpecs, err := getFlavorExtras(novaClient, flavor.ID)
+		if err != nil {
+			return nil, err
+		}
+		for key, value := range extraSpecs {
+			if strings.HasPrefix(key, "capabilities:") {
+				capability := strings.TrimPrefix(key, "capabilities:")
+				flavor.Capabilities[capability] = value
+			}
+		}
+	}
+	return result, nil
+}
+
+func (n ironicNode) Matches(f ironicFlavorInfo) bool {
+	if uint64(n.Properties.Cores) != f.Cores {
+		util.LogDebug("core mismatch: %d != %d", n.Properties.Cores, f.Cores)
+		return false
+	}
+	if uint64(n.Properties.MemoryMiB) != f.MemoryMiB {
+		util.LogDebug("memory mismatch: %d != %d", n.Properties.MemoryMiB, f.MemoryMiB)
+		return false
+	}
+	if uint64(n.Properties.DiskGiB) != f.DiskGiB {
+		util.LogDebug("disk mismatch: %d != %d", n.Properties.DiskGiB, f.DiskGiB)
+		return false
+	}
+
+	nodeCaps := make(map[string]string)
+	if n.Properties.CPUArchitecture != "" {
+		nodeCaps["cpu_arch"] = n.Properties.CPUArchitecture
+	}
+	for _, field := range strings.Split(n.Properties.Capabilities, ",") {
+		fields := strings.SplitN(field, ":", 2)
+		if len(fields) == 2 {
+			nodeCaps[fields[0]] = fields[1]
+		}
+	}
+
+	for key, flavorValue := range f.Capabilities {
+		nodeValue, exists := nodeCaps[key]
+		if !exists || nodeValue != flavorValue {
+			util.LogDebug("capability %s mismatch: %q != %q", key, nodeValue, flavorValue)
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/plugins/client_ironic.go
+++ b/pkg/plugins/client_ironic.go
@@ -1,0 +1,137 @@
+/*******************************************************************************
+*
+* Copyright 2018 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package plugins
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type ironicClient struct {
+	*gophercloud.ServiceClient
+}
+
+func newIronicClient(provider *gophercloud.ProviderClient) (*ironicClient, error) {
+	serviceType := "baremetal"
+	eo := gophercloud.EndpointOpts{Availability: gophercloud.AvailabilityPublic}
+	eo.ApplyDefaults(serviceType)
+
+	url, err := provider.EndpointLocator(eo)
+	if err != nil {
+		return nil, err
+	}
+	return &ironicClient{
+		ServiceClient: &gophercloud.ServiceClient{
+			ProviderClient: provider,
+			Endpoint:       url,
+			Type:           serviceType,
+		},
+	}, nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// list nodes
+
+type ironicNode struct {
+	ID         string `json:"uuid"`
+	Name       string `json:"name"`
+	Properties struct {
+		Cores           veryFlexibleUint64 `json:"cpu"`
+		DiskGiB         veryFlexibleUint64 `json:"local_gb"`
+		MemoryMiB       veryFlexibleUint64 `json:"memory_mb"`
+		CPUArchitecture string             `json:"cpu_arch"`
+		Capabilities    string             `json:"capabilities"` //e.g. "cpu_txt:true,cpu_aes:true"
+	} `json:"properties"`
+}
+
+func extractNodes(page pagination.Page) (nodes []ironicNode, err error) {
+	err = page.(ironicNodePage).Result.ExtractIntoSlicePtr(&nodes, "nodes")
+	return
+}
+
+type ironicNodePage struct {
+	pagination.MarkerPageBase
+}
+
+func (p ironicNodePage) IsEmpty() (bool, error) {
+	nodes, err := extractNodes(p)
+	return len(nodes) == 0, err
+}
+
+func (p ironicNodePage) LastMarker() (string, error) {
+	nodes, err := extractNodes(p)
+	if err != nil || len(nodes) == 0 {
+		return "", err
+	}
+	return nodes[len(nodes)-1].ID, nil
+}
+
+func (c ironicClient) GetNodes() ([]ironicNode, error) {
+	url := c.ServiceURL("nodes", "detail")
+	pager := pagination.NewPager(c.ServiceClient, url, func(r pagination.PageResult) pagination.Page {
+		page := ironicNodePage{pagination.MarkerPageBase{PageResult: r}}
+		page.MarkerPageBase.Owner = page
+		return page
+	})
+
+	var result []ironicNode
+	err := pager.EachPage(func(page pagination.Page) (bool, error) {
+		pageNodes, err := extractNodes(page)
+		if err != nil {
+			return false, err
+		}
+		result = append(result, pageNodes...)
+		return true, nil
+	})
+	return result, err
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// OpenStack is being inconsistent with itself again
+
+//For fields that are sometimes missing, sometimes an integer, sometimes a string.
+type veryFlexibleUint64 uint64
+
+//UnmarshalJSON implements the json.Unmarshaler interface.
+func (value *veryFlexibleUint64) UnmarshalJSON(buf []byte) error {
+	if string(buf) == "null" {
+		*value = 0
+		return nil
+	}
+
+	if buf[0] == '"' {
+		var str string
+		err := json.Unmarshal(buf, &str)
+		if err != nil {
+			return err
+		}
+		val, err := strconv.ParseUint(str, 10, 64)
+		*value = veryFlexibleUint64(val)
+		return err
+	}
+
+	var val uint64
+	err := json.Unmarshal(buf, &val)
+	*value = veryFlexibleUint64(val)
+	return err
+}

--- a/pkg/plugins/constants.go
+++ b/pkg/plugins/constants.go
@@ -176,3 +176,16 @@ var isValidVMwareOSType = map[string]bool{
 	"winXPPro64Guest":         true,
 	"winXPProGuest":           true,
 }
+
+//This is a list of all *stable* provisioning states of an Ironic node which will
+//cause that node to not be considered when counting capacity.
+//
+//Reference: https://github.com/openstack/ironic/blob/master/ironic/common/states.py
+var isAvailableProvisionState = map[string]bool{
+	"enroll":     false,
+	"manageable": false,
+	"available":  true,
+	"active":     true,
+	"error":      true, //occurs during delete or rebuild, so node was active before
+	"rescue":     true,
+}


### PR DESCRIPTION
~Regarding testing: It basically works, but the RAM values in our Ironic DBs look weird, so maybe we have to fix those to conduct an actual test.~ Test was successful in Sterling DC after RAM values were fixed in Ironic.

Checklist:

- [x] If this PR is about a plugin, I tested the plugin against an OpenStack cluster.
- [x] I updated the documentation to describe the semantical or interface changes I introduced.
