### PR TITLE
added interface option to cluster auth section

### DIFF
--- a/docs/operators/config.md
+++ b/docs/operators/config.md
@@ -90,6 +90,7 @@ Configuration options describing the OpenStack clusters which Limes shall cover.
 | `clusters.$id.auth.project_domain_name` | yes | Domain containing that project. | `OS_PROJECT_DOMAIN_NAME` |
 | `clusters.$id.auth.password` | yes | Password for Limes service user. | `OS_PASSWORD` |
 | `clusters.$id.auth.region_name` | no | In multi-region OpenStack clusters, this selects the region to work on. | `OS_REGION_NAME` |
+| `clusters.$id.auth.interface` | no | The endpoint type Limes should use for the OpenStack services. | `OS_INTERFACE` |
 
 | Field | Required | Description |
 | --- | --- | --- |

--- a/pkg/core/auth.go
+++ b/pkg/core/auth.go
@@ -38,6 +38,7 @@ type AuthParameters struct {
 	ProjectDomainName string      `yaml:"project_domain_name"`
 	Password          string      `yaml:"password"`
 	RegionName        string      `yaml:"region_name"`
+	Interface         string      `yaml:"interface"`
 	tokenRenewalMutex *sync.Mutex `yaml:"-"`
 	//The following fields are only valid after calling Connect().
 	ProviderClient *gophercloud.ProviderClient `yaml:"-"`
@@ -80,7 +81,7 @@ func (auth *AuthParameters) Connect() error {
 	}
 
 	auth.EndpointOpts = gophercloud.EndpointOpts{
-		Availability: gophercloud.AvailabilityPublic,
+		Availability: gophercloud.Availability(auth.Interface),
 		Region:       auth.RegionName,
 	}
 	return nil


### PR DESCRIPTION
allows to configure OpenStack endpoint type to use

Checklist:

- [x] I updated the documentation to describe the semantical or interface changes I introduced.
