### PR TITLE
Add availability zone and state info to Ironic node's subcapacities

### DIFF
--- a/pkg/plugins/capacity_sapcc_ironic.go
+++ b/pkg/plugins/capacity_sapcc_ironic.go
@@ -159,8 +159,15 @@ func (p *capacitySapccIronicPlugin) Scrape(provider *gophercloud.ProviderClient,
 
 				if p.reportSubcapacities {
 					sub := map[string]interface{}{
-						"id":   node.ID,
-						"name": node.Name,
+						"id":              node.ID,
+						"name":            node.Name,
+						"provision_state": node.ProvisionState,
+					}
+					if node.TargetProvisionState != nil && *node.TargetProvisionState != "" {
+						sub["target_provision_state"] = *node.TargetProvisionState
+					}
+					if nodeAZ != "" {
+						sub["availability_zone"] = nodeAZ
 					}
 					if node.Properties.MemoryMiB > 0 {
 						sub["ram"] = limes.ValueWithUnit{Unit: limes.UnitMebibytes, Value: uint64(node.Properties.MemoryMiB)}


### PR DESCRIPTION
Closes #115 

Checklist:

- [x] If this PR is about a plugin, I tested the plugin against an OpenStack cluster.
- [x] I updated the documentation to describe the semantical or interface changes I introduced.
