### PR TITLE
manila: don't set replica quota for non-replication enabled types

### DIFF
--- a/docs/operators/config.md
+++ b/docs/operators/config.md
@@ -563,7 +563,7 @@ The quota values in Manila are assigned as follows:
   replica and replica capacity quotas set to the same value as the share and
   share capacity quotas. (This makes sense since the shares themselves also use
   up replica quota.) If `replication_enabled` is false or unset, the replica
-  quotas will be set to 0 instead.
+  quotas will not be set.
 - Besides the share-type-specific quotas, the general quotas are set to the sum
   across all share types.
 

--- a/pkg/plugins/manila.go
+++ b/pkg/plugins/manila.go
@@ -267,8 +267,8 @@ func (p *manilaPlugin) SetQuota(provider *gophercloud.ProviderClient, eo gopherc
 			Gigabytes:         quotas[p.makeResourceName("share_capacity", stName)],
 			Snapshots:         quotas[p.makeResourceName("share_snapshots", stName)],
 			SnapshotGigabytes: quotas[p.makeResourceName("snapshot_capacity", stName)],
-			Replicas:          0,
-			ReplicaGigabytes:  0,
+			Replicas:          nil,
+			ReplicaGigabytes:  nil,
 			ShareNetworks:     nil,
 		}
 		if p.hasReplicaQuotas && shareType.ReplicationEnabled {
@@ -316,8 +316,8 @@ type manilaQuotaSetDetail struct {
 	Shares            manilaQuotaDetail `json:"shares"`
 	SnapshotGigabytes manilaQuotaDetail `json:"snapshot_gigabytes"`
 	Snapshots         manilaQuotaDetail `json:"snapshots"`
-	ReplicaGigabytes  manilaQuotaDetail `json:"replica_gigabytes"`
-	Replicas          manilaQuotaDetail `json:"share_replicas"`
+	ReplicaGigabytes  manilaQuotaDetail `json:"replica_gigabytes,omitempty"`
+	Replicas          manilaQuotaDetail `json:"share_replicas,omitempty"`
 	ShareNetworks     manilaQuotaDetail `json:"share_networks,omitempty"`
 }
 


### PR DESCRIPTION
use implicit defaults from the manila service instead

Checklist:

- [ ] If this PR is about a plugin, I tested the plugin against an OpenStack cluster.
- [x] I updated the documentation to describe the semantical or interface changes I introduced.


I need help, I have no experience with go, the travis errors are real.
Also https://github.com/sapcc/limes/pull/110/files#diff-b0174593825027531cd9d5cf073b71f27d92f07d70c3b454901d10b889f49463R160-R163 can go now, our manila is on victoria release now globally.