### PR TITLE
respect region setting in auth parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 sudo: false
 
 go:
-    - 1.9
+    - 1.11
 
 install:
     - go get -u github.com/golang/lint/golint

--- a/main.go
+++ b/main.go
@@ -222,7 +222,8 @@ func taskTestScrape(config limes.Configuration, cluster *limes.Cluster, args []s
 	result := make(map[string]map[string]limes.ResourceData)
 
 	for serviceType, plugin := range cluster.QuotaPlugins {
-		data, err := plugin.Scrape(cluster.ProviderClientForService(serviceType), cluster.ID, domainUUID, projectUUID)
+		provider, eo := cluster.ProviderClientForService(serviceType)
+		data, err := plugin.Scrape(provider, eo, cluster.ID, domainUUID, projectUUID)
 		if err != nil {
 			logg.Error("scrape failed for %s: %s", serviceType, err.Error())
 		}
@@ -280,7 +281,8 @@ func taskTestScanCapacity(config limes.Configuration, cluster *limes.Cluster, ar
 
 	result := make(map[string]map[string]limes.CapacityData)
 	for capacitorID, plugin := range cluster.CapacityPlugins {
-		capacities, err := plugin.Scrape(cluster.ProviderClient(), cluster.ID)
+		provider, eo := cluster.ProviderClient()
+		capacities, err := plugin.Scrape(provider, eo, cluster.ID)
 		if err != nil {
 			logg.Error("scan capacity with capacitor %s failed: %s", capacitorID, err.Error())
 		}

--- a/pkg/api/projects.go
+++ b/pkg/api/projects.go
@@ -310,10 +310,8 @@ func (p *v1Provider) PutProject(w http.ResponseWriter, r *http.Request) {
 		for _, res := range resources {
 			quotaValues[res.Name] = res.Quota
 		}
-		err = plugin.SetQuota(
-			updater.Cluster.ProviderClientForService(srv.Type),
-			updater.Cluster.ID, updater.Domain.UUID, updater.Project.UUID, quotaValues,
-		)
+		provider, eo := updater.Cluster.ProviderClientForService(srv.Type)
+		err = plugin.SetQuota(provider, eo, updater.Cluster.ID, updater.Domain.UUID, updater.Project.UUID, quotaValues)
 		if err != nil {
 			errors = append(errors, err.Error())
 			continue

--- a/pkg/api/token.go
+++ b/pkg/api/token.go
@@ -23,7 +23,6 @@ import (
 	"net/http"
 
 	policy "github.com/databus23/goslo.policy"
-	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gorilla/mux"
 	"github.com/sapcc/go-bits/gopherpolicy"
@@ -43,9 +42,7 @@ func (p *v1Provider) CheckToken(r *http.Request) *gopherpolicy.Token {
 		}
 	}
 
-	client, err := openstack.NewIdentityV3(auth.ProviderClient,
-		gophercloud.EndpointOpts{Availability: gophercloud.AvailabilityPublic},
-	)
+	client, err := openstack.NewIdentityV3(auth.ProviderClient, auth.EndpointOpts)
 	if err != nil {
 		return &gopherpolicy.Token{Err: err}
 	}

--- a/pkg/audit/rabbit.go
+++ b/pkg/audit/rabbit.go
@@ -55,11 +55,11 @@ func sendEvents(clusterID string, config limes.CADFConfiguration, events []CADFE
 	//declare a queue to hold and deliver messages to consumers
 	q, err := ch.QueueDeclare(
 		config.RabbitMQ.QueueName, // name of the queue
-		false, // durable: queue should survive cluster reset (or broker restart)
-		false, // autodelete when unused
-		false, // exclusive: queue only accessible by connection that declares and deleted when the connection closes
-		false, // noWait: the queue will assume to be declared on the server
-		nil,   // arguments for advanced config
+		false,                     // durable: queue should survive cluster reset (or broker restart)
+		false,                     // autodelete when unused
+		false,                     // exclusive: queue only accessible by connection that declares and deleted when the connection closes
+		false,                     // noWait: the queue will assume to be declared on the server
+		nil,                       // arguments for advanced config
 	)
 	if err != nil {
 		eventPublishFailedCounter.With(labels).Inc()

--- a/pkg/collector/capacity.go
+++ b/pkg/collector/capacity.go
@@ -65,7 +65,8 @@ func (c *Collector) scanCapacity() {
 		clusterCapacitorSuccessCounter.With(labels).Add(0)
 		clusterCapacitorFailedCounter.With(labels).Add(0)
 
-		capacities, err := plugin.Scrape(c.Cluster.ProviderClient(), c.Cluster.ID)
+		provider, eo := c.Cluster.ProviderClient()
+		capacities, err := plugin.Scrape(provider, eo, c.Cluster.ID)
 		if err != nil {
 			c.LogError("scan capacity with capacitor %s failed: %s", capacitorID, err.Error())
 			clusterCapacitorFailedCounter.With(labels).Inc()

--- a/pkg/collector/keystone.go
+++ b/pkg/collector/keystone.go
@@ -206,7 +206,8 @@ func ScanProjects(cluster *limes.Cluster, domain *db.Domain) (result []string, r
 	}()
 
 	//list projects in Keystone
-	projects, err := cluster.DiscoveryPlugin.ListProjects(cluster.ProviderClient(), domain.UUID)
+	provider, eo := cluster.ProviderClient()
+	projects, err := cluster.DiscoveryPlugin.ListProjects(provider, eo, domain.UUID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/collector/scrape.go
+++ b/pkg/collector/scrape.go
@@ -104,10 +104,8 @@ func (c *Collector) Scrape() {
 		}
 
 		logg.Debug("scraping %s for %s/%s", serviceType, domainName, projectName)
-		resourceData, err := c.Plugin.Scrape(
-			c.Cluster.ProviderClientForService(serviceType),
-			c.Cluster.ID, domainUUID, projectUUID,
-		)
+		provider, eo := c.Cluster.ProviderClientForService(serviceType)
+		resourceData, err := c.Plugin.Scrape(provider, eo, c.Cluster.ID, domainUUID, projectUUID)
 		if err != nil {
 			//special case: stop scraping for a while when the backend service is not
 			//yet registered in the catalog (this prevents log spamming during buildup)
@@ -317,10 +315,8 @@ func (c *Collector) writeScrapeResult(domainName, domainUUID, projectName, proje
 	//to get stuck because some project has backend_quota > usage > quota, for
 	//example)
 	if needToSetQuota {
-		err := c.Plugin.SetQuota(
-			c.Cluster.ProviderClientForService(serviceType),
-			c.Cluster.ID, domainUUID, projectUUID, quotaValues,
-		)
+		provider, eo := c.Cluster.ProviderClientForService(serviceType)
+		err := c.Plugin.SetQuota(provider, eo, c.Cluster.ID, domainUUID, projectUUID, quotaValues)
 		if err != nil {
 			serviceType := c.Plugin.ServiceInfo().Type
 			logg.Error("could not rectify frontend/backend quota mismatch for service %s in project %s: %s",

--- a/pkg/collector/scrape_test.go
+++ b/pkg/collector/scrape_test.go
@@ -214,7 +214,7 @@ type autoApprovalTestPlugin struct {
 	StaticBackendQuota uint64
 }
 
-func (p *autoApprovalTestPlugin) Init(provider *gophercloud.ProviderClient) error {
+func (p *autoApprovalTestPlugin) Init(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) error {
 	return nil
 }
 
@@ -228,24 +228,24 @@ func (p *autoApprovalTestPlugin) Resources() []limes.ResourceInfo {
 	//one resource can auto-approve, one cannot because BackendQuota != AutoApproveInitialQuota
 	return []limes.ResourceInfo{
 		{
-			Name: "approve",
+			Name:                    "approve",
 			AutoApproveInitialQuota: p.StaticBackendQuota,
 		},
 		{
-			Name: "noapprove",
+			Name:                    "noapprove",
 			AutoApproveInitialQuota: p.StaticBackendQuota,
 		},
 	}
 }
 
-func (p *autoApprovalTestPlugin) Scrape(provider *gophercloud.ProviderClient, clusterID, domainUUID, projectUUID string) (map[string]limes.ResourceData, error) {
+func (p *autoApprovalTestPlugin) Scrape(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string) (map[string]limes.ResourceData, error) {
 	return map[string]limes.ResourceData{
 		"approve":   {Usage: 0, Quota: int64(p.StaticBackendQuota)},
 		"noapprove": {Usage: 0, Quota: int64(p.StaticBackendQuota) + 10},
 	}, nil
 }
 
-func (p *autoApprovalTestPlugin) SetQuota(provider *gophercloud.ProviderClient, clusterID, domainUUID, projectUUID string, quotas map[string]uint64) error {
+func (p *autoApprovalTestPlugin) SetQuota(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string, quotas map[string]uint64) error {
 	return errors.New("unimplemented")
 }
 

--- a/pkg/limes/auth.go
+++ b/pkg/limes/auth.go
@@ -39,8 +39,9 @@ type AuthParameters struct {
 	Password          string      `yaml:"password"`
 	RegionName        string      `yaml:"region_name"`
 	tokenRenewalMutex *sync.Mutex `yaml:"-"`
-	//ProviderClient is only valid after calling Connect().
+	//The following fields are only valid after calling Connect().
 	ProviderClient *gophercloud.ProviderClient `yaml:"-"`
+	EndpointOpts   gophercloud.EndpointOpts    `yaml:"-"`
 }
 
 //Connect creates the gophercloud.ProviderClient instance for these credentials.
@@ -74,10 +75,13 @@ func (auth *AuthParameters) Connect() error {
 			DomainName:  auth.ProjectDomainName,
 		},
 	})
-	//FIXME: honor auth.RegionName
 	if err != nil {
 		return fmt.Errorf("cannot fetch initial Keystone token: %v", err)
 	}
 
+	auth.EndpointOpts = gophercloud.EndpointOpts{
+		Availability: gophercloud.AvailabilityPublic,
+		Region:       auth.RegionName,
+	}
 	return nil
 }

--- a/pkg/limes/constraints_test.go
+++ b/pkg/limes/constraints_test.go
@@ -141,16 +141,16 @@ type quotaConstraintTestPlugin struct {
 	ServiceType string
 }
 
-func (p quotaConstraintTestPlugin) Init(client *gophercloud.ProviderClient) error {
+func (p quotaConstraintTestPlugin) Init(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) error {
 	return nil
 }
 func (p quotaConstraintTestPlugin) ServiceInfo() ServiceInfo {
 	return ServiceInfo{Type: p.ServiceType}
 }
-func (p quotaConstraintTestPlugin) Scrape(client *gophercloud.ProviderClient, clusterID, domainUUID, projectUUID string) (map[string]ResourceData, error) {
+func (p quotaConstraintTestPlugin) Scrape(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string) (map[string]ResourceData, error) {
 	return nil, nil
 }
-func (p quotaConstraintTestPlugin) SetQuota(client *gophercloud.ProviderClient, clusterID, domainUUID, projectUUID string, quotas map[string]uint64) error {
+func (p quotaConstraintTestPlugin) SetQuota(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string, quotas map[string]uint64) error {
 	return nil
 }
 

--- a/pkg/limes/plugin.go
+++ b/pkg/limes/plugin.go
@@ -43,9 +43,9 @@ type DiscoveryPlugin interface {
 	//identify it in the configuration.
 	Method() string
 	//ListDomains returns all Keystone domains in the cluster.
-	ListDomains(client *gophercloud.ProviderClient) ([]KeystoneDomain, error)
+	ListDomains(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) ([]KeystoneDomain, error)
 	//ListProjects returns all Keystone projects in the given domain.
-	ListProjects(client *gophercloud.ProviderClient, domainUUID string) ([]KeystoneProject, error)
+	ListProjects(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, domainUUID string) ([]KeystoneProject, error)
 }
 
 //ResourceData contains quota and usage data for a single resource.
@@ -66,7 +66,7 @@ type QuotaPlugin interface {
 	//Init is guaranteed to be called before all other methods exposed by the
 	//interface. Implementations can use it f.i. to discover the available
 	//Resources().
-	Init(client *gophercloud.ProviderClient) error
+	Init(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) error
 	//ServiceInfo returns metadata for this service.
 	ServiceInfo() ServiceInfo
 	//Resources returns metadata for all the resources that this plugin scrapes
@@ -80,7 +80,7 @@ type QuotaPlugin interface {
 	//The clusterID is usually not needed, but should be given as a label to
 	//Prometheus metrics emitted by the plugin (if the plugin does that sort of
 	//thing).
-	Scrape(client *gophercloud.ProviderClient, clusterID, domainUUID, projectUUID string) (map[string]ResourceData, error)
+	Scrape(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string) (map[string]ResourceData, error)
 	//SetQuota updates the backend service's quotas for the given project in the
 	//given domain to the values specified here. The map is guaranteed to contain
 	//values for all resources defined by Resources().
@@ -91,7 +91,7 @@ type QuotaPlugin interface {
 	//The clusterID is usually not needed, but should be given as a label to
 	//Prometheus metrics emitted by the plugin (if the plugin does that sort of
 	//thing).
-	SetQuota(client *gophercloud.ProviderClient, clusterID, domainUUID, projectUUID string, quotas map[string]uint64) error
+	SetQuota(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string, quotas map[string]uint64) error
 }
 
 //CapacityData contains capacity data for a single resource.
@@ -130,7 +130,7 @@ type CapacityPlugin interface {
 	//The clusterID is usually not needed, but should be given as a label to
 	//Prometheus metrics emitted by the plugin (if the plugin does that sort of
 	//thing).
-	Scrape(client *gophercloud.ProviderClient, clusterID string) (map[string]map[string]CapacityData, error)
+	Scrape(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID string) (map[string]map[string]CapacityData, error)
 }
 
 //ResourceInfo contains the metadata for a resource (i.e. some thing for which

--- a/pkg/plugins/capacity_cinder.go
+++ b/pkg/plugins/capacity_cinder.go
@@ -37,20 +37,14 @@ func init() {
 	})
 }
 
-func (p *capacityCinderPlugin) Client(provider *gophercloud.ProviderClient) (*gophercloud.ServiceClient, error) {
-	return openstack.NewBlockStorageV2(provider,
-		gophercloud.EndpointOpts{Availability: gophercloud.AvailabilityPublic},
-	)
-}
-
 //ID implements the limes.CapacityPlugin interface.
 func (p *capacityCinderPlugin) ID() string {
 	return "cinder"
 }
 
 //Scrape implements the limes.CapacityPlugin interface.
-func (p *capacityCinderPlugin) Scrape(provider *gophercloud.ProviderClient, clusterID string) (map[string]map[string]limes.CapacityData, error) {
-	client, err := p.Client(provider)
+func (p *capacityCinderPlugin) Scrape(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID string) (map[string]map[string]limes.CapacityData, error) {
+	client, err := openstack.NewBlockStorageV2(provider, eo)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/plugins/capacity_manila.go
+++ b/pkg/plugins/capacity_manila.go
@@ -38,19 +38,13 @@ func init() {
 	})
 }
 
-func (p *capacityManilaPlugin) Client(provider *gophercloud.ProviderClient) (*gophercloud.ServiceClient, error) {
-	return openstack.NewSharedFileSystemV2(provider,
-		gophercloud.EndpointOpts{Availability: gophercloud.AvailabilityPublic},
-	)
-}
-
 //ID implements the limes.CapacityPlugin interface.
 func (p *capacityManilaPlugin) ID() string {
 	return "manila"
 }
 
 //Scrape implements the limes.CapacityPlugin interface.
-func (p *capacityManilaPlugin) Scrape(provider *gophercloud.ProviderClient, clusterID string) (map[string]map[string]limes.CapacityData, error) {
+func (p *capacityManilaPlugin) Scrape(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID string) (map[string]map[string]limes.CapacityData, error) {
 	cfg := p.cfg.Manila
 	if cfg.ShareNetworks == 0 {
 		return nil, errors.New("missing configuration parameter: share_networks")
@@ -65,7 +59,7 @@ func (p *capacityManilaPlugin) Scrape(provider *gophercloud.ProviderClient, clus
 		cfg.CapacityOvercommitFactor = 1 //default is no overcommit
 	}
 
-	client, err := p.Client(provider)
+	client, err := openstack.NewSharedFileSystemV2(provider, eo)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/plugins/capacity_manual.go
+++ b/pkg/plugins/capacity_manual.go
@@ -44,7 +44,7 @@ func (p *capacityManualPlugin) ID() string {
 var errNoManualData = errors.New(`missing values for capacitor plugin "manual"`)
 
 //Scrape implements the limes.CapacityPlugin interface.
-func (p *capacityManualPlugin) Scrape(provider *gophercloud.ProviderClient, clusterID string) (map[string]map[string]limes.CapacityData, error) {
+func (p *capacityManualPlugin) Scrape(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID string) (map[string]map[string]limes.CapacityData, error) {
 	if p.cfg.Manual == nil {
 		return nil, errNoManualData
 	}

--- a/pkg/plugins/capacity_nova.go
+++ b/pkg/plugins/capacity_nova.go
@@ -42,18 +42,12 @@ func init() {
 	})
 }
 
-func (p *capacityNovaPlugin) Client(provider *gophercloud.ProviderClient) (*gophercloud.ServiceClient, error) {
-	return openstack.NewComputeV2(provider,
-		gophercloud.EndpointOpts{Availability: gophercloud.AvailabilityPublic},
-	)
-}
-
 func (p *capacityNovaPlugin) ID() string {
 	return "nova"
 }
 
 //Scrape implements the limes.CapacityPlugin interface.
-func (p *capacityNovaPlugin) Scrape(provider *gophercloud.ProviderClient, clusterID string) (map[string]map[string]limes.CapacityData, error) {
+func (p *capacityNovaPlugin) Scrape(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID string) (map[string]map[string]limes.CapacityData, error) {
 	var hypervisorTypeRx *regexp.Regexp
 	if p.cfg.Nova.HypervisorTypePattern != "" {
 		var err error
@@ -63,7 +57,7 @@ func (p *capacityNovaPlugin) Scrape(provider *gophercloud.ProviderClient, cluste
 		}
 	}
 
-	client, err := p.Client(provider)
+	client, err := openstack.NewComputeV2(provider, eo)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/plugins/capacity_prometheus.go
+++ b/pkg/plugins/capacity_prometheus.go
@@ -67,7 +67,7 @@ func (p *capacityPrometheusPlugin) ID() string {
 }
 
 //Scrape implements the limes.CapacityPlugin interface.
-func (p *capacityPrometheusPlugin) Scrape(provider *gophercloud.ProviderClient, clusterID string) (map[string]map[string]limes.CapacityData, error) {
+func (p *capacityPrometheusPlugin) Scrape(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID string) (map[string]map[string]limes.CapacityData, error) {
 
 	client, err := p.Client(p.cfg.Prometheus.APIURL)
 	if err != nil {

--- a/pkg/plugins/capacity_sapcc_ironic.go
+++ b/pkg/plugins/capacity_sapcc_ironic.go
@@ -51,12 +51,6 @@ func init() {
 	prometheus.MustRegister(ironicUnmatchedNodesGauge)
 }
 
-func (p *capacitySapccIronicPlugin) NovaClient(provider *gophercloud.ProviderClient) (*gophercloud.ServiceClient, error) {
-	return openstack.NewComputeV2(provider,
-		gophercloud.EndpointOpts{Availability: gophercloud.AvailabilityPublic},
-	)
-}
-
 //ID implements the limes.CapacityPlugin interface.
 func (p *capacitySapccIronicPlugin) ID() string {
 	return "sapcc-ironic"
@@ -72,9 +66,9 @@ type ironicFlavorInfo struct {
 }
 
 //Scrape implements the limes.CapacityPlugin interface.
-func (p *capacitySapccIronicPlugin) Scrape(provider *gophercloud.ProviderClient, clusterID string) (map[string]map[string]limes.CapacityData, error) {
+func (p *capacitySapccIronicPlugin) Scrape(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID string) (map[string]map[string]limes.CapacityData, error) {
 	//collect info about flavors with separate instance quota
-	novaClient, err := p.NovaClient(provider)
+	novaClient, err := openstack.NewComputeV2(provider, eo)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +84,7 @@ func (p *capacitySapccIronicPlugin) Scrape(provider *gophercloud.ProviderClient,
 	}
 
 	//count Ironic nodes
-	ironicClient, err := newIronicClient(provider)
+	ironicClient, err := newIronicClient(provider, eo)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/plugins/cinder.go
+++ b/pkg/plugins/cinder.go
@@ -57,7 +57,7 @@ func init() {
 }
 
 //Init implements the limes.QuotaPlugin interface.
-func (p *cinderPlugin) Init(provider *gophercloud.ProviderClient) error {
+func (p *cinderPlugin) Init(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) error {
 	return nil
 }
 
@@ -75,15 +75,9 @@ func (p *cinderPlugin) Resources() []limes.ResourceInfo {
 	return cinderResources
 }
 
-func (p *cinderPlugin) Client(provider *gophercloud.ProviderClient) (*gophercloud.ServiceClient, error) {
-	return openstack.NewBlockStorageV2(provider,
-		gophercloud.EndpointOpts{Availability: gophercloud.AvailabilityPublic},
-	)
-}
-
 //Scrape implements the limes.QuotaPlugin interface.
-func (p *cinderPlugin) Scrape(provider *gophercloud.ProviderClient, clusterID, domainUUID, projectUUID string) (map[string]limes.ResourceData, error) {
-	client, err := p.Client(provider)
+func (p *cinderPlugin) Scrape(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string) (map[string]limes.ResourceData, error) {
+	client, err := openstack.NewBlockStorageV2(provider, eo)
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +154,7 @@ func (p *cinderPlugin) Scrape(provider *gophercloud.ProviderClient, clusterID, d
 }
 
 //SetQuota implements the limes.QuotaPlugin interface.
-func (p *cinderPlugin) SetQuota(provider *gophercloud.ProviderClient, clusterID, domainUUID, projectUUID string, quotas map[string]uint64) error {
+func (p *cinderPlugin) SetQuota(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string, quotas map[string]uint64) error {
 	requestData := map[string]map[string]uint64{
 		"quota_set": {
 			"gigabytes": quotas["capacity"],
@@ -169,7 +163,7 @@ func (p *cinderPlugin) SetQuota(provider *gophercloud.ProviderClient, clusterID,
 		},
 	}
 
-	client, err := p.Client(provider)
+	client, err := openstack.NewBlockStorageV2(provider, eo)
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/client_ironic.go
+++ b/pkg/plugins/client_ironic.go
@@ -31,9 +31,8 @@ type ironicClient struct {
 	*gophercloud.ServiceClient
 }
 
-func newIronicClient(provider *gophercloud.ProviderClient) (*ironicClient, error) {
+func newIronicClient(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*ironicClient, error) {
 	serviceType := "baremetal"
-	eo := gophercloud.EndpointOpts{Availability: gophercloud.AvailabilityPublic}
 	eo.ApplyDefaults(serviceType)
 
 	url, err := provider.EndpointLocator(eo)

--- a/pkg/plugins/designate.go
+++ b/pkg/plugins/designate.go
@@ -50,7 +50,7 @@ func init() {
 }
 
 //Init implements the limes.QuotaPlugin interface.
-func (p *designatePlugin) Init(provider *gophercloud.ProviderClient) error {
+func (p *designatePlugin) Init(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) error {
 	return nil
 }
 
@@ -68,15 +68,9 @@ func (p *designatePlugin) Resources() []limes.ResourceInfo {
 	return designateResources
 }
 
-func (p *designatePlugin) Client(provider *gophercloud.ProviderClient) (*gophercloud.ServiceClient, error) {
-	return openstack.NewDNSV2(provider,
-		gophercloud.EndpointOpts{Availability: gophercloud.AvailabilityPublic},
-	)
-}
-
 //Scrape implements the limes.QuotaPlugin interface.
-func (p *designatePlugin) Scrape(provider *gophercloud.ProviderClient, clusterID, domainUUID, projectUUID string) (map[string]limes.ResourceData, error) {
-	client, err := p.Client(provider)
+func (p *designatePlugin) Scrape(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string) (map[string]limes.ResourceData, error) {
+	client, err := openstack.NewDNSV2(provider, eo)
 	if err != nil {
 		return nil, err
 	}
@@ -122,8 +116,8 @@ func (p *designatePlugin) Scrape(provider *gophercloud.ProviderClient, clusterID
 }
 
 //SetQuota implements the limes.QuotaPlugin interface.
-func (p *designatePlugin) SetQuota(provider *gophercloud.ProviderClient, clusterID, domainUUID, projectUUID string, quotas map[string]uint64) error {
-	client, err := p.Client(provider)
+func (p *designatePlugin) SetQuota(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string, quotas map[string]uint64) error {
+	client, err := openstack.NewDNSV2(provider, eo)
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/discovery_list.go
+++ b/pkg/plugins/discovery_list.go
@@ -40,15 +40,9 @@ func (p *listDiscoveryPlugin) Method() string {
 	return "list"
 }
 
-func (p *listDiscoveryPlugin) Client(provider *gophercloud.ProviderClient) (*gophercloud.ServiceClient, error) {
-	return openstack.NewIdentityV3(provider,
-		gophercloud.EndpointOpts{Availability: gophercloud.AvailabilityPublic},
-	)
-}
-
 //ListDomains implements the limes.DiscoveryPlugin interface.
-func (p *listDiscoveryPlugin) ListDomains(provider *gophercloud.ProviderClient) ([]limes.KeystoneDomain, error) {
-	client, err := p.Client(provider)
+func (p *listDiscoveryPlugin) ListDomains(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) ([]limes.KeystoneDomain, error) {
+	client, err := openstack.NewIdentityV3(provider, eo)
 	if err != nil {
 		return nil, err
 	}
@@ -69,8 +63,8 @@ func (p *listDiscoveryPlugin) ListDomains(provider *gophercloud.ProviderClient) 
 }
 
 //ListProjects implements the limes.DiscoveryPlugin interface.
-func (p *listDiscoveryPlugin) ListProjects(provider *gophercloud.ProviderClient, domainUUID string) ([]limes.KeystoneProject, error) {
-	client, err := p.Client(provider)
+func (p *listDiscoveryPlugin) ListProjects(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, domainUUID string) ([]limes.KeystoneProject, error) {
+	client, err := openstack.NewIdentityV3(provider, eo)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/plugins/discovery_roleassignment.go
+++ b/pkg/plugins/discovery_roleassignment.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/roles"
 	"github.com/gophercloud/gophercloud/pagination"
 	"github.com/sapcc/go-bits/logg"
@@ -51,17 +52,17 @@ func (p *roleAssignmentDiscoveryPlugin) Method() string {
 }
 
 //ListDomains implements the limes.DiscoveryPlugin interface.
-func (p *roleAssignmentDiscoveryPlugin) ListDomains(provider *gophercloud.ProviderClient) ([]limes.KeystoneDomain, error) {
-	return p.lister.ListDomains(provider)
+func (p *roleAssignmentDiscoveryPlugin) ListDomains(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) ([]limes.KeystoneDomain, error) {
+	return p.lister.ListDomains(provider, eo)
 }
 
 //ListProjects implements the limes.DiscoveryPlugin interface.
-func (p *roleAssignmentDiscoveryPlugin) ListProjects(provider *gophercloud.ProviderClient, domainUUID string) ([]limes.KeystoneProject, error) {
+func (p *roleAssignmentDiscoveryPlugin) ListProjects(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, domainUUID string) ([]limes.KeystoneProject, error) {
 	if p.cfg.RoleAssignment.RoleName == "" {
 		logg.Fatal(`missing role name for discovery plugin "role-assignment"`)
 	}
 
-	client, err := p.lister.Client(provider)
+	client, err := openstack.NewIdentityV3(provider, eo)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/plugins/manila.go
+++ b/pkg/plugins/manila.go
@@ -64,7 +64,7 @@ func init() {
 }
 
 //Init implements the limes.QuotaPlugin interface.
-func (p *manilaPlugin) Init(provider *gophercloud.ProviderClient) error {
+func (p *manilaPlugin) Init(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) error {
 	return nil
 }
 
@@ -82,15 +82,9 @@ func (p *manilaPlugin) Resources() []limes.ResourceInfo {
 	return manilaResources
 }
 
-func (p *manilaPlugin) Client(provider *gophercloud.ProviderClient) (*gophercloud.ServiceClient, error) {
-	return openstack.NewSharedFileSystemV2(provider,
-		gophercloud.EndpointOpts{Availability: gophercloud.AvailabilityPublic},
-	)
-}
-
 //Scrape implements the limes.QuotaPlugin interface.
-func (p *manilaPlugin) Scrape(provider *gophercloud.ProviderClient, clusterID, domainUUID, projectUUID string) (map[string]limes.ResourceData, error) {
-	client, err := p.Client(provider)
+func (p *manilaPlugin) Scrape(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string) (map[string]limes.ResourceData, error) {
+	client, err := openstack.NewSharedFileSystemV2(provider, eo)
 	if err != nil {
 		return nil, err
 	}
@@ -199,8 +193,8 @@ func (p *manilaPlugin) Scrape(provider *gophercloud.ProviderClient, clusterID, d
 }
 
 //SetQuota implements the limes.QuotaPlugin interface.
-func (p *manilaPlugin) SetQuota(provider *gophercloud.ProviderClient, clusterID, domainUUID, projectUUID string, quotas map[string]uint64) error {
-	client, err := p.Client(provider)
+func (p *manilaPlugin) SetQuota(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string, quotas map[string]uint64) error {
+	client, err := openstack.NewSharedFileSystemV2(provider, eo)
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/neutron.go
+++ b/pkg/plugins/neutron.go
@@ -118,7 +118,7 @@ func init() {
 }
 
 //Init implements the limes.QuotaPlugin interface.
-func (p *neutronPlugin) Init(provider *gophercloud.ProviderClient) error {
+func (p *neutronPlugin) Init(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) error {
 	return nil
 }
 
@@ -134,12 +134,6 @@ func (p *neutronPlugin) ServiceInfo() limes.ServiceInfo {
 //Resources implements the limes.QuotaPlugin interface.
 func (p *neutronPlugin) Resources() []limes.ResourceInfo {
 	return neutronResources
-}
-
-func (p *neutronPlugin) Client(provider *gophercloud.ProviderClient) (*gophercloud.ServiceClient, error) {
-	return openstack.NewNetworkV2(provider,
-		gophercloud.EndpointOpts{Availability: gophercloud.AvailabilityPublic},
-	)
 }
 
 type neutronResourceMetadata struct {
@@ -242,8 +236,8 @@ type neutronQueryOpts struct {
 }
 
 //Scrape implements the limes.QuotaPlugin interface.
-func (p *neutronPlugin) Scrape(provider *gophercloud.ProviderClient, clusterID, domainUUID, projectUUID string) (map[string]limes.ResourceData, error) {
-	client, err := p.Client(provider)
+func (p *neutronPlugin) Scrape(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string) (map[string]limes.ResourceData, error) {
+	client, err := openstack.NewNetworkV2(provider, eo)
 	if err != nil {
 		return nil, err
 	}
@@ -289,7 +283,7 @@ func (p *neutronPlugin) Scrape(provider *gophercloud.ProviderClient, clusterID, 
 }
 
 //SetQuota implements the limes.QuotaPlugin interface.
-func (p *neutronPlugin) SetQuota(provider *gophercloud.ProviderClient, clusterID, domainUUID, projectUUID string, quotas map[string]uint64) error {
+func (p *neutronPlugin) SetQuota(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string, quotas map[string]uint64) error {
 	//map resource names from Limes to Neutron
 	var requestData struct {
 		Quotas map[string]uint64 `json:"quota"`
@@ -302,7 +296,7 @@ func (p *neutronPlugin) SetQuota(provider *gophercloud.ProviderClient, clusterID
 		}
 	}
 
-	client, err := p.Client(provider)
+	client, err := openstack.NewNetworkV2(provider, eo)
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/swift.go
+++ b/pkg/plugins/swift.go
@@ -48,7 +48,7 @@ func init() {
 }
 
 //Init implements the limes.QuotaPlugin interface.
-func (p *swiftPlugin) Init(provider *gophercloud.ProviderClient) error {
+func (p *swiftPlugin) Init(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) error {
 	return nil
 }
 
@@ -66,10 +66,8 @@ func (p *swiftPlugin) Resources() []limes.ResourceInfo {
 	return swiftResources
 }
 
-func (p *swiftPlugin) Account(provider *gophercloud.ProviderClient, projectUUID string) (*schwift.Account, error) {
-	client, err := openstack.NewObjectStorageV1(provider,
-		gophercloud.EndpointOpts{Availability: gophercloud.AvailabilityPublic},
-	)
+func (p *swiftPlugin) Account(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, projectUUID string) (*schwift.Account, error) {
+	client, err := openstack.NewObjectStorageV1(provider, eo)
 	if err != nil {
 		return nil, err
 	}
@@ -82,8 +80,8 @@ func (p *swiftPlugin) Account(provider *gophercloud.ProviderClient, projectUUID 
 }
 
 //Scrape implements the limes.QuotaPlugin interface.
-func (p *swiftPlugin) Scrape(provider *gophercloud.ProviderClient, clusterID, domainUUID, projectUUID string) (map[string]limes.ResourceData, error) {
-	account, err := p.Account(provider, projectUUID)
+func (p *swiftPlugin) Scrape(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string) (map[string]limes.ResourceData, error) {
+	account, err := p.Account(provider, eo, projectUUID)
 	if err != nil {
 		return nil, err
 	}
@@ -112,8 +110,8 @@ func (p *swiftPlugin) Scrape(provider *gophercloud.ProviderClient, clusterID, do
 }
 
 //SetQuota implements the limes.QuotaPlugin interface.
-func (p *swiftPlugin) SetQuota(provider *gophercloud.ProviderClient, clusterID, domainUUID, projectUUID string, quotas map[string]uint64) error {
-	account, err := p.Account(provider, projectUUID)
+func (p *swiftPlugin) SetQuota(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string, quotas map[string]uint64) error {
+	account, err := p.Account(provider, eo, projectUUID)
 	if err != nil {
 		return err
 	}

--- a/pkg/test/discovery.go
+++ b/pkg/test/discovery.go
@@ -56,11 +56,11 @@ func (p *DiscoveryPlugin) Method() string {
 }
 
 //ListDomains implements the limes.DiscoveryPlugin interface.
-func (p *DiscoveryPlugin) ListDomains(provider *gophercloud.ProviderClient) ([]limes.KeystoneDomain, error) {
+func (p *DiscoveryPlugin) ListDomains(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) ([]limes.KeystoneDomain, error) {
 	return p.StaticDomains, nil
 }
 
 //ListProjects implements the limes.DiscoveryPlugin interface.
-func (p *DiscoveryPlugin) ListProjects(provider *gophercloud.ProviderClient, domainUUID string) ([]limes.KeystoneProject, error) {
+func (p *DiscoveryPlugin) ListProjects(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, domainUUID string) ([]limes.KeystoneProject, error) {
 	return p.StaticProjects[domainUUID], nil
 }

--- a/pkg/test/plugin.go
+++ b/pkg/test/plugin.go
@@ -71,7 +71,7 @@ func NewPluginFactory(serviceType string) func(limes.ServiceConfiguration, map[s
 }
 
 //Init implements the limes.QuotaPlugin interface.
-func (p *Plugin) Init(provider *gophercloud.ProviderClient) error {
+func (p *Plugin) Init(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) error {
 	return nil
 }
 
@@ -97,7 +97,7 @@ func (p *Plugin) Resources() []limes.ResourceInfo {
 }
 
 //Scrape implements the limes.QuotaPlugin interface.
-func (p *Plugin) Scrape(provider *gophercloud.ProviderClient, clusterID, domainUUID, projectUUID string) (map[string]limes.ResourceData, error) {
+func (p *Plugin) Scrape(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string) (map[string]limes.ResourceData, error) {
 	result := make(map[string]limes.ResourceData)
 	for key, val := range p.StaticResourceData {
 		if !p.WithExternallyManagedResource && key == "external_things" {
@@ -134,7 +134,7 @@ func (p *Plugin) Scrape(provider *gophercloud.ProviderClient, clusterID, domainU
 }
 
 //SetQuota implements the limes.QuotaPlugin interface.
-func (p *Plugin) SetQuota(provider *gophercloud.ProviderClient, clusterID, domainUUID, projectUUID string, quotas map[string]uint64) error {
+func (p *Plugin) SetQuota(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string, quotas map[string]uint64) error {
 	if p.SetQuotaFails {
 		return errors.New("SetQuota failed as requested")
 	}
@@ -161,7 +161,7 @@ func (p *CapacityPlugin) ID() string {
 }
 
 //Scrape implements the limes.CapacityPlugin interface.
-func (p *CapacityPlugin) Scrape(provider *gophercloud.ProviderClient, clusterID string) (map[string]map[string]limes.CapacityData, error) {
+func (p *CapacityPlugin) Scrape(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID string) (map[string]map[string]limes.CapacityData, error) {
 	var subcapacities []interface{}
 	if p.WithSubcapacities {
 		subcapacities = []interface{}{


### PR DESCRIPTION
By generating suitable gophercloud.EndpointOpts and passing them into the plugins.

This is good to go from my side, but I know better than to merge this on a Friday.

@reimannf FYI - This should fix the monsoon2 alert.