### PR TITLE
manila: use the new netapp exporter metric format

### DIFF
--- a/docs/operators/config.md
+++ b/docs/operators/config.md
@@ -468,9 +468,8 @@ The area for this service is `storage`.
 | `snapshot_capacity` | GiB |
 
 Optionally, when the `sharev2.prometheus_api` configuration option is set,
-physical usage data will be scraped from the Prometheus metric
-`netapp_capacity_svm`. The expected metric format is that of the
-[netapp-api-exporter](https://github.com/sapcc/netapp-api-exporter).
+physical usage data will be scraped using the Prometheus metrics exported by
+the [netapp-api-exporter](https://github.com/sapcc/netapp-api-exporter).
 
 Only the `prometheus_api.url` field is required. You can pin the server's CA
 certificate (`prometheus_api.ca_cert`) and/or specify a TLS client certificate

--- a/pkg/plugins/manila.go
+++ b/pkg/plugins/manila.go
@@ -306,7 +306,7 @@ func manilaCollectPhysicalUsage(usage *manilaUsage, projectUUID string, promAPIC
 	//NOTE: The `max by (share_id)` is necessary for when a share is being
 	//migrated to another shareserver and thus appears in the metrics twice.
 	queryStr := fmt.Sprintf(
-		`sum(max by (share_id) (netapp_capacity_svm{project_id=%q,metric="size_used"}))`,
+		`sum(max by (share_id) (netapp_volume_used_bytes{project_id=%q}))`,
 		projectUUID,
 	)
 	bytesPhysical, err := prometheusGetSingleValue(client, queryStr, &defaultValue)
@@ -316,7 +316,7 @@ func manilaCollectPhysicalUsage(usage *manilaUsage, projectUUID string, promAPIC
 	usage.GigabytesPhysical = roundUp(bytesPhysical)
 
 	queryStr = fmt.Sprintf(
-		`sum(max by (share_id) (netapp_capacity_svm{project_id=%q,metric="size_used_by_snapshots"}))`,
+		`sum(max by (share_id) (netapp_volume_snapshot_used_bytes{project_id=%q}))`,
 		projectUUID,
 	)
 	snapshotBytesPhysical, err := prometheusGetSingleValue(client, queryStr, &defaultValue)


### PR DESCRIPTION
Checklist:

- [x] If this PR is about a plugin, I tested the plugin against an OpenStack cluster.
- [x] I updated the documentation to describe the semantical or interface changes I introduced.
