### PR TITLE
add "physical_usage" attribute to "project_resources"

### DIFF
--- a/docs/users/api-v1-specification.md
+++ b/docs/users/api-v1-specification.md
@@ -66,7 +66,8 @@ Returns 200 (OK) on success. Result is a JSON document like:
               "unit": "MiB",
               "quota": 10240,
               "usable_quota": 12288,
-              "usage": 2048
+              "usage": 2048,
+              "physical_usage": 1058
             }
           ],
           "scraped_at": 1486738599
@@ -145,13 +146,15 @@ resource. The `backend_quota` field will only be shown if the backend quota diff
 the `usable_quota` field. While `usable_quota` is usually computed as `floor(quota * (1 + bursting.multiplier))`,
 different multipliers may apply per resource.
 
+For some resources, a separate `physical_usage` can be reported which may be at or below `usage`. If `physical_usage` is
+not given, it shall be assumed to be equal to `usage`. Physical usage is especially useful for storage: When you have a
+2 GiB volume that contains 600 MiB worth of files, then `usage` is 2 GiB and `physical_usage` would be 600 MiB.
+
 The `scraped_at` timestamp for each service denotes when Limes last checked the quota and usage values in the backing
 service. The value is a standard UNIX timestamp (seconds since `1970-00-00T00:00:00Z`).
 
 Valid values for quotas include all non-negative numbers. Backend quotas can also have the special value `-1` which
 indicates an infinite or disabled quota.
-
-TODO: Might need to add ordering and pagination to this at some point.
 
 ### Subresources
 
@@ -238,7 +241,8 @@ Returns 200 (OK) on success. Result is a JSON document like:
               "quota": 204800,
               "projects_quota": 10240,
               "usage": 2048,
-              "burst_usage": 128
+              "burst_usage": 128,
+              "physical_usage": 1376
             }
           ],
           "max_scraped_at": 1486738599,
@@ -287,6 +291,9 @@ shows the sum of all project quotas as seen by the backing service. If any of th
 
 Furthermore, if quota bursting is available on this cluster, the `burst_usage` field contains
 `sum(max(0, usage - quota))` over all projects in this domain.
+
+If any project in the domain reports a `physical_usage`, then the domain will report the aggregated `physical_usage`
+over all projects. If the `physical_usage` is not present in the output, it shall be assumed to be equal to `usage`.
 
 In contrast to project data, `scraped_at` is replaced by `min_scraped_at` and `max_scraped_at`, which aggregate over the
 `scraped_at` timestamps of all project data for that service and domain.
@@ -385,6 +392,9 @@ show the overcommitted capacity (`raw_capacity` times overcommitment factor).
 
 Furthermore, if quota bursting is available on this cluster, the `burst_usage` field contains
 `sum(max(0, usage - quota))` over all projects in this cluster.
+
+If any project in the cluster reports a `physical_usage`, then the cluster will report the aggregated `physical_usage`
+over all projects. If the `physical_usage` is not present in the output, it shall be assumed to be equal to `usage`.
 
 The `min_scraped_at` and `max_scraped_at` timestamps on the service level refer to the usage values (aggregated over all
 projects just like for `GET /domains`).

--- a/pkg/api/fixtures/cluster-get-west-with-overcommit.json
+++ b/pkg/api/fixtures/cluster-get-west-with-overcommit.json
@@ -11,7 +11,8 @@
             "name": "capacity",
             "unit": "B",
             "domains_quota": 50,
