### PR TITLE
use Placement API to gather hypervisor capacity/usage

### DIFF
--- a/docs/operators/config.md
+++ b/docs/operators/config.md
@@ -599,6 +599,7 @@ capacitors:
         second: 'bar'
       cpu_multiplier: 0.9
       ram_multiplier: 0.9
+      use_placement_api: true
 ```
 
 | Resource | Method |
@@ -617,6 +618,10 @@ This is particularly useful to filter Ironic flavors, which usually have much la
 
 If the `nova.cpu_multiplier` and/or `nova.ram_multiplier` values are set, the reported capacities are multipled with
 these factors. If you want to keep a reserve, set this to slightly smaller than 1. The default value is 1.
+
+If the `nova.use_placement_api` parameter is set, capacity and usage data is gathered from the Placement API instead of
+from Nova's hypervisor list. The data from the Placement API is usually more reliable, but the Placement API may not be
+available in all OpenStack installations, so it remains opt-in for now.
 
 ## `prometheus`
 

--- a/pkg/core/config.go
+++ b/pkg/core/config.go
@@ -189,6 +189,7 @@ type CapacitorConfiguration struct {
 		HypervisorTypePattern string            `yaml:"hypervisor_type_pattern"`
 		CPUMultiplier         float64           `yaml:"cpu_multiplier"`
 		RAMMultiplier         float64           `yaml:"ram_multiplier"`
+		UsePlacementAPI       bool              `yaml:"use_placement_api"`
 	} `yaml:"nova"`
 	Prometheus struct {
 		APIConfig PrometheusAPIConfiguration   `yaml:"api"`

--- a/pkg/core/plugin.go
+++ b/pkg/core/plugin.go
@@ -96,16 +96,22 @@ type QuotaPlugin interface {
 	SetQuota(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string, quotas map[string]uint64) error
 }
 
-//CapacityData contains the total, and the per availability zone capacity data
-//for a single resource.
+//CapacityData contains the total and per-availability-zone capacity data for a
+//single resource.
 //
 //The Subcapacities field may optionally be populated with subcapacities, if the
 //capacity plugin providing this CapacityData instance has been instructed to (and
 //is able to) scrape subcapacities for this resource.
 type CapacityData struct {
 	Capacity      uint64
-	CapacityPerAZ limes.ClusterAvailabilityZoneReports
+	CapacityPerAZ map[string]*CapacityDataForAZ
 	Subcapacities []interface{}
+}
+
+//CapacityDataForAZ is the capacity data for a single resource in a single AZ.
+type CapacityDataForAZ struct {
+	Capacity uint64
+	Usage    uint64
 }
 
 //CapacityPlugin is the interface that all capacity collector plugins must

--- a/pkg/plugins/capacity_cinder.go
+++ b/pkg/plugins/capacity_cinder.go
@@ -25,7 +25,6 @@ import (
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/sapcc/go-bits/logg"
-	"github.com/sapcc/limes"
 	"github.com/sapcc/limes/pkg/core"
 	"github.com/sapcc/limes/pkg/util"
 )
@@ -109,7 +108,7 @@ func (p *capacityCinderPlugin) Scrape(provider *gophercloud.ProviderClient, eo g
 
 	var (
 		totalCapacityGb uint64
-		capacityPerAZ   = make(limes.ClusterAvailabilityZoneReports)
+		capacityPerAZ   = make(map[string]*core.CapacityDataForAZ)
 
 		volumeBackendName = p.cfg.Cinder.VolumeBackendName
 	)
@@ -140,7 +139,7 @@ func (p *capacityCinderPlugin) Scrape(provider *gophercloud.ProviderClient, eo g
 			poolAZ = "unknown"
 		}
 		if _, ok := capacityPerAZ[poolAZ]; !ok {
-			capacityPerAZ[poolAZ] = &limes.ClusterAvailabilityZoneReport{Name: poolAZ}
+			capacityPerAZ[poolAZ] = &core.CapacityDataForAZ{}
 		}
 
 		capacityPerAZ[poolAZ].Capacity += uint64(element.Capabilities.TotalCapacityGb)

--- a/pkg/plugins/capacity_manila.go
+++ b/pkg/plugins/capacity_manila.go
@@ -26,7 +26,6 @@ import (
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/sapcc/go-bits/logg"
-	"github.com/sapcc/limes"
 	"github.com/sapcc/limes/pkg/core"
 )
 
@@ -159,27 +158,23 @@ func (p *capacityManilaPlugin) Scrape(provider *gophercloud.ProviderClient, eo g
 
 	//derive availability zone usage and capacities
 	var (
-		shareCountPerAZ       = make(limes.ClusterAvailabilityZoneReports)
-		shareSnapshotsPerAZ   = make(limes.ClusterAvailabilityZoneReports)
-		shareCapacityPerAZ    = make(limes.ClusterAvailabilityZoneReports)
-		snapshotCapacityPerAZ = make(limes.ClusterAvailabilityZoneReports)
+		shareCountPerAZ       = make(map[string]*core.CapacityDataForAZ)
+		shareSnapshotsPerAZ   = make(map[string]*core.CapacityDataForAZ)
+		shareCapacityPerAZ    = make(map[string]*core.CapacityDataForAZ)
+		snapshotCapacityPerAZ = make(map[string]*core.CapacityDataForAZ)
 	)
 	for az := range availabilityZones {
-		shareCountPerAZ[az] = &limes.ClusterAvailabilityZoneReport{
-			Name:     az,
+		shareCountPerAZ[az] = &core.CapacityDataForAZ{
 			Capacity: getShareCount(poolCountPerAZ[az], cfg.SharesPerPool, (cfg.ShareNetworks / uint64(len(availabilityZones)))),
 		}
-		shareSnapshotsPerAZ[az] = &limes.ClusterAvailabilityZoneReport{
-			Name:     az,
+		shareSnapshotsPerAZ[az] = &core.CapacityDataForAZ{
 			Capacity: getShareSnapshots(shareCountPerAZ[az].Capacity, cfg.SnapshotsPerShare),
 		}
-		shareCapacityPerAZ[az] = &limes.ClusterAvailabilityZoneReport{
-			Name:     az,
+		shareCapacityPerAZ[az] = &core.CapacityDataForAZ{
 			Capacity: getShareCapacity(totalCapacityGbPerAZ[az], capBalance),
 			Usage:    getShareCapacity(allocatedCapacityGbPerAZ[az], capBalance),
 		}
-		snapshotCapacityPerAZ[az] = &limes.ClusterAvailabilityZoneReport{
-			Name:     az,
+		snapshotCapacityPerAZ[az] = &core.CapacityDataForAZ{
 			Capacity: getSnapshotCapacity(totalCapacityGbPerAZ[az], capBalance),
 			Usage:    getSnapshotCapacity(allocatedCapacityGbPerAZ[az], capBalance),
 		}

--- a/pkg/plugins/capacity_nova.go
+++ b/pkg/plugins/capacity_nova.go
@@ -31,7 +31,6 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sapcc/go-bits/logg"
-	"github.com/sapcc/limes"
 	"github.com/sapcc/limes/pkg/core"
 )
 
@@ -133,8 +132,8 @@ func (p *capacityNovaPlugin) Scrape(provider *gophercloud.ProviderClient, eo gop
 		localGbPerAZ    = make(map[string]uint64)
 		runningVmsPerAZ = make(map[string]uint64)
 
-		vcpusPerAZ    = make(limes.ClusterAvailabilityZoneReports)
-		memoryMbPerAZ = make(limes.ClusterAvailabilityZoneReports)
+		vcpusPerAZ    = make(map[string]*core.CapacityDataForAZ)
+		memoryMbPerAZ = make(map[string]*core.CapacityDataForAZ)
 
 		hvStates []novaHypervisorState
 	)
@@ -163,8 +162,8 @@ func (p *capacityNovaPlugin) Scrape(provider *gophercloud.ProviderClient, eo gop
 			hypervisorAZ = "unknown"
 		}
 		if _, ok := vcpusPerAZ[hypervisorAZ]; !ok {
-			vcpusPerAZ[hypervisorAZ] = &limes.ClusterAvailabilityZoneReport{Name: hypervisorAZ}
-			memoryMbPerAZ[hypervisorAZ] = &limes.ClusterAvailabilityZoneReport{Name: hypervisorAZ}
+			vcpusPerAZ[hypervisorAZ] = &core.CapacityDataForAZ{}
+			memoryMbPerAZ[hypervisorAZ] = &core.CapacityDataForAZ{}
 		}
 
 		vcpusPerAZ[hypervisorAZ].Capacity += hypervisor.VCPUs
@@ -270,10 +269,9 @@ func (p *capacityNovaPlugin) Scrape(provider *gophercloud.ProviderClient, eo gop
 	if maxFlavorSize != 0 {
 		totalInstances := calculateInstanceAmount(azCount, totalLocalGb, maxFlavorSize)
 
-		instancesPerAZ := make(limes.ClusterAvailabilityZoneReports)
+		instancesPerAZ := make(map[string]*core.CapacityDataForAZ)
 		for az, localGb := range localGbPerAZ {
-			instancesPerAZ[az] = &limes.ClusterAvailabilityZoneReport{
-				Name:     az,
+			instancesPerAZ[az] = &core.CapacityDataForAZ{
 				Capacity: calculateInstanceAmount(1, localGb, maxFlavorSize),
 				Usage:    runningVmsPerAZ[az],
 			}

--- a/pkg/plugins/capacity_nova.go
+++ b/pkg/plugins/capacity_nova.go
@@ -380,14 +380,14 @@ func (h novaHypervisor) getCapacityViaPlacementAPI(provider *gophercloud.Provide
 
 	return partialNovaCapacity{
 		VCPUs: core.CapacityDataForAZ{
-			Capacity: inventory["VCPU"].Total,
+			Capacity: inventory["VCPU"].UsableCapacity(),
 			Usage:    usages["VCPU"],
 		},
 		MemoryMB: core.CapacityDataForAZ{
-			Capacity: inventory["MEMORY_MB"].Total,
+			Capacity: inventory["MEMORY_MB"].UsableCapacity(),
 			Usage:    usages["MEMORY_MB"],
 		},
-		LocalGB:    inventory["DISK_GB"].Total,
+		LocalGB:    inventory["DISK_GB"].UsableCapacity(),
 		RunningVMs: h.RunningVMs,
 	}, nil
 }

--- a/pkg/plugins/capacity_sapcc_ironic.go
+++ b/pkg/plugins/capacity_sapcc_ironic.go
@@ -99,7 +99,7 @@ func (p *capacitySapccIronicPlugin) Scrape(provider *gophercloud.ProviderClient,
 	for _, flavor := range flavors {
 		result["instances_"+flavor.Name] = &core.CapacityData{
 			Capacity:      0,
-			CapacityPerAZ: limes.ClusterAvailabilityZoneReports{},
+			CapacityPerAZ: map[string]*core.CapacityDataForAZ{},
 		}
 	}
 
@@ -162,7 +162,7 @@ func (p *capacitySapccIronicPlugin) Scrape(provider *gophercloud.ProviderClient,
 				}
 
 				if _, ok := data.CapacityPerAZ[nodeAZ]; !ok {
-					data.CapacityPerAZ[nodeAZ] = &limes.ClusterAvailabilityZoneReport{Name: nodeAZ}
+					data.CapacityPerAZ[nodeAZ] = &core.CapacityDataForAZ{}
 				}
 				data.CapacityPerAZ[nodeAZ].Capacity++
 				if node.StableProvisionState() == "active" {

--- a/pkg/plugins/client_placement.go
+++ b/pkg/plugins/client_placement.go
@@ -76,6 +76,10 @@ type placementInventoryRecord struct {
 	Total           uint64  `json:"total"`
 }
 
+func (r placementInventoryRecord) UsableCapacity() uint64 {
+	return r.Total - r.Reserved
+}
+
 func (c *placementClient) GetInventory(resourceProviderID string) (map[string]placementInventoryRecord, error) {
 	var result gophercloud.Result
 	url := c.ServiceURL("resource_providers", resourceProviderID, "inventories")

--- a/pkg/plugins/client_placement.go
+++ b/pkg/plugins/client_placement.go
@@ -1,0 +1,101 @@
+/******************************************************************************
+*
+*  Copyright 2019 SAP SE
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+******************************************************************************/
+
+package plugins
+
+import "github.com/gophercloud/gophercloud"
+
+type placementClient struct {
+	*gophercloud.ServiceClient
+}
+
+func newPlacementClient(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*placementClient, error) {
+	serviceType := "placement"
+	eo.ApplyDefaults(serviceType)
+
+	url, err := provider.EndpointLocator(eo)
+	if err != nil {
+		return nil, err
+	}
+	return &placementClient{
+		ServiceClient: &gophercloud.ServiceClient{
+			ProviderClient: provider,
+			Endpoint:       url,
+			Type:           serviceType,
+		},
+	}, nil
+}
+
+func (c *placementClient) reqOpts(okCodes ...int) *gophercloud.RequestOpts {
+	return &gophercloud.RequestOpts{
+		OkCodes:      okCodes,
+		ErrorContext: cfmNotFoundError{},
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+type placementResourceProvider struct {
+	ID   string `json:"uuid"`
+	Name string `json:"name"`
+}
+
+func (c *placementClient) ListResourceProviders() ([]placementResourceProvider, error) {
+	var result gophercloud.Result
+	url := c.ServiceURL("resource_providers")
+	_, result.Err = c.Get(url, &result.Body, c.reqOpts(200))
+
+	var data struct {
+		Providers []placementResourceProvider `json:"resource_providers"`
+	}
+	err := result.ExtractInto(&data)
+	return data.Providers, err
+}
+
+type placementInventoryRecord struct {
+	AllocationRatio float64 `json:"allocation_ratio"`
+	MaxUnit         uint64  `json:"max_unit"`
+	MinUnit         uint64  `json:"min_unit"`
+	Reserved        uint64  `json:"reserved"`
+	StepSize        uint64  `json:"step_size"`
+	Total           uint64  `json:"total"`
+}
+
+func (c *placementClient) GetInventory(resourceProviderID string) (map[string]placementInventoryRecord, error) {
+	var result gophercloud.Result
+	url := c.ServiceURL("resource_providers", resourceProviderID, "inventories")
+	_, result.Err = c.Get(url, &result.Body, c.reqOpts(200))
+
+	var data struct {
+		Inventories map[string]placementInventoryRecord `json:"inventories"`
+	}
+	err := result.ExtractInto(&data)
+	return data.Inventories, err
+}
+
+func (c *placementClient) GetUsages(resourceProviderID string) (map[string]uint64, error) {
+	var result gophercloud.Result
+	url := c.ServiceURL("resource_providers", resourceProviderID, "usages")
+	_, result.Err = c.Get(url, &result.Body, c.reqOpts(200))
+
+	var data struct {
+		Inventories map[string]uint64 `json:"usages"`
+	}
+	err := result.ExtractInto(&data)
+	return data.Inventories, err
+}

--- a/pkg/test/plugin.go
+++ b/pkg/test/plugin.go
@@ -183,16 +183,14 @@ func (p *CapacityPlugin) ID() string {
 
 //Scrape implements the core.CapacityPlugin interface.
 func (p *CapacityPlugin) Scrape(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID string) (map[string]map[string]core.CapacityData, error) {
-	var capacityPerAZ limes.ClusterAvailabilityZoneReports
+	var capacityPerAZ map[string]*core.CapacityDataForAZ
 	if p.WithAZCapData {
-		capacityPerAZ = limes.ClusterAvailabilityZoneReports{
+		capacityPerAZ = map[string]*core.CapacityDataForAZ{
 			"az-one": {
-				Name:     "az-one",
 				Capacity: p.Capacity / 2,
 				Usage:    uint64(float64(p.Capacity) * 0.1),
 			},
 			"az-two": {
-				Name:     "az-two",
 				Capacity: p.Capacity / 2,
 				Usage:    uint64(float64(p.Capacity) * 0.1),
 			},

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/hypervisors/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/hypervisors/doc.go
@@ -1,0 +1,70 @@
+/*
+Package hypervisors returns details about list of hypervisors, shows details for a hypervisor
+and shows summary statistics for all hypervisors over all compute nodes in the OpenStack cloud.
+
+Example of Show Hypervisor Details
+
+	hypervisorID := "42"
+	hypervisor, err := hypervisors.Get(computeClient, hypervisorID).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", hypervisor)
+
+Example of Show Hypervisor Details with Compute API microversion greater than 2.53
+
+    hypervisorID := "c48f6247-abe4-4a24-824e-ea39e108874f"
+    hypervisor, err := hypervisors.Get(computeClient, hypervisorID).Extract()
+    if err != nil {
+        panic(err)
+    }
+
+	fmt.Printf("%+v\n", hypervisor)
+
+Example of Retrieving Details of All Hypervisors
+
+	allPages, err := hypervisors.List(computeClient).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allHypervisors, err := hypervisors.ExtractHypervisors(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, hypervisor := range allHypervisors {
+		fmt.Printf("%+v\n", hypervisor)
+	}
+
+Example of Show Hypervisors Statistics
+
+	hypervisorsStatistics, err := hypervisors.GetStatistics(computeClient).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", hypervisorsStatistics)
+
+Example of Show Hypervisor Uptime
+
+	hypervisorID := "42"
+	hypervisorUptime, err := hypervisors.GetUptime(computeClient, hypervisorID).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", hypervisorUptime)
+
+Example of Show Hypervisor Uptime with Compute API microversion greater than 2.53
+
+    hypervisorID := "c48f6247-abe4-4a24-824e-ea39e108874f"
+    hypervisorUptime, err := hypervisors.GetUptime(computeClient, hypervisorID).Extract()
+    if err != nil {
+        panic(err)
+    }
+
+	fmt.Printf("%+v\n", hypervisorUptime)
+*/
+package hypervisors

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/hypervisors/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/hypervisors/requests.go
@@ -1,0 +1,37 @@
+package hypervisors
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// List makes a request against the API to list hypervisors.
+func List(client *gophercloud.ServiceClient) pagination.Pager {
+	return pagination.NewPager(client, hypervisorsListDetailURL(client), func(r pagination.PageResult) pagination.Page {
+		return HypervisorPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// Statistics makes a request against the API to get hypervisors statistics.
+func GetStatistics(client *gophercloud.ServiceClient) (r StatisticsResult) {
+	_, r.Err = client.Get(hypervisorsStatisticsURL(client), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Get makes a request against the API to get details for specific hypervisor.
+func Get(client *gophercloud.ServiceClient, hypervisorID string) (r HypervisorResult) {
+	_, r.Err = client.Get(hypervisorsGetURL(client, hypervisorID), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// GetUptime makes a request against the API to get uptime for specific hypervisor.
+func GetUptime(client *gophercloud.ServiceClient, hypervisorID string) (r UptimeResult) {
+	_, r.Err = client.Get(hypervisorsUptimeURL(client, hypervisorID), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/hypervisors/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/hypervisors/results.go
@@ -1,0 +1,367 @@
+package hypervisors
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Topology represents a CPU Topology.
+type Topology struct {
+	Sockets int `json:"sockets"`
+	Cores   int `json:"cores"`
+	Threads int `json:"threads"`
+}
+
+// CPUInfo represents CPU information of the hypervisor.
+type CPUInfo struct {
+	Vendor   string   `json:"vendor"`
+	Arch     string   `json:"arch"`
+	Model    string   `json:"model"`
+	Features []string `json:"features"`
+	Topology Topology `json:"topology"`
+}
+
+// Service represents a Compute service running on the hypervisor.
+type Service struct {
+	Host           string `json:"host"`
+	ID             string `json:"-"`
+	DisabledReason string `json:"disabled_reason"`
+}
+
+func (r *Service) UnmarshalJSON(b []byte) error {
+	type tmp Service
+	var s struct {
+		tmp
+		ID interface{} `json:"id"`
+	}
+
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = Service(s.tmp)
+
+	// OpenStack Compute service returns ID in string representation since
+	// 2.53 microversion API (Pike release).
+	switch t := s.ID.(type) {
+	case int:
+		r.ID = strconv.Itoa(t)
+	case float64:
+		r.ID = strconv.Itoa(int(t))
+	case string:
+		r.ID = t
+	default:
+		return fmt.Errorf("ID has unexpected type: %T", t)
+	}
+
+	return nil
+}
+
+// Hypervisor represents a hypervisor in the OpenStack cloud.
+type Hypervisor struct {
+	// A structure that contains cpu information like arch, model, vendor,
+	// features and topology.
+	CPUInfo CPUInfo `json:"-"`
+
+	// The current_workload is the number of tasks the hypervisor is responsible
+	// for. This will be equal or greater than the number of active VMs on the
+	// system (it can be greater when VMs are being deleted and the hypervisor is
+	// still cleaning up).
+	CurrentWorkload int `json:"current_workload"`
+
+	// Status of the hypervisor, either "enabled" or "disabled".
+	Status string `json:"status"`
+
+	// State of the hypervisor, either "up" or "down".
+	State string `json:"state"`
+
+	// DiskAvailableLeast is the actual free disk on this hypervisor,
+	// measured in GB.
+	DiskAvailableLeast int `json:"disk_available_least"`
+
+	// HostIP is the hypervisor's IP address.
+	HostIP string `json:"host_ip"`
+
+	// FreeDiskGB is the free disk remaining on the hypervisor, measured in GB.
+	FreeDiskGB int `json:"-"`
+
+	// FreeRAMMB is the free RAM in the hypervisor, measured in MB.
+	FreeRamMB int `json:"free_ram_mb"`
+
+	// HypervisorHostname is the hostname of the hypervisor.
+	HypervisorHostname string `json:"hypervisor_hostname"`
+
+	// HypervisorType is the type of hypervisor.
+	HypervisorType string `json:"hypervisor_type"`
+
+	// HypervisorVersion is the version of the hypervisor.
+	HypervisorVersion int `json:"-"`
+
+	// ID is the unique ID of the hypervisor.
+	ID string `json:"-"`
+
+	// LocalGB is the disk space in the hypervisor, measured in GB.
+	LocalGB int `json:"-"`
+
+	// LocalGBUsed is the used disk space of the  hypervisor, measured in GB.
+	LocalGBUsed int `json:"local_gb_used"`
+
+	// MemoryMB is the total memory of the hypervisor, measured in MB.
+	MemoryMB int `json:"memory_mb"`
+
+	// MemoryMBUsed is the used memory of the hypervisor, measured in MB.
+	MemoryMBUsed int `json:"memory_mb_used"`
+
+	// RunningVMs is the The number of running vms on the hypervisor.
+	RunningVMs int `json:"running_vms"`
+
+	// Service is the service this hypervisor represents.
+	Service Service `json:"service"`
+
+	// VCPUs is the total number of vcpus on the hypervisor.
+	VCPUs int `json:"vcpus"`
+
+	// VCPUsUsed is the number of used vcpus on the hypervisor.
+	VCPUsUsed int `json:"vcpus_used"`
+}
+
+func (r *Hypervisor) UnmarshalJSON(b []byte) error {
+	type tmp Hypervisor
+	var s struct {
+		tmp
+		ID                interface{} `json:"id"`
+		CPUInfo           interface{} `json:"cpu_info"`
+		HypervisorVersion interface{} `json:"hypervisor_version"`
+		FreeDiskGB        interface{} `json:"free_disk_gb"`
+		LocalGB           interface{} `json:"local_gb"`
+	}
+
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = Hypervisor(s.tmp)
+
+	// Newer versions return the CPU info as the correct type.
+	// Older versions return the CPU info as a string and need to be
+	// unmarshalled by the json parser.
+	var tmpb []byte
+
+	switch t := s.CPUInfo.(type) {
+	case string:
+		tmpb = []byte(t)
+	case map[string]interface{}:
+		tmpb, err = json.Marshal(t)
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("CPUInfo has unexpected type: %T", t)
+	}
+
+	if len(tmpb) != 0 {
+		err = json.Unmarshal(tmpb, &r.CPUInfo)
+		if err != nil {
+			return err
+		}
+	}
+
+	// These fields may be returned as a scientific notation, so they need
+	// converted to int.
+	switch t := s.HypervisorVersion.(type) {
+	case int:
+		r.HypervisorVersion = t
+	case float64:
+		r.HypervisorVersion = int(t)
+	default:
+		return fmt.Errorf("Hypervisor version has unexpected type: %T", t)
+	}
+
+	switch t := s.FreeDiskGB.(type) {
+	case int:
+		r.FreeDiskGB = t
+	case float64:
+		r.FreeDiskGB = int(t)
+	default:
+		return fmt.Errorf("Free disk GB has unexpected type: %T", t)
+	}
+
+	switch t := s.LocalGB.(type) {
+	case int:
+		r.LocalGB = t
+	case float64:
+		r.LocalGB = int(t)
+	default:
+		return fmt.Errorf("Local GB has unexpected type: %T", t)
+	}
+
+	// OpenStack Compute service returns ID in string representation since
+	// 2.53 microversion API (Pike release).
+	switch t := s.ID.(type) {
+	case int:
+		r.ID = strconv.Itoa(t)
+	case float64:
+		r.ID = strconv.Itoa(int(t))
+	case string:
+		r.ID = t
+	default:
+		return fmt.Errorf("ID has unexpected type: %T", t)
+	}
+
+	return nil
+}
+
+// HypervisorPage represents a single page of all Hypervisors from a List
+// request.
+type HypervisorPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty determines whether or not a HypervisorPage is empty.
+func (page HypervisorPage) IsEmpty() (bool, error) {
+	va, err := ExtractHypervisors(page)
+	return len(va) == 0, err
+}
+
+// ExtractHypervisors interprets a page of results as a slice of Hypervisors.
+func ExtractHypervisors(p pagination.Page) ([]Hypervisor, error) {
+	var h struct {
+		Hypervisors []Hypervisor `json:"hypervisors"`
+	}
+	err := (p.(HypervisorPage)).ExtractInto(&h)
+	return h.Hypervisors, err
+}
+
+type HypervisorResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets any HypervisorResult as a Hypervisor, if possible.
+func (r HypervisorResult) Extract() (*Hypervisor, error) {
+	var s struct {
+		Hypervisor Hypervisor `json:"hypervisor"`
+	}
+	err := r.ExtractInto(&s)
+	return &s.Hypervisor, err
+}
+
+// Statistics represents a summary statistics for all enabled
+// hypervisors over all compute nodes in the OpenStack cloud.
+type Statistics struct {
+	// The number of hypervisors.
+	Count int `json:"count"`
+
+	// The current_workload is the number of tasks the hypervisor is responsible for
+	CurrentWorkload int `json:"current_workload"`
+
+	// The actual free disk on this hypervisor(in GB).
+	DiskAvailableLeast int `json:"disk_available_least"`
+
+	// The free disk remaining on this hypervisor(in GB).
+	FreeDiskGB int `json:"free_disk_gb"`
+
+	// The free RAM in this hypervisor(in MB).
+	FreeRamMB int `json:"free_ram_mb"`
+
+	// The disk in this hypervisor(in GB).
+	LocalGB int `json:"local_gb"`
+
+	// The disk used in this hypervisor(in GB).
+	LocalGBUsed int `json:"local_gb_used"`
+
+	// The memory of this hypervisor(in MB).
+	MemoryMB int `json:"memory_mb"`
+
+	// The memory used in this hypervisor(in MB).
+	MemoryMBUsed int `json:"memory_mb_used"`
+
+	// The total number of running vms on all hypervisors.
+	RunningVMs int `json:"running_vms"`
+
+	// The number of vcpu in this hypervisor.
+	VCPUs int `json:"vcpus"`
+
+	// The number of vcpu used in this hypervisor.
+	VCPUsUsed int `json:"vcpus_used"`
+}
+
+type StatisticsResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets any StatisticsResult as a Statistics, if possible.
+func (r StatisticsResult) Extract() (*Statistics, error) {
+	var s struct {
+		Stats Statistics `json:"hypervisor_statistics"`
+	}
+	err := r.ExtractInto(&s)
+	return &s.Stats, err
+}
+
+// Uptime represents uptime and additional info for a specific hypervisor.
+type Uptime struct {
+	// The hypervisor host name provided by the Nova virt driver.
+	// For the Ironic driver, it is the Ironic node uuid.
+	HypervisorHostname string `json:"hypervisor_hostname"`
+
+	// The id of the hypervisor.
+	ID string `json:"-"`
+
+	// The state of the hypervisor. One of up or down.
+	State string `json:"state"`
+
+	// The status of the hypervisor. One of enabled or disabled.
+	Status string `json:"status"`
+
+	// The total uptime of the hypervisor and information about average load.
+	Uptime string `json:"uptime"`
+}
+
+func (r *Uptime) UnmarshalJSON(b []byte) error {
+	type tmp Uptime
+	var s struct {
+		tmp
+		ID interface{} `json:"id"`
+	}
+
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = Uptime(s.tmp)
+
+	// OpenStack Compute service returns ID in string representation since
+	// 2.53 microversion API (Pike release).
+	switch t := s.ID.(type) {
+	case int:
+		r.ID = strconv.Itoa(t)
+	case float64:
+		r.ID = strconv.Itoa(int(t))
+	case string:
+		r.ID = t
+	default:
+		return fmt.Errorf("ID has unexpected type: %T", t)
+	}
+
+	return nil
+}
+
+type UptimeResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets any UptimeResult as a Uptime, if possible.
+func (r UptimeResult) Extract() (*Uptime, error) {
+	var s struct {
+		Uptime Uptime `json:"hypervisor"`
+	}
+	err := r.ExtractInto(&s)
+	return &s.Uptime, err
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/hypervisors/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/hypervisors/urls.go
@@ -1,0 +1,19 @@
+package hypervisors
+
+import "github.com/gophercloud/gophercloud"
+
+func hypervisorsListDetailURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("os-hypervisors", "detail")
+}
+
+func hypervisorsStatisticsURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("os-hypervisors", "statistics")
+}
+
+func hypervisorsGetURL(c *gophercloud.ServiceClient, hypervisorID string) string {
+	return c.ServiceURL("os-hypervisors", hypervisorID)
+}
+
+func hypervisorsUptimeURL(c *gophercloud.ServiceClient, hypervisorID string) string {
+	return c.ServiceURL("os-hypervisors", hypervisorID, "uptime")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -14,6 +14,7 @@ github.com/gophercloud/gophercloud/internal
 github.com/gophercloud/gophercloud/openstack
 github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes
 github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones
+github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/hypervisors
 github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/limits
 github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/quotasets
 github.com/gophercloud/gophercloud/openstack/compute/v2/flavors


### PR DESCRIPTION
@reimannf This is looking good from my side, but the numbers are different with and without Placement API. That's to be expected, otherwise we wouldn't need to bother with this, but we should probably validate in some way the numbers that the Placement API gives us.

To test-drive this, checkout this branch and run
```
make && ./build/limes test-scan-capacity eu-de-1.yaml ccloud
```
where `eu-de-1.yaml` is in the Gist that I sent you via chat. Toggle the config option `use_placement_api` in that file to check before vs. after.