### PR TITLE
Swift Plugin - Respect Account Status 410

### DIFF
--- a/pkg/plugins/swift.go
+++ b/pkg/plugins/swift.go
@@ -89,8 +89,8 @@ func (p *swiftPlugin) Scrape(provider *gophercloud.ProviderClient, clusterID, do
 	}
 
 	headers, err := account.Headers()
-	if schwift.Is(err, http.StatusNotFound) {
-		//Swift account does not exist, but the keystone project
+	if schwift.Is(err, http.StatusNotFound) || schwift.Is(err, http.StatusGone) {
+		//Swift account does not exist or was deleted and not yet reaped, but the keystone project exist
 		return map[string]limes.ResourceData{
 			"capacity": {
 				Quota: 0,


### PR DESCRIPTION
If a swift account was deleted but not yet reaped, a client will receive
HTTP Status Code 410 (Gone). After reaping clients will get 404.
This case was not yet handled from limes. This will treat it like not found
and prevent scraping errors.

Checklist:

- [ ] If this PR is about a plugin, I tested the plugin against an OpenStack cluster.
- [ ] I updated the documentation to describe the semantical or interface changes I introduced.