-            "usage": 8
+            "usage": 8,
+            "physical_usage": 7
           },
           {
             "name": "external_things",

--- a/pkg/api/fixtures/cluster-get-west.json
+++ b/pkg/api/fixtures/cluster-get-west.json
@@ -13,7 +13,8 @@
             "capacity": 185,
             "comment": "hand-counted",
             "domains_quota": 50,
-            "usage": 8
+            "usage": 8,
+            "physical_usage": 7
           },
           {
             "name": "external_things",

--- a/pkg/api/fixtures/cluster-list-detail.json
+++ b/pkg/api/fixtures/cluster-list-detail.json
@@ -15,7 +15,8 @@
               "capacity": 185,
               "comment": "hand-counted",
               "domains_quota": 50,
-              "usage": 8
+              "usage": 8,
+              "physical_usage": 7
             },
             {
               "name": "external_things",
@@ -51,7 +52,8 @@
               "capacity": 1000,
               "comment": "rough estimate",
               "domains_quota": 15,
-              "usage": 2
+              "usage": 2,
+              "physical_usage": 1
             },
             {
               "name": "things",
@@ -89,7 +91,8 @@
               "capacity": 185,
               "comment": "hand-counted",
               "domains_quota": 50,
-              "usage": 8
+              "usage": 8,
+              "physical_usage": 7
             },
             {
               "name": "external_things",

--- a/pkg/api/fixtures/cluster-list-local.json
+++ b/pkg/api/fixtures/cluster-list-local.json
@@ -15,7 +15,8 @@
               "capacity": 185,
               "comment": "hand-counted",
               "domains_quota": 25,
-              "usage": 2
+              "usage": 2,
+              "physical_usage": 1
             },
             {
               "name": "external_things",
@@ -43,7 +44,8 @@
               "capacity": 1000,
               "comment": "rough estimate",
               "domains_quota": 15,
-              "usage": 2
+              "usage": 2,
+              "physical_usage": 1
             },
             {
               "name": "things",

--- a/pkg/api/fixtures/cluster-list.json
+++ b/pkg/api/fixtures/cluster-list.json
@@ -15,7 +15,8 @@
               "capacity": 185,
               "comment": "hand-counted",
               "domains_quota": 50,
-              "usage": 8
+              "usage": 8,
+              "physical_usage": 7
             },
             {
               "name": "external_things",
@@ -43,7 +44,8 @@
               "capacity": 1000,
               "comment": "rough estimate",
               "domains_quota": 15,
-              "usage": 2
+              "usage": 2,
+              "physical_usage": 1
             },
             {
               "name": "things",
@@ -73,7 +75,8 @@
               "capacity": 185,
               "comment": "hand-counted",
               "domains_quota": 50,
-              "usage": 8
+              "usage": 8,
+              "physical_usage": 7
             },
             {
               "name": "external_things",

--- a/pkg/api/fixtures/domain-get-poland.json
+++ b/pkg/api/fixtures/domain-get-poland.json
@@ -12,7 +12,8 @@
             "unit": "B",
             "quota": 25,
             "projects_quota": 10,
-            "usage": 2
+            "usage": 2,
+            "physical_usage": 1
           },
           {
             "name": "external_things",
@@ -40,7 +41,8 @@
             "unit": "B",
             "quota": 15,
             "projects_quota": 10,
-            "usage": 2
+            "usage": 2,
+            "physical_usage": 1
           },
           {
             "name": "things",

--- a/pkg/api/fixtures/domain-list-east.json
+++ b/pkg/api/fixtures/domain-list-east.json
@@ -13,7 +13,8 @@
               "unit": "B",
               "quota": 25,
               "projects_quota": 10,
-              "usage": 2
+              "usage": 2,
+              "physical_usage": 1
             },
             {
               "name": "external_things",
@@ -41,7 +42,8 @@
               "unit": "B",
               "quota": 15,
               "projects_quota": 10,
-              "usage": 2
+              "usage": 2,
+              "physical_usage": 1
             },
             {
               "name": "things",

--- a/pkg/api/fixtures/project-get-warsaw.json
+++ b/pkg/api/fixtures/project-get-warsaw.json
@@ -13,7 +13,8 @@
             "unit": "B",
             "quota": 10,
             "usable_quota": 10,
-            "usage": 2
+            "usage": 2,
+            "physical_usage": 1
           },
           {
             "name": "external_things",
@@ -40,7 +41,8 @@
             "unit": "B",
             "quota": 10,
             "usable_quota": 10,
-            "usage": 2
+            "usage": 2,
+            "physical_usage": 1
           },
           {
             "name": "things",

--- a/pkg/api/fixtures/project-list-poland.json
+++ b/pkg/api/fixtures/project-list-poland.json
@@ -14,7 +14,8 @@
               "unit": "B",
               "quota": 10,
               "usable_quota": 10,
-              "usage": 2
+              "usage": 2,
+              "physical_usage": 1
             },
             {
               "name": "external_things",
@@ -41,7 +42,8 @@
               "unit": "B",
               "quota": 10,
               "usable_quota": 10,
-              "usage": 2
+              "usage": 2,
+              "physical_usage": 1
             },
             {
               "name": "things",

--- a/pkg/api/fixtures/start-data-inconsistencies.sql
+++ b/pkg/api/fixtures/start-data-inconsistencies.sql
@@ -31,12 +31,12 @@ INSERT INTO project_services (id, project_id, type, scraped_at) VALUES (5, 3, 'c
 INSERT INTO project_services (id, project_id, type, scraped_at) VALUES (6, 3, 'network', '2018-06-13 15:06:37');
 
 -- project_resources contains some pathological cases
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'cores',         30,  14, 10,  '', 30);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'ram',           100, 88, 100, '', 100);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'loadbalancers', 10,  5,  10,  '', 10);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (3, 'cores',         14,  18, 14,  '', 14);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (3, 'ram',           60,  45, 60,  '', 60);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (4, 'loadbalancers', 5,   2,  5,   '', 5);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (5, 'cores',         30,  20,  30,  '', 30);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (5, 'ram',           62,  48, 62,  '', 62);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (6, 'loadbalancers', 10,  4,  10,  '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'cores',         30,  14, 10,  '', 30, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'ram',           100, 88, 100, '', 100, 92);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'loadbalancers', 10,  5,  10,  '', 10, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (3, 'cores',         14,  18, 14,  '', 14, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (3, 'ram',           60,  45, 60,  '', 60, 40);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (4, 'loadbalancers', 5,   2,  5,   '', 5, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (5, 'cores',         30,  20,  30,  '', 30, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (5, 'ram',           62,  48, 62,  '', 62, 43);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (6, 'loadbalancers', 10,  4,  10,  '', 10, NULL);

--- a/pkg/api/fixtures/start-data.sql
+++ b/pkg/api/fixtures/start-data.sql
@@ -55,29 +55,29 @@ INSERT INTO project_services (id, project_id, type, scraped_at) VALUES (8, 4, 's
 
 -- project_resources contains some pathological cases
 -- berlin (also used for test cases concerning subresources)
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'things',   10, 2, 10, '[{"id":"firstthing","value":23},{"id":"secondthing","value":42}]', 10);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'capacity', 10, 2, 10, '', 10);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'things',   10, 2, 10, '[{"id":"thirdthing","value":5},{"id":"fourththing","value":123}]', 10);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'capacity', 10, 2, 10, '', 10);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'external_things', 1, 0, 1, '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'things',   10, 2, 10, '[{"id":"firstthing","value":23},{"id":"secondthing","value":42}]', 10, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'capacity', 10, 2, 10, '', 10, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'things',   10, 2, 10, '[{"id":"thirdthing","value":5},{"id":"fourththing","value":123}]', 10, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'capacity', 10, 2, 10, '', 10, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'external_things', 1, 0, 1, '', 10, NULL);
 -- dresden (backend quota for shared/capacity mismatches approved quota and exceeds domain quota)
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (3, 'things',   10, 2, 10, '', 10);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (3, 'capacity', 10, 2, 10, '', 10);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (4, 'things',   10, 2, 10, '', 10);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (4, 'capacity', 10, 2, 100, '', 10);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (4, 'external_things', 1, 0, 1, '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (3, 'things',   10, 2, 10, '', 10, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (3, 'capacity', 10, 2, 10, '', 10, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (4, 'things',   10, 2, 10, '', 10, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (4, 'capacity', 10, 2, 100, '', 10, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (4, 'external_things', 1, 0, 1, '', 10, NULL);
 -- paris (infinite backend quota for unshared/things)
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (5, 'things',   10, 2, -1, '', 10);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (5, 'capacity', 10, 2, 10, '', 10);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (6, 'things',   10, 2, 10, '', 10);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (6, 'capacity', 10, 2, 10, '', 10);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (6, 'external_things', 1, 0, 1, '', 10);
--- warsaw
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (7, 'things',   10, 2, 10, '', 10);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (7, 'capacity', 10, 2, 10, '', 10);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (8, 'things',   10, 2, 10, '', 10);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (8, 'capacity', 10, 2, 10, '', 10);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (8, 'external_things', 1, 0, 1, '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (5, 'things',   10, 2, -1, '', 10, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (5, 'capacity', 10, 2, 10, '', 10, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (6, 'things',   10, 2, 10, '', 10, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (6, 'capacity', 10, 2, 10, '', 10, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (6, 'external_things', 1, 0, 1, '', 10, NULL);
+-- warsaw (only project with non-null physical_usage (for shared/capacity and unshared/capacity); all other projects should report physical_usage = usage in aggregations)
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (7, 'things',   10, 2, 10, '', 10, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (7, 'capacity', 10, 2, 10, '', 10, 1);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (8, 'things',   10, 2, 10, '', 10, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (8, 'capacity', 10, 2, 10, '', 10, 1);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (8, 'external_things', 1, 0, 1, '', 10, NULL);
 
 -- insert some bullshit data that should be filtered out by the pkg/reports/ logic
 -- (cluster "north", service "weird" and resource "items" are not configured)
@@ -89,7 +89,7 @@ INSERT INTO cluster_resources (service_id, name, capacity) VALUES (102, 'things'
 INSERT INTO domain_services (id, domain_id, type) VALUES (101, 1, 'weird');
 INSERT INTO domain_resources (service_id, name, quota) VALUES (101, 'things', 1);
 INSERT INTO project_services (id, project_id, type) VALUES (101, 1, 'weird');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (101, 'things', 2, 1, 2, '', 2);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (101, 'things', 2, 1, 2, '', 2, 1);
 
 INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'items', 1);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'items', 2, 1, 2, '', 2);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'items', 2, 1, 2, '', 2, 1);

--- a/pkg/collector/fixtures/checkconsistency1.sql
+++ b/pkg/collector/fixtures/checkconsistency1.sql
@@ -20,4 +20,4 @@ INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (3
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (5, 3, 'unshared', NULL, FALSE);
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (6, 1, 'whatever', NULL, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'capacity', 20, 0, 0, '', 0);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'capacity', 20, 0, 0, '', 0, NULL);

--- a/pkg/collector/fixtures/checkconsistency2.sql
+++ b/pkg/collector/fixtures/checkconsistency2.sql
@@ -24,5 +24,5 @@ INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (6
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (7, 2, 'shared', NULL, FALSE);
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (8, 3, 'shared', NULL, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'capacity', 20, 0, 0, '', 0);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (7, 'capacity', 10, 0, 0, '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'capacity', 20, 0, 0, '', 0, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (7, 'capacity', 10, 0, 0, '', 10, NULL);

--- a/pkg/collector/fixtures/scandomains1.sql
+++ b/pkg/collector/fixtures/scandomains1.sql
@@ -20,5 +20,5 @@ INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (4
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (5, 3, 'unshared', NULL, FALSE);
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (6, 3, 'shared', NULL, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'things', 5, 0, 0, '', 5);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'capacity', 10, 0, 0, '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'things', 5, 0, 0, '', 5, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'capacity', 10, 0, 0, '', 10, NULL);

--- a/pkg/collector/fixtures/scandomains2.sql
+++ b/pkg/collector/fixtures/scandomains2.sql
@@ -23,5 +23,5 @@ INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (6
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (7, 4, 'unshared', NULL, FALSE);
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (8, 4, 'shared', NULL, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'things', 5, 0, 0, '', 5);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'capacity', 10, 0, 0, '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'things', 5, 0, 0, '', 5, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'capacity', 10, 0, 0, '', 10, NULL);

--- a/pkg/collector/fixtures/scandomains3.sql
+++ b/pkg/collector/fixtures/scandomains3.sql
@@ -14,5 +14,5 @@ INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (2
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (3, 2, 'unshared', NULL, FALSE);
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (4, 2, 'shared', NULL, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'things', 5, 0, 0, '', 5);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'capacity', 10, 0, 0, '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'things', 5, 0, 0, '', 5, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'capacity', 10, 0, 0, '', 10, NULL);

--- a/pkg/collector/fixtures/scandomains4.sql
+++ b/pkg/collector/fixtures/scandomains4.sql
@@ -14,5 +14,5 @@ INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (2
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (3, 2, 'unshared', NULL, FALSE);
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (4, 2, 'shared', NULL, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'things', 5, 0, 0, '', 5);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'capacity', 10, 0, 0, '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'things', 5, 0, 0, '', 5, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'capacity', 10, 0, 0, '', 10, NULL);

--- a/pkg/collector/fixtures/scrape-autoapprove1.sql
+++ b/pkg/collector/fixtures/scrape-autoapprove1.sql
@@ -6,5 +6,5 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALU
 
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (1, 1, 'autoapprovaltest', 1, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'approve', 10, 0, 10, '', 10);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'noapprove', 0, 0, 20, '', 0);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'approve', 10, 0, 10, '', 10, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'noapprove', 0, 0, 20, '', 0, NULL);

--- a/pkg/collector/fixtures/scrape-autoapprove2.sql
+++ b/pkg/collector/fixtures/scrape-autoapprove2.sql
@@ -6,5 +6,5 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALU
 
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (1, 1, 'autoapprovaltest', 3, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'approve', 10, 0, 20, '', 10);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'noapprove', 0, 0, 30, '', 0);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'approve', 10, 0, 20, '', 10, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'noapprove', 0, 0, 30, '', 0, NULL);

--- a/pkg/collector/fixtures/scrape-failures1.sql
+++ b/pkg/collector/fixtures/scrape-failures1.sql
@@ -8,7 +8,7 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALU
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (1, 1, 'unittest', 0, FALSE);
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (2, 2, 'unittest', 0, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'capacity', 10, 0, -1, '', 10);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'things', 0, 0, -1, '', 0);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'capacity', 10, 0, -1, '', 12);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'things', 0, 0, -1, '', 0);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'capacity', 10, 0, -1, '', 10, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'things', 0, 0, -1, '', 0, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'capacity', 10, 0, -1, '', 12, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'things', 0, 0, -1, '', 0, NULL);

