### PR TITLE
Report on size_used for CFM usage

### DIFF
--- a/pkg/plugins/cfm.go
+++ b/pkg/plugins/cfm.go
@@ -78,7 +78,7 @@ func (p *cfmPlugin) Scrape(provider *gophercloud.ProviderClient, eo gophercloud.
 		StorageQuota struct {
 			SizeLimitBytes int64 `json:"size_limit"`
 			Usage          struct {
-				BytesUsed uint64 `json:"potential_growth_size"`
+				BytesUsed uint64 `json:"size_used"`
 			} `json:"usage"`
 		} `json:"storage_quota"`
 	}


### PR DESCRIPTION
Previously `usage.potential_growth_size` was used to report the usage with auto-grow option. We switch back to the real size used.

Want to hold that back until billing and reporting is informed.

Checklist:

- [ ] If this PR is about a plugin, I tested the plugin against an OpenStack cluster.
- [ ] I updated the documentation to describe the semantical or interface changes I introduced.
