### PR TITLE
API proposal for generalization of rate limits

### DIFF
--- a/cmd/limes/main.go
+++ b/cmd/limes/main.go
@@ -138,7 +138,12 @@ func taskCollect(config core.Configuration, cluster *core.Cluster, args []string
 	//state, mostly through usage of DB transactions.)
 	for _, plugin := range cluster.QuotaPlugins {
 		c := collector.NewCollector(cluster, plugin, config.Collector)
-		go c.Scrape()
+		if len(plugin.Resources()) > 0 {
+			go c.Scrape()
+		}
+		if len(plugin.Rates()) > 0 {
+			go c.ScrapeRates()
+		}
 	}
 
 	//start those collector threads which operate over all services simultaneously

--- a/docs/operators/config.md
+++ b/docs/operators/config.md
@@ -769,29 +769,24 @@ For further details see the [rate limits API specification](../users/api-v1-spec
 | --- | --- | --- |
 | `global` | list |  Defines rate limits meant to protect the service from being overloaded. Requests are counted across all domains and projects. |
 | `project_default` | list | Defines default rate limits for every project. |
-| `$level[].target_type_uri` | string | The target type URI of the rate limit action. |
-| `$level[].actions[].name` | string | The name of the rate limit action. |
-| `$level[].actions[].limit` | integer | The rate limit as integer. |
-| `$level[].actions[].unit` | string | The unit of the rate limit. Available units are `r/ms`, `r/s`, `r/m`, `r/h`. |
-
+| `$level[].name` | string | The name of the rate. |
+| `$level[].unit` | string | The unit of the rate. Available units are `B`, `KiB`, `MiB` and so on. If not given, the resource is counted (e.g. API requests) rather than measured. |
+| `$level[].limit` | integer | The rate limit as integer. |
 
 Example configuration:
+
 ```yaml
 clusters:
   staging:
     services:
       - type: object-store
         rates:
-           - global:
-               - target_type_uri: "services/swift/account/container/object"
-                 actions:
-                   - name:  create
-                     limit: 1000000
-                     unit:  "r/s"
-           - project_default:
-               - target_type_uri: "services/swift/account/container/object"
-                 actions:
-                   - name:  create
-                     limit: 1000
-                     unit:  "r/s"
+          global:
+           - name:   services/swift/account/container/object:create
+             limit:  1000000
+             window: "1s"
+          project_default:
+           - name:   services/swift/account/container/object:create
+             limit:  1000
+             window: "1s"
 ```

--- a/docs/users/api-v1-specification.md
+++ b/docs/users/api-v1-specification.md
@@ -11,9 +11,10 @@ policy differently, so that certain requests may require other roles or token sc
   * [X\-Limes\-Cluster\-Id](#x-limes-cluster-id)
 * [GET /v1/domains/:domain\_id/projects](#get-v1domainsdomain_idprojects)
 * [GET /v1/domains/:domain\_id/projects/:project\_id](#get-v1domainsdomain_idprojectsproject_id)
+  * [Quota/usage for resources](#quota-usage-for-resources)
   * [Subresources](#subresources)
   * [Quota bursting details](#quota-bursting-details)
-  * [Rate limits](#rate-limits)
+  * [Rate limits and throughput tracking](#rate-limits-and-throughput-tracking)
     * [Default rate limits](#default-rate-limits)
 * [GET /v1/domains](#get-v1domains)
 * [GET /v1/domains/:domain\_id](#get-v1domainsdomain_id)
@@ -56,7 +57,7 @@ projects in that token's domain. With project member permission, shows that toke
   (e.g. `?service=compute&resource=instances`). May be given multiple times.
 * `detail`: If given, list subresources for resources that support it. (See subheading below for details.)
 * `rates`: If given, list rate limits for resources that support it. (See [subheading](#rate-limits) below for details.)
-  When combined with `?service=`, limit query to these rates (e.g. `?service=compute&rates). May be given multiple times.
+  When combined with `?service=`, limit query to these rates (e.g. `?service=compute&rates`). May be given multiple times.
 
 Returns 200 (OK) on success. Result is a JSON document like:
 
@@ -100,32 +101,24 @@ Returns 200 (OK) on success. Result is a JSON document like:
           ],
           "rates": [
             {
-              "target_type_uri": "service/compute/servers",
-              "actions": [
-                {
-                  "name": "create",
-                  "limit": 5,
-                  "unit": "r/m"
-                }
-              ]
+              "name": "service/compute/servers:create",
+              "limit": 5,
+              "window": "2m",
+              "usage_as_bigint": "1069298"
             },
             {
-              "target_type_uri": "service/compute/servers/action",
-              "actions": [
-                {
-                  "name": "update/addFloatingIp",
-                  "limit": 2,
-                  "unit": "r/m"
-                },
-                {
-                  "name": "update/removeFloatingIp",
-                  "limit": 2,
-                  "unit": "r/m"
-                }
-              ]
+              "name": "service/compute/servers/action:update/addFloatingIp",
+              "limit": 2,
+              "window": "1m"
+            },
+            {
+              "name": "service/compute/servers/action:update/removeFloatingIp",
+              "limit": 2,
+              "window": "1m"
             }
           ],
-          "scraped_at": 1486738599
+          "scraped_at": 1486738599,
+          "rates_scraped_at": 1486738206
         },
         {
           "type": "object-store",
@@ -153,6 +146,8 @@ If `:project_id` was given, the outer key is `project` and its value is the obje
 
 On the project level, the `id`, `name` and `parent_id` from Keystone are shown. (The parent ID refers to the parent
 project if there is one, otherwise it is identical to the domain ID.)
+
+### Quota/usage for resources
 
 Quota/usage data for the project is ordered into `services`, then into `resources`. In the example above, services
 include `compute` and `object_storage`, and the `compute` service has three resources, `instances`, `cores` and `ram`.
@@ -255,59 +250,71 @@ exists and is non-zero), then resources with `usage > quota` will display an add
 The `burst_usage` field is guaranteed to be equal to `usage - quota`. Applications should prefer to read the `quota` and
 `usage` values directly instead of using this field.
 
-### Rate limits
+### Rate limits and throughput tracking
 
- If the `?rates` query parameter is given, rate limits for the service are included in the response.
-Additionally the response can be limited to only include rate limits by providing the query parameter `?rates=only`.
-Rate limits can be used to control the traffic received by an API in order to prevent service capacities from being exhausted.
-They can be set on 2 levels:
-1. On *cluster* level in order to ensure a service does not receive more request than it can handle.
-2. Per *project* in order to ensure a fair usage among projects within a cluster.
+In Limes parlance, **resources** are strictly those things whose usage value refers to a consumption at a specific point
+in time, and where quota is the upper limit on usage at each individual point in time. In contrast, **rates** are all
+those things where the usage is accumulated over time. Instead of a quota, rates can have a **rate limit** that refers
+to the highest allowed increased in usage over a certain amount of time (the limit's **window**). Rate limits are
+typically applied to data throughput or to API request traffic, to prevent service capacities from being exhausted. Rate
+limits can be set on two levels:
 
- A prerequisite to traffic control is a normative scheme of classification for actions initiated by users.
-The [CADF specification](https://www.dmtf.org/sites/default/files/standards/documents/DSP2038_1.1.0.pdf) established such a classification for the OpenStack ecosystem.
-In terms of rate limits, requests sent to and OpenStack API are characterized by their `target_type_uri` and `action`.
-The `target_type_uri` represents the request path against which the activity was performed and the `action` the activity that was performed.
+1. on *cluster* level in order to ensure a service does not receive more requests or transfer more data than it can handle, and
+2. per *project* in order to ensure a fair usage among projects within a cluster.
 
- A rate limit entity in limes, as shown at the end of this subsection, consist of a `target_type_uri` which characterizes the request path and a list of `actions`.
-An action has a `name`, `limit` and `unit` which defines the maximum number of requests.
-The  `default_limit` and `default_unit` is used to reflect the default rate limit and unit set on cluster level.
-Valid action names can be `create`, `read`, `read/list`, `update`, `delete`, `authenticate`, etc. .
-Limits are defined using the following syntax: `<n>r/<unit>`.
-Valid units are `ms`, `s`, `m`, `h`.
+Each rate has a `name`. For rates that describe API request traffic, the
+[CADF specification](https://www.dmtf.org/sites/default/files/standards/documents/DSP2038_1.1.0.pdf) establishes a
+classification for the OpenStack ecosystem. Within CADF, requests sent to and OpenStack API are characterized by their
+`target_type_uri` and `action`. The `target_type_uri` represents the request path against which the activity was
+performed and the `action` the activity that was performed. Limes honors this structure for API request rates: As shown
+in the large example above, the action `create` on the target\_type\_uri `service/compute/servers` is represented by a
+Limes rate with the name `service/compute/servers:create`.
 
-The following example shows a configured rate limit of 5 server creations per minute in the compute (nova) service.
- ```json
+Rates may have a `unit` if they do not refer to countable things like API requests. For example, network throughput
+rates usually have a `unit` of `B` or `KiB`.
+
+If the rate has a rate limit, it will be shown in the fields `limit` and `window` like this:
+
+```json
 {
-  "target_type_uri": "service/compute/servers",
-  "actions": [
-    {
-      "name": "create",
-      "limit": 5,
-      "unit": "r/m"
-    }
-  ]
+  "name": "service/compute/servers/action:update/addFloatingIp",
+  "limit": 2,
+  "window": "1m"
 }
 ```
+
+This means that within any 1-minute window, not more than 2 API requests of this type are allowed for the project in
+question. The `window` is a string with the syntax `<number><unit>`, where `<unit>` is one of:
+
+```
+ms    - millisecond
+s     - second
+m     - minute
+h     - hour
+```
+
+If Limes knows how to track usage for a certain rate, the field `usage_as_bigint` will be shown (like in the large
+example above). The value of this field is an ever-increasing counter, guaranteed to never reset. Most JSON parser
+libraries parse integers into 64-bit-wide types, a size which can be reasonably expected to overflow esp. for rates
+relating to data throughput. Therefore the `usage_as_bigint` field (as indicated by the name) is set up like a bigint
+and serialized as a string. For now, clients SHOULD be able to handle at least 128-bit-wide unsigned integers in this field.
+
+Each service that has at least one rate with usage tracking will show a `rates_scraped_at` timestamp, analogous to the
+`scraped_at` timestamp for resource usage.
 
 #### Default rate limits
 
 Default rate limits on a project level can be defined via the [service configuration](../operators/config.md#rate-limits).
 The can be overwritten on a project level via the [API](#put-v1domainsdomain_idprojectsproject_id).
-The fields `default_limit` and `default_unit` in the response to a `GET /v1/domains/:domain\_id/projects/:project\_id` request
-are used to indicate deviations from the default project rate limits:
+The fields `default_limit` and `default_window` in the response to a `GET /v1/domains/:domain\_id/projects/:project\_id`
+request are used to indicate deviations from the default project rate limits:
 ```json
 {
-  "target_type_uri": "service/compute/servers",
-  "actions": [
-    {
-      "name": "create",
-      "limit": 5,
-      "unit": "r/m",
-      "default_limit": 10,
-      "default_unit": "r/m"
-    }
-  ]
+  "name": "service/compute/servers:create",
+  "limit": 5,
+  "window": "1m",
+  "default_limit": 10,
+  "default_window": "1m"
 }
 ```
 
@@ -825,17 +832,12 @@ project-admin token for the specified project. Other than that, the call works i
     {
       "services": [
         {
-          "type": "object-store",
+          "type": "compute",
           "rates": [
             {
-              "target_type_uri": "service/compute/servers",
-              "actions": [
-                {
-                  "name": "create",
-                  "limit": 5,
-                  "unit": "r/m"
-                }
-              ]
+              "name": "service/compute/servers:create",
+              "limit": 5,
+              "unit": "r/m"
             }
           ]
         }

--- a/docs/users/api-v1-specification.md
+++ b/docs/users/api-v1-specification.md
@@ -285,7 +285,8 @@ If the rate has a rate limit, it will be shown in the fields `limit` and `window
 ```
 
 This means that within any 1-minute window, not more than 2 API requests of this type are allowed for the project in
-question. The `window` is a string with the syntax `<number><unit>`, where `<unit>` is one of:
+question. (Rate limits are applied on a sliding window, not on fixed window boundaries.) The value of the `window` field
+is a string with the syntax `<number><unit>`, where `<unit>` is one of:
 
 ```
 ms    - millisecond

--- a/docs/users/api-v1-specification.md
+++ b/docs/users/api-v1-specification.md
@@ -271,7 +271,8 @@ in the large example above, the action `create` on the target\_type\_uri `servic
 Limes rate with the name `service/compute/servers:create`.
 
 Rates may have a `unit` if they do not refer to countable things like API requests. For example, network throughput
-rates usually have a `unit` of `B` or `KiB`.
+rates usually have a `unit` of `B` or `KiB`. The unit applies to the values in the fields `limit` and `usage_as_bigint`
+(see below).
 
 If the rate has a rate limit, it will be shown in the fields `limit` and `window` like this:
 

--- a/input_test.go
+++ b/input_test.go
@@ -37,7 +37,7 @@ var quotas = QuotaRequest{
 				Unit:  UnitNone,
 			},
 		},
-		Rates: RateQuotaRequest{},
+		Rates: map[string]RateLimitRequest{},
 	},
 }
 
@@ -64,34 +64,33 @@ var quotaJSON = `
 
 var rateLimits = QuotaRequest{
 	"object-store": ServiceQuotaRequest{
-		Rates: RateQuotaRequest{
-			"object/account/container": {
-				"create": {Value: 1000, Unit: UnitRequestsPerSecond},
-			},
+		Rates: map[string]RateLimitRequest{
+			"object/account/container:create": {Limit: 1000, Window: 1 * WindowSeconds},
+			"object/account/container:delete": {Limit: 100, Window: 1 * WindowSeconds},
 		},
 		Resources: ResourceQuotaRequest{},
 	},
 }
 
 var rateLimitJSON = `
-  [
-    {
-      "type": "object-store",
-      "resources": [],
-      "rates": [
-        {
-          "target_type_uri": "object/account/container",
-          "actions": [
-            {
-              "name": "create",
-              "limit": 1000,
-              "unit": "r/s"
-            }
-          ]
-        }
-      ]
-    }
-  ]
+	[
+		{
+			"type": "object-store",
+			"resources": [],
+			"rates": [
+				{
+					"name": "object/account/container:create",
+					"limit": 1000,
+					"window": "1s"
+				},
+				{
+					"name": "object/account/container:delete",
+					"limit": 100,
+					"window": "1s"
+				}
+			]
+		}
+	]
 `
 
 func TestQuotaRequestMarshall(t *testing.T) {

--- a/metadata.go
+++ b/metadata.go
@@ -39,6 +39,14 @@ type ResourceInfo struct {
 	ExternallyManaged bool `json:"externally_managed,omitempty"`
 }
 
+//RateInfo contains the metadata for a rate (i.e. some type of event that can
+//be rate-limited and for which there may a way to retrieve a count of past
+//events from a backend service).
+type RateInfo struct {
+	Name string `json:"name"`
+	Unit Unit   `json:"unit,omitempty"`
+}
+
 //ServiceInfo contains the metadata for a backend service.
 type ServiceInfo struct {
 	//Type returns the service type that the backend service for this

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -97,71 +97,64 @@ func setupTest(t *testing.T, clusterName, startData string) (*core.Cluster, http
 		Services: []core.ServiceConfiguration{
 			{
 				Type: "shared",
-				Rates: core.ServiceRateLimitConfiguration{
+				RateLimits: core.ServiceRateLimitConfiguration{
 					Global: []core.RateLimitConfiguration{
 						{
-							TargetTypeURI: "service/shared/objects",
-							Actions: []core.RateLimitActionConfiguration{
-								{
-									Name:  "create",
-									Limit: 5000,
-									Unit:  "r/s",
-								},
-							},
+							Name:   "service/shared/objects:create",
+							Unit:   limes.UnitNone,
+							Limit:  5000,
+							Window: 1 * limes.WindowSeconds,
 						},
 					},
 					ProjectDefault: []core.RateLimitConfiguration{
 						{
-							TargetTypeURI: "service/shared/objects",
-							Actions: []core.RateLimitActionConfiguration{
-								{
-									Name:  "create",
-									Limit: 5,
-									Unit:  "r/m",
-								},
-								{
-									Name:  "delete",
-									Limit: 1,
-									Unit:  "r/m",
-								},
-								{
-									Name:  "update",
-									Limit: 2,
-									Unit:  "r/s",
-								},
-								{
-									Name:  "read/list",
-									Limit: 3,
-									Unit:  "r/s",
-								},
-							},
+							Name:   "service/shared/objects:create",
+							Unit:   limes.UnitNone,
+							Limit:  5,
+							Window: 1 * limes.WindowMinutes,
+						},
+						{
+							Name:   "service/shared/objects:delete",
+							Unit:   limes.UnitNone,
+							Limit:  1,
+							Window: 1 * limes.WindowMinutes,
+						},
+						{
+							Name:   "service/shared/objects:update",
+							Unit:   limes.UnitNone,
+							Limit:  2,
+							Window: 1 * limes.WindowSeconds,
+						},
+						{
+							Name:   "service/shared/objects:read/list",
+							Unit:   limes.UnitNone,
+							Limit:  3,
+							Window: 1 * limes.WindowSeconds,
 						},
 					},
 				},
 			},
 			{
 				Type: "unshared",
-				Rates: core.ServiceRateLimitConfiguration{
+				RateLimits: core.ServiceRateLimitConfiguration{
 					ProjectDefault: []core.RateLimitConfiguration{
 						{
-							TargetTypeURI: "service/unshared/instances",
-							Actions: []core.RateLimitActionConfiguration{
-								{
-									Name:  "create",
-									Limit: 5,
-									Unit:  "r/m",
-								},
-								{
-									Name:  "delete",
-									Limit: 1,
-									Unit:  "r/m",
-								},
-								{
-									Name:  "update",
-									Limit: 2,
-									Unit:  "r/s",
-								},
-							},
+							Name:   "service/unshared/instances:create",
+							Unit:   limes.UnitNone,
+							Limit:  5,
+							Window: 1 * limes.WindowMinutes,
+						},
+						{
+							Name:   "service/unshared/instances:delete",
+							Unit:   limes.UnitNone,
+							Limit:  1,
+							Window: 1 * limes.WindowMinutes,
+						},
+						{
+							Name:   "service/unshared/instances:update",
+							Unit:   limes.UnitNone,
+							Limit:  2,
+							Window: 1 * limes.WindowSeconds,
 						},
 					},
 				},
@@ -1254,7 +1247,7 @@ func Test_ProjectOperations(t *testing.T) {
 		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin",
 		ExpectStatus: 403,
 		ExpectBody: assert.StringData(
-			"cannot change shared/service/shared/notexistent/bogus rate limits: user is not allowed to create new rate limits\n",
+			"cannot change shared/service/shared/notexistent:bogus rate limits: user is not allowed to create new rate limits\n",
 		),
 		Body: assert.JSONObject{
 			"project": assert.JSONObject{
@@ -1263,14 +1256,9 @@ func Test_ProjectOperations(t *testing.T) {
 						"type": "shared",
 						"rates": []assert.JSONObject{
 							{
-								"target_type_uri": "service/shared/notexistent",
-								"actions": []assert.JSONObject{
-									{
-										"name":  "bogus",
-										"limit": 1,
-										"unit":  "r/h",
-									},
-								},
+								"name":   "service/shared/notexistent:bogus",
+								"limit":  1,
+								"window": "1h",
 							},
 						},
 					},
@@ -1279,25 +1267,24 @@ func Test_ProjectOperations(t *testing.T) {
 		},
 	}.Check(t, router)
 	var (
-		actualLimit uint64
-		actualUnit  limes.Unit
+		actualLimit  uint64
+		actualWindow limes.Window
 	)
 	err = db.DB.QueryRow(`
-		SELECT prl.rate_limit, prl.unit FROM project_rate_limits prl
-		JOIN project_services ps ON ps.id = prl.service_id
+		SELECT pra.rate_limit, pra.window_ns FROM project_rates pra
+		JOIN project_services ps ON ps.id = pra.service_id
 		JOIN projects p ON p.id = ps.project_id
-		WHERE p.name = $1 AND ps.type = $2 AND prl.target_type_uri = $3 AND prl.action = $4`,
-		"berlin", "shared", "service/shared/notexistent", "bogus").Scan(&actualLimit, &actualUnit)
+		WHERE p.name = $1 AND ps.type = $2 AND pra.name = $3`,
+		"berlin", "shared", "service/shared/notexistent:bogus").Scan(&actualLimit, &actualWindow)
 	//There shouldn't be anything in the DB.
 	if err.Error() != "sql: no rows in result set" {
 		t.Fatalf("expected error %v but got %v", "sql: no rows in result set", err)
 	}
 
 	//Attempt setting a rate limit for which a default exists should be successful.
-	targetTypeURI := "service/shared/objects"
-	action := "read/list"
+	rateName := "service/shared/objects:read/list"
 	expectedLimit := uint64(100)
-	expectedUnit := limes.UnitRequestsPerSecond
+	expectedWindow := 1 * limes.WindowSeconds
 
 	assert.HTTPRequest{
 		Method:       "PUT",
@@ -1310,14 +1297,9 @@ func Test_ProjectOperations(t *testing.T) {
 						"type": "shared",
 						"rates": []assert.JSONObject{
 							{
-								"target_type_uri": targetTypeURI,
-								"actions": []assert.JSONObject{
-									{
-										"name":  action,
-										"limit": expectedLimit,
-										"unit":  expectedUnit,
-									},
-								},
+								"name":   rateName,
+								"limit":  expectedLimit,
+								"window": expectedWindow.String(),
 							},
 						},
 					},
@@ -1327,24 +1309,24 @@ func Test_ProjectOperations(t *testing.T) {
 	}.Check(t, router)
 
 	err = db.DB.QueryRow(`
-		SELECT prl.rate_limit, prl.unit FROM project_rate_limits prl
-		JOIN project_services ps ON ps.id = prl.service_id
+		SELECT pra.rate_limit, pra.window_ns FROM project_rates pra
+		JOIN project_services ps ON ps.id = pra.service_id
 		JOIN projects p ON p.id = ps.project_id
-		WHERE p.name = $1 AND ps.type = $2 AND prl.target_type_uri = $3 AND prl.action = $4`,
-		"berlin", "shared", targetTypeURI, action).Scan(&actualLimit, &actualUnit)
+		WHERE p.name = $1 AND ps.type = $2 AND pra.name = $3`,
+		"berlin", "shared", rateName).Scan(&actualLimit, &actualWindow)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if actualLimit != expectedLimit {
 		t.Errorf(
-			"rate limit was not updated in database for %s %s. expected limit %d but got %d",
-			targetTypeURI, action, expectedLimit, actualLimit,
+			"rate limit %s was not updated in database: expected limit %d, but got %d",
+			rateName, expectedLimit, actualLimit,
 		)
 	}
-	if actualUnit != expectedUnit {
+	if actualWindow != expectedWindow {
 		t.Errorf(
-			"rate limit was not updated in database for %s %s. expected unit %s but got %s",
-			targetTypeURI, action, expectedUnit, actualUnit,
+			"rate limit %s was not updated in database: expected window %d, but got %d",
+			rateName, expectedWindow, actualWindow,
 		)
 	}
 

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -1834,7 +1834,7 @@ func expectStaleProjectServices(t *testing.T, pairs ...string) {
 	queryStr := `
 		SELECT p.name, ps.type
 		  FROM projects p JOIN project_services ps ON ps.project_id = p.id
-		 WHERE ps.stale
+		 WHERE ps.stale AND ps.rates_stale
 		 ORDER BY p.name, ps.type
 	`
 	var actualPairs []string

--- a/pkg/api/fixtures/cluster-get-west-only-rates.json
+++ b/pkg/api/fixtures/cluster-get-west-only-rates.json
@@ -9,14 +9,9 @@
         "resources": [],
         "rates": [
           {
-            "target_type_uri": "service/shared/objects",
-            "actions": [
-              {
-                "name": "create",
-                "limit": 5000,
-                "unit": "r/s"
-              }
-            ]
+            "name": "service/shared/objects:create",
+            "limit": 5000,
+            "window": "1s"
           }
         ]
       },

--- a/pkg/api/fixtures/cluster-get-west-with-overcommit.json
+++ b/pkg/api/fixtures/cluster-get-west-with-overcommit.json
@@ -30,7 +30,9 @@
           }
         ],
         "max_scraped_at": 66,
-        "min_scraped_at": 22
+        "min_scraped_at": 22,
+        "max_rates_scraped_at": 45,
+        "min_rates_scraped_at": 23
       },
       {
         "type": "unshared",
@@ -65,7 +67,9 @@
           }
         ],
         "max_scraped_at": 55,
-        "min_scraped_at": 11
+        "min_scraped_at": 11,
+        "max_rates_scraped_at": 34,
+        "min_rates_scraped_at": 12
       }
     ],
     "max_scraped_at": 1100,

--- a/pkg/api/fixtures/cluster-get-west-with-rates.json
+++ b/pkg/api/fixtures/cluster-get-west-with-rates.json
@@ -30,14 +30,9 @@
         ],
         "rates": [
           {
-            "target_type_uri": "service/shared/objects",
-            "actions": [
-              {
-                "name": "create",
-                "limit": 5000,
-                "unit": "r/s"
-              }
-            ]
+            "name": "service/shared/objects:create",
+            "limit": 5000,
+            "window": "1s"
           }
         ],
         "max_scraped_at": 66,

--- a/pkg/api/fixtures/cluster-get-west-with-rates.json
+++ b/pkg/api/fixtures/cluster-get-west-with-rates.json
@@ -36,7 +36,9 @@
           }
         ],
         "max_scraped_at": 66,
-        "min_scraped_at": 22
+        "min_scraped_at": 22,
+        "max_rates_scraped_at": 45,
+        "min_rates_scraped_at": 23
       },
       {
         "type": "unshared",
@@ -68,7 +70,9 @@
           }
         ],
         "max_scraped_at": 55,
-        "min_scraped_at": 11
+        "min_scraped_at": 11,
+        "max_rates_scraped_at": 34,
+        "min_rates_scraped_at": 12
       }
     ],
     "max_scraped_at": 1100,

--- a/pkg/api/fixtures/cluster-get-west.json
+++ b/pkg/api/fixtures/cluster-get-west.json
@@ -29,7 +29,9 @@
           }
         ],
         "max_scraped_at": 66,
-        "min_scraped_at": 22
+        "min_scraped_at": 22,
+        "max_rates_scraped_at": 45,
+        "min_rates_scraped_at": 23
       },
       {
         "type": "unshared",
@@ -61,7 +63,9 @@
           }
         ],
         "max_scraped_at": 55,
-        "min_scraped_at": 11
+        "min_scraped_at": 11,
+        "max_rates_scraped_at": 34,
+        "min_rates_scraped_at": 12
       }
     ],
     "max_scraped_at": 1100,

--- a/pkg/api/fixtures/cluster-list-detail.json
+++ b/pkg/api/fixtures/cluster-list-detail.json
@@ -113,7 +113,9 @@
             }
           ],
           "max_scraped_at": 66,
-          "min_scraped_at": 22
+          "min_scraped_at": 22,
+          "max_rates_scraped_at": 45,
+          "min_rates_scraped_at": 23
         },
         {
           "type": "unshared",
@@ -153,7 +155,9 @@
             }
           ],
           "max_scraped_at": 55,
-          "min_scraped_at": 11
+          "min_scraped_at": 11,
+          "max_rates_scraped_at": 34,
+          "min_rates_scraped_at": 12
         }
       ],
       "max_scraped_at": 1100,

--- a/pkg/api/fixtures/cluster-list-filtered-foreign.json
+++ b/pkg/api/fixtures/cluster-list-filtered-foreign.json
@@ -39,7 +39,9 @@
             }
           ],
           "max_scraped_at": 66,
-          "min_scraped_at": 22
+          "min_scraped_at": 22,
+          "max_rates_scraped_at": 45,
+          "min_rates_scraped_at": 23
         }
       ],
       "max_scraped_at": 1100,

--- a/pkg/api/fixtures/cluster-list-filtered.json
+++ b/pkg/api/fixtures/cluster-list-filtered.json
@@ -39,7 +39,9 @@
             }
           ],
           "max_scraped_at": 66,
-          "min_scraped_at": 22
+          "min_scraped_at": 22,
+          "max_rates_scraped_at": 45,
+          "min_rates_scraped_at": 23
         }
       ],
       "max_scraped_at": 1100,

--- a/pkg/api/fixtures/cluster-list-local.json
+++ b/pkg/api/fixtures/cluster-list-local.json
@@ -88,7 +88,9 @@
             }
           ],
           "max_scraped_at": 66,
-          "min_scraped_at": 22
+          "min_scraped_at": 22,
+          "max_rates_scraped_at": 45,
+          "min_rates_scraped_at": 23
         },
         {
           "type": "unshared",
@@ -120,7 +122,9 @@
             }
           ],
           "max_scraped_at": 55,
-          "min_scraped_at": 11
+          "min_scraped_at": 11,
+          "max_rates_scraped_at": 34,
+          "min_rates_scraped_at": 12
         }
       ],
       "max_scraped_at": 1100,

--- a/pkg/api/fixtures/cluster-list-no-resources.json
+++ b/pkg/api/fixtures/cluster-list-no-resources.json
@@ -25,7 +25,9 @@
           "shared": true,
           "resources": [],
           "max_scraped_at": 66,
-          "min_scraped_at": 22
+          "min_scraped_at": 22,
+          "max_rates_scraped_at": 45,
+          "min_rates_scraped_at": 23
         }
       ],
       "max_scraped_at": 1100,

--- a/pkg/api/fixtures/cluster-list.json
+++ b/pkg/api/fixtures/cluster-list.json
@@ -89,7 +89,9 @@
             }
           ],
           "max_scraped_at": 66,
-          "min_scraped_at": 22
+          "min_scraped_at": 22,
+          "max_rates_scraped_at": 45,
+          "min_rates_scraped_at": 23
         },
         {
           "type": "unshared",
@@ -121,7 +123,9 @@
             }
           ],
           "max_scraped_at": 55,
-          "min_scraped_at": 11
+          "min_scraped_at": 11,
+          "max_rates_scraped_at": 34,
+          "min_rates_scraped_at": 12
         }
       ],
       "max_scraped_at": 1100,

--- a/pkg/api/fixtures/domain-get-germany.json
+++ b/pkg/api/fixtures/domain-get-germany.json
@@ -38,7 +38,9 @@
           }
         ],
         "max_scraped_at": 44,
-        "min_scraped_at": 22
+        "min_scraped_at": 22,
+        "max_rates_scraped_at": 45,
+        "min_rates_scraped_at": 23
       },
       {
         "type": "unshared",
@@ -64,7 +66,9 @@
           }
         ],
         "max_scraped_at": 33,
-        "min_scraped_at": 11
+        "min_scraped_at": 11,
+        "max_rates_scraped_at": 34,
+        "min_rates_scraped_at": 12
       }
     ]
   }

--- a/pkg/api/fixtures/domain-list-filtered.json
+++ b/pkg/api/fixtures/domain-list-filtered.json
@@ -40,7 +40,9 @@
             }
           ],
           "max_scraped_at": 44,
-          "min_scraped_at": 22
+          "min_scraped_at": 22,
+          "max_rates_scraped_at": 45,
+          "min_rates_scraped_at": 23
         }
       ]
     }

--- a/pkg/api/fixtures/domain-list-no-resources.json
+++ b/pkg/api/fixtures/domain-list-no-resources.json
@@ -22,7 +22,9 @@
           "area": "shared",
           "resources": [],
           "max_scraped_at": 44,
-          "min_scraped_at": 22
+          "min_scraped_at": 22,
+          "max_rates_scraped_at": 45,
+          "min_rates_scraped_at": 23
         }
       ]
     }

--- a/pkg/api/fixtures/domain-list.json
+++ b/pkg/api/fixtures/domain-list.json
@@ -101,7 +101,9 @@
             }
           ],
           "max_scraped_at": 44,
-          "min_scraped_at": 22
+          "min_scraped_at": 22,
+          "max_rates_scraped_at": 45,
+          "min_rates_scraped_at": 23
         },
         {
           "type": "unshared",
@@ -127,7 +129,9 @@
             }
           ],
           "max_scraped_at": 33,
-          "min_scraped_at": 11
+          "min_scraped_at": 11,
+          "max_rates_scraped_at": 34,
+          "min_rates_scraped_at": 12
         }
       ]
     }

--- a/pkg/api/fixtures/project-get-berlin-only-rates.json
+++ b/pkg/api/fixtures/project-get-berlin-only-rates.json
@@ -36,7 +36,7 @@
             "default_window": "1s"
           }
         ],
-        "scraped_at": 22
+        "rates_scraped_at": 23
       },
       {
         "type": "unshared",
@@ -64,7 +64,7 @@
             "default_window": "1s"
           }
         ],
-        "scraped_at": 11
+        "rates_scraped_at": 12
       }
     ]
   }

--- a/pkg/api/fixtures/project-get-berlin-only-rates.json
+++ b/pkg/api/fixtures/project-get-berlin-only-rates.json
@@ -10,31 +10,28 @@
         "resources": [],
         "rates": [
           {
-            "target_type_uri": "service/shared/objects",
-            "actions": [
-              {
-                "name": "create",
-                "limit": 5,
-                "unit": "r/m"
-              },
-              {
-                "name": "delete",
-                "limit": 2,
-                "unit": "r/m",
-                "default_limit": 1
-              },
-              {
-                "name": "read/list",
-                "limit": 3,
-                "unit": "r/s"
-              },
-              {
-                "name": "update",
-                "limit": 2,
-                "unit": "r/m",
-                "default_unit": "r/s"
-              }
-            ]
+            "name": "service/shared/objects:create",
+            "limit": 5,
+            "window": "1m"
+          },
+          {
+            "name": "service/shared/objects:delete",
+            "limit": 2,
+            "window": "1m",
+            "default_limit": 1,
+            "default_window": "1m"
+          },
+          {
+            "name": "service/shared/objects:read/list",
+            "limit": 3,
+            "window": "1s"
+          },
+          {
+            "name": "service/shared/objects:update",
+            "limit": 2,
+            "window": "1m",
+            "default_limit": 2,
+            "default_window": "1s"
           }
         ],
         "scraped_at": 22
@@ -45,26 +42,23 @@
         "resources": [],
         "rates": [
           {
-            "target_type_uri": "service/unshared/instances",
-            "actions": [
-              {
-                "name": "create",
-                "limit": 5,
-                "unit": "r/m"
-              },
-              {
-                "name": "delete",
-                "limit": 2,
-                "unit": "r/m",
-                "default_limit": 1
-              },
-              {
-                "name": "update",
-                "limit": 2,
-                "unit": "r/m",
-                "default_unit": "r/s"
-              }
-            ]
+            "name": "service/unshared/instances:create",
+            "limit": 5,
+            "window": "1m"
+          },
+          {
+            "name": "service/unshared/instances:delete",
+            "limit": 2,
+            "window": "1m",
+            "default_limit": 1,
+            "default_window": "1m"
+          },
+          {
+            "name": "service/unshared/instances:update",
+            "limit": 2,
+            "window": "1m",
+            "default_limit": 2,
+            "default_window": "1s"
           }
         ],
         "scraped_at": 11

--- a/pkg/api/fixtures/project-get-berlin-only-rates.json
+++ b/pkg/api/fixtures/project-get-berlin-only-rates.json
@@ -16,10 +16,12 @@
           },
           {
             "name": "service/shared/objects:delete",
+            "unit": "MiB",
             "limit": 2,
             "window": "1m",
             "default_limit": 1,
-            "default_window": "1m"
+            "default_window": "1m",
+            "usage_as_bigint": "23456"
           },
           {
             "name": "service/shared/objects:read/list",
@@ -51,7 +53,8 @@
             "limit": 2,
             "window": "1m",
             "default_limit": 1,
-            "default_window": "1m"
+            "default_window": "1m",
+            "usage_as_bigint": "12345"
           },
           {
             "name": "service/unshared/instances:update",

--- a/pkg/api/fixtures/project-get-berlin-with-rates.json
+++ b/pkg/api/fixtures/project-get-berlin-with-rates.json
@@ -57,7 +57,8 @@
             "default_window": "1s"
           }
         ],
-        "scraped_at": 22
+        "scraped_at": 22,
+        "rates_scraped_at": 23
       },
       {
         "type": "unshared",
@@ -104,7 +105,8 @@
             "default_window": "1s"
           }
         ],
-        "scraped_at": 11
+        "scraped_at": 11,
+        "rates_scraped_at": 12
       }
     ]
   }

--- a/pkg/api/fixtures/project-get-berlin-with-rates.json
+++ b/pkg/api/fixtures/project-get-berlin-with-rates.json
@@ -31,31 +31,28 @@
         ],
         "rates": [
           {
-            "target_type_uri": "service/shared/objects",
-            "actions": [
-              {
-                "name": "create",
-                "limit": 5,
-                "unit": "r/m"
-              },
-              {
-                "name": "delete",
-                "limit": 2,
-                "unit": "r/m",
-                "default_limit": 1
-              },
-              {
-                "name": "read/list",
-                "limit": 3,
-                "unit": "r/s"
-              },
-              {
-                "name": "update",
-                "limit": 2,
-                "unit": "r/m",
-                "default_unit": "r/s"
-              }
-            ]
+            "name": "service/shared/objects:create",
+            "limit": 5,
+            "window": "1m"
+          },
+          {
+            "name": "service/shared/objects:delete",
+            "limit": 2,
+            "window": "1m",
+            "default_limit": 1,
+            "default_window": "1m"
+          },
+          {
+            "name": "service/shared/objects:read/list",
+            "limit": 3,
+            "window": "1s"
+          },
+          {
+            "name": "service/shared/objects:update",
+            "limit": 2,
+            "window": "1m",
+            "default_limit": 2,
+            "default_window": "1s"
           }
         ],
         "scraped_at": 22
@@ -85,26 +82,23 @@
         ],
         "rates": [
           {
-            "target_type_uri": "service/unshared/instances",
-            "actions": [
-              {
-                "name": "create",
-                "limit": 5,
-                "unit": "r/m"
-              },
-              {
-                "name": "delete",
-                "limit": 2,
-                "unit": "r/m",
-                "default_limit": 1
-              },
-              {
-                "name": "update",
-                "limit": 2,
-                "unit": "r/m",
-                "default_unit": "r/s"
-              }
-            ]
+            "name": "service/unshared/instances:create",
+            "limit": 5,
+            "window": "1m"
+          },
+          {
+            "name": "service/unshared/instances:delete",
+            "limit": 2,
+            "window": "1m",
+            "default_limit": 1,
+            "default_window": "1m"
+          },
+          {
+            "name": "service/unshared/instances:update",
+            "limit": 2,
+            "window": "1m",
+            "default_limit": 2,
+            "default_window": "1s"
           }
         ],
         "scraped_at": 11

--- a/pkg/api/fixtures/project-get-dresden-with-rates.json
+++ b/pkg/api/fixtures/project-get-dresden-with-rates.json
@@ -67,7 +67,8 @@
             "window": "1s"
           }
         ],
-        "scraped_at": 44
+        "scraped_at": 44,
+        "rates_scraped_at": 45
       },
       {
         "type": "unshared",
@@ -110,7 +111,8 @@
             "window": "1s"
           }
         ],
-        "scraped_at": 33
+        "scraped_at": 33,
+        "rates_scraped_at": 34
       }
     ]
   }

--- a/pkg/api/fixtures/project-get-dresden-with-rates.json
+++ b/pkg/api/fixtures/project-get-dresden-with-rates.json
@@ -1,8 +1,8 @@
 {
   "project": {
-    "id": "uuid-for-berlin",
-    "name": "berlin",
-    "parent_id": "uuid-for-germany",
+    "id": "uuid-for-dresden",
+    "name": "dresden",
+    "parent_id": "uuid-for-berlin",
     "services": [
       {
         "type": "shared",
@@ -13,20 +13,29 @@
             "unit": "B",
             "quota": 10,
             "usable_quota": 10,
-            "usage": 2
+            "usage": 2,
+            "backend_quota": 100
           },
           {
             "name": "external_things",
             "externally_managed": true,
             "quota": 1,
             "usable_quota": 1,
-            "usage": 0
+            "usage": 0,
+            "annotations": {
+              "annotated": true,
+              "text": "this annotation appears on shared/external_things of project dresden only"
+            }
           },
           {
             "name": "things",
             "quota": 10,
             "usable_quota": 10,
-            "usage": 2
+            "usage": 2,
+            "annotations": {
+              "annotated": true,
+              "text": "this annotation appears on shared things of domain germany and project dresden"
+            }
           }
         ],
         "rates": [
@@ -38,11 +47,9 @@
           {
             "name": "service/shared/objects:delete",
             "unit": "MiB",
-            "limit": 2,
+            "limit": 1,
             "window": "1m",
-            "default_limit": 1,
-            "default_window": "1m",
-            "usage_as_bigint": "23456"
+            "usage_as_bigint": "0"
           },
           {
             "name": "service/shared/objects:read/list",
@@ -50,14 +57,17 @@
             "window": "1s"
           },
           {
+            "name": "service/shared/objects:unlimited",
+            "unit": "KiB",
+            "usage_as_bigint": "1048576"
+          },
+          {
             "name": "service/shared/objects:update",
             "limit": 2,
-            "window": "1m",
-            "default_limit": 2,
-            "default_window": "1s"
+            "window": "1s"
           }
         ],
-        "scraped_at": 22
+        "scraped_at": 44
       },
       {
         "type": "unshared",
@@ -90,21 +100,17 @@
           },
           {
             "name": "service/unshared/instances:delete",
-            "limit": 2,
+            "limit": 1,
             "window": "1m",
-            "default_limit": 1,
-            "default_window": "1m",
-            "usage_as_bigint": "12345"
+            "usage_as_bigint": "0"
           },
           {
             "name": "service/unshared/instances:update",
             "limit": 2,
-            "window": "1m",
-            "default_limit": 2,
-            "default_window": "1s"
+            "window": "1s"
           }
         ],
-        "scraped_at": 11
+        "scraped_at": 33
       }
     ]
   }

--- a/pkg/api/fixtures/project-get-paris-only-default-rates.json
+++ b/pkg/api/fixtures/project-get-paris-only-default-rates.json
@@ -16,6 +16,7 @@
           },
           {
             "name": "service/shared/objects:delete",
+            "unit": "MiB",
             "limit": 1,
             "window": "1m"
           },

--- a/pkg/api/fixtures/project-get-paris-only-default-rates.json
+++ b/pkg/api/fixtures/project-get-paris-only-default-rates.json
@@ -10,29 +10,24 @@
         "resources": [],
         "rates": [
           {
-            "target_type_uri": "service/shared/objects",
-            "actions": [
-              {
-                "name": "create",
-                "limit": 5,
-                "unit": "r/m"
-              },
-              {
-                "name": "delete",
-                "limit": 1,
-                "unit": "r/m"
-              },
-              {
-                "name": "read/list",
-                "limit": 3,
-                "unit": "r/s"
-              },
-              {
-                "name": "update",
-                "limit": 2,
-                "unit": "r/s"
-              }
-            ]
+            "name": "service/shared/objects:create",
+            "limit": 5,
+            "window": "1m"
+          },
+          {
+            "name": "service/shared/objects:delete",
+            "limit": 1,
+            "window": "1m"
+          },
+          {
+            "name": "service/shared/objects:read/list",
+            "limit": 3,
+            "window": "1s"
+          },
+          {
+            "name": "service/shared/objects:update",
+            "limit": 2,
+            "window": "1s"
           }
         ],
         "scraped_at": 66
@@ -43,24 +38,19 @@
         "resources": [],
         "rates": [
           {
-            "target_type_uri": "service/unshared/instances",
-            "actions": [
-              {
-                "name": "create",
-                "limit": 5,
-                "unit": "r/m"
-              },
-              {
-                "name": "delete",
-                "limit": 1,
-                "unit": "r/m"
-              },
-              {
-                "name": "update",
-                "limit": 2,
-                "unit": "r/s"
-              }
-            ]
+            "name": "service/unshared/instances:create",
+            "limit": 5,
+            "window": "1m"
+          },
+          {
+            "name": "service/unshared/instances:delete",
+            "limit": 1,
+            "window": "1m"
+          },
+          {
+            "name": "service/unshared/instances:update",
+            "limit": 2,
+            "window": "1s"
           }
         ],
         "scraped_at": 55

--- a/pkg/api/fixtures/project-get-paris-only-default-rates.json
+++ b/pkg/api/fixtures/project-get-paris-only-default-rates.json
@@ -30,8 +30,7 @@
             "limit": 2,
             "window": "1s"
           }
-        ],
-        "scraped_at": 66
+        ]
       },
       {
         "type": "unshared",
@@ -53,8 +52,7 @@
             "limit": 2,
             "window": "1s"
           }
-        ],
-        "scraped_at": 55
+        ]
       }
     ]
   }

--- a/pkg/api/fixtures/start-data.sql
+++ b/pkg/api/fixtures/start-data.sql
@@ -83,14 +83,14 @@ INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, su
 
 -- project rate limits
 -- unshared
-INSERT INTO project_rate_limits (service_id, target_type_uri, action, rate_limit, unit) VALUES (1, 'service/unshared/instances',  'create', 5, 'r/m');
-INSERT INTO project_rate_limits (service_id, target_type_uri, action, rate_limit, unit) VALUES (1, 'service/unshared/instances',  'delete', 2, 'r/m');
-INSERT INTO project_rate_limits (service_id, target_type_uri, action, rate_limit, unit) VALUES (1, 'service/unshared/instances',  'update', 2, 'r/m');
+INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_bigint) VALUES (1, 'service/unshared/instances:create', 5, 60000000000, '');
+INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_bigint) VALUES (1, 'service/unshared/instances:delete', 2, 60000000000, '');
+INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_bigint) VALUES (1, 'service/unshared/instances:update', 2, 60000000000, '');
 
 -- shared
-INSERT INTO project_rate_limits (service_id, target_type_uri, action, rate_limit, unit) VALUES (2, 'service/shared/objects',  'create', 5, 'r/m');
-INSERT INTO project_rate_limits (service_id, target_type_uri, action, rate_limit, unit) VALUES (2, 'service/shared/objects',  'delete', 2, 'r/m');
-INSERT INTO project_rate_limits (service_id, target_type_uri, action, rate_limit, unit) VALUES (2, 'service/shared/objects',  'update', 2, 'r/m');
+INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_bigint) VALUES (2, 'service/shared/objects:create', 5, 60000000000, '');
+INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_bigint) VALUES (2, 'service/shared/objects:delete', 2, 60000000000, '');
+INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_bigint) VALUES (2, 'service/shared/objects:update', 2, 60000000000, '');
 
 -- insert some bullshit data that should be filtered out by the pkg/reports/ logic
 -- (cluster "north", service "weird" and resource "items" are not configured)

--- a/pkg/api/fixtures/start-data.sql
+++ b/pkg/api/fixtures/start-data.sql
@@ -46,14 +46,14 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALU
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (4, 3, 'warsaw', 'uuid-for-warsaw', 'uuid-for-poland', FALSE);
 
 -- project_services is fully populated (as ensured by the collector's consistency check)
-INSERT INTO project_services (id, project_id, type, scraped_at) VALUES (1, 1, 'unshared', UNIX(11));
-INSERT INTO project_services (id, project_id, type, scraped_at) VALUES (2, 1, 'shared',   UNIX(22));
-INSERT INTO project_services (id, project_id, type, scraped_at) VALUES (3, 2, 'unshared', UNIX(33));
-INSERT INTO project_services (id, project_id, type, scraped_at) VALUES (4, 2, 'shared',   UNIX(44));
-INSERT INTO project_services (id, project_id, type, scraped_at) VALUES (5, 3, 'unshared', UNIX(55));
-INSERT INTO project_services (id, project_id, type, scraped_at) VALUES (6, 3, 'shared',   UNIX(66));
-INSERT INTO project_services (id, project_id, type, scraped_at) VALUES (7, 4, 'unshared', UNIX(77));
-INSERT INTO project_services (id, project_id, type, scraped_at) VALUES (8, 4, 'shared',   UNIX(88));
+INSERT INTO project_services (id, project_id, type, scraped_at, rates_scraped_at) VALUES (1, 1, 'unshared', UNIX(11), UNIX(12));
+INSERT INTO project_services (id, project_id, type, scraped_at, rates_scraped_at) VALUES (2, 1, 'shared',   UNIX(22), UNIX(23));
+INSERT INTO project_services (id, project_id, type, scraped_at, rates_scraped_at) VALUES (3, 2, 'unshared', UNIX(33), UNIX(34));
+INSERT INTO project_services (id, project_id, type, scraped_at, rates_scraped_at) VALUES (4, 2, 'shared',   UNIX(44), UNIX(45));
+INSERT INTO project_services (id, project_id, type, scraped_at, rates_scraped_at) VALUES (5, 3, 'unshared', UNIX(55), NULL);
+INSERT INTO project_services (id, project_id, type, scraped_at, rates_scraped_at) VALUES (6, 3, 'shared',   UNIX(66), NULL);
+INSERT INTO project_services (id, project_id, type, scraped_at, rates_scraped_at) VALUES (7, 4, 'unshared', UNIX(77), NULL);
+INSERT INTO project_services (id, project_id, type, scraped_at, rates_scraped_at) VALUES (8, 4, 'shared',   UNIX(88), NULL);
 
 -- project_resources contains some pathological cases
 -- berlin (also used for test cases concerning subresources)

--- a/pkg/api/fixtures/start-data.sql
+++ b/pkg/api/fixtures/start-data.sql
@@ -81,19 +81,23 @@ INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, su
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (8, 'capacity', 10, 2, 10, '', 10, 1);
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (8, 'external_things', 1, 0, 1, '', 10, NULL);
 
--- project rate limits
--- unshared
+-- project_rates also has multiple different setups to test different cases
+-- berlin has custom rate limits
 INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_bigint) VALUES (1, 'service/unshared/instances:create', 5, 60000000000, '');
-INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_bigint) VALUES (1, 'service/unshared/instances:delete', 2, 60000000000, '');
+INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_bigint) VALUES (1, 'service/unshared/instances:delete', 2, 60000000000, '12345');
 INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_bigint) VALUES (1, 'service/unshared/instances:update', 2, 60000000000, '');
-
--- shared
 INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_bigint) VALUES (2, 'service/shared/objects:create', 5, 60000000000, '');
-INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_bigint) VALUES (2, 'service/shared/objects:delete', 2, 60000000000, '');
+INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_bigint) VALUES (2, 'service/shared/objects:delete', 2, 60000000000, '23456');
 INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_bigint) VALUES (2, 'service/shared/objects:update', 2, 60000000000, '');
+-- dresden only has usage values, and it also shows usage for a rate that does not have rate limits
+-- also, dresden has some zero-valued usage values, which is different from empty string (empty string means "usage unknown", 0 means "no usage yet")
+INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_bigint) VALUES (3, 'service/unshared/instances:delete', NULL, NULL, '0');
+INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_bigint) VALUES (4, 'service/shared/objects:delete', NULL, NULL, '0');
+INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_bigint) VALUES (4, 'service/shared/objects:unlimited', NULL, NULL, '1048576');
+-- not pictures: paris has no records at all, so the API will only display the default rate limits
 
 -- insert some bullshit data that should be filtered out by the pkg/reports/ logic
--- (cluster "north", service "weird" and resource "items" are not configured)
+-- (cluster "north", service "weird", resource "items" and rate "frobnicate" are not configured)
 INSERT INTO cluster_services (id, cluster_id, type, scraped_at) VALUES (101, 'north', 'unshared', UNIX(1000));
 INSERT INTO cluster_services (id, cluster_id, type, scraped_at) VALUES (102, 'north', 'shared',   UNIX(1100));
 INSERT INTO cluster_resources (service_id, name, capacity) VALUES (101, 'things', 1);
@@ -106,3 +110,6 @@ INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, su
 
 INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'items', 1);
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'items', 2, 1, 2, '', 2, 1);
+
+INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_bigint) VALUES (1, 'service/unshared/instances:frobnicate', 5, 1000000000, '');
+INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_bigint) VALUES (2, 'service/shared/objects:frobnicate', 5, 1000000000, '');

--- a/pkg/api/projects.go
+++ b/pkg/api/projects.go
@@ -163,7 +163,7 @@ func (p *v1Provider) SyncProject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	//mark all project services as stale to force limes-collect to sync ASAP
-	_, err := db.DB.Exec(`UPDATE project_services SET stale = '1' WHERE project_id = $1`, dbProject.ID)
+	_, err := db.DB.Exec(`UPDATE project_services SET stale = '1', rates_stale = '1' WHERE project_id = $1`, dbProject.ID)
 	if respondwith.ErrorText(w, err) {
 		return
 	}

--- a/pkg/api/quota_updater.go
+++ b/pkg/api/quota_updater.go
@@ -255,9 +255,9 @@ func (u *QuotaUpdater) ValidateInput(input limes.QuotaRequest, dbi db.Interface)
 
 				if projectService, exists := projectReport.Services[svcType]; exists {
 					projectRate, exists := projectService.Rates[rateName]
-					if exists {
+					if exists && projectRate.Limit != 0 && projectRate.Window != nil {
 						req.OldLimit = projectRate.Limit
-						req.OldWindow = projectRate.Window
+						req.OldWindow = *projectRate.Window
 					} else {
 						req.OldLimit = defaultRateLimit.Limit
 						req.OldWindow = defaultRateLimit.Window

--- a/pkg/collector/fixtures/checkconsistency-pre.sql
+++ b/pkg/collector/fixtures/checkconsistency-pre.sql
@@ -6,12 +6,12 @@ INSERT INTO domain_services (id, domain_id, type) VALUES (4, 2, 'shared');
 INSERT INTO domains (id, cluster_id, name, uuid) VALUES (1, 'west', 'germany', 'uuid-for-germany');
 INSERT INTO domains (id, cluster_id, name, uuid) VALUES (2, 'west', 'france', 'uuid-for-france');
 
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (1, 1, 'unshared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (2, 1, 'shared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (3, 2, 'unshared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (4, 2, 'shared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (5, 3, 'unshared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (6, 3, 'shared', NULL, FALSE, 0);
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (1, 1, 'unshared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (2, 1, 'shared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (3, 2, 'unshared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (4, 2, 'shared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (5, 3, 'unshared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (6, 3, 'shared', NULL, FALSE, 0, NULL, FALSE, 0, '');
 
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany', FALSE);
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (2, 1, 'dresden', 'uuid-for-dresden', 'uuid-for-berlin', FALSE);

--- a/pkg/collector/fixtures/checkconsistency0.sql
+++ b/pkg/collector/fixtures/checkconsistency0.sql
@@ -9,12 +9,12 @@ INSERT INTO domain_services (id, domain_id, type) VALUES (4, 2, 'shared');
 INSERT INTO domains (id, cluster_id, name, uuid) VALUES (1, 'west', 'germany', 'uuid-for-germany');
 INSERT INTO domains (id, cluster_id, name, uuid) VALUES (2, 'west', 'france', 'uuid-for-france');
 
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (1, 1, 'unshared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (2, 1, 'shared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (3, 2, 'unshared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (4, 2, 'shared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (5, 3, 'unshared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (6, 3, 'shared', NULL, FALSE, 0);
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (1, 1, 'unshared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (2, 1, 'shared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (3, 2, 'unshared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (4, 2, 'shared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (5, 3, 'unshared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (6, 3, 'shared', NULL, FALSE, 0, NULL, FALSE, 0, '');
 
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany', FALSE);
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (2, 1, 'dresden', 'uuid-for-dresden', 'uuid-for-berlin', FALSE);

--- a/pkg/collector/fixtures/checkconsistency1.sql
+++ b/pkg/collector/fixtures/checkconsistency1.sql
@@ -13,10 +13,10 @@ INSERT INTO domains (id, cluster_id, name, uuid) VALUES (2, 'west', 'france', 'u
 
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'capacity', 20, 0, 0, '', 0, NULL);
 
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (1, 1, 'unshared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (3, 2, 'unshared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (5, 3, 'unshared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (7, 1, 'whatever', NULL, FALSE, 0);
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (1, 1, 'unshared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (3, 2, 'unshared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (5, 3, 'unshared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (7, 1, 'whatever', NULL, FALSE, 0, NULL, FALSE, 0, '');
 
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany', FALSE);
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (2, 1, 'dresden', 'uuid-for-dresden', 'uuid-for-berlin', FALSE);

--- a/pkg/collector/fixtures/checkconsistency2.sql
+++ b/pkg/collector/fixtures/checkconsistency2.sql
@@ -16,12 +16,12 @@ INSERT INTO domains (id, cluster_id, name, uuid) VALUES (2, 'west', 'france', 'u
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'capacity', 20, 0, 0, '', 0, NULL);
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (9, 'capacity', 10, 0, 0, '', 10, NULL);
 
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (1, 1, 'unshared', NULL, TRUE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (10, 3, 'shared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (3, 2, 'unshared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (5, 3, 'unshared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (8, 1, 'shared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (9, 2, 'shared', NULL, FALSE, 0);
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (1, 1, 'unshared', NULL, TRUE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (10, 3, 'shared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (3, 2, 'unshared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (5, 3, 'unshared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (8, 1, 'shared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (9, 2, 'shared', NULL, FALSE, 0, NULL, FALSE, 0, '');
 
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany', FALSE);
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (2, 1, 'dresden', 'uuid-for-dresden', 'uuid-for-berlin', FALSE);

--- a/pkg/collector/fixtures/scandomains1.sql
+++ b/pkg/collector/fixtures/scandomains1.sql
@@ -12,12 +12,12 @@ INSERT INTO domains (id, cluster_id, name, uuid) VALUES (2, 'west', 'france', 'u
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'things', 5, 0, 0, '', 5, NULL);
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'capacity', 10, 0, 0, '', 10, NULL);
 
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (1, 1, 'unshared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (2, 1, 'shared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (3, 2, 'unshared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (4, 2, 'shared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (5, 3, 'unshared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (6, 3, 'shared', NULL, FALSE, 0);
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (1, 1, 'unshared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (2, 1, 'shared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (3, 2, 'unshared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (4, 2, 'shared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (5, 3, 'unshared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (6, 3, 'shared', NULL, FALSE, 0, NULL, FALSE, 0, '');
 
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany', FALSE);
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (2, 1, 'dresden', 'uuid-for-dresden', 'uuid-for-berlin', FALSE);

--- a/pkg/collector/fixtures/scandomains2.sql
+++ b/pkg/collector/fixtures/scandomains2.sql
@@ -12,14 +12,14 @@ INSERT INTO domains (id, cluster_id, name, uuid) VALUES (2, 'west', 'france', 'u
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'things', 5, 0, 0, '', 5, NULL);
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'capacity', 10, 0, 0, '', 10, NULL);
 
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (1, 1, 'unshared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (2, 1, 'shared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (3, 2, 'unshared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (4, 2, 'shared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (5, 3, 'unshared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (6, 3, 'shared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (7, 4, 'unshared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (8, 4, 'shared', NULL, FALSE, 0);
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (1, 1, 'unshared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (2, 1, 'shared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (3, 2, 'unshared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (4, 2, 'shared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (5, 3, 'unshared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (6, 3, 'shared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (7, 4, 'unshared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (8, 4, 'shared', NULL, FALSE, 0, NULL, FALSE, 0, '');
 
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany', FALSE);
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (2, 1, 'dresden', 'uuid-for-dresden', 'uuid-for-berlin', FALSE);

--- a/pkg/collector/fixtures/scandomains3.sql
+++ b/pkg/collector/fixtures/scandomains3.sql
@@ -9,10 +9,10 @@ INSERT INTO domains (id, cluster_id, name, uuid) VALUES (1, 'west', 'germany', '
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'things', 5, 0, 0, '', 5, NULL);
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'capacity', 10, 0, 0, '', 10, NULL);
 
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (1, 1, 'unshared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (2, 1, 'shared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (3, 2, 'unshared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (4, 2, 'shared', NULL, FALSE, 0);
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (1, 1, 'unshared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (2, 1, 'shared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (3, 2, 'unshared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (4, 2, 'shared', NULL, FALSE, 0, NULL, FALSE, 0, '');
 
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany', FALSE);
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (2, 1, 'dresden', 'uuid-for-dresden', 'uuid-for-berlin', FALSE);

--- a/pkg/collector/fixtures/scandomains4.sql
+++ b/pkg/collector/fixtures/scandomains4.sql
@@ -9,10 +9,10 @@ INSERT INTO domains (id, cluster_id, name, uuid) VALUES (1, 'west', 'germany-cha
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'things', 5, 0, 0, '', 5, NULL);
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'capacity', 10, 0, 0, '', 10, NULL);
 
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (1, 1, 'unshared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (2, 1, 'shared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (3, 2, 'unshared', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (4, 2, 'shared', NULL, FALSE, 0);
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (1, 1, 'unshared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (2, 1, 'shared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (3, 2, 'unshared', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (4, 2, 'shared', NULL, FALSE, 0, NULL, FALSE, 0, '');
 
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (1, 1, 'berlin-changed', 'uuid-for-berlin', 'uuid-for-germany', FALSE);
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (2, 1, 'dresden', 'uuid-for-dresden', 'uuid-for-berlin', FALSE);

--- a/pkg/collector/fixtures/scrape-autoapprove1.sql
+++ b/pkg/collector/fixtures/scrape-autoapprove1.sql
@@ -5,6 +5,6 @@ INSERT INTO domains (id, cluster_id, name, uuid) VALUES (1, 'west', 'germany', '
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'approve', 10, 0, 10, '', 10, NULL);
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'noapprove', 0, 0, 20, '', 0, NULL);
 
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (1, 1, 'autoapprovaltest', 1, FALSE, 1);
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (1, 1, 'autoapprovaltest', 1, FALSE, 1, NULL, FALSE, 0, '');
 
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany', FALSE);

--- a/pkg/collector/fixtures/scrape-autoapprove2.sql
+++ b/pkg/collector/fixtures/scrape-autoapprove2.sql
@@ -5,6 +5,6 @@ INSERT INTO domains (id, cluster_id, name, uuid) VALUES (1, 'west', 'germany', '
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'approve', 10, 0, 20, '', 10, NULL);
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'noapprove', 0, 0, 30, '', 0, NULL);
 
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (1, 1, 'autoapprovaltest', 3, FALSE, 1);
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (1, 1, 'autoapprovaltest', 3, FALSE, 1, NULL, FALSE, 0, '');
 
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany', FALSE);

--- a/pkg/collector/fixtures/scrape-failures1.sql
+++ b/pkg/collector/fixtures/scrape-failures1.sql
@@ -7,8 +7,8 @@ INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, su
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'capacity', 10, 0, -1, '', 12, NULL);
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'things', 0, 0, -1, '', 0, NULL);
 
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (1, 1, 'unittest', 0, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (2, 2, 'unittest', 0, FALSE, 0);
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (1, 1, 'unittest', 0, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (2, 2, 'unittest', 0, FALSE, 0, NULL, FALSE, 0, '');
 
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany', FALSE);
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (2, 1, 'dresden', 'uuid-for-dresden', 'uuid-for-berlin', TRUE);

--- a/pkg/collector/fixtures/scrape-failures2.sql
+++ b/pkg/collector/fixtures/scrape-failures2.sql
@@ -7,8 +7,8 @@ INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, su
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'capacity', 10, 0, 100, '', 12, 0);
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'things', 0, 2, 42, '[{"index":0},{"index":1}]', 0, NULL);
 
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (1, 1, 'unittest', 5, FALSE, 1);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (2, 2, 'unittest', 7, FALSE, 1);
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (1, 1, 'unittest', 5, FALSE, 1, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (2, 2, 'unittest', 7, FALSE, 1, NULL, FALSE, 0, '');
 
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany', FALSE);
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (2, 1, 'dresden', 'uuid-for-dresden', 'uuid-for-berlin', TRUE);

--- a/pkg/collector/fixtures/scrape-failures3.sql
+++ b/pkg/collector/fixtures/scrape-failures3.sql
@@ -7,8 +7,8 @@ INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, su
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'capacity', 10, 0, 100, '', 12, 0);
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'things', 0, 2, 42, '[{"index":0},{"index":1}]', 0, NULL);
 
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (1, 1, 'unittest', 5, TRUE, 1);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (2, 2, 'unittest', 7, TRUE, 1);
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (1, 1, 'unittest', 5, TRUE, 1, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (2, 2, 'unittest', 7, TRUE, 1, NULL, FALSE, 0, '');
 
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany', FALSE);
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (2, 1, 'dresden', 'uuid-for-dresden', 'uuid-for-berlin', TRUE);

--- a/pkg/collector/fixtures/scrape-no-resources.sql
+++ b/pkg/collector/fixtures/scrape-no-resources.sql
@@ -1,0 +1,7 @@
+INSERT INTO domain_services (id, domain_id, type) VALUES (1, 1, 'noop');
+
+INSERT INTO domains (id, cluster_id, name, uuid) VALUES (1, 'west', 'germany', 'uuid-for-germany');
+
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (1, 1, 'noop', 1, FALSE, 1, NULL, FALSE, 0, '');
+
+INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany', FALSE);

--- a/pkg/collector/fixtures/scrape0.sql
+++ b/pkg/collector/fixtures/scrape0.sql
@@ -2,8 +2,8 @@ INSERT INTO domain_services (id, domain_id, type) VALUES (1, 1, 'unittest');
 
 INSERT INTO domains (id, cluster_id, name, uuid) VALUES (1, 'west', 'germany', 'uuid-for-germany');
 
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (1, 1, 'unittest', NULL, FALSE, 0);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (2, 2, 'unittest', NULL, FALSE, 0);
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (1, 1, 'unittest', NULL, FALSE, 0, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (2, 2, 'unittest', NULL, FALSE, 0, NULL, FALSE, 0, '');
 
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany', FALSE);
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (2, 1, 'dresden', 'uuid-for-dresden', 'uuid-for-berlin', TRUE);

--- a/pkg/collector/fixtures/scrape1.sql
+++ b/pkg/collector/fixtures/scrape1.sql
@@ -7,8 +7,8 @@ INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, su
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'capacity', 10, 0, 100, '', 12, 0);
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'things', 0, 2, 42, '[{"index":0},{"index":1}]', 0, NULL);
 
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (1, 1, 'unittest', 1, FALSE, 1);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (2, 2, 'unittest', 3, FALSE, 1);
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (1, 1, 'unittest', 1, FALSE, 1, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (2, 2, 'unittest', 3, FALSE, 1, NULL, FALSE, 0, '');
 
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany', FALSE);
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (2, 1, 'dresden', 'uuid-for-dresden', 'uuid-for-berlin', TRUE);

--- a/pkg/collector/fixtures/scrape2.sql
+++ b/pkg/collector/fixtures/scrape2.sql
@@ -7,8 +7,8 @@ INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, su
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'capacity', 10, 0, 110, '', 12, 0);
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'things', 0, 5, 42, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 0, NULL);
 
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (1, 1, 'unittest', 6, FALSE, 1);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (2, 2, 'unittest', 8, FALSE, 1);
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (1, 1, 'unittest', 6, FALSE, 1, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (2, 2, 'unittest', 8, FALSE, 1, NULL, FALSE, 0, '');
 
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany', FALSE);
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (2, 1, 'dresden', 'uuid-for-dresden', 'uuid-for-berlin', TRUE);

--- a/pkg/collector/fixtures/scrape3.sql
+++ b/pkg/collector/fixtures/scrape3.sql
@@ -7,8 +7,8 @@ INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, su
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'capacity', 20, 0, 24, '', 24, 0);
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'things', 13, 5, 15, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 15, NULL);
 
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (1, 1, 'unittest', 10, FALSE, 1);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (2, 2, 'unittest', 12, FALSE, 1);
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (1, 1, 'unittest', 10, FALSE, 1, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (2, 2, 'unittest', 12, FALSE, 1, NULL, FALSE, 0, '');
 
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany', FALSE);
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (2, 1, 'dresden', 'uuid-for-dresden', 'uuid-for-berlin', TRUE);

--- a/pkg/collector/fixtures/scrape4.sql
+++ b/pkg/collector/fixtures/scrape4.sql
@@ -7,8 +7,8 @@ INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, su
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'capacity', 20, 0, 24, '', 24, 0);
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'things', 13, 5, 15, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 15, NULL);
 
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (1, 1, 'unittest', 14, FALSE, 1);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (2, 2, 'unittest', 16, FALSE, 1);
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (1, 1, 'unittest', 14, FALSE, 1, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (2, 2, 'unittest', 16, FALSE, 1, NULL, FALSE, 0, '');
 
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany', FALSE);
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (2, 1, 'dresden', 'uuid-for-dresden', 'uuid-for-berlin', TRUE);

--- a/pkg/collector/fixtures/scrape5.sql
+++ b/pkg/collector/fixtures/scrape5.sql
@@ -7,8 +7,8 @@ INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, su
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'capacity', 40, 0, 48, '', 48, 0);
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'things', 13, 5, 15, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 15, NULL);
 
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (1, 1, 'unittest', 18, FALSE, 1);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (2, 2, 'unittest', 20, FALSE, 1);
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (1, 1, 'unittest', 18, FALSE, 1, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (2, 2, 'unittest', 20, FALSE, 1, NULL, FALSE, 0, '');
 
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany', FALSE);
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (2, 1, 'dresden', 'uuid-for-dresden', 'uuid-for-berlin', TRUE);

--- a/pkg/collector/fixtures/scrape6.sql
+++ b/pkg/collector/fixtures/scrape6.sql
@@ -9,8 +9,8 @@ INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, su
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'external_things', 5, 0, 5, '', 5, NULL);
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'things', 13, 5, 15, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 15, NULL);
 
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (1, 1, 'unittest', 22, FALSE, 1);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (2, 2, 'unittest', 24, FALSE, 1);
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (1, 1, 'unittest', 22, FALSE, 1, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (2, 2, 'unittest', 24, FALSE, 1, NULL, FALSE, 0, '');
 
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany', FALSE);
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (2, 1, 'dresden', 'uuid-for-dresden', 'uuid-for-berlin', TRUE);

--- a/pkg/collector/fixtures/scrape7.sql
+++ b/pkg/collector/fixtures/scrape7.sql
@@ -9,8 +9,8 @@ INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, su
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'external_things', 10, 0, 10, '', 10, NULL);
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'things', 13, 5, 15, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 15, NULL);
 
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (1, 1, 'unittest', 26, FALSE, 1);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (2, 2, 'unittest', 28, FALSE, 1);
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (1, 1, 'unittest', 26, FALSE, 1, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (2, 2, 'unittest', 28, FALSE, 1, NULL, FALSE, 0, '');
 
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany', FALSE);
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (2, 1, 'dresden', 'uuid-for-dresden', 'uuid-for-berlin', TRUE);

--- a/pkg/collector/fixtures/scrape8.sql
+++ b/pkg/collector/fixtures/scrape8.sql
@@ -9,8 +9,8 @@ INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, su
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'external_things', 10, 0, 10, '', 10, NULL);
 INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'things', 13, 5, 15, '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]', 15, NULL);
 
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (1, 1, 'unittest', 30, FALSE, 1);
-INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs) VALUES (2, 2, 'unittest', 32, FALSE, 1);
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (1, 1, 'unittest', 30, FALSE, 1, NULL, FALSE, 0, '');
+INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state) VALUES (2, 2, 'unittest', 32, FALSE, 1, NULL, FALSE, 0, '');
 
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany', FALSE);
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (2, 1, 'dresden', 'uuid-for-dresden', 'uuid-for-berlin', TRUE);

--- a/pkg/collector/ratescrape.go
+++ b/pkg/collector/ratescrape.go
@@ -1,0 +1,214 @@
+/*******************************************************************************
+*
+* Copyright 2020 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package collector
+
+import (
+	"database/sql"
+	"math/big"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sapcc/go-bits/logg"
+	"github.com/sapcc/limes/pkg/db"
+	"github.com/sapcc/limes/pkg/util"
+)
+
+//query that finds the next project that needs to have rates scraped
+var findProjectForRateScrapeQuery = db.SimplifyWhitespaceInSQL(`
+	SELECT ps.id, ps.rates_scraped_at, ps.rates_scrape_state, p.name, p.uuid, d.name, d.uuid
+	FROM project_services ps
+	JOIN projects p ON p.id = ps.project_id
+	JOIN domains d ON d.id = p.domain_id
+	-- filter by cluster ID and service type
+	WHERE d.cluster_id = $1 AND ps.type = $2
+	-- filter by need to be updated (because of user request, because of missing data, or because of outdated data)
+	AND (ps.stale OR ps.rates_scraped_at IS NULL OR ps.rates_scraped_at < $3)
+	-- order by update priority (in the same way: first user-requested, then new projects, then outdated projects, then ID for deterministic test behavior)
+	ORDER BY ps.rates_stale DESC, COALESCE(ps.rates_scraped_at, to_timestamp(-1)) ASC, ps.id ASC
+	-- find only one project to scrape per iteration
+	LIMIT 1
+`)
+
+//ScrapeRates checks the database periodically for outdated or missing rate
+//records for the given cluster and the given service type, and updates them by
+//querying the backend service.
+//
+//Errors are logged instead of returned. The function will not return unless
+//startup fails.
+func (c *Collector) ScrapeRates() {
+	serviceInfo := c.Plugin.ServiceInfo()
+	serviceType := serviceInfo.Type
+
+	//make sure that the counters are reported
+	labels := prometheus.Labels{
+		"os_cluster":   c.Cluster.ID,
+		"service":      serviceType,
+		"service_name": serviceInfo.ProductName,
+	}
+	ratesScrapeSuccessCounter.With(labels).Add(0)
+	ratesScrapeFailedCounter.With(labels).Add(0)
+	ratesScrapeSuspendedCounter.With(labels).Add(0)
+
+	for {
+		var (
+			serviceID               int64
+			serviceRatesScrapedAt   *time.Time
+			serviceRatesScrapeState string
+			projectName             string
+			projectUUID             string
+			domainName              string
+			domainUUID              string
+		)
+		scrapeStartedAt := c.TimeNow()
+		err := db.DB.QueryRow(findProjectForResourceScrapeQuery, c.Cluster.ID, serviceType, scrapeStartedAt.Add(-scrapeInterval)).
+			Scan(&serviceID, &serviceRatesScrapedAt, &serviceRatesScrapeState, &projectName, &projectUUID, &domainName, &domainUUID)
+		if err != nil {
+			//ErrNoRows is okay; it just means that nothing needs scraping right now
+			if err != sql.ErrNoRows {
+				c.LogError("cannot select next project for which to scrape %s rate data: %s", serviceType, err.Error())
+			}
+			if c.Once {
+				return
+			}
+			time.Sleep(idleInterval)
+			continue
+		}
+
+		logg.Debug("scraping %s rates for %s/%s", serviceType, domainName, projectName)
+		provider, eo := c.Cluster.ProviderClientForService(serviceType)
+		rateData, serviceRatesScrapeState, err := c.Plugin.ScrapeRates(provider, eo, c.Cluster.ID, domainUUID, projectUUID, serviceRatesScrapeState)
+		if err != nil {
+			ratesScrapeFailedCounter.With(labels).Inc()
+			//special case: stop scraping for a while when the backend service is not
+			//yet registered in the catalog (this prevents log spamming during buildup)
+			sleepInterval := idleInterval
+			if _, ok := err.(*gophercloud.ErrEndpointNotFound); ok {
+				sleepInterval = serviceNotDeployedIdleInterval
+				c.LogError("suspending %s rate scraping for %d minutes: %s", serviceType, sleepInterval/time.Minute, err.Error())
+				ratesScrapeSuspendedCounter.With(labels).Inc()
+			} else {
+				c.LogError("scrape %s rate data for %s/%s failed: %s", serviceType, domainName, projectName, util.ErrorToString(err))
+			}
+
+			if c.Once {
+				return
+			}
+			time.Sleep(sleepInterval)
+			continue
+		}
+
+		scrapeEndedAt := c.TimeNow()
+		err = c.writeRateScrapeResult(domainName, projectName, serviceType, serviceID, rateData, serviceRatesScrapeState, scrapeEndedAt, scrapeEndedAt.Sub(scrapeStartedAt))
+		if err != nil {
+			c.LogError("write %s rate data for %s/%s failed: %s", serviceType, domainName, projectName, err.Error())
+			ratesScrapeFailedCounter.With(labels).Inc()
+			if c.Once {
+				return
+			}
+			time.Sleep(idleInterval)
+			continue
+		}
+
+		ratesScrapeSuccessCounter.With(labels).Inc()
+		if c.Once {
+			break
+		}
+		//If no error occurred, continue with the next project immediately, so as
+		//to finish scraping as fast as possible when there are multiple projects
+		//to scrape at once.
+	}
+}
+
+func (c *Collector) writeRateScrapeResult(domainName, projectName, serviceType string, serviceID int64, rateData map[string]*big.Int, serviceRatesScrapeState string, scrapedAt time.Time, scrapeDuration time.Duration) error {
+	tx, err := db.DB.Begin()
+	if err != nil {
+		return err
+	}
+	defer db.RollbackUnlessCommitted(tx)
+
+	//update existing project_rates entries
+	rateExists := make(map[string]bool)
+	var rates []db.ProjectRate
+	_, err = tx.Select(&rates, `SELECT * FROM project_rates WHERE service_id = $1`, serviceID)
+	if err != nil {
+		return err
+	}
+
+	if len(rates) > 0 {
+		stmt, err := tx.Prepare(`UPDATE project_rates SET usage_as_bigint = $1 WHERE service_id = $2 AND name = $3`)
+		if err != nil {
+			return err
+		}
+
+		for _, rate := range rates {
+			rateExists[rate.Name] = true
+
+			usageData, exists := rateData[rate.Name]
+			if !exists {
+				c.LogError(
+					"could not scrape new data for rate %s in project service %d (was this rate type removed from the scraper plugin?)",
+					rate.Name, serviceID,
+				)
+				continue
+			}
+			usageAsBigint := usageData.String()
+			if usageAsBigint != rate.UsageAsBigint {
+				_, err := stmt.Exec(usageAsBigint, serviceID, rate.Name)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	//insert missing project_rates entries
+	for _, rateMetadata := range c.Plugin.Rates() {
+		if _, exists := rateExists[rateMetadata.Name]; exists {
+			continue
+		}
+		usageData := rateData[rateMetadata.Name]
+
+		rate := &db.ProjectRate{
+			ServiceID: serviceID,
+			Name:      rateMetadata.Name,
+		}
+		if usageData != nil {
+			rate.UsageAsBigint = usageData.String()
+		}
+
+		err = tx.Insert(rate)
+		if err != nil {
+			return err
+		}
+	}
+
+	//update rate scraping metadata and also reset the rates_stale flag on this
+	//service so that we don't scrape it again immediately afterwards
+	_, err = tx.Exec(
+		`UPDATE project_services SET rates_scraped_at = $1, rates_scrape_duration_secs = $2, rates_scrape_state = $3, rates_stale = $4 WHERE id = $5`,
+		scrapedAt, scrapeDuration.Seconds(), serviceRatesScrapeState, false, serviceID,
+	)
+	if err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}

--- a/pkg/collector/scrape_test.go
+++ b/pkg/collector/scrape_test.go
@@ -22,6 +22,7 @@ package collector
 import (
 	"errors"
 	"fmt"
+	"math/big"
 	"regexp"
 	"sort"
 	"testing"
@@ -258,7 +259,7 @@ func Test_ScrapeFailure(t *testing.T) {
 		Once:    true,
 	}
 	//we will see an expected ERROR during testing, do not make the test fail because of this
-	expectedErrorRx := regexp.MustCompile(`^scrape unittest data for germany/(berlin|dresden) failed: Scrape failed as requested$`)
+	expectedErrorRx := regexp.MustCompile(`^scrape unittest resources for germany/(berlin|dresden) failed: Scrape failed as requested$`)
 	c.LogError = func(msg string, args ...interface{}) {
 		msg = fmt.Sprintf(msg, args...)
 		if expectedErrorRx.MatchString(msg) {
@@ -333,6 +334,9 @@ func (p *autoApprovalTestPlugin) Resources() []limes.ResourceInfo {
 func (p *autoApprovalTestPlugin) Rates() []limes.RateInfo {
 	return nil
 }
+func (p *autoApprovalTestPlugin) ScrapeRates(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string, prevSerializedState string) (map[string]*big.Int, string, error) {
+	return nil, "", nil
+}
 
 func (p *autoApprovalTestPlugin) Scrape(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string) (map[string]core.ResourceData, error) {
 	return map[string]core.ResourceData{
@@ -368,4 +372,47 @@ func Test_AutoApproveInitialQuota(t *testing.T) {
 	setProjectServicesStale(t)
 	c.Scrape()
 	test.AssertDBContent(t, "fixtures/scrape-autoapprove2.sql")
+}
+
+//A quota plugin with absolutely no resources and rates.
+type noopQuotaPlugin struct{}
+
+func (noopQuotaPlugin) Init(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) error {
+	return nil
+}
+func (noopQuotaPlugin) ServiceInfo() limes.ServiceInfo {
+	return limes.ServiceInfo{Type: "noop"}
+}
+func (noopQuotaPlugin) Resources() []limes.ResourceInfo {
+	return nil
+}
+func (noopQuotaPlugin) Scrape(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string) (map[string]core.ResourceData, error) {
+	return nil, nil
+}
+func (noopQuotaPlugin) SetQuota(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string, quotas map[string]uint64) error {
+	return nil
+}
+func (noopQuotaPlugin) Rates() []limes.RateInfo {
+	return nil
+}
+func (noopQuotaPlugin) ScrapeRates(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string, prevSerializedState string) (result map[string]*big.Int, serializedState string, err error) {
+	return nil, "", nil
+}
+
+func Test_ScrapeButNoResources(t *testing.T) {
+	plugin := noopQuotaPlugin{}
+	cluster := prepareScrapeTest(t, 1, plugin)
+	c := Collector{
+		Cluster:  cluster,
+		Plugin:   plugin,
+		LogError: t.Errorf,
+		TimeNow:  test.TimeNow,
+		Once:     true,
+	}
+
+	//check that Scrape() behaves properly when encountering a quota plugin with
+	//no Resources() (in the wild, this can happen because some quota plugins
+	//only have Rates())
+	c.Scrape()
+	test.AssertDBContent(t, "fixtures/scrape-no-resources.sql")
 }

--- a/pkg/collector/scrape_test.go
+++ b/pkg/collector/scrape_test.go
@@ -330,6 +330,10 @@ func (p *autoApprovalTestPlugin) Resources() []limes.ResourceInfo {
 	}
 }
 
+func (p *autoApprovalTestPlugin) Rates() []limes.RateInfo {
+	return nil
+}
+
 func (p *autoApprovalTestPlugin) Scrape(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string) (map[string]core.ResourceData, error) {
 	return map[string]core.ResourceData{
 		"approve":   {Usage: 0, Quota: int64(p.StaticBackendQuota)},

--- a/pkg/core/constraints_test.go
+++ b/pkg/core/constraints_test.go
@@ -166,6 +166,9 @@ func (p quotaConstraintTestPlugin) Init(client *gophercloud.ProviderClient, eo g
 func (p quotaConstraintTestPlugin) ServiceInfo() limes.ServiceInfo {
 	return limes.ServiceInfo{Type: p.ServiceType}
 }
+func (p quotaConstraintTestPlugin) Rates() []limes.RateInfo {
+	return nil
+}
 func (p quotaConstraintTestPlugin) Scrape(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string) (map[string]ResourceData, error) {
 	return nil, nil
 }

--- a/pkg/core/constraints_test.go
+++ b/pkg/core/constraints_test.go
@@ -21,6 +21,7 @@ package core
 
 import (
 	"encoding/json"
+	"math/big"
 	"reflect"
 	"testing"
 
@@ -174,6 +175,9 @@ func (p quotaConstraintTestPlugin) Scrape(client *gophercloud.ProviderClient, eo
 }
 func (p quotaConstraintTestPlugin) SetQuota(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string, quotas map[string]uint64) error {
 	return nil
+}
+func (p quotaConstraintTestPlugin) ScrapeRates(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string, prevSerializedState string) (result map[string]*big.Int, serializedState string, err error) {
+	return nil, "", nil
 }
 
 func (p quotaConstraintTestPlugin) Resources() []limes.ResourceInfo {

--- a/pkg/core/plugin.go
+++ b/pkg/core/plugin.go
@@ -74,6 +74,9 @@ type QuotaPlugin interface {
 	//Resources returns metadata for all the resources that this plugin scrapes
 	//from the backend service.
 	Resources() []limes.ResourceInfo
+	//Rates returns metadata for all the rates that this plugin scrapes
+	//from the backend service.
+	Rates() []limes.RateInfo
 	//Scrape queries the backend service for the quota and usage data of all
 	//known resources for the given project in the given domain. The string keys
 	//in the result map must be identical to the resource names

--- a/pkg/db/migrations.go
+++ b/pkg/db/migrations.go
@@ -204,4 +204,16 @@ var SQLMigrations = map[string]string{
 			PRIMARY KEY (service_id, name)
 		);
 	`,
+	"015_rate_scraping.down.sql": `
+		ALTER TABLE project_services DROP COLUMN rates_scraped_at;
+		ALTER TABLE project_services DROP COLUMN rates_stale;
+		ALTER TABLE project_services DROP COLUMN rates_scrape_duration_secs;
+		ALTER TABLE project_services DROP COLUMN rates_scrape_state;
+	`,
+	"015_rate_scraping.up.sql": `
+		ALTER TABLE project_services ADD COLUMN rates_scraped_at TIMESTAMP; -- defaults to NULL to indicate that scraping did not happen yet
+		ALTER TABLE project_services ADD COLUMN rates_stale BOOLEAN NOT NULL DEFAULT FALSE;
+		ALTER TABLE project_services ADD COLUMN rates_scrape_duration_secs REAL NOT NULL DEFAULT 0;
+		ALTER TABLE project_services ADD COLUMN rates_scrape_state TEXT NOT NULL DEFAULT '';
+	`,
 }

--- a/pkg/db/migrations.go
+++ b/pkg/db/migrations.go
@@ -1,6 +1,6 @@
 /*******************************************************************************
 *
-* Copyright 2017-2018 SAP SE
+* Copyright 2017-2020 SAP SE
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -181,5 +181,27 @@ var SQLMigrations = map[string]string{
 	`,
 	"013_remove_cluster_resource_comment.up.sql": `
 		ALTER TABLE cluster_resources DROP COLUMN comment;
+	`,
+	"014_restructure_project_rate_limits.down.sql": `
+		DROP TABLE project_rates;
+		CREATE TABLE project_rate_limits (
+			service_id      BIGINT NOT NULL REFERENCES project_services ON DELETE CASCADE,
+			target_type_uri TEXT   NOT NULL,
+			action          TEXT   NOT NULL,
+			rate_limit      BIGINT NOT NULL,
+			unit            TEXT   NOT NULL,
+			PRIMARY KEY (service_id, target_type_uri, action)
+		);
+	`,
+	"014_restructure_project_rate_limits.up.sql": `
+		DROP TABLE project_rate_limits;
+		CREATE TABLE project_rates (
+			service_id      BIGINT NOT NULL REFERENCES project_services ON DELETE CASCADE,
+			name            TEXT   NOT NULL,
+			rate_limit      BIGINT DEFAULT NULL,        -- null = not rate-limited
+			window_ns       BIGINT DEFAULT NULL,        -- null = not rate-limited, unit = nanoseconds
+			usage_as_bigint TEXT   NOT NULL DEFAULT '', -- empty = not scraped
+			PRIMARY KEY (service_id, name)
+		);
 	`,
 }

--- a/pkg/db/models.go
+++ b/pkg/db/models.go
@@ -76,12 +76,16 @@ type Project struct {
 
 //ProjectService contains a record from the `project_services` table.
 type ProjectService struct {
-	ID                 int64      `db:"id"`
-	ProjectID          int64      `db:"project_id"`
-	Type               string     `db:"type"`
-	ScrapedAt          *time.Time `db:"scraped_at"` //pointer type to allow for NULL value
-	Stale              bool       `db:"stale"`
-	ScrapeDurationSecs float64    `db:"scrape_duration_secs"`
+	ID                      int64      `db:"id"`
+	ProjectID               int64      `db:"project_id"`
+	Type                    string     `db:"type"`
+	ScrapedAt               *time.Time `db:"scraped_at"` //pointer type to allow for NULL value
+	Stale                   bool       `db:"stale"`
+	ScrapeDurationSecs      float64    `db:"scrape_duration_secs"`
+	RatesScrapedAt          *time.Time `db:"rates_scraped_at"` //same as above
+	RatesStale              bool       `db:"rates_stale"`
+	RatesScrapeDurationSecs float64    `db:"rates_scrape_duration_secs"`
+	RatesScrapeState        string     `db:"rates_scrape_state"`
 }
 
 //ProjectResource contains a record from the `project_resources` table.

--- a/pkg/plugins/cfm.go
+++ b/pkg/plugins/cfm.go
@@ -68,6 +68,11 @@ func (p *cfmPlugin) Resources() []limes.ResourceInfo {
 	}}
 }
 
+//Rates implements the core.QuotaPlugin interface.
+func (p *cfmPlugin) Rates() []limes.RateInfo {
+	return nil
+}
+
 //Scrape implements the core.QuotaPlugin interface.
 func (p *cfmPlugin) Scrape(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string) (map[string]core.ResourceData, error) {
 	client, err := newCFMClient(provider, eo, p.projectID)

--- a/pkg/plugins/cfm.go
+++ b/pkg/plugins/cfm.go
@@ -21,6 +21,7 @@ package plugins
 
 import (
 	"errors"
+	"math/big"
 	"time"
 
 	"github.com/gophercloud/gophercloud"
@@ -71,6 +72,11 @@ func (p *cfmPlugin) Resources() []limes.ResourceInfo {
 //Rates implements the core.QuotaPlugin interface.
 func (p *cfmPlugin) Rates() []limes.RateInfo {
 	return nil
+}
+
+//ScrapeRates implements the core.QuotaPlugin interface.
+func (p *cfmPlugin) ScrapeRates(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string, prevSerializedState string) (result map[string]*big.Int, serializedState string, err error) {
+	return nil, "", nil
 }
 
 //Scrape implements the core.QuotaPlugin interface.

--- a/pkg/plugins/cinder.go
+++ b/pkg/plugins/cinder.go
@@ -22,6 +22,7 @@ package plugins
 import (
 	"encoding/json"
 	"errors"
+	"math/big"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
@@ -130,6 +131,11 @@ func (f quotaSetField) ToResourceData(subresources []interface{}) core.ResourceD
 		Usage:        f.Usage,
 		Subresources: subresources,
 	}
+}
+
+//ScrapeRates implements the core.QuotaPlugin interface.
+func (p *cinderPlugin) ScrapeRates(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string, prevSerializedState string) (result map[string]*big.Int, serializedState string, err error) {
+	return nil, "", nil
 }
 
 //Scrape implements the core.QuotaPlugin interface.

--- a/pkg/plugins/cinder.go
+++ b/pkg/plugins/cinder.go
@@ -88,6 +88,11 @@ func (p *cinderPlugin) Resources() []limes.ResourceInfo {
 	return result
 }
 
+//Rates implements the core.QuotaPlugin interface.
+func (p *cinderPlugin) Rates() []limes.RateInfo {
+	return nil
+}
+
 func (p *cinderPlugin) makeResourceName(kind, volumeType string) string {
 	if p.cfg.VolumeV2.VolumeTypes[0] == volumeType {
 		//the resources for the first volume type don't get the volume type suffix

--- a/pkg/plugins/designate.go
+++ b/pkg/plugins/designate.go
@@ -69,6 +69,11 @@ func (p *designatePlugin) Resources() []limes.ResourceInfo {
 	return designateResources
 }
 
+//Rates implements the core.QuotaPlugin interface.
+func (p *designatePlugin) Rates() []limes.RateInfo {
+	return nil
+}
+
 //Scrape implements the core.QuotaPlugin interface.
 func (p *designatePlugin) Scrape(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string) (map[string]core.ResourceData, error) {
 	client, err := openstack.NewDNSV2(provider, eo)

--- a/pkg/plugins/designate.go
+++ b/pkg/plugins/designate.go
@@ -20,6 +20,8 @@
 package plugins
 
 import (
+	"math/big"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/dns/v2/zones"
@@ -72,6 +74,11 @@ func (p *designatePlugin) Resources() []limes.ResourceInfo {
 //Rates implements the core.QuotaPlugin interface.
 func (p *designatePlugin) Rates() []limes.RateInfo {
 	return nil
+}
+
+//ScrapeRates implements the core.QuotaPlugin interface.
+func (p *designatePlugin) ScrapeRates(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string, prevSerializedState string) (result map[string]*big.Int, serializedState string, err error) {
+	return nil, "", nil
 }
 
 //Scrape implements the core.QuotaPlugin interface.

--- a/pkg/plugins/keppel.go
+++ b/pkg/plugins/keppel.go
@@ -62,6 +62,11 @@ func (p *keppelPlugin) Resources() []limes.ResourceInfo {
 	return keppelResources
 }
 
+//Rates implements the core.QuotaPlugin interface.
+func (p *keppelPlugin) Rates() []limes.RateInfo {
+	return nil
+}
+
 //Scrape implements the core.QuotaPlugin interface.
 func (p *keppelPlugin) Scrape(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string) (map[string]core.ResourceData, error) {
 	client, err := newKeppelClient(provider, eo)

--- a/pkg/plugins/keppel.go
+++ b/pkg/plugins/keppel.go
@@ -19,6 +19,7 @@
 package plugins
 
 import (
+	"math/big"
 	"net/http"
 
 	"github.com/gophercloud/gophercloud"
@@ -65,6 +66,11 @@ func (p *keppelPlugin) Resources() []limes.ResourceInfo {
 //Rates implements the core.QuotaPlugin interface.
 func (p *keppelPlugin) Rates() []limes.RateInfo {
 	return nil
+}
+
+//ScrapeRates implements the core.QuotaPlugin interface.
+func (p *keppelPlugin) ScrapeRates(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string, prevSerializedState string) (result map[string]*big.Int, serializedState string, err error) {
+	return nil, "", nil
 }
 
 //Scrape implements the core.QuotaPlugin interface.

--- a/pkg/plugins/manila.go
+++ b/pkg/plugins/manila.go
@@ -95,6 +95,11 @@ func (p *manilaPlugin) Resources() []limes.ResourceInfo {
 	return result
 }
 
+//Rates implements the core.QuotaPlugin interface.
+func (p *manilaPlugin) Rates() []limes.RateInfo {
+	return nil
+}
+
 func (p *manilaPlugin) makeResourceName(kind, shareType string) string {
 	if p.cfg.ShareV2.ShareTypes[0] == shareType {
 		//the resources for the first share type don't get the share type suffix

--- a/pkg/plugins/manila.go
+++ b/pkg/plugins/manila.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"math/big"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
@@ -124,6 +125,11 @@ type manilaQuotaSet struct {
 	SnapshotGigabytes int64  `json:"snapshot_gigabytes"`
 	Snapshots         int64  `json:"snapshots"`
 	ShareNetworks     *int64 `json:"share_networks,omitempty"`
+}
+
+//ScrapeRates implements the core.QuotaPlugin interface.
+func (p *manilaPlugin) ScrapeRates(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string, prevSerializedState string) (result map[string]*big.Int, serializedState string, err error) {
+	return nil, "", nil
 }
 
 //Scrape implements the core.QuotaPlugin interface.

--- a/pkg/plugins/neutron.go
+++ b/pkg/plugins/neutron.go
@@ -21,6 +21,7 @@ package plugins
 
 import (
 	"fmt"
+	"math/big"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
@@ -267,6 +268,11 @@ var neutronResourceMeta = []neutronResourceMetadata{
 type neutronQueryOpts struct {
 	Fields      string `q:"fields"`
 	ProjectUUID string `q:"tenant_id"`
+}
+
+//ScrapeRates implements the core.QuotaPlugin interface.
+func (p *neutronPlugin) ScrapeRates(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string, prevSerializedState string) (result map[string]*big.Int, serializedState string, err error) {
+	return nil, "", nil
 }
 
 //Scrape implements the core.QuotaPlugin interface.

--- a/pkg/plugins/neutron.go
+++ b/pkg/plugins/neutron.go
@@ -21,6 +21,7 @@ package plugins
 
 import (
 	"fmt"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/common/extensions"
@@ -174,6 +175,11 @@ func (p *neutronPlugin) ServiceInfo() limes.ServiceInfo {
 //Resources implements the core.QuotaPlugin interface.
 func (p *neutronPlugin) Resources() []limes.ResourceInfo {
 	return p.resources
+}
+
+//Rates implements the core.QuotaPlugin interface.
+func (p *neutronPlugin) Rates() []limes.RateInfo {
+	return nil
 }
 
 type neutronResourceMetadata struct {

--- a/pkg/plugins/nova.go
+++ b/pkg/plugins/nova.go
@@ -22,6 +22,7 @@ package plugins
 import (
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"regexp"
 	"sort"
 	"strconv"
@@ -194,6 +195,11 @@ func (p *novaPlugin) Resources() []limes.ResourceInfo {
 //Rates implements the core.QuotaPlugin interface.
 func (p *novaPlugin) Rates() []limes.RateInfo {
 	return nil
+}
+
+//ScrapeRates implements the core.QuotaPlugin interface.
+func (p *novaPlugin) ScrapeRates(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string, prevSerializedState string) (result map[string]*big.Int, serializedState string, err error) {
+	return nil, "", nil
 }
 
 //Scrape implements the core.QuotaPlugin interface.

--- a/pkg/plugins/nova.go
+++ b/pkg/plugins/nova.go
@@ -191,6 +191,11 @@ func (p *novaPlugin) Resources() []limes.ResourceInfo {
 	return p.resources
 }
 
+//Rates implements the core.QuotaPlugin interface.
+func (p *novaPlugin) Rates() []limes.RateInfo {
+	return nil
+}
+
 //Scrape implements the core.QuotaPlugin interface.
 func (p *novaPlugin) Scrape(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string) (map[string]core.ResourceData, error) {
 	client, err := openstack.NewComputeV2(provider, eo)

--- a/pkg/plugins/swift.go
+++ b/pkg/plugins/swift.go
@@ -78,6 +78,11 @@ func (p *swiftPlugin) Resources() []limes.ResourceInfo {
 	return swiftResources
 }
 
+//Rates implements the core.QuotaPlugin interface.
+func (p *swiftPlugin) Rates() []limes.RateInfo {
+	return nil
+}
+
 func (p *swiftPlugin) Account(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, projectUUID string) (*schwift.Account, error) {
 	client, err := openstack.NewObjectStorageV1(provider, eo)
 	if err != nil {

--- a/pkg/plugins/swift.go
+++ b/pkg/plugins/swift.go
@@ -20,6 +20,7 @@
 package plugins
 
 import (
+	"math/big"
 	"net/http"
 
 	"github.com/gophercloud/gophercloud"
@@ -94,6 +95,11 @@ func (p *swiftPlugin) Account(provider *gophercloud.ProviderClient, eo gopherclo
 	}
 	//TODO Make Auth prefix configurable
 	return resellerAccount.SwitchAccount("AUTH_" + projectUUID), nil
+}
+
+//ScrapeRates implements the core.QuotaPlugin interface.
+func (p *swiftPlugin) ScrapeRates(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string, prevSerializedState string) (result map[string]*big.Int, serializedState string, err error) {
+	return nil, "", nil
 }
 
 //Scrape implements the core.QuotaPlugin interface.

--- a/pkg/reports/cluster.go
+++ b/pkg/reports/cluster.go
@@ -421,27 +421,13 @@ func GetClusters(config core.Configuration, clusterID *string, dbi db.Interface,
 				if _, serviceReport, _ := clusters.Find(config, *clusterID, &serviceConfig.Type, nil); serviceReport != nil {
 					serviceReport.Rates = limes.ClusterRateLimitReports{}
 
-					for _, configuredRateLimit := range serviceConfig.Rates.Global {
-						rl, exists := serviceReport.Rates[configuredRateLimit.TargetTypeURI]
-						if !exists {
-							rl = &limes.ClusterRateLimitReport{
-								TargetTypeURI: configuredRateLimit.TargetTypeURI,
-								Actions:       make(limes.ClusterRateLimitActionReports),
-							}
+					for _, rateCfg := range serviceConfig.RateLimits.Global {
+						serviceReport.Rates[rateCfg.Name] = &limes.ClusterRateLimitReport{
+							Name:   rateCfg.Name,
+							Unit:   rateCfg.Unit,
+							Limit:  rateCfg.Limit,
+							Window: rateCfg.Window,
 						}
-
-						for _, configuredAction := range configuredRateLimit.Actions {
-							act, exists := rl.Actions[configuredAction.Name]
-							if !exists {
-								act = &limes.ClusterRateLimitActionReport{
-									Name: configuredAction.Name,
-								}
-							}
-							act.Limit = configuredAction.Limit
-							act.Unit = limes.Unit(configuredAction.Unit)
-							rl.Actions[act.Name] = act
-						}
-						serviceReport.Rates[rl.TargetTypeURI] = rl
 					}
 				}
 			}

--- a/pkg/reports/cluster.go
+++ b/pkg/reports/cluster.go
@@ -423,8 +423,10 @@ func GetClusters(config core.Configuration, clusterID *string, dbi db.Interface,
 
 					for _, rateCfg := range serviceConfig.RateLimits.Global {
 						serviceReport.Rates[rateCfg.Name] = &limes.ClusterRateLimitReport{
-							Name:   rateCfg.Name,
-							Unit:   rateCfg.Unit,
+							RateInfo: limes.RateInfo{
+								Name: rateCfg.Name,
+								Unit: rateCfg.Unit,
+							},
 							Limit:  rateCfg.Limit,
 							Window: rateCfg.Window,
 						}

--- a/pkg/reports/domain.go
+++ b/pkg/reports/domain.go
@@ -35,7 +35,8 @@ var domainReportQuery1 = db.SimplifyWhitespaceInSQL(`
 	       SUM(GREATEST(pr.usage - pr.quota, 0)),
 	       SUM(GREATEST(pr.backend_quota, 0)), MIN(pr.backend_quota) < 0,
 	       SUM(COALESCE(pr.physical_usage, pr.usage)), COUNT(pr.physical_usage) > 0,
-	       MIN(ps.scraped_at), MAX(ps.scraped_at)
+	       MIN(ps.scraped_at), MAX(ps.scraped_at),
+	       MIN(ps.rates_scraped_at), MAX(ps.rates_scraped_at)
 	  FROM domains d
 	  JOIN projects p ON p.domain_id = d.id
 	  LEFT OUTER JOIN project_services ps ON ps.project_id = p.id {{AND ps.type = $service_type}}
@@ -80,6 +81,8 @@ func GetDomains(cluster *core.Cluster, domainID *int64, dbi db.Interface, filter
 			showPhysicalUsage    *bool
 			minScrapedAt         *time.Time
 			maxScrapedAt         *time.Time
+			minRatesScrapedAt    *time.Time
+			maxRatesScrapedAt    *time.Time
 		)
 		err := rows.Scan(
 			&domainUUID, &domainName, &serviceType, &resourceName,
@@ -87,6 +90,7 @@ func GetDomains(cluster *core.Cluster, domainID *int64, dbi db.Interface, filter
 			&backendQuota, &infiniteBackendQuota,
 			&physicalUsage, &showPhysicalUsage,
 			&minScrapedAt, &maxScrapedAt,
+			&minRatesScrapedAt, &maxRatesScrapedAt,
 		)
 		if err != nil {
 			return err
@@ -105,6 +109,18 @@ func GetDomains(cluster *core.Cluster, domainID *int64, dbi db.Interface, filter
 				val := time.Time(*minScrapedAt).Unix()
 				if service.MinScrapedAt == nil || *service.MinScrapedAt > val {
 					service.MinScrapedAt = &val
+				}
+			}
+			if maxRatesScrapedAt != nil {
+				val := time.Time(*maxRatesScrapedAt).Unix()
+				if service.MaxRatesScrapedAt == nil || *service.MaxRatesScrapedAt < val {
+					service.MaxRatesScrapedAt = &val
+				}
+			}
+			if minRatesScrapedAt != nil {
+				val := time.Time(*minRatesScrapedAt).Unix()
+				if service.MinRatesScrapedAt == nil || *service.MinRatesScrapedAt > val {
+					service.MinRatesScrapedAt = &val
 				}
 			}
 		}

--- a/pkg/reports/inconsistency.go
+++ b/pkg/reports/inconsistency.go
@@ -103,7 +103,7 @@ var ocdqReportQuery = db.SimplifyWhitespaceInSQL(`
 	  LEFT OUTER JOIN domain_resources dr ON dr.service_id = ds.id AND dr.name = pr.name
 	WHERE %s GROUP BY d.uuid, d.name, ps.type, pr.name
 	HAVING MAX(COALESCE(dr.quota, 0)) < SUM(pr.quota)
-	ORDER BY d.uuid ASC;
+	ORDER BY d.name, ps.type, pr.name
 `)
 
 var ospqReportQuery = db.SimplifyWhitespaceInSQL(`
@@ -114,7 +114,7 @@ var ospqReportQuery = db.SimplifyWhitespaceInSQL(`
 	  LEFT OUTER JOIN project_resources pr ON pr.service_id = ps.id {{AND pr.name = $resource_name}}
 	WHERE %s GROUP BY d.uuid, d.name, p.uuid, p.name, ps.type, pr.name
 	HAVING SUM(pr.usage) > SUM(pr.desired_backend_quota)
-	ORDER BY p.uuid ASC
+	ORDER BY d.name, p.name, ps.type, pr.name
 `)
 
 var mmpqReportQuery = db.SimplifyWhitespaceInSQL(`
@@ -125,7 +125,7 @@ var mmpqReportQuery = db.SimplifyWhitespaceInSQL(`
 	  LEFT OUTER JOIN project_resources pr ON pr.service_id = ps.id {{AND pr.name = $resource_name}}
 	WHERE %s GROUP BY d.uuid, d.name, p.uuid, p.name, ps.type, pr.name
 	HAVING SUM(pr.backend_quota) != SUM(pr.desired_backend_quota)
-	ORDER BY p.uuid ASC
+	ORDER BY d.name, p.name, ps.type, pr.name
 `)
 
 //GetInconsistencies returns Inconsistency reports for all inconsistencies and their projects in the current cluster.

--- a/pkg/test/plugin.go
+++ b/pkg/test/plugin.go
@@ -31,6 +31,7 @@ import (
 //Plugin is a core.QuotaPlugin implementation for unit tests.
 type Plugin struct {
 	StaticServiceType  string
+	StaticRateInfos    []limes.RateInfo
 	StaticResourceData map[string]*core.ResourceData
 	StaticCapacity     map[string]uint64
 	OverrideQuota      map[string]map[string]uint64
@@ -52,9 +53,10 @@ var resources = []limes.ResourceInfo{
 }
 
 //NewPlugin creates a new Plugin for the given service type.
-func NewPlugin(serviceType string) *Plugin {
+func NewPlugin(serviceType string, rates ...limes.RateInfo) *Plugin {
 	return &Plugin{
 		StaticServiceType: serviceType,
+		StaticRateInfos:   rates,
 		StaticResourceData: map[string]*core.ResourceData{
 			"things":          {Quota: 42, Usage: 2},
 			"capacity":        {Quota: 100, Usage: 0},
@@ -96,6 +98,11 @@ func (p *Plugin) Resources() []limes.ResourceInfo {
 		})
 	}
 	return result
+}
+
+//Rates implements the core.QuotaPlugin interface.
+func (p *Plugin) Rates() []limes.RateInfo {
+	return p.StaticRateInfos
 }
 
 //Scrape implements the core.QuotaPlugin interface.

--- a/pkg/test/plugin.go
+++ b/pkg/test/plugin.go
@@ -21,6 +21,7 @@ package test
 
 import (
 	"errors"
+	"math/big"
 	"strings"
 
 	"github.com/gophercloud/gophercloud"
@@ -103,6 +104,16 @@ func (p *Plugin) Resources() []limes.ResourceInfo {
 //Rates implements the core.QuotaPlugin interface.
 func (p *Plugin) Rates() []limes.RateInfo {
 	return p.StaticRateInfos
+}
+
+//ScrapeRates implements the core.QuotaPlugin interface.
+func (p *Plugin) ScrapeRates(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clusterID, domainUUID, projectUUID string, prevSerializedState string) (result map[string]*big.Int, serializedState string, err error) {
+	if p.ScrapeFails {
+		return nil, "", errors.New("ScrapeRates failed as requested")
+	}
+
+	//TODO
+	return nil, "", nil
 }
 
 //Scrape implements the core.QuotaPlugin interface.

--- a/report_cluster.go
+++ b/report_cluster.go
@@ -37,11 +37,13 @@ type ClusterReport struct {
 //a single backend service.
 type ClusterServiceReport struct {
 	ServiceInfo
-	Shared       bool                    `json:"shared,omitempty"`
-	Resources    ClusterResourceReports  `json:"resources,keepempty"`
-	Rates        ClusterRateLimitReports `json:"rates,omitempty"`
-	MaxScrapedAt *int64                  `json:"max_scraped_at,omitempty"`
-	MinScrapedAt *int64                  `json:"min_scraped_at,omitempty"`
+	Shared            bool                    `json:"shared,omitempty"`
+	Resources         ClusterResourceReports  `json:"resources,keepempty"`
+	Rates             ClusterRateLimitReports `json:"rates,omitempty"`
+	MaxScrapedAt      *int64                  `json:"max_scraped_at,omitempty"`
+	MinScrapedAt      *int64                  `json:"min_scraped_at,omitempty"`
+	MaxRatesScrapedAt *int64                  `json:"max_rates_scraped_at,omitempty"`
+	MinRatesScrapedAt *int64                  `json:"min_rates_scraped_at,omitempty"`
 }
 
 //ClusterResourceReport is a substructure of ClusterReport containing data for

--- a/report_cluster.go
+++ b/report_cluster.go
@@ -69,15 +69,10 @@ type ClusterAvailabilityZoneReport struct {
 
 // ClusterRateLimitReport is the structure for rate limits per target type URI and their rate limited actions.
 type ClusterRateLimitReport struct {
-	TargetTypeURI string                        `json:"target_type_uri,keepempty"`
-	Actions       ClusterRateLimitActionReports `json:"actions,keepempty"`
-}
-
-// ClusterRateLimitActionReport defines an action and its rate limit.
-type ClusterRateLimitActionReport struct {
-	Name  string `json:"name,keepempty"`
-	Limit uint64 `json:"limit,keepempty"`
-	Unit  Unit   `json:"unit,keepempty"`
+	Name   string `json:"name,keepempty"`
+	Unit   Unit   `json:"unit,omitempty"`
+	Limit  uint64 `json:"limit,omitempty"`
+	Window Window `json:"window,omitempty"`
 }
 
 //ClusterServiceReports provides fast lookup of services by service type, but
@@ -209,41 +204,8 @@ func (r *ClusterRateLimitReports) UnmarshalJSON(b []byte) error {
 	}
 	t := make(ClusterRateLimitReports)
 	for _, prl := range tmp {
-		t[prl.TargetTypeURI] = prl
+		t[prl.Name] = prl
 	}
 	*r = ClusterRateLimitReports(t)
-	return nil
-}
-
-//ClusterRateLimitActionReports provides fast lookup of rate limit actions using
-//a map, but serializes to JSON as a list.
-type ClusterRateLimitActionReports map[string]*ClusterRateLimitActionReport
-
-//MarshalJSON implements the json.Marshaler interface.
-func (r ClusterRateLimitActionReports) MarshalJSON() ([]byte, error) {
-	names := make([]string, 0, len(r))
-	for name := range r {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	list := make([]*ClusterRateLimitActionReport, len(r))
-	for idx, name := range names {
-		list[idx] = r[name]
-	}
-	return json.Marshal(list)
-}
-
-//UnmarshalJSON implements the json.Unmarshaler interface.
-func (r *ClusterRateLimitActionReports) UnmarshalJSON(b []byte) error {
-	tmp := make([]*ClusterRateLimitActionReport, 0)
-	err := json.Unmarshal(b, &tmp)
-	if err != nil {
-		return err
-	}
-	t := make(ClusterRateLimitActionReports)
-	for _, a := range tmp {
-		t[a.Name] = a
-	}
-	*r = ClusterRateLimitActionReports(t)
 	return nil
 }

--- a/report_cluster.go
+++ b/report_cluster.go
@@ -69,8 +69,7 @@ type ClusterAvailabilityZoneReport struct {
 
 // ClusterRateLimitReport is the structure for rate limits per target type URI and their rate limited actions.
 type ClusterRateLimitReport struct {
-	Name   string `json:"name,keepempty"`
-	Unit   Unit   `json:"unit,omitempty"`
+	RateInfo
 	Limit  uint64 `json:"limit,omitempty"`
 	Window Window `json:"window,omitempty"`
 }

--- a/report_cluster_test.go
+++ b/report_cluster_test.go
@@ -147,9 +147,9 @@ var clusterServicesOnlyRates = &ClusterServiceReports{
 		Resources: ClusterResourceReports{},
 		Rates: ClusterRateLimitReports{
 			"service/shared/objects:create": {
-				Name:   "service/shared/objects:create",
-				Limit:  5000,
-				Window: 1 * WindowSeconds,
+				RateInfo: RateInfo{Name: "service/shared/objects:create"},
+				Limit:    5000,
+				Window:   1 * WindowSeconds,
 			},
 		},
 	},

--- a/report_cluster_test.go
+++ b/report_cluster_test.go
@@ -82,14 +82,9 @@ var clusterServicesOnlyRatesMockJSON = `
 			"resources": [],
 			"rates": [
 				{
-					"target_type_uri": "service/shared/objects",
-					"actions": [
-						{
-							"name": "create",
-							"limit": 5000,
-							"unit": "r/s"
-						}
-					]
+					"name": "service/shared/objects:create",
+					"limit": 5000,
+					"window": "1s"
 				}
 			]
 		}
@@ -151,15 +146,10 @@ var clusterServicesOnlyRates = &ClusterServiceReports{
 		},
 		Resources: ClusterResourceReports{},
 		Rates: ClusterRateLimitReports{
-			"service/shared/objects": {
-				TargetTypeURI: "service/shared/objects",
-				Actions: ClusterRateLimitActionReports{
-					"create": &ClusterRateLimitActionReport{
-						Name:  "create",
-						Limit: 5000,
-						Unit:  UnitRequestsPerSecond,
-					},
-				},
+			"service/shared/objects:create": {
+				Name:   "service/shared/objects:create",
+				Limit:  5000,
+				Window: 1 * WindowSeconds,
 			},
 		},
 	},

--- a/report_domain.go
+++ b/report_domain.go
@@ -36,9 +36,11 @@ type DomainReport struct {
 //a single backend service.
 type DomainServiceReport struct {
 	ServiceInfo
-	Resources    DomainResourceReports `json:"resources,keepempty"`
-	MaxScrapedAt *int64                `json:"max_scraped_at,omitempty"`
-	MinScrapedAt *int64                `json:"min_scraped_at,omitempty"`
+	Resources         DomainResourceReports `json:"resources,keepempty"`
+	MaxScrapedAt      *int64                `json:"max_scraped_at,omitempty"`
+	MinScrapedAt      *int64                `json:"min_scraped_at,omitempty"`
+	MaxRatesScrapedAt *int64                `json:"max_rates_scraped_at,omitempty"`
+	MinRatesScrapedAt *int64                `json:"min_rates_scraped_at,omitempty"`
 }
 
 //DomainResourceReport is a substructure of DomainReport containing data for

--- a/report_project.go
+++ b/report_project.go
@@ -70,13 +70,14 @@ type ProjectResourceReport struct {
 
 // ProjectRateLimitReport is the structure for rate limits per target type URI and their rate limited actions.
 type ProjectRateLimitReport struct {
-	Name          string `json:"name,keepempty"`
-	Unit          Unit   `json:"unit,omitempty"`
-	Limit         uint64 `json:"limit,keepempty"`
-	Window        Window `json:"window,keepempty"`
-	DefaultLimit  uint64 `json:"default_limit,omitempty"`
-	DefaultWindow Window `json:"default_window,omitempty"`
-	UsageAsBigint string `json:"usage_as_bigint,omitempty"`
+	RateInfo
+	//NOTE: Both Window fields must have pointer types because omitempty does not
+	//work directly on json.Marshaler-implementing types.
+	Limit         uint64  `json:"limit,omitempty"`
+	Window        *Window `json:"window,omitempty"`
+	DefaultLimit  uint64  `json:"default_limit,omitempty"`
+	DefaultWindow *Window `json:"default_window,omitempty"`
+	UsageAsBigint string  `json:"usage_as_bigint,omitempty"`
 }
 
 //ProjectServiceReports provides fast lookup of services using a map, but serializes

--- a/report_project.go
+++ b/report_project.go
@@ -70,17 +70,13 @@ type ProjectResourceReport struct {
 
 // ProjectRateLimitReport is the structure for rate limits per target type URI and their rate limited actions.
 type ProjectRateLimitReport struct {
-	TargetTypeURI string                        `json:"target_type_uri,keepempty"`
-	Actions       ProjectRateLimitActionReports `json:"actions,keepempty"`
-}
-
-// ProjectRateLimitActionReport is defines an action and its rate limit.
-type ProjectRateLimitActionReport struct {
-	Name         string `json:"name,keepempty"`
-	Limit        uint64 `json:"limit,keepempty"`
-	Unit         Unit   `json:"unit,keepempty"`
-	DefaultLimit uint64 `json:"default_limit,omitempty"`
-	DefaultUnit  Unit   `json:"default_unit,omitempty"`
+	Name          string `json:"name,keepempty"`
+	Unit          Unit   `json:"unit,omitempty"`
+	Limit         uint64 `json:"limit,keepempty"`
+	Window        Window `json:"window,keepempty"`
+	DefaultLimit  uint64 `json:"default_limit,omitempty"`
+	DefaultWindow Window `json:"default_window,omitempty"`
+	UsageAsBigint string `json:"usage_as_bigint,omitempty"`
 }
 
 //ProjectServiceReports provides fast lookup of services using a map, but serializes
@@ -178,41 +174,8 @@ func (r *ProjectRateLimitReports) UnmarshalJSON(b []byte) error {
 	}
 	t := make(ProjectRateLimitReports)
 	for _, prl := range tmp {
-		t[prl.TargetTypeURI] = prl
+		t[prl.Name] = prl
 	}
 	*r = ProjectRateLimitReports(t)
-	return nil
-}
-
-//ProjectRateLimitActionReports provides fast lookup of resources using a map, but serializes
-//to JSON as a list.
-type ProjectRateLimitActionReports map[string]*ProjectRateLimitActionReport
-
-//MarshalJSON implements the json.Marshaler interface.
-func (r ProjectRateLimitActionReports) MarshalJSON() ([]byte, error) {
-	names := make([]string, 0, len(r))
-	for name := range r {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	list := make([]*ProjectRateLimitActionReport, len(r))
-	for idx, name := range names {
-		list[idx] = r[name]
-	}
-	return json.Marshal(list)
-}
-
-//UnmarshalJSON implements the json.Unmarshaler interface.
-func (r *ProjectRateLimitActionReports) UnmarshalJSON(b []byte) error {
-	tmp := make([]*ProjectRateLimitActionReport, 0)
-	err := json.Unmarshal(b, &tmp)
-	if err != nil {
-		return err
-	}
-	t := make(ProjectRateLimitActionReports)
-	for _, a := range tmp {
-		t[a.Name] = a
-	}
-	*r = ProjectRateLimitActionReports(t)
 	return nil
 }

--- a/report_project.go
+++ b/report_project.go
@@ -45,9 +45,10 @@ type ProjectBurstingInfo struct {
 //a single backend service.
 type ProjectServiceReport struct {
 	ServiceInfo
-	Resources ProjectResourceReports  `json:"resources,keepempty"`
-	Rates     ProjectRateLimitReports `json:"rates,omitempty"`
-	ScrapedAt *int64                  `json:"scraped_at,omitempty"`
+	Resources      ProjectResourceReports  `json:"resources,keepempty"`
+	Rates          ProjectRateLimitReports `json:"rates,omitempty"`
+	ScrapedAt      *int64                  `json:"scraped_at,omitempty"`
+	RatesScrapedAt *int64                  `json:"rates_scraped_at,omitempty"`
 }
 
 //ProjectResourceReport is a substructure of ProjectReport containing data for

--- a/report_project_test.go
+++ b/report_project_test.go
@@ -32,7 +32,7 @@ var projectServicesMockJSON = `
 `
 
 var projectResourcesMockJSON = `
- [
+	[
 		{
 			"name": "capacity",
 			"unit": "B",
@@ -151,19 +151,19 @@ var projectMockServicesRateLimit = &ProjectServiceReports{
 		Resources: ProjectResourceReports{},
 		Rates: ProjectRateLimitReports{
 			"services/swift/account/container/object:create": {
-				Name:   "services/swift/account/container/object:create",
-				Limit:  1000,
-				Window: 1 * WindowSeconds,
+				RateInfo: RateInfo{Name: "services/swift/account/container/object:create"},
+				Limit:    1000,
+				Window:   p2window(1 * WindowSeconds),
 			},
 			"services/swift/account/container/object:delete": {
-				Name:   "services/swift/account/container/object:delete",
-				Limit:  1000,
-				Window: 1 * WindowSeconds,
+				RateInfo: RateInfo{Name: "services/swift/account/container/object:delete"},
+				Limit:    1000,
+				Window:   p2window(1 * WindowSeconds),
 			},
 			"services/swift/account:create": {
-				Name:   "services/swift/account:create",
-				Limit:  10,
-				Window: 1 * WindowMinutes,
+				RateInfo: RateInfo{Name: "services/swift/account:create"},
+				Limit:    10,
+				Window:   p2window(1 * WindowMinutes),
 			},
 		},
 		ScrapedAt: p2i64(22),
@@ -179,25 +179,25 @@ var projectMockServicesRateLimitDeviatingFromDefaults = &ProjectServiceReports{
 		Resources: ProjectResourceReports{},
 		Rates: ProjectRateLimitReports{
 			"services/swift/account/container/object:create": {
-				Name:          "services/swift/account/container/object:create",
+				RateInfo:      RateInfo{Name: "services/swift/account/container/object:create"},
 				Limit:         1000,
-				Window:        1 * WindowSeconds,
+				Window:        p2window(1 * WindowSeconds),
 				DefaultLimit:  500,
-				DefaultWindow: 1 * WindowSeconds,
+				DefaultWindow: p2window(1 * WindowSeconds),
 			},
 			"services/swift/account/container/object:delete": {
-				Name:          "services/swift/account/container/object:delete",
+				RateInfo:      RateInfo{Name: "services/swift/account/container/object:delete"},
 				Limit:         1000,
-				Window:        1 * WindowSeconds,
+				Window:        p2window(1 * WindowSeconds),
 				DefaultLimit:  500,
-				DefaultWindow: 1 * WindowSeconds,
+				DefaultWindow: p2window(1 * WindowSeconds),
 			},
 			"services/swift/account:create": {
-				Name:          "services/swift/account:create",
+				RateInfo:      RateInfo{Name: "services/swift/account:create"},
 				Limit:         10,
-				Window:        1 * WindowMinutes,
+				Window:        p2window(1 * WindowMinutes),
 				DefaultLimit:  5,
-				DefaultWindow: 1 * WindowMinutes,
+				DefaultWindow: p2window(1 * WindowMinutes),
 			},
 		},
 		ScrapedAt: p2i64(22),
@@ -246,4 +246,8 @@ func TestProjectServicesRateLimitDeviatingFromDefaultsUnmarshall(t *testing.T) {
 	err := actual.UnmarshalJSON([]byte(projectServicesRateLimitDeviatingFromDefaultsMockJSON))
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, projectMockServicesRateLimitDeviatingFromDefaults, actual)
+}
+
+func p2window(val Window) *Window {
+	return &val
 }

--- a/report_project_test.go
+++ b/report_project_test.go
@@ -57,29 +57,19 @@ var projectServicesRateLimitMockJSON = `
 			"resources": [],
 			"rates": [
 				{
-					"target_type_uri": "services/swift/account",
-					"actions": [
-						{
-							"name": "create",
-							"limit": 10,
-							"unit": "r/m"
-						}
-					]
+					"name": "services/swift/account/container/object:create",
+					"limit": 1000,
+					"window": "1s"
 				},
 				{
-					"target_type_uri": "services/swift/account/container/object",
-					"actions": [
-						{
-							"name": "create",
-							"limit": 1000,
-							"unit": "r/s"
-						},
-						{
-							"name": "delete",
-							"limit": 1000,
-							"unit": "r/s"
-						}
-					]
+					"name": "services/swift/account/container/object:delete",
+					"limit": 1000,
+					"window": "1s"
+				},
+				{
+					"name": "services/swift/account:create",
+					"limit": 10,
+					"window": "1m"
 				}
 			],
 			"scraped_at": 22
@@ -95,35 +85,25 @@ var projectServicesRateLimitDeviatingFromDefaultsMockJSON = `
 			"resources": [],
 			"rates": [
 				{
-					"target_type_uri": "services/swift/account",
-					"actions": [
-						{
-							"name": "create",
-							"limit": 10,
-							"unit": "r/m",
-							"default_limit": 5,
-							"default_unit": "r/m"
-						}
-					]
+					"name": "services/swift/account/container/object:create",
+					"limit": 1000,
+					"window": "1s",
+					"default_limit": 500,
+					"default_window": "1s"
 				},
 				{
-					"target_type_uri": "services/swift/account/container/object",
-					"actions": [
-						{
-							"name": "create",
-							"limit": 1000,
-							"unit": "r/s",
-							"default_limit": 500,
-							"default_unit": "r/s"
-						},
-						{
-							"name": "delete",
-							"limit": 1000,
-							"unit": "r/s",
-							"default_limit": 500,
-							"default_unit": "r/s"
-						}
-					]
+					"name": "services/swift/account/container/object:delete",
+					"limit": 1000,
+					"window": "1s",
+					"default_limit": 500,
+					"default_window": "1s"
+				},
+				{
+					"name": "services/swift/account:create",
+					"limit": 10,
+					"window": "1m",
+					"default_limit": 5,
+					"default_window": "1m"
 				}
 			],
 			"scraped_at": 22
@@ -170,30 +150,20 @@ var projectMockServicesRateLimit = &ProjectServiceReports{
 		},
 		Resources: ProjectResourceReports{},
 		Rates: ProjectRateLimitReports{
-			"services/swift/account/container/object": &ProjectRateLimitReport{
-				TargetTypeURI: "services/swift/account/container/object",
-				Actions: ProjectRateLimitActionReports{
-					"create": &ProjectRateLimitActionReport{
-						Name:  "create",
-						Limit: 1000,
-						Unit:  UnitRequestsPerSecond,
-					},
-					"delete": &ProjectRateLimitActionReport{
-						Name:  "delete",
-						Limit: 1000,
-						Unit:  UnitRequestsPerSecond,
-					},
-				},
+			"services/swift/account/container/object:create": {
+				Name:   "services/swift/account/container/object:create",
+				Limit:  1000,
+				Window: 1 * WindowSeconds,
 			},
-			"services/swift/account": &ProjectRateLimitReport{
-				TargetTypeURI: "services/swift/account",
-				Actions: ProjectRateLimitActionReports{
-					"create": &ProjectRateLimitActionReport{
-						Name:  "create",
-						Limit: 10,
-						Unit:  UnitRequestsPerMinute,
-					},
-				},
+			"services/swift/account/container/object:delete": {
+				Name:   "services/swift/account/container/object:delete",
+				Limit:  1000,
+				Window: 1 * WindowSeconds,
+			},
+			"services/swift/account:create": {
+				Name:   "services/swift/account:create",
+				Limit:  10,
+				Window: 1 * WindowMinutes,
 			},
 		},
 		ScrapedAt: p2i64(22),
@@ -208,36 +178,26 @@ var projectMockServicesRateLimitDeviatingFromDefaults = &ProjectServiceReports{
 		},
 		Resources: ProjectResourceReports{},
 		Rates: ProjectRateLimitReports{
-			"services/swift/account/container/object": &ProjectRateLimitReport{
-				TargetTypeURI: "services/swift/account/container/object",
-				Actions: ProjectRateLimitActionReports{
-					"create": &ProjectRateLimitActionReport{
-						Name:         "create",
-						Limit:        1000,
-						Unit:         UnitRequestsPerSecond,
-						DefaultLimit: 500,
-						DefaultUnit:  UnitRequestsPerSecond,
-					},
-					"delete": &ProjectRateLimitActionReport{
-						Name:         "delete",
-						Limit:        1000,
-						Unit:         UnitRequestsPerSecond,
-						DefaultLimit: 500,
-						DefaultUnit:  UnitRequestsPerSecond,
-					},
-				},
+			"services/swift/account/container/object:create": {
+				Name:          "services/swift/account/container/object:create",
+				Limit:         1000,
+				Window:        1 * WindowSeconds,
+				DefaultLimit:  500,
+				DefaultWindow: 1 * WindowSeconds,
 			},
-			"services/swift/account": &ProjectRateLimitReport{
-				TargetTypeURI: "services/swift/account",
-				Actions: ProjectRateLimitActionReports{
-					"create": &ProjectRateLimitActionReport{
-						Name:         "create",
-						Limit:        10,
-						Unit:         UnitRequestsPerMinute,
-						DefaultLimit: 5,
-						DefaultUnit:  UnitRequestsPerMinute,
-					},
-				},
+			"services/swift/account/container/object:delete": {
+				Name:          "services/swift/account/container/object:delete",
+				Limit:         1000,
+				Window:        1 * WindowSeconds,
+				DefaultLimit:  500,
+				DefaultWindow: 1 * WindowSeconds,
+			},
+			"services/swift/account:create": {
+				Name:          "services/swift/account:create",
+				Limit:         10,
+				Window:        1 * WindowMinutes,
+				DefaultLimit:  5,
+				DefaultWindow: 1 * WindowMinutes,
 			},
 		},
 		ScrapedAt: p2i64(22),

--- a/unit.go
+++ b/unit.go
@@ -1,6 +1,6 @@
 /*******************************************************************************
 *
-* Copyright 2017 SAP SE
+* Copyright 2017-2020 SAP SE
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ package limes
 
 import (
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
 )
@@ -49,16 +48,35 @@ const (
 	UnitExbibytes Unit = "EiB"
 	//UnitUnspecified is used as a placeholder when the unit is not known.
 	UnitUnspecified Unit = "UNSPECIFIED"
-
-	//UnitRequestsPerMillisecond is exactly that.
-	UnitRequestsPerMillisecond Unit = "r/ms"
-	//UnitRequestsPerSecond is exactly that.
-	UnitRequestsPerSecond Unit = "r/s"
-	//UnitRequestsPerMinute is exactly that.
-	UnitRequestsPerMinute Unit = "r/m"
-	//UnitRequestsPerHour is exactly that.
-	UnitRequestsPerHour Unit = "r/h"
 )
+
+var allValidUnits = []Unit{
+	UnitNone,
+	UnitBytes,
+	UnitKibibytes,
+	UnitMebibytes,
+	UnitGibibytes,
+	UnitTebibytes,
+	UnitPebibytes,
+	UnitExbibytes,
+}
+
+//UnmarshalYAML implements the yaml.Unmarshaler interface. This method validates
+//that units in the config file actually exist.
+func (u *Unit) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var s string
+	err := unmarshal(&s)
+	if err != nil {
+		return err
+	}
+	for _, unit := range allValidUnits {
+		if string(unit) == s {
+			*u = unit
+			return nil
+		}
+	}
+	return fmt.Errorf("unknown unit: %q", s)
+}
 
 //Base returns the base unit of this unit. For units defined as a multiple of
 //another unit, that unit is the base unit. Otherwise, the same unit and a
@@ -82,8 +100,6 @@ func (u Unit) Base() (Unit, uint64) {
 	}
 }
 
-var measuredQuotaValueRx = regexp.MustCompile(`^\s*([0-9]+)\s*([A-Za-z]+)$`)
-
 //Parse parses the string representation of a value with this unit (or any unit
 //that can be converted to it).
 //
@@ -103,14 +119,12 @@ func (u Unit) Parse(str string) (uint64, error) {
 	fields := strings.Fields(str)
 	// Measured resources are a number and unit with space.
 	if len(fields) != 2 {
-		return 0, fmt.Errorf("value %q does not match expected format \"<number> <unit>\"",
-			str)
+		return 0, fmt.Errorf("value %q does not match expected format \"<number> <unit>\"", str)
 	}
 
 	number, err := strconv.ParseUint(fields[0], 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf("invalid value %q: %s",
-			str, err.Error())
+		return 0, fmt.Errorf("invalid value %q: %s", str, err.Error())
 	}
 	value := ValueWithUnit{
 		Value: number,
@@ -136,12 +150,7 @@ func (v ValueWithUnit) String() string {
 	if v.Unit == UnitNone {
 		return str
 	}
-	switch v.Unit {
-	case UnitRequestsPerMillisecond, UnitRequestsPerSecond, UnitRequestsPerMinute, UnitRequestsPerHour:
-		return str + string(v.Unit)
-	default:
-		return str + " " + string(v.Unit)
-	}
+	return str + " " + string(v.Unit)
 }
 
 //ConvertTo returns an equal value in the given Unit. IncompatibleUnitsError is

--- a/unit_test.go
+++ b/unit_test.go
@@ -57,17 +57,3 @@ func Test_ValueWithUnit_ConvertTo(t *testing.T) {
 		"value of 42 B cannot be represented as integer number of MiB",
 	)
 }
-
-func TestValueWithUnitRateLimit(t *testing.T) {
-	tests := map[ValueWithUnit]string{
-		{1, UnitRequestsPerSecond}:    "1r/s",
-		{1000, UnitRequestsPerMinute}: "1000r/m",
-		{22, UnitRequestsPerHour}:     "22r/h",
-	}
-
-	for input, expected := range tests {
-		if input.String() != expected {
-			t.Errorf("expected %s but got %s", expected, input.String())
-		}
-	}
-}

--- a/window.go
+++ b/window.go
@@ -1,0 +1,143 @@
+/*******************************************************************************
+*
+* Copyright 2020 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package limes
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+)
+
+//Window is the size (in nanoseconds) of the time window that is considered
+//when enforcing a rate limit. For example, a rate limit of "10 per second" has
+//a limit of 10 and a window of 1 second.
+//
+//This type is very similar to time.Duration, but does not allow negative
+//values and uses a different parsing logic that does not allow phrases with
+//multiple units like time.Duration does (e.g. "2h30m").
+type Window uint64
+
+const (
+	//WindowMilliseconds is a Window unit.
+	WindowMilliseconds Window = 1000 * 1000
+	//WindowSeconds is a Window unit.
+	WindowSeconds Window = 1000 * WindowMilliseconds
+	//WindowMinutes is a Window unit.
+	WindowMinutes Window = 60 * WindowSeconds
+	//WindowHours is a Window unit.
+	WindowHours Window = 60 * WindowMinutes
+)
+
+var windowUnits = map[string]Window{
+	"ms": WindowMilliseconds,
+	"s":  WindowSeconds,
+	"m":  WindowMinutes,
+	"h":  WindowHours,
+}
+
+var windowFormatRx = regexp.MustCompile(`^\s*([0-9]+)\s*([A-Za-z]+)$`)
+
+//MustParseWindow is like ParseWindow, but panics on error. This should only be used for compile-time constants.
+func MustParseWindow(input string) Window {
+	w, err := ParseWindow(input)
+	if err != nil {
+		panic(err.Error())
+	}
+	return w
+}
+
+//ParseWindow parses a string representation like "1s" or "5m".
+func ParseWindow(input string) (Window, error) {
+	if input == "" {
+		return Window(0), nil
+	}
+
+	match := windowFormatRx.FindStringSubmatch(input)
+	if match == nil {
+		return 0, fmt.Errorf("invalid value %q: does not match expected format \"<number> <unit>\"", input)
+	}
+	number, err := strconv.ParseUint(match[1], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid value %q: %s", input, err.Error())
+	}
+	multiplier, isValidUnit := windowUnits[match[2]]
+	if !isValidUnit {
+		return 0, fmt.Errorf("invalid value %q: unknown time unit %q", input, match[2])
+	}
+	return Window(number) * multiplier, nil
+}
+
+//String returns the optimal string representation for this window.
+func (w Window) String() string {
+	if w == 0 {
+		return ""
+	}
+
+	//find the unit that yields the shortest exact representation
+	shortest := ""
+	for unit, multiplier := range windowUnits {
+		if w%multiplier == 0 {
+			repr := fmt.Sprintf("%d%s", uint64(w/multiplier), unit)
+			if shortest == "" || len(shortest) > len(repr) {
+				shortest = repr
+			}
+		}
+	}
+	return shortest
+}
+
+//MarshalJSON implements the json.Marshaler interface.
+func (w Window) MarshalJSON() ([]byte, error) {
+	repr := w.String()
+	if repr == "" {
+		return nil, fmt.Errorf("unrepresentable window size: %d ns", uint64(w))
+	}
+	return []byte(fmt.Sprintf("%q", repr)), nil
+}
+
+//UnmarshalJSON implements the json.Unmarshaler interface.
+func (w *Window) UnmarshalJSON(buf []byte) error {
+	var s string
+	err := json.Unmarshal(buf, &s)
+	if err != nil {
+		return err
+	}
+	win, err := ParseWindow(s)
+	if err == nil {
+		*w = win
+	}
+	return err
+}
+
+//UnmarshalYAML implements the yaml.Unmarshaler interface. This method validates
+//that windows in the config file are valid.
+func (w *Window) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var s string
+	err := unmarshal(&s)
+	if err != nil {
+		return err
+	}
+	win, err := ParseWindow(s)
+	if err == nil {
+		*w = win
+	}
+	return err
+}

--- a/window_test.go
+++ b/window_test.go
@@ -1,0 +1,52 @@
+/*******************************************************************************
+*
+* Copyright 2020 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package limes
+
+import "testing"
+
+func TestWindowSerializeRoundtrip(t *testing.T) {
+	tests := map[string]string{
+		"1ms":    "1ms",
+		"500ms":  "500ms",
+		"1000ms": "1s",
+		"1s":     "1s",
+		"42s":    "42s",
+		"90s":    "90s",
+		"120s":   "2m",
+		"1m":     "1m",
+		"42m":    "42m",
+		"90m":    "90m",
+		"120m":   "2h",
+		"1h":     "1h",
+		"120h":   "120h",
+	}
+
+	for input, expected := range tests {
+		parsed, err := ParseWindow(input)
+		if err != nil {
+			t.Error(err.Error())
+			continue
+		}
+		actual := parsed.String()
+		if actual != expected {
+			t.Errorf("for input %q: expected %q, got %q", input, expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
@reimannf As always with large API changes, I'm open to feedback.

@auhlig Also from you, since this affects the [openstack-rate-limit-middleware](https://github.com/sapcc/openstack-rate-limit-middleware). There are several backwards-incompatible changes in here to make my future life easier, but from a cursory study of the middleware code, it shouldn't be too hard to adapt it to the proposed API.

1. Since we will in the future have several rates that are not for API requests and thus don't fit in the CADF framework, we don't replicate the target_type_uri/action structure on the Limes API level anymore. Instead, `rates` are a flat list within each service just like `resources`, and we encode the target_type_uri/action pair into the rate name where necessary.

2. The existing `unit` field for rate limits is split into `unit` and `window`. With this change, `unit` has the same meaning as for resources and also makes sense for usage values. On API request rates, the `unit` field is omitted, just like for countable resources.

3. For rates where we know how to scrape usage, `usage_as_bigint` is added to the rate and `rates_scraped_at` is added to the service.

4. In general, a bunch of wording surrounding rates is being clarified and codified in the spec.