--- a/pkg/collector/fixtures/scrape-failures2.sql
+++ b/pkg/collector/fixtures/scrape-failures2.sql
@@ -8,7 +8,7 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALU
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (1, 1, 'unittest', 5, FALSE);
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (2, 2, 'unittest', 7, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'capacity', 10, 0, 100, '', 10);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'things', 0, 2, 42, '[{"index":0},{"index":1}]', 0);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'capacity', 10, 0, 100, '', 12);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'things', 0, 2, 42, '[{"index":0},{"index":1}]', 0);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'capacity', 10, 0, 100, '', 10, 0);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'things', 0, 2, 42, '[{"index":0},{"index":1}]', 0, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'capacity', 10, 0, 100, '', 12, 0);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'things', 0, 2, 42, '[{"index":0},{"index":1}]', 0, NULL);

--- a/pkg/collector/fixtures/scrape-failures3.sql
+++ b/pkg/collector/fixtures/scrape-failures3.sql
@@ -8,7 +8,7 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALU
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (1, 1, 'unittest', 5, TRUE);
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (2, 2, 'unittest', 7, TRUE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'capacity', 10, 0, 100, '', 10);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'things', 0, 2, 42, '[{"index":0},{"index":1}]', 0);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'capacity', 10, 0, 100, '', 12);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'things', 0, 2, 42, '[{"index":0},{"index":1}]', 0);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'capacity', 10, 0, 100, '', 10, 0);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'things', 0, 2, 42, '[{"index":0},{"index":1}]', 0, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'capacity', 10, 0, 100, '', 12, 0);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'things', 0, 2, 42, '[{"index":0},{"index":1}]', 0, NULL);

