### PR TITLE
Support audit events for rejected quota changes

### DIFF
--- a/pkg/api/projects.go
+++ b/pkg/api/projects.go
@@ -177,14 +177,9 @@ func (p *v1Provider) SyncProject(w http.ResponseWriter, r *http.Request) {
 //PutProject handles PUT /v1/domains/:domain_id/projects/:project_id.
 func (p *v1Provider) PutProject(w http.ResponseWriter, r *http.Request) {
 	requestTime := time.Now().Format("2006-01-02T15:04:05.999999+00:00")
-	token := p.CheckToken(r)
-	canRaise := token.Check("project:raise")
-	canLower := token.Check("project:lower")
-	if !canRaise && !canLower {
-		token.Require(w, "project:raise") //produce standard Unauthorized response
-		return
-	}
+	var auditTrail audit.Trail
 
+	token := p.CheckToken(r)
 	cluster := p.FindClusterFromRequest(w, r, token)
 	if cluster == nil {
 		return
@@ -209,6 +204,13 @@ func (p *v1Provider) PutProject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	serviceQuotas := parseTarget.Project.Services
+
+	canRaise := token.Check("project:raise")
+	canLower := token.Check("project:lower")
+	if !canRaise && !canLower {
+		token.Require(w, "project:raise") //produce standard Unauthorized response
+		return
+	}
 
 	//start a transaction for the quota updates
 	tx, err := db.DB.Begin()
@@ -245,7 +247,6 @@ func (p *v1Provider) PutProject(w http.ResponseWriter, r *http.Request) {
 	servicesToUpdate := make(map[string]bool)
 	var errors []string
 
-	var auditTrail audit.Trail
 	for _, srv := range services {
 		resourceQuotas, exists := serviceQuotas[srv.Type]
 		if !exists {
@@ -277,7 +278,24 @@ func (p *v1Provider) PutProject(w http.ResponseWriter, r *http.Request) {
 			constraint := constraints[srv.Type][res.Name]
 			err = checkProjectQuotaUpdate(srv, res, resInfo.Unit, domainReport, constraint, newQuota, canRaise, canLower)
 			if err != nil {
-				errors = append(errors, err.Error())
+				auditTrail.Add(audit.EventParams{
+					Token:        token,
+					Request:      r,
+					ReasonCode:   http.StatusUnprocessableEntity,
+					Time:         requestTime,
+					DomainID:     dbDomain.UUID,
+					ProjectID:    dbProject.UUID,
+					ServiceType:  srv.Type,
+					ResourceName: res.Name,
+					OldQuota:     res.Quota,
+					NewQuota:     newQuota,
+					QuotaUnit:    resInfo.Unit,
+					RejectReason: err.Error(),
+				})
+
+				errors = append(errors, fmt.Sprintf(
+					"cannot change %s/%s quota: %s", srv.Type, res.Name, err.Error()),
+				)
 				continue
 			}
 
@@ -286,8 +304,19 @@ func (p *v1Provider) PutProject(w http.ResponseWriter, r *http.Request) {
 			//would contain only identical pointers)
 			res := res
 
-			auditEvent := audit.NewEvent(token, r, requestTime, dbDomain.UUID, dbProject.UUID, srv.Type, res.Name, resInfo.Unit, res.Quota, newQuota)
-			auditTrail.Add(auditEvent)
+			auditTrail.Add(audit.EventParams{
+				Token:        token,
+				Request:      r,
+				ReasonCode:   http.StatusOK,
+				Time:         requestTime,
+				DomainID:     dbDomain.UUID,
+				ProjectID:    dbProject.UUID,
+				ServiceType:  srv.Type,
+				ResourceName: res.Name,
+				OldQuota:     res.Quota,
+				NewQuota:     newQuota,
+				QuotaUnit:    resInfo.Unit,
+			})
 
 			res.Quota = newQuota
 			resourcesToUpdate = append(resourcesToUpdate, res)
@@ -298,6 +327,7 @@ func (p *v1Provider) PutProject(w http.ResponseWriter, r *http.Request) {
 
 	//if not legal, report errors to the user
 	if len(errors) > 0 {
+		auditTrail.Commit(cluster.ID, cluster.Config.CADF)
 		http.Error(w, strings.Join(errors, "\n"), 422)
 		return
 	}
@@ -387,8 +417,8 @@ func (p *v1Provider) PutProject(w http.ResponseWriter, r *http.Request) {
 
 func checkProjectQuotaUpdate(srv db.ProjectService, res db.ProjectResource, unit limes.Unit, domain *reports.Domain, constraint limes.QuotaConstraint, newQuota uint64, canRaise, canLower bool) error {
 	if !constraint.Allows(newQuota) {
-		return fmt.Errorf("cannot change %s/%s quota: requested value %q contradicts constraint %q for this project and resource",
-			srv.Type, res.Name, limes.ValueWithUnit{Value: newQuota, Unit: unit}, constraint.ToString(unit))
+		return fmt.Errorf("requested value %q contradicts constraint %q for this project and resource",
+			limes.ValueWithUnit{Value: newQuota, Unit: unit}, constraint.ToString(unit))
 	}
 
 	//if quota is being reduced, permission is required and usage must fit into quota
@@ -396,17 +426,17 @@ func checkProjectQuotaUpdate(srv db.ProjectService, res db.ProjectResource, unit
 	//cover the case of infinite quotas)
 	if res.Quota > newQuota {
 		if !canLower {
-			return fmt.Errorf("cannot change %s/%s quota: user is not allowed to lower quotas in this project", srv.Type, res.Name)
+			return fmt.Errorf("user is not allowed to lower quotas in this project")
 		}
 		if res.Usage > newQuota {
-			return fmt.Errorf("cannot change %s/%s quota: quota may not be lower than current usage", srv.Type, res.Name)
+			return fmt.Errorf("quota may not be lower than current usage")
 		}
 		return nil
 	}
 
 	//if quota is being raised, permission is required and also the domain quota may not be exceeded
 	if !canRaise {
-		return fmt.Errorf("cannot change %s/%s quota: user is not allowed to raise quotas in this project", srv.Type, res.Name)
+		return fmt.Errorf("user is not allowed to raise quotas in this project")
 	}
 	domainQuota := uint64(0)
 	projectsQuota := uint64(0)
@@ -428,8 +458,7 @@ func checkProjectQuotaUpdate(srv db.ProjectService, res db.ProjectResource, unit
 		if domainQuota < projectsQuota-res.Quota {
 			maxQuota = 0
 		}
-		return fmt.Errorf("cannot change %s/%s quota: domain quota exceeded (maximum acceptable project quota is %s)",
-			srv.Type, res.Name,
+		return fmt.Errorf("domain quota exceeded (maximum acceptable project quota is %s)",
 			limes.ValueWithUnit{Value: maxQuota, Unit: unit},
 		)
 	}

--- a/pkg/audit/log.go
+++ b/pkg/audit/log.go
@@ -25,6 +25,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/sapcc/go-bits/gopherpolicy"
@@ -104,48 +105,70 @@ type Host struct {
 	Platform string `json:"platform,omitempty"`
 }
 
-//NewEvent takes the necessary parameters from an API request and returns a new audit event.
-func NewEvent(
-	t *gopherpolicy.Token, r *http.Request, requestTime, dbDomainID, dbProjectID,
-	srvType, resName string, resUnit limes.Unit, resQuota, newQuota uint64,
-) CADFEvent {
-	targetID := dbProjectID
-	if dbProjectID == "" {
-		targetID = dbDomainID
+//EventParams to-do
+type EventParams struct {
+	Token        *gopherpolicy.Token
+	Request      *http.Request
+	ReasonCode   int
+	Time         string
+	DomainID     string
+	ProjectID    string
+	ServiceType  string
+	ResourceName string
+	OldQuota     uint64
+	NewQuota     uint64
+	QuotaUnit    limes.Unit
+	RejectReason string
+}
+
+//newEvent takes the necessary parameters from an API request and returns a new audit event.
+func (p EventParams) newEvent() CADFEvent {
+	targetID := p.ProjectID
+	if p.ProjectID == "" {
+		targetID = p.DomainID
+	}
+
+	outcome := "failure"
+	if p.ReasonCode == http.StatusOK {
+		outcome = "success"
 	}
 
 	return CADFEvent{
 		TypeURI:   "http://schemas.dmtf.org/cloud/audit/1.0/event",
 		ID:        generateUUID(),
-		EventTime: requestTime,
+		EventTime: p.Time,
 		EventType: "activity",
 		Action:    "update",
-		Outcome:   "success",
+		Outcome:   outcome,
 		Reason: Reason{
 			ReasonType: "HTTP",
-			ReasonCode: "200",
+			ReasonCode: strconv.Itoa(p.ReasonCode),
 		},
 		Initiator: Resource{
 			TypeURI:   "service/security/account/user",
-			Name:      t.Context.Auth["user_name"],
-			ID:        t.Context.Auth["user_id"],
-			Domain:    t.Context.Auth["domain_name"],
-			DomainID:  t.Context.Auth["domain_id"],
-			ProjectID: t.Context.Auth["project_id"],
+			Name:      p.Token.Context.Auth["user_name"],
+			ID:        p.Token.Context.Auth["user_id"],
+			Domain:    p.Token.Context.Auth["domain_name"],
+			DomainID:  p.Token.Context.Auth["domain_id"],
+			ProjectID: p.Token.Context.Auth["project_id"],
 			Host: &Host{
-				Address: TryStripPort(r.RemoteAddr),
-				Agent:   r.Header.Get("User-Agent"),
+				Address: TryStripPort(p.Request.RemoteAddr),
+				Agent:   p.Request.Header.Get("User-Agent"),
 			},
 		},
 		Target: Resource{
-			TypeURI:   fmt.Sprintf("service/%s/%s/quota", srvType, resName),
+			TypeURI:   fmt.Sprintf("service/%s/%s/quota", p.ServiceType, p.ResourceName),
 			ID:        targetID,
-			DomainID:  dbDomainID,
-			ProjectID: dbProjectID,
+			DomainID:  p.DomainID,
+			ProjectID: p.ProjectID,
 			Attachments: []Attachment{{
 				Name:    "payload",
 				TypeURI: "mime:application/json",
-				Content: attachmentContent{OldQuota: resQuota, NewQuota: newQuota, Unit: resUnit},
+				Content: attachmentContent{
+					OldQuota:     p.OldQuota,
+					NewQuota:     p.NewQuota,
+					Unit:         p.QuotaUnit,
+					RejectReason: p.RejectReason},
 			}},
 		},
 		Observer: Resource{
@@ -153,28 +176,31 @@ func NewEvent(
 			Name:    "limes",
 			ID:      observerUUID,
 		},
-		RequestPath: r.URL.String(),
+		RequestPath: p.Request.URL.String(),
 	}
 }
 
 //This type is needed for the custom MarshalJSON behavior.
 type attachmentContent struct {
-	OldQuota uint64
-	NewQuota uint64
-	Unit     limes.Unit
+	OldQuota     uint64
+	NewQuota     uint64
+	Unit         limes.Unit
+	RejectReason string
 }
 
 //MarshalJSON implements the json.Marshaler interface.
 func (a attachmentContent) MarshalJSON() ([]byte, error) {
 	//copy data into a struct that does not have a custom MarshalJSON
 	data := struct {
-		OldQuota uint64     `json:"oldQuota"`
-		NewQuota uint64     `json:"newQuota"`
-		Unit     limes.Unit `json:"unit,omitempty"`
+		OldQuota     uint64     `json:"oldQuota,omitempty"`
+		NewQuota     uint64     `json:"newQuota,omitempty"`
+		Unit         limes.Unit `json:"unit,omitempty"`
+		RejectReason string     `json:"rejectReason,omitempty"`
 	}{
-		OldQuota: a.OldQuota,
-		NewQuota: a.NewQuota,
-		Unit:     a.Unit,
+		OldQuota:     a.OldQuota,
+		NewQuota:     a.NewQuota,
+		Unit:         a.Unit,
+		RejectReason: a.RejectReason,
 	}
 	//Hermes does not accept a JSON object at target.attachments[].content, so we need
 	//to wrap the marshaled JSON into a JSON string
@@ -186,7 +212,8 @@ func (a attachmentContent) MarshalJSON() ([]byte, error) {
 }
 
 //Add adds an event to the audit trail.
-func (t *Trail) Add(event CADFEvent) {
+func (t *Trail) Add(p EventParams) {
+	event := p.newEvent()
 	t.events = append(t.events, event)
 }
 

--- a/pkg/audit/log.go
+++ b/pkg/audit/log.go
@@ -105,7 +105,7 @@ type Host struct {
 	Platform string `json:"platform,omitempty"`
 }
 
-//EventParams to-do
+//EventParams contains parameters for creating an audit event.
 type EventParams struct {
 	Token        *gopherpolicy.Token
 	Request      *http.Request
@@ -121,7 +121,7 @@ type EventParams struct {
 	RejectReason string
 }
 
-//newEvent takes the necessary parameters from an API request and returns a new audit event.
+//newEvent takes the necessary parameters and returns a new audit event.
 func (p EventParams) newEvent() CADFEvent {
 	targetID := p.ProjectID
 	if p.ProjectID == "" {


### PR DESCRIPTION
Progress:

* Audit events for token authentication failure is a bit tricky, need to work on that.
* The rest of the error types for which we need audit events have been implemented.