### PR TITLE
add new column `project_resources.desired_backend_quota`

### DIFF
--- a/pkg/api/fixtures/start-data-inconsistencies.sql
+++ b/pkg/api/fixtures/start-data-inconsistencies.sql
@@ -31,12 +31,12 @@ INSERT INTO project_services (id, project_id, type, scraped_at) VALUES (5, 3, 'c
 INSERT INTO project_services (id, project_id, type, scraped_at) VALUES (6, 3, 'network', '2018-06-13 15:06:37');
 
 -- project_resources contains some pathological cases
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'cores',         30,  14, 10,  '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'ram',           100, 88, 100, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (2, 'loadbalancers', 10,  5,  10,  '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (3, 'cores',         14,  18, 14,  '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (3, 'ram',           60,  45, 60,  '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (4, 'loadbalancers', 5,   2,  5,   '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (5, 'cores',         30,  20,  30,  '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (5, 'ram',           62,  48, 62,  '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (6, 'loadbalancers', 10,  4,  10,  '');
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'cores',         30,  14, 10,  '', 30);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'ram',           100, 88, 100, '', 100);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'loadbalancers', 10,  5,  10,  '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (3, 'cores',         14,  18, 14,  '', 14);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (3, 'ram',           60,  45, 60,  '', 60);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (4, 'loadbalancers', 5,   2,  5,   '', 5);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (5, 'cores',         30,  20,  30,  '', 30);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (5, 'ram',           62,  48, 62,  '', 62);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (6, 'loadbalancers', 10,  4,  10,  '', 10);

--- a/pkg/api/fixtures/start-data.sql
+++ b/pkg/api/fixtures/start-data.sql
@@ -55,29 +55,29 @@ INSERT INTO project_services (id, project_id, type, scraped_at) VALUES (8, 4, 's
 
 -- project_resources contains some pathological cases
 -- berlin (also used for test cases concerning subresources)
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'things',   10, 2, 10, '[{"id":"firstthing","value":23},{"id":"secondthing","value":42}]');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'capacity', 10, 2, 10, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (2, 'things',   10, 2, 10, '[{"id":"thirdthing","value":5},{"id":"fourththing","value":123}]');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (2, 'capacity', 10, 2, 10, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (2, 'external_things', 1, 0, 1, '');
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'things',   10, 2, 10, '[{"id":"firstthing","value":23},{"id":"secondthing","value":42}]', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'capacity', 10, 2, 10, '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'things',   10, 2, 10, '[{"id":"thirdthing","value":5},{"id":"fourththing","value":123}]', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'capacity', 10, 2, 10, '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'external_things', 1, 0, 1, '', 10);
 -- dresden (backend quota for shared/capacity mismatches approved quota and exceeds domain quota)
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (3, 'things',   10, 2, 10, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (3, 'capacity', 10, 2, 10, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (4, 'things',   10, 2, 10, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (4, 'capacity', 10, 2, 100, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (4, 'external_things', 1, 0, 1, '');
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (3, 'things',   10, 2, 10, '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (3, 'capacity', 10, 2, 10, '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (4, 'things',   10, 2, 10, '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (4, 'capacity', 10, 2, 100, '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (4, 'external_things', 1, 0, 1, '', 10);
 -- paris (infinite backend quota for unshared/things)
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (5, 'things',   10, 2, -1, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (5, 'capacity', 10, 2, 10, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (6, 'things',   10, 2, 10, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (6, 'capacity', 10, 2, 10, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (6, 'external_things', 1, 0, 1, '');
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (5, 'things',   10, 2, -1, '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (5, 'capacity', 10, 2, 10, '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (6, 'things',   10, 2, 10, '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (6, 'capacity', 10, 2, 10, '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (6, 'external_things', 1, 0, 1, '', 10);
 -- warsaw
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (7, 'things',   10, 2, 10, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (7, 'capacity', 10, 2, 10, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (8, 'things',   10, 2, 10, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (8, 'capacity', 10, 2, 10, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (8, 'external_things', 1, 0, 1, '');
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (7, 'things',   10, 2, 10, '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (7, 'capacity', 10, 2, 10, '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (8, 'things',   10, 2, 10, '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (8, 'capacity', 10, 2, 10, '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (8, 'external_things', 1, 0, 1, '', 10);
 
 -- insert some bullshit data that should be filtered out by the pkg/reports/ logic
 -- (cluster "north", service "weird" and resource "items" are not configured)
@@ -89,7 +89,7 @@ INSERT INTO cluster_resources (service_id, name, capacity) VALUES (102, 'things'
 INSERT INTO domain_services (id, domain_id, type) VALUES (101, 1, 'weird');
 INSERT INTO domain_resources (service_id, name, quota) VALUES (101, 'things', 1);
 INSERT INTO project_services (id, project_id, type) VALUES (101, 1, 'weird');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (101, 'things', 2, 1, 2, '');
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (101, 'things', 2, 1, 2, '', 2);
 
 INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'items', 1);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'items', 2, 1, 2, '');
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'items', 2, 1, 2, '', 2);

--- a/pkg/collector/fixtures/checkconsistency1.sql
+++ b/pkg/collector/fixtures/checkconsistency1.sql
@@ -20,4 +20,4 @@ INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (3
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (5, 3, 'unshared', NULL, FALSE);
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (6, 1, 'whatever', NULL, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'capacity', 20, 0, 0, '');
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'capacity', 20, 0, 0, '', 0);

--- a/pkg/collector/fixtures/checkconsistency2.sql
+++ b/pkg/collector/fixtures/checkconsistency2.sql
@@ -24,5 +24,5 @@ INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (6
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (7, 2, 'shared', NULL, FALSE);
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (8, 3, 'shared', NULL, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'capacity', 20, 0, 0, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (7, 'capacity', 10, 0, 0, '');
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'capacity', 20, 0, 0, '', 0);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (7, 'capacity', 10, 0, 0, '', 10);

--- a/pkg/collector/fixtures/scandomains1.sql
+++ b/pkg/collector/fixtures/scandomains1.sql
@@ -20,5 +20,5 @@ INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (4
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (5, 3, 'unshared', NULL, FALSE);
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (6, 3, 'shared', NULL, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'things', 5, 0, 0, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (2, 'capacity', 10, 0, 0, '');
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'things', 5, 0, 0, '', 5);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'capacity', 10, 0, 0, '', 10);

--- a/pkg/collector/fixtures/scandomains2.sql
+++ b/pkg/collector/fixtures/scandomains2.sql
@@ -23,5 +23,5 @@ INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (6
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (7, 4, 'unshared', NULL, FALSE);
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (8, 4, 'shared', NULL, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'things', 5, 0, 0, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (2, 'capacity', 10, 0, 0, '');
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'things', 5, 0, 0, '', 5);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'capacity', 10, 0, 0, '', 10);

--- a/pkg/collector/fixtures/scandomains3.sql
+++ b/pkg/collector/fixtures/scandomains3.sql
@@ -14,5 +14,5 @@ INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (2
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (3, 2, 'unshared', NULL, FALSE);
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (4, 2, 'shared', NULL, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'things', 5, 0, 0, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (2, 'capacity', 10, 0, 0, '');
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'things', 5, 0, 0, '', 5);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'capacity', 10, 0, 0, '', 10);

--- a/pkg/collector/fixtures/scandomains4.sql
+++ b/pkg/collector/fixtures/scandomains4.sql
@@ -14,5 +14,5 @@ INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (2
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (3, 2, 'unshared', NULL, FALSE);
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (4, 2, 'shared', NULL, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'things', 5, 0, 0, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (2, 'capacity', 10, 0, 0, '');
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'things', 5, 0, 0, '', 5);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'capacity', 10, 0, 0, '', 10);

--- a/pkg/collector/fixtures/scrape-autoapprove1.sql
+++ b/pkg/collector/fixtures/scrape-autoapprove1.sql
@@ -6,5 +6,5 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALU
 
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (1, 1, 'autoapprovaltest', 1, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'approve', 10, 0, 10, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'noapprove', 0, 0, 20, '');
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'approve', 10, 0, 10, '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'noapprove', 0, 0, 20, '', 0);

--- a/pkg/collector/fixtures/scrape-autoapprove2.sql
+++ b/pkg/collector/fixtures/scrape-autoapprove2.sql
@@ -6,5 +6,5 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALU
 
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (1, 1, 'autoapprovaltest', 3, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'approve', 10, 0, 20, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'noapprove', 0, 0, 30, '');
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'approve', 10, 0, 20, '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'noapprove', 0, 0, 30, '', 0);

--- a/pkg/collector/fixtures/scrape-failures1.sql
+++ b/pkg/collector/fixtures/scrape-failures1.sql
@@ -8,7 +8,7 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALU
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (1, 1, 'unittest', 0, FALSE);
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (2, 2, 'unittest', 0, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'capacity', 10, 0, -1, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'things', 0, 0, -1, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (2, 'capacity', 10, 0, -1, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (2, 'things', 0, 0, -1, '');
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'capacity', 10, 0, -1, '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'things', 0, 0, -1, '', 0);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'capacity', 10, 0, -1, '', 12);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'things', 0, 0, -1, '', 0);

--- a/pkg/collector/fixtures/scrape-failures2.sql
+++ b/pkg/collector/fixtures/scrape-failures2.sql
@@ -8,7 +8,7 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALU
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (1, 1, 'unittest', 5, FALSE);
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (2, 2, 'unittest', 7, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'capacity', 10, 0, 100, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'things', 0, 2, 42, '[{"index":0},{"index":1}]');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (2, 'capacity', 10, 0, 100, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (2, 'things', 0, 2, 42, '[{"index":0},{"index":1}]');
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'capacity', 10, 0, 100, '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'things', 0, 2, 42, '[{"index":0},{"index":1}]', 0);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'capacity', 10, 0, 100, '', 12);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'things', 0, 2, 42, '[{"index":0},{"index":1}]', 0);

--- a/pkg/collector/fixtures/scrape-failures3.sql
+++ b/pkg/collector/fixtures/scrape-failures3.sql
@@ -8,7 +8,7 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALU
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (1, 1, 'unittest', 5, TRUE);
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (2, 2, 'unittest', 7, TRUE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'capacity', 10, 0, 100, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'things', 0, 2, 42, '[{"index":0},{"index":1}]');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (2, 'capacity', 10, 0, 100, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (2, 'things', 0, 2, 42, '[{"index":0},{"index":1}]');
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'capacity', 10, 0, 100, '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'things', 0, 2, 42, '[{"index":0},{"index":1}]', 0);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'capacity', 10, 0, 100, '', 12);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'things', 0, 2, 42, '[{"index":0},{"index":1}]', 0);

--- a/pkg/collector/fixtures/scrape1.sql
+++ b/pkg/collector/fixtures/scrape1.sql
@@ -8,7 +8,7 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALU
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (1, 1, 'unittest', 1, FALSE);
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (2, 2, 'unittest', 3, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'capacity', 10, 0, 100, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'things', 0, 2, 42, '[{"index":0},{"index":1}]');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (2, 'capacity', 10, 0, 100, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (2, 'things', 0, 2, 42, '[{"index":0},{"index":1}]');
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'capacity', 10, 0, 100, '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'things', 0, 2, 42, '[{"index":0},{"index":1}]', 0);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'capacity', 10, 0, 100, '', 12);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'things', 0, 2, 42, '[{"index":0},{"index":1}]', 0);

--- a/pkg/collector/fixtures/scrape2.sql
+++ b/pkg/collector/fixtures/scrape2.sql
@@ -8,7 +8,7 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALU
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (1, 1, 'unittest', 6, FALSE);
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (2, 2, 'unittest', 8, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'capacity', 10, 0, 110, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'things', 0, 5, 42, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (2, 'capacity', 10, 0, 110, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (2, 'things', 0, 5, 42, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]');
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'capacity', 10, 0, 110, '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'things', 0, 5, 42, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 0);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'capacity', 10, 0, 110, '', 12);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'things', 0, 5, 42, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 0);

--- a/pkg/collector/fixtures/scrape3.sql
+++ b/pkg/collector/fixtures/scrape3.sql
@@ -8,7 +8,7 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALU
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (1, 1, 'unittest', 10, FALSE);
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (2, 2, 'unittest', 12, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'capacity', 20, 0, 20, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'things', 13, 5, 13, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (2, 'capacity', 20, 0, 24, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (2, 'things', 13, 5, 15, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]');
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'capacity', 20, 0, 20, '', 20);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'things', 13, 5, 13, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 13);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'capacity', 20, 0, 24, '', 24);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'things', 13, 5, 15, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 15);

--- a/pkg/collector/fixtures/scrape4.sql
+++ b/pkg/collector/fixtures/scrape4.sql
@@ -8,7 +8,7 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALU
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (1, 1, 'unittest', 14, FALSE);
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (2, 2, 'unittest', 16, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'capacity', 20, 0, 20, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'things', 13, 5, 13, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (2, 'capacity', 20, 0, 24, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (2, 'things', 13, 5, 15, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]');
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'capacity', 20, 0, 20, '', 20);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'things', 13, 5, 13, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 13);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'capacity', 20, 0, 24, '', 24);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'things', 13, 5, 15, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 15);

--- a/pkg/collector/fixtures/scrape5.sql
+++ b/pkg/collector/fixtures/scrape5.sql
@@ -8,7 +8,7 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALU
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (1, 1, 'unittest', 18, FALSE);
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (2, 2, 'unittest', 20, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'capacity', 40, 0, 40, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'things', 13, 5, 13, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (2, 'capacity', 40, 0, 48, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (2, 'things', 13, 5, 15, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]');
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'capacity', 40, 0, 40, '', 40);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'things', 13, 5, 13, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 13);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'capacity', 40, 0, 48, '', 48);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'things', 13, 5, 15, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 15);

--- a/pkg/collector/fixtures/scrape6.sql
+++ b/pkg/collector/fixtures/scrape6.sql
@@ -8,9 +8,9 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALU
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (1, 1, 'unittest', 22, FALSE);
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (2, 2, 'unittest', 24, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'capacity', 40, 0, 40, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'things', 13, 5, 13, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (2, 'capacity', 40, 0, 48, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (2, 'things', 13, 5, 15, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'external_things', 5, 0, 5, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (2, 'external_things', 5, 0, 5, '');
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'capacity', 40, 0, 40, '', 40);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'things', 13, 5, 13, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 13);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'capacity', 40, 0, 48, '', 48);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'things', 13, 5, 15, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 15);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'external_things', 5, 0, 5, '', 5);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'external_things', 5, 0, 5, '', 5);

--- a/pkg/collector/fixtures/scrape7.sql
+++ b/pkg/collector/fixtures/scrape7.sql
@@ -8,9 +8,9 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALU
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (1, 1, 'unittest', 26, FALSE);
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (2, 2, 'unittest', 28, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'capacity', 40, 0, 40, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'things', 13, 5, 13, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (2, 'capacity', 40, 0, 48, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (2, 'things', 13, 5, 15, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'external_things', 10, 0, 10, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (2, 'external_things', 10, 0, 10, '');
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'capacity', 40, 0, 40, '', 40);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'things', 13, 5, 13, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 13);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'capacity', 40, 0, 48, '', 48);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'things', 13, 5, 15, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 15);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'external_things', 10, 0, 10, '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'external_things', 10, 0, 10, '', 10);

--- a/pkg/collector/fixtures/scrape8.sql
+++ b/pkg/collector/fixtures/scrape8.sql
@@ -8,9 +8,9 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALU
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (1, 1, 'unittest', 30, FALSE);
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (2, 2, 'unittest', 32, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'capacity', 40, 0, 40, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'things', 13, 5, 13, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (2, 'capacity', 40, 0, 48, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (2, 'things', 13, 5, 15, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (1, 'external_things', 10, 0, 10, '');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources) VALUES (2, 'external_things', 10, 0, 10, '');
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'capacity', 40, 0, 40, '', 40);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'things', 13, 5, 13, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 13);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'capacity', 40, 0, 48, '', 48);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'things', 13, 5, 15, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 15);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'external_things', 10, 0, 10, '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'external_things', 10, 0, 10, '', 10);

--- a/pkg/db/migrations.go
+++ b/pkg/db/migrations.go
@@ -143,4 +143,10 @@ var SQLMigrations = map[string]string{
 	"007_add_projects_has_bursting.up.sql": `
 		ALTER TABLE projects ADD COLUMN has_bursting BOOLEAN NOT NULL DEFAULT TRUE;
 	`,
+	"008_add_project_resources_desired_backend_quota.down.sql": `
+		ALTER TABLE project_resources DROP COLUMN desired_backend_quota;
+	`,
+	"008_add_project_resources_desired_backend_quota.up.sql": `
+		ALTER TABLE project_resources ADD COLUMN desired_backend_quota BIGINT NOT NULL DEFAULT 0;
+	`,
 }

--- a/pkg/db/models.go
+++ b/pkg/db/models.go
@@ -81,12 +81,13 @@ type ProjectService struct {
 
 //ProjectResource contains a record from the `project_resources` table.
 type ProjectResource struct {
-	ServiceID        int64  `db:"service_id"`
-	Name             string `db:"name"`
-	Quota            uint64 `db:"quota"`
-	Usage            uint64 `db:"usage"`
-	BackendQuota     int64  `db:"backend_quota"`
-	SubresourcesJSON string `db:"subresources"`
+	ServiceID           int64  `db:"service_id"`
+	Name                string `db:"name"`
+	Quota               uint64 `db:"quota"`
+	Usage               uint64 `db:"usage"`
+	BackendQuota        int64  `db:"backend_quota"`
+	DesiredBackendQuota uint64 `db:"desired_backend_quota"`
+	SubresourcesJSON    string `db:"subresources"`
 }
 
 //InitGorp is used by Init() to setup the ORM part of the database connection.


### PR DESCRIPTION
With this, it will be possible to detect quota-mismatch inconsistencies in pure SQL without having to compute burst multipliers in the SQL expression.

Will merge this on Monday.

@talal When this is merged, rebase #74 onto this and use the new column in the SQL statements so that you don't have to fiddle with quota calculations in Go.

@reimannf FYI