--- a/pkg/collector/fixtures/scrape1.sql
+++ b/pkg/collector/fixtures/scrape1.sql
@@ -8,7 +8,7 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALU
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (1, 1, 'unittest', 1, FALSE);
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (2, 2, 'unittest', 3, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'capacity', 10, 0, 100, '', 10);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'things', 0, 2, 42, '[{"index":0},{"index":1}]', 0);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'capacity', 10, 0, 100, '', 12);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'things', 0, 2, 42, '[{"index":0},{"index":1}]', 0);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'capacity', 10, 0, 100, '', 10, 0);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'things', 0, 2, 42, '[{"index":0},{"index":1}]', 0, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'capacity', 10, 0, 100, '', 12, 0);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'things', 0, 2, 42, '[{"index":0},{"index":1}]', 0, NULL);

--- a/pkg/collector/fixtures/scrape2.sql
+++ b/pkg/collector/fixtures/scrape2.sql
@@ -8,7 +8,7 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALU
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (1, 1, 'unittest', 6, FALSE);
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (2, 2, 'unittest', 8, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'capacity', 10, 0, 110, '', 10);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'things', 0, 5, 42, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 0);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'capacity', 10, 0, 110, '', 12);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'things', 0, 5, 42, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 0);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'capacity', 10, 0, 110, '', 10, 0);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'things', 0, 5, 42, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 0, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'capacity', 10, 0, 110, '', 12, 0);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'things', 0, 5, 42, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 0, NULL);

