### PR TITLE
check lbaasv2 support

### DIFF
--- a/pkg/plugins/neutron.go
+++ b/pkg/plugins/neutron.go
@@ -144,7 +144,7 @@ func (p *neutronPlugin) Init(provider *gophercloud.ProviderClient, eo gopherclou
 	case nil:
 		p.hasLBaaS = true
 	default:
-		return r.Result.Err
+		return fmt.Errorf("cannot check for lbaasv2 support in Neutron: %s", r.Result.Err.Error())
 	}
 
 	// Octavia supported?

--- a/vendor/github.com/gophercloud/gophercloud/openstack/common/extensions/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/common/extensions/doc.go
@@ -1,0 +1,52 @@
+/*
+Package extensions provides information and interaction with the different
+extensions available for an OpenStack service.
+
+The purpose of OpenStack API extensions is to:
+
+- Introduce new features in the API without requiring a version change.
+- Introduce vendor-specific niche functionality.
+- Act as a proving ground for experimental functionalities that might be
+included in a future version of the API.
+
+Extensions usually have tags that prevent conflicts with other extensions that
+define attributes or resources with the same names, and with core resources and
+attributes. Because an extension might not be supported by all plug-ins, its
+availability varies with deployments and the specific plug-in.
+
+The results of this package vary depending on the type of Service Client used.
+In the following examples, note how the only difference is the creation of the
+Service Client.
+
+Example of Retrieving Compute Extensions
+
+	ao, err := openstack.AuthOptionsFromEnv()
+	provider, err := openstack.AuthenticatedClient(ao)
+	computeClient, err := openstack.NewComputeV2(provider, gophercloud.EndpointOpts{
+		Region: os.Getenv("OS_REGION_NAME"),
+	})
+
+	allPages, err := extensions.List(computeClient).Allpages()
+	allExtensions, err := extensions.ExtractExtensions(allPages)
+
+	for _, extension := range allExtensions{
+		fmt.Println("%+v\n", extension)
+	}
+
+
+Example of Retrieving Network Extensions
+
+	ao, err := openstack.AuthOptionsFromEnv()
+	provider, err := openstack.AuthenticatedClient(ao)
+	networkClient, err := openstack.NewNetworkV2(provider, gophercloud.EndpointOpts{
+		Region: os.Getenv("OS_REGION_NAME"),
+	})
+
+	allPages, err := extensions.List(networkClient).Allpages()
+	allExtensions, err := extensions.ExtractExtensions(allPages)
+
+	for _, extension := range allExtensions{
+		fmt.Println("%+v\n", extension)
+	}
+*/
+package extensions

--- a/vendor/github.com/gophercloud/gophercloud/openstack/common/extensions/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/common/extensions/requests.go
@@ -1,0 +1,20 @@
+package extensions
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Get retrieves information for a specific extension using its alias.
+func Get(c *gophercloud.ServiceClient, alias string) (r GetResult) {
+	_, r.Err = c.Get(ExtensionURL(c, alias), &r.Body, nil)
+	return
+}
+
+// List returns a Pager which allows you to iterate over the full collection of extensions.
+// It does not accept query parameters.
+func List(c *gophercloud.ServiceClient) pagination.Pager {
+	return pagination.NewPager(c, ListExtensionURL(c), func(r pagination.PageResult) pagination.Page {
+		return ExtensionPage{pagination.SinglePageBase(r)}
+	})
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/common/extensions/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/common/extensions/results.go
@@ -1,0 +1,53 @@
+package extensions
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// GetResult temporarily stores the result of a Get call.
+// Use its Extract() method to interpret it as an Extension.
+type GetResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets a GetResult as an Extension.
+func (r GetResult) Extract() (*Extension, error) {
+	var s struct {
+		Extension *Extension `json:"extension"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Extension, err
+}
+
+// Extension is a struct that represents an OpenStack extension.
+type Extension struct {
+	Updated     string        `json:"updated"`
+	Name        string        `json:"name"`
+	Links       []interface{} `json:"links"`
+	Namespace   string        `json:"namespace"`
+	Alias       string        `json:"alias"`
+	Description string        `json:"description"`
+}
+
+// ExtensionPage is the page returned by a pager when traversing over a collection of extensions.
+type ExtensionPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty checks whether an ExtensionPage struct is empty.
+func (r ExtensionPage) IsEmpty() (bool, error) {
+	is, err := ExtractExtensions(r)
+	return len(is) == 0, err
+}
+
+// ExtractExtensions accepts a Page struct, specifically an ExtensionPage
+// struct, and extracts the elements into a slice of Extension structs.
+// In other words, a generic collection is mapped into a relevant slice.
+func ExtractExtensions(r pagination.Page) ([]Extension, error) {
+	var s struct {
+		Extensions []Extension `json:"extensions"`
+	}
+	err := (r.(ExtensionPage)).ExtractInto(&s)
+	return s.Extensions, err
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/common/extensions/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/common/extensions/urls.go
@@ -1,0 +1,13 @@
+package extensions
+
+import "github.com/gophercloud/gophercloud"
+
+// ExtensionURL generates the URL for an extension resource by name.
+func ExtensionURL(c *gophercloud.ServiceClient, name string) string {
+	return c.ServiceURL("extensions", name)
+}
+
+// ListExtensionURL generates the URL for the extensions resource collection.
+func ListExtensionURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("extensions")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -23,6 +23,7 @@ github.com/gophercloud/gophercloud
 github.com/gophercloud/gophercloud/internal
 github.com/gophercloud/gophercloud/openstack
 github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes
+github.com/gophercloud/gophercloud/openstack/common/extensions
 github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones
 github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/hypervisors
 github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/limits


### PR DESCRIPTION
This change introduces a pre-flight check for the neutron plugin that checks
if the lbaasv2 extension is enabled for setting lbaasv2 related quotas.

TLDR: Now works lbaasv2-less neutrons, since lbaasv2 is dropped with train.

Checklist:

- [x] If this PR is about a plugin, I tested the plugin against an OpenStack cluster.
- [x] I updated the documentation to describe the semantical or interface changes I introduced.