### PR TITLE
CFM: compute correct capacity when duplicate pools are reported

### DIFF
--- a/pkg/plugins/client_cfm.go
+++ b/pkg/plugins/client_cfm.go
@@ -247,6 +247,9 @@ func (c *cfmClient) GetShareserver(url string) (*cfmShareserver, error) {
 // capacity API
 
 type cfmPool struct {
+	HostName     string `json:"host"`
+	Name         string `json:"name"`
+	Type         string `json:"pool"`
 	Capabilities struct {
 		TotalCapacityBytes uint64 `json:"total_capacity"`
 	} `json:"capabilities"`


### PR DESCRIPTION
Checklist:

- [x] If this PR is about a plugin, I tested the plugin against an OpenStack cluster.
- [ ] ~I updated the documentation to describe the semantical or interface changes I introduced.~