--- a/pkg/collector/fixtures/scrape3.sql
+++ b/pkg/collector/fixtures/scrape3.sql
@@ -8,7 +8,7 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALU
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (1, 1, 'unittest', 10, FALSE);
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (2, 2, 'unittest', 12, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'capacity', 20, 0, 20, '', 20);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'things', 13, 5, 13, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 13);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'capacity', 20, 0, 24, '', 24);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'things', 13, 5, 15, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 15);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'capacity', 20, 0, 20, '', 20, 0);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'things', 13, 5, 13, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 13, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'capacity', 20, 0, 24, '', 24, 0);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'things', 13, 5, 15, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 15, NULL);

--- a/pkg/collector/fixtures/scrape4.sql
+++ b/pkg/collector/fixtures/scrape4.sql
@@ -8,7 +8,7 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALU
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (1, 1, 'unittest', 14, FALSE);
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (2, 2, 'unittest', 16, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'capacity', 20, 0, 20, '', 20);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'things', 13, 5, 13, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 13);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'capacity', 20, 0, 24, '', 24);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'things', 13, 5, 15, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 15);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'capacity', 20, 0, 20, '', 20, 0);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'things', 13, 5, 13, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 13, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'capacity', 20, 0, 24, '', 24, 0);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'things', 13, 5, 15, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 15, NULL);

