### PR TITLE
[capacity_manila] filter by default share-type

### DIFF
--- a/pkg/plugins/capacity_manila.go
+++ b/pkg/plugins/capacity_manila.go
@@ -70,6 +70,7 @@ func (p *capacityManilaPlugin) Scrape(provider *gophercloud.ProviderClient, clus
 	}
 
 	//query Manila for known pools and hosts
+	//filtered by share-type 'default'
 	var data struct {
 		Pools []struct {
 			Host         string `json:"host"`
@@ -113,7 +114,7 @@ func (p *capacityManilaPlugin) Scrape(provider *gophercloud.ProviderClient, clus
 }
 
 func manilaGetPoolsDetailed(client *gophercloud.ServiceClient) (result gophercloud.Result) {
-	url := client.ServiceURL("scheduler-stats", "pools", "detail")
+	url := client.ServiceURL("scheduler-stats", "pools", "detail") + "?share_type=default"
 	_, result.Err = client.Get(url, &result.Body, nil)
 	return
 }


### PR DESCRIPTION
I just copied the way of providing a url param from https://github.com/sapcc/limes/blob/05ecf7cde6734a445cf2614fd8fec346ae89474e/pkg/plugins/cinder.go#L92 and extracted the param from the python-manilaclient api debug

i.e. not tested, but I'm quite certain it works if there are no syntax errors
