### PR TITLE
Plugins cinder: convert to gophercloud

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,7 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
@@ -494,9 +495,11 @@ golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 h1:XfKQ4OlFl8okEOr5UvAqFRVj8pY/4yfcXrddB8qAbU0=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -504,6 +507,7 @@ golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/pkg/plugins/cinder.go
+++ b/pkg/plugins/cinder.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/quotasets"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes"
 	"github.com/gophercloud/gophercloud/pagination"
 	"github.com/prometheus/client_golang/prometheus"
@@ -145,18 +146,10 @@ func (p *cinderPlugin) Scrape(provider *gophercloud.ProviderClient, eo gopherclo
 	if err != nil {
 		return nil, "", err
 	}
-
-	var result gophercloud.Result
-	url := client.ServiceURL("os-quota-sets", project.UUID) + "?usage=True"
-	_, err = client.Get(url, &result.Body, nil)
-	if err != nil {
-		return nil, "", err
-	}
-
 	var data struct {
 		QuotaSet map[string]quotaSetField `json:"quota_set"`
 	}
-	err = result.ExtractInto(&data)
+	err = quotasets.GetUsage(client, project.UUID).ExtractInto(&data)
 	if err != nil {
 		return nil, "", err
 	}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/quotasets/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/quotasets/doc.go
@@ -1,0 +1,61 @@
+/*
+Package quotasets enables retrieving and managing Block Storage quotas.
+
+Example to Get a Quota Set
+
+	quotaset, err := quotasets.Get(blockStorageClient, "project-id").Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", quotaset)
+
+Example to Get Quota Set Usage
+
+	quotaset, err := quotasets.GetUsage(blockStorageClient, "project-id").Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", quotaset)
+
+Example to Update a Quota Set
+
+	updateOpts := quotasets.UpdateOpts{
+		Volumes: gophercloud.IntToPointer(100),
+	}
+
+	quotaset, err := quotasets.Update(blockStorageClient, "project-id", updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", quotaset)
+
+Example to Update a Quota set with volume_type quotas
+
+	updateOpts := quotasets.UpdateOpts{
+		Volumes: gophercloud.IntToPointer(100),
+		Extra: map[string]interface{}{
+			"gigabytes_foo": gophercloud.IntToPointer(100),
+			"snapshots_foo": gophercloud.IntToPointer(10),
+			"volumes_foo":   gophercloud.IntToPointer(10),
+		},
+	}
+
+	quotaset, err := quotasets.Update(blockStorageClient, "project-id", updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", quotaset)
+
+
+Example to Delete a Quota Set
+
+	err := quotasets.Delete(blockStorageClient, "project-id").ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package quotasets

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/quotasets/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/quotasets/requests.go
@@ -1,0 +1,116 @@
+package quotasets
+
+import (
+	"fmt"
+
+	"github.com/gophercloud/gophercloud"
+)
+
+// Get returns public data about a previously created QuotaSet.
+func Get(client *gophercloud.ServiceClient, projectID string) (r GetResult) {
+	resp, err := client.Get(getURL(client, projectID), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// GetDefaults returns public data about the project's default block storage quotas.
+func GetDefaults(client *gophercloud.ServiceClient, projectID string) (r GetResult) {
+	resp, err := client.Get(getDefaultsURL(client, projectID), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// GetUsage returns detailed public data about a previously created QuotaSet.
+func GetUsage(client *gophercloud.ServiceClient, projectID string) (r GetUsageResult) {
+	u := fmt.Sprintf("%s?usage=true", getURL(client, projectID))
+	resp, err := client.Get(u, &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Updates the quotas for the given projectID and returns the new QuotaSet.
+func Update(client *gophercloud.ServiceClient, projectID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToBlockStorageQuotaUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	resp, err := client.Put(updateURL(client, projectID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// UpdateOptsBuilder enables extensions to add parameters to the update request.
+type UpdateOptsBuilder interface {
+	// Extra specific name to prevent collisions with interfaces for other quotas
+	// (e.g. neutron)
+	ToBlockStorageQuotaUpdateMap() (map[string]interface{}, error)
+}
+
+// ToBlockStorageQuotaUpdateMap builds the update options into a serializable
+// format.
+func (opts UpdateOpts) ToBlockStorageQuotaUpdateMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "quota_set")
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.Extra != nil {
+		if v, ok := b["quota_set"].(map[string]interface{}); ok {
+			for key, value := range opts.Extra {
+				v[key] = value
+			}
+		}
+	}
+
+	return b, nil
+}
+
+// Options for Updating the quotas of a Tenant.
+// All int-values are pointers so they can be nil if they are not needed.
+// You can use gopercloud.IntToPointer() for convenience
+type UpdateOpts struct {
+	// Volumes is the number of volumes that are allowed for each project.
+	Volumes *int `json:"volumes,omitempty"`
+
+	// Snapshots is the number of snapshots that are allowed for each project.
+	Snapshots *int `json:"snapshots,omitempty"`
+
+	// Gigabytes is the size (GB) of volumes and snapshots that are allowed for
+	// each project.
+	Gigabytes *int `json:"gigabytes,omitempty"`
+
+	// PerVolumeGigabytes is the size (GB) of volumes and snapshots that are
+	// allowed for each project and the specifed volume type.
+	PerVolumeGigabytes *int `json:"per_volume_gigabytes,omitempty"`
+
+	// Backups is the number of backups that are allowed for each project.
+	Backups *int `json:"backups,omitempty"`
+
+	// BackupGigabytes is the size (GB) of backups that are allowed for each
+	// project.
+	BackupGigabytes *int `json:"backup_gigabytes,omitempty"`
+
+	// Groups is the number of groups that are allowed for each project.
+	Groups *int `json:"groups,omitempty"`
+
+	// Force will update the quotaset even if the quota has already been used
+	// and the reserved quota exceeds the new quota.
+	Force bool `json:"force,omitempty"`
+
+	// Extra is a collection of miscellaneous key/values used to set
+	// quota per volume_type
+	Extra map[string]interface{} `json:"-"`
+}
+
+// Resets the quotas for the given tenant to their default values.
+func Delete(client *gophercloud.ServiceClient, projectID string) (r DeleteResult) {
+	resp, err := client.Delete(updateURL(client, projectID), &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/quotasets/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/quotasets/results.go
@@ -1,0 +1,205 @@
+package quotasets
+
+import (
+	"encoding/json"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// QuotaSet is a set of operational limits that allow for control of block
+// storage usage.
+type QuotaSet struct {
+	// ID is project associated with this QuotaSet.
+	ID string `json:"id"`
+
+	// Volumes is the number of volumes that are allowed for each project.
+	Volumes int `json:"volumes"`
+
+	// Snapshots is the number of snapshots that are allowed for each project.
+	Snapshots int `json:"snapshots"`
+
+	// Gigabytes is the size (GB) of volumes and snapshots that are allowed for
+	// each project.
+	Gigabytes int `json:"gigabytes"`
+
+	// PerVolumeGigabytes is the size (GB) of volumes and snapshots that are
+	// allowed for each project and the specifed volume type.
+	PerVolumeGigabytes int `json:"per_volume_gigabytes"`
+
+	// Backups is the number of backups that are allowed for each project.
+	Backups int `json:"backups"`
+
+	// BackupGigabytes is the size (GB) of backups that are allowed for each
+	// project.
+	BackupGigabytes int `json:"backup_gigabytes"`
+
+	// Groups is the number of groups that are allowed for each project.
+	Groups int `json:"groups,omitempty"`
+
+	// Extra is a collection of miscellaneous key/values used to set
+	// quota per volume_type
+	Extra map[string]interface{} `json:"-"`
+}
+
+// UnmarshalJSON is used on QuotaSet to unmarshal extra keys that are
+// used for volume_type quota
+func (r *QuotaSet) UnmarshalJSON(b []byte) error {
+	type tmp QuotaSet
+	var s struct {
+		tmp
+		Extra map[string]interface{} `json:"extra"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = QuotaSet(s.tmp)
+
+	var result interface{}
+	err = json.Unmarshal(b, &result)
+	if err != nil {
+		return err
+	}
+	if resultMap, ok := result.(map[string]interface{}); ok {
+		r.Extra = gophercloud.RemainingKeys(QuotaSet{}, resultMap)
+	}
+
+	return err
+}
+
+// QuotaUsageSet represents details of both operational limits of block
+// storage resources and the current usage of those resources.
+type QuotaUsageSet struct {
+	// ID is the project ID associated with this QuotaUsageSet.
+	ID string `json:"id"`
+
+	// Volumes is the volume usage information for this project, including
+	// in_use, limit, reserved and allocated attributes. Note: allocated
+	// attribute is available only when nested quota is enabled.
+	Volumes QuotaUsage `json:"volumes"`
+
+	// Snapshots is the snapshot usage information for this project, including
+	// in_use, limit, reserved and allocated attributes. Note: allocated
+	// attribute is available only when nested quota is enabled.
+	Snapshots QuotaUsage `json:"snapshots"`
+
+	// Gigabytes is the size (GB) usage information of volumes and snapshots
+	// for this project, including in_use, limit, reserved and allocated
+	// attributes. Note: allocated attribute is available only when nested
+	// quota is enabled.
+	Gigabytes QuotaUsage `json:"gigabytes"`
+
+	// PerVolumeGigabytes is the size (GB) usage information for each volume,
+	// including in_use, limit, reserved and allocated attributes. Note:
+	// allocated attribute is available only when nested quota is enabled and
+	// only limit is meaningful here.
+	PerVolumeGigabytes QuotaUsage `json:"per_volume_gigabytes"`
+
+	// Backups is the backup usage information for this project, including
+	// in_use, limit, reserved and allocated attributes. Note: allocated
+	// attribute is available only when nested quota is enabled.
+	Backups QuotaUsage `json:"backups"`
+
+	// BackupGigabytes is the size (GB) usage information of backup for this
+	// project, including in_use, limit, reserved and allocated attributes.
+	// Note: allocated attribute is available only when nested quota is
+	// enabled.
+	BackupGigabytes QuotaUsage `json:"backup_gigabytes"`
+
+	// Groups is the number of groups that are allowed for each project.
+	// Note: allocated attribute is available only when nested quota is
+	// enabled.
+	Groups QuotaUsage `json:"groups"`
+}
+
+// QuotaUsage is a set of details about a single operational limit that allows
+// for control of block storage usage.
+type QuotaUsage struct {
+	// InUse is the current number of provisioned resources of the given type.
+	InUse int `json:"in_use"`
+
+	// Allocated is the current number of resources of a given type allocated
+	// for use.  It is only available when nested quota is enabled.
+	Allocated int `json:"allocated"`
+
+	// Reserved is a transitional state when a claim against quota has been made
+	// but the resource is not yet fully online.
+	Reserved int `json:"reserved"`
+
+	// Limit is the maximum number of a given resource that can be
+	// allocated/provisioned.  This is what "quota" usually refers to.
+	Limit int `json:"limit"`
+}
+
+// QuotaSetPage stores a single page of all QuotaSet results from a List call.
+type QuotaSetPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty determines whether or not a QuotaSetsetPage is empty.
+func (r QuotaSetPage) IsEmpty() (bool, error) {
+	ks, err := ExtractQuotaSets(r)
+	return len(ks) == 0, err
+}
+
+// ExtractQuotaSets interprets a page of results as a slice of QuotaSets.
+func ExtractQuotaSets(r pagination.Page) ([]QuotaSet, error) {
+	var s struct {
+		QuotaSets []QuotaSet `json:"quotas"`
+	}
+	err := (r.(QuotaSetPage)).ExtractInto(&s)
+	return s.QuotaSets, err
+}
+
+type quotaResult struct {
+	gophercloud.Result
+}
+
+// Extract is a method that attempts to interpret any QuotaSet resource response
+// as a QuotaSet struct.
+func (r quotaResult) Extract() (*QuotaSet, error) {
+	var s struct {
+		QuotaSet *QuotaSet `json:"quota_set"`
+	}
+	err := r.ExtractInto(&s)
+	return s.QuotaSet, err
+}
+
+// GetResult is the response from a Get operation. Call its Extract method to
+// interpret it as a QuotaSet.
+type GetResult struct {
+	quotaResult
+}
+
+// UpdateResult is the response from a Update operation. Call its Extract method
+// to interpret it as a QuotaSet.
+type UpdateResult struct {
+	quotaResult
+}
+
+type quotaUsageResult struct {
+	gophercloud.Result
+}
+
+// GetUsageResult is the response from a Get operation. Call its Extract
+// method to interpret it as a QuotaSet.
+type GetUsageResult struct {
+	quotaUsageResult
+}
+
+// Extract is a method that attempts to interpret any QuotaUsageSet resource
+// response as a set of QuotaUsageSet structs.
+func (r quotaUsageResult) Extract() (QuotaUsageSet, error) {
+	var s struct {
+		QuotaUsageSet QuotaUsageSet `json:"quota_set"`
+	}
+	err := r.ExtractInto(&s)
+	return s.QuotaUsageSet, err
+}
+
+// DeleteResult is the response from a Delete operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/quotasets/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/quotasets/urls.go
@@ -1,0 +1,21 @@
+package quotasets
+
+import "github.com/gophercloud/gophercloud"
+
+const resourcePath = "os-quota-sets"
+
+func getURL(c *gophercloud.ServiceClient, projectID string) string {
+	return c.ServiceURL(resourcePath, projectID)
+}
+
+func getDefaultsURL(c *gophercloud.ServiceClient, projectID string) string {
+	return c.ServiceURL(resourcePath, projectID, "defaults")
+}
+
+func updateURL(c *gophercloud.ServiceClient, projectID string) string {
+	return getURL(c, projectID)
+}
+
+func deleteURL(c *gophercloud.ServiceClient, projectID string) string {
+	return getURL(c, projectID)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -29,6 +29,7 @@ github.com/golang/protobuf/ptypes/timestamp
 github.com/gophercloud/gophercloud
 github.com/gophercloud/gophercloud/openstack
 github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes
+github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/quotasets
 github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/schedulerstats
 github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/services
 github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes


### PR DESCRIPTION
Checklist:

- [x] If this PR is about a plugin, I tested the plugin against an OpenStack cluster.
- [ ] I updated the documentation to describe the semantical or interface changes I introduced.


Sadly Gophercloud does not provide a map string for quota sets https://github.com/gophercloud/gophercloud/blob/master/openstack/blockstorage/extensions/quotasets/results.go#L163