--- a/pkg/collector/fixtures/scrape5.sql
+++ b/pkg/collector/fixtures/scrape5.sql
@@ -8,7 +8,7 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALU
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (1, 1, 'unittest', 18, FALSE);
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (2, 2, 'unittest', 20, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'capacity', 40, 0, 40, '', 40);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'things', 13, 5, 13, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 13);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'capacity', 40, 0, 48, '', 48);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'things', 13, 5, 15, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 15);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'capacity', 40, 0, 40, '', 40, 0);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'things', 13, 5, 13, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 13, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'capacity', 40, 0, 48, '', 48, 0);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'things', 13, 5, 15, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 15, NULL);

--- a/pkg/collector/fixtures/scrape6.sql
+++ b/pkg/collector/fixtures/scrape6.sql
@@ -8,9 +8,9 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALU
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (1, 1, 'unittest', 22, FALSE);
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (2, 2, 'unittest', 24, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'capacity', 40, 0, 40, '', 40);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'things', 13, 5, 13, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 13);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'capacity', 40, 0, 48, '', 48);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'things', 13, 5, 15, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 15);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'external_things', 5, 0, 5, '', 5);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'external_things', 5, 0, 5, '', 5);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'capacity', 40, 0, 40, '', 40, 0);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'things', 13, 5, 13, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 13, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'capacity', 40, 0, 48, '', 48, 0);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'things', 13, 5, 15, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 15, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'external_things', 5, 0, 5, '', 5, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'external_things', 5, 0, 5, '', 5, NULL);

--- a/pkg/collector/fixtures/scrape7.sql
+++ b/pkg/collector/fixtures/scrape7.sql
@@ -8,9 +8,9 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALU
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (1, 1, 'unittest', 26, FALSE);
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (2, 2, 'unittest', 28, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'capacity', 40, 0, 40, '', 40);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'things', 13, 5, 13, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 13);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'capacity', 40, 0, 48, '', 48);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'things', 13, 5, 15, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 15);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'external_things', 10, 0, 10, '', 10);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'external_things', 10, 0, 10, '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'capacity', 40, 0, 40, '', 40, 0);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'things', 13, 5, 13, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 13, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'capacity', 40, 0, 48, '', 48, 0);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'things', 13, 5, 15, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 15, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'external_things', 10, 0, 10, '', 10, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'external_things', 10, 0, 10, '', 10, NULL);

--- a/pkg/collector/fixtures/scrape8.sql
+++ b/pkg/collector/fixtures/scrape8.sql
@@ -8,9 +8,9 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALU
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (1, 1, 'unittest', 30, FALSE);
 INSERT INTO project_services (id, project_id, type, scraped_at, stale) VALUES (2, 2, 'unittest', 32, FALSE);
 
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'capacity', 40, 0, 40, '', 40);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'things', 13, 5, 13, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 13);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'capacity', 40, 0, 48, '', 48);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'things', 13, 5, 15, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 15);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'external_things', 10, 0, 10, '', 10);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'external_things', 10, 0, 10, '', 10);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'capacity', 40, 0, 40, '', 40, 0);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'things', 13, 5, 13, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 13, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'capacity', 40, 0, 48, '', 48, 0);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'things', 13, 5, 15, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 15, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'external_things', 10, 0, 10, '', 10, NULL);
+INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'external_things', 10, 0, 10, '', 10, NULL);

