### PR TITLE
implements unmarshalling support for projects

### DIFF
--- a/pkg/reports/project.go
+++ b/pkg/reports/project.go
@@ -77,6 +77,21 @@ func (s ProjectServices) MarshalJSON() ([]byte, error) {
 	return json.Marshal(list)
 }
 
+//UnmarshalJSON implements the json.Unmarshaler interface
+func (s *ProjectServices) UnmarshalJSON(b []byte) error {
+	tmp := make([]*ProjectService, 0)
+	err := json.Unmarshal(b, &tmp)
+	if err != nil {
+		return err
+	}
+	t := make(ProjectServices)
+	for _, ps := range tmp {
+		t[ps.Type] = ps
+	}
+	*s = ProjectServices(t)
+	return nil
+}
+
 //ProjectResources provides fast lookup of resources using a map, but serializes
 //to JSON as a list.
 type ProjectResources map[string]*ProjectResource
@@ -94,6 +109,21 @@ func (r ProjectResources) MarshalJSON() ([]byte, error) {
 		list[idx] = r[name]
 	}
 	return json.Marshal(list)
+}
+
+//UnmarshalJSON implements the json.Unmarshaler interface
+func (r *ProjectResources) UnmarshalJSON(b []byte) error {
+	tmp := make([]*ProjectResource, 0)
+	err := json.Unmarshal(b, &tmp)
+	if err != nil {
+		return err
+	}
+	t := make(ProjectResources)
+	for _, pr := range tmp {
+		t[pr.Name] = pr
+	}
+	*r = ProjectResources(t)
+	return nil
 }
 
 var projectReportQuery = `

--- a/pkg/reports/project_test.go
+++ b/pkg/reports/project_test.go
@@ -1,0 +1,98 @@
+package reports
+
+import (
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/sapcc/limes/pkg/limes"
+)
+
+var sharedServicesJSON = `
+	[
+		{
+			"type": "shared",
+			"area": "shared",
+			"resources": [
+				{
+					"name": "capacity",
+					"unit": "B",
+					"quota": 10,
+					"usage": 2
+				},
+				{
+					"name": "things",
+					"quota": 10,
+					"usage": 2
+				}
+			],
+			"scraped_at": 22
+		}
+	]
+`
+
+var resourcesJSON = `
+ [
+		{
+			"name": "capacity",
+			"unit": "B",
+			"quota": 10,
+			"usage": 2
+		},
+		{
+			"name": "things",
+			"quota": 10,
+			"usage": 2
+		}
+	]
+`
+
+var resources = &ProjectResources{
+	"capacity": &ProjectResource{
+		ResourceInfo: limes.ResourceInfo{
+			Name: "capacity",
+			Unit: limes.UnitBytes,
+		},
+		Quota: 10,
+		Usage: 2,
+	},
+	"things": &ProjectResource{
+		ResourceInfo: limes.ResourceInfo{
+			Name: "things",
+		},
+		Quota: 10,
+		Usage: 2,
+	},
+}
+
+var sharedServices = &ProjectServices{
+	"shared": &ProjectService{
+		ServiceInfo: limes.ServiceInfo{
+			Type: "shared",
+			Area: "shared",
+		},
+		Resources: *resources,
+		ScrapedAt: 22,
+	},
+}
+
+func TestProjectServicesMarshall(t *testing.T) {
+	th.CheckJSONEquals(t, sharedServicesJSON, sharedServices)
+}
+
+func TestProjectServicesUnmarshall(t *testing.T) {
+	actual := &ProjectServices{}
+	err := actual.UnmarshalJSON([]byte(sharedServicesJSON))
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, sharedServices, actual)
+}
+
+func TestProjectResourcesMarshall(t *testing.T) {
+	th.CheckJSONEquals(t, sharedServicesJSON, sharedServices)
+}
+
+func TestProjectResourcesUnmarshall(t *testing.T) {
+	actual := &ProjectServices{}
+	err := actual.UnmarshalJSON([]byte(sharedServicesJSON))
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, sharedServices, actual)
+}

--- a/pkg/util/datatypes.go
+++ b/pkg/util/datatypes.go
@@ -68,3 +68,9 @@ type JSONString string
 func (s JSONString) MarshalJSON() ([]byte, error) {
 	return []byte(s), nil
 }
+
+//UnmarshalJSON implements the json.Unmarshaler interface
+func (s *JSONString) UnmarshalJSON(b []byte) error {
+	*s = JSONString(b)
+	return nil
+}


### PR DESCRIPTION
This PR adds `UnmarshalJSON` functions to the project types. This allows to reuse the `Project` for retrieving responses from Limes.