--- a/pkg/collector/scrape.go
+++ b/pkg/collector/scrape.go
@@ -207,6 +207,7 @@ func (c *Collector) writeScrapeResult(domainName, domainUUID, projectName, proje
 
 		//update existing resource record
 		res.Usage = data.Usage
+		res.PhysicalUsage = data.PhysicalUsage
 		res.BackendQuota = data.Quota
 		if c.Cluster.InfoForResource(serviceType, res.Name).ExternallyManaged {
 			if data.Quota >= 0 {
@@ -258,6 +259,7 @@ func (c *Collector) writeScrapeResult(domainName, domainUUID, projectName, proje
 			Name:             resMetadata.Name,
 			Quota:            initialQuota,
 			Usage:            data.Usage,
+			PhysicalUsage:    data.PhysicalUsage,
 			BackendQuota:     data.Quota,
 			SubresourcesJSON: "", //but see below
 		}
@@ -395,6 +397,7 @@ func (c *Collector) writeDummyResources(domainName, projectName string, projectH
 			Name:             resMetadata.Name,
 			Quota:            initialQuota,
 			Usage:            0,
+			PhysicalUsage:    nil,
 			BackendQuota:     -1,
 			SubresourcesJSON: "",
 		}

--- a/pkg/core/plugin.go
+++ b/pkg/core/plugin.go
@@ -55,9 +55,10 @@ type DiscoveryPlugin interface {
 //quota plugin providing this ResourceData instance has been instructed to (and
 //is able to) scrape subresources for this resource.
 type ResourceData struct {
-	Quota        int64 //negative values indicate infinite quota
-	Usage        uint64
-	Subresources []interface{}
+	Quota         int64 //negative values indicate infinite quota
+	Usage         uint64
+	PhysicalUsage *uint64 //only supported by some plugins
+	Subresources  []interface{}
 }
 
 //QuotaPlugin is the interface that the quota/usage collector plugins for all

--- a/pkg/db/migrations.go
+++ b/pkg/db/migrations.go
@@ -149,4 +149,10 @@ var SQLMigrations = map[string]string{
 	"008_add_project_resources_desired_backend_quota.up.sql": `
 		ALTER TABLE project_resources ADD COLUMN desired_backend_quota BIGINT NOT NULL DEFAULT 0;
 	`,
+	"009_add_project_resources_physical_usage.down.sql": `
+		ALTER TABLE project_resources DROP COLUMN physical_usage;
+	`,
+	"009_add_project_resources_physical_usage.up.sql": `
+		ALTER TABLE project_resources ADD COLUMN physical_usage BIGINT DEFAULT NULL;
+	`,
 }

--- a/pkg/db/models.go
+++ b/pkg/db/models.go
@@ -81,13 +81,14 @@ type ProjectService struct {
 
 //ProjectResource contains a record from the `project_resources` table.
 type ProjectResource struct {
-	ServiceID           int64  `db:"service_id"`
-	Name                string `db:"name"`
-	Quota               uint64 `db:"quota"`
-	Usage               uint64 `db:"usage"`
-	BackendQuota        int64  `db:"backend_quota"`
-	DesiredBackendQuota uint64 `db:"desired_backend_quota"`
-	SubresourcesJSON    string `db:"subresources"`
+	ServiceID           int64   `db:"service_id"`
+	Name                string  `db:"name"`
+	Quota               uint64  `db:"quota"`
+	Usage               uint64  `db:"usage"`
+	PhysicalUsage       *uint64 `db:"physical_usage"`
+	BackendQuota        int64   `db:"backend_quota"`
+	DesiredBackendQuota uint64  `db:"desired_backend_quota"`
+	SubresourcesJSON    string  `db:"subresources"`
 }
 
 //InitGorp is used by Init() to setup the ORM part of the database connection.

--- a/pkg/plugins/cfm.go
+++ b/pkg/plugins/cfm.go
@@ -78,17 +78,20 @@ func (p *cfmPlugin) Scrape(provider *gophercloud.ProviderClient, eo gophercloud.
 		StorageQuota struct {
 			SizeLimitBytes int64 `json:"size_limit"`
 			Usage          struct {
-				BytesUsed uint64 `json:"size_used"`
+				PotentialGrowthSize uint64 `json:"potential_growth_size"`
+				BytesUsed           uint64 `json:"size_used"`
 			} `json:"usage"`
 		} `json:"storage_quota"`
 	}
 	err = client.GetQuotaSet(projectUUID).ExtractInto(&data)
 	if err == nil {
 		logg.Info("using CFM quota set for project %s", projectUUID)
+		physicalUsage := data.StorageQuota.Usage.BytesUsed
 		return map[string]core.ResourceData{
 			"cfm_share_capacity": {
-				Quota: data.StorageQuota.SizeLimitBytes,
-				Usage: data.StorageQuota.Usage.BytesUsed,
+				Quota:         data.StorageQuota.SizeLimitBytes,
+				Usage:         data.StorageQuota.Usage.PotentialGrowthSize,
+				PhysicalUsage: &physicalUsage,
 			},
 		}, nil
 	}

--- a/pkg/test/plugin.go
+++ b/pkg/test/plugin.go
@@ -109,15 +109,24 @@ func (p *Plugin) Scrape(provider *gophercloud.ProviderClient, eo gophercloud.End
 		if !p.WithExternallyManagedResource && key == "external_things" {
 			continue
 		}
-		result[key] = *val
+		copyOfVal := *val
+
+		//test coverage for PhysicalUsage != Usage
+		if key == "capacity" {
+			physUsage := val.Usage / 2
+			copyOfVal.PhysicalUsage = &physUsage
+		}
+
+		result[key] = copyOfVal
 	}
 
 	data, exists := p.OverrideQuota[projectUUID]
 	if exists {
 		for resourceName, quota := range data {
 			result[resourceName] = core.ResourceData{
-				Quota: int64(quota),
-				Usage: result[resourceName].Usage,
+				Quota:         int64(quota),
+				Usage:         result[resourceName].Usage,
+				PhysicalUsage: result[resourceName].PhysicalUsage,
 			}
 		}
 	}

--- a/report_cluster.go
+++ b/report_cluster.go
@@ -53,6 +53,7 @@ type ClusterResourceReport struct {
 	DomainsQuota  uint64     `json:"domains_quota,keepempty"`
 	Usage         uint64     `json:"usage,keepempty"`
 	BurstUsage    uint64     `json:"burst_usage,omitempty"`
+	PhysicalUsage *uint64    `json:"physical_usage,omitempty"`
 	Subcapacities JSONString `json:"subcapacities,omitempty"`
 }
 

--- a/report_domain.go
+++ b/report_domain.go
@@ -50,6 +50,7 @@ type DomainResourceReport struct {
 	Usage         uint64 `json:"usage,keepempty"`
 	BurstUsage    uint64 `json:"burst_usage,omitempty"`
 	//These are pointers to values to enable precise control over whether this field is rendered in output.
+	PhysicalUsage        *uint64          `json:"physical_usage,omitempty"`
 	BackendQuota         *uint64          `json:"backend_quota,omitempty"`
 	InfiniteBackendQuota *bool            `json:"infinite_backend_quota,omitempty"`
 	Scaling              *ScalingBehavior `json:"scales_with,omitempty"`

--- a/report_project.go
+++ b/report_project.go
@@ -54,13 +54,14 @@ type ProjectServiceReport struct {
 type ProjectResourceReport struct {
 	//Several fields are pointers to values to enable precise control over which fields are rendered in output.
 	ResourceInfo
-	Quota        uint64           `json:"quota,keepempty"`
-	UsableQuota  uint64           `json:"usable_quota,keepempty"`
-	Usage        uint64           `json:"usage,keepempty"`
-	BurstUsage   uint64           `json:"burst_usage,omitempty"`
-	BackendQuota *int64           `json:"backend_quota,omitempty"`
-	Subresources JSONString       `json:"subresources,omitempty"`
-	Scaling      *ScalingBehavior `json:"scales_with,omitempty"`
+	Quota         uint64           `json:"quota,keepempty"`
+	UsableQuota   uint64           `json:"usable_quota,keepempty"`
+	Usage         uint64           `json:"usage,keepempty"`
+	BurstUsage    uint64           `json:"burst_usage,omitempty"`
+	PhysicalUsage *uint64          `json:"physical_usage,omitempty"`
+	BackendQuota  *int64           `json:"backend_quota,omitempty"`
+	Subresources  JSONString       `json:"subresources,omitempty"`
+	Scaling       *ScalingBehavior `json:"scales_with,omitempty"`
 }
 
 //ProjectServiceReports provides fast lookup of services using a map, but serializes


### PR DESCRIPTION
I also updated the CFM plugin to report `size_used` as `physical_usage` and `potential_growth_size` as `usage`.

@reimannf As usual, please have a look at the documentation changes in particular. `pkg/plugins/cfm.go` may also be interesting to you.