### PR TITLE
Remove support for `X-Limes-Cluster-Id` header

### DIFF
--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -305,13 +305,6 @@ func Test_ClusterOperations(t *testing.T) {
 	}.Check(t, router)
 	assert.HTTPRequest{
 		Method:       "GET",
-		Path:         "/v1/clusters/current",
-		Header:       map[string]string{"X-Limes-Cluster-Id": "current"}, //still allowed for backwards compatibility
-		ExpectStatus: 200,
-		ExpectBody:   assert.JSONFixtureFile("fixtures/cluster-get-west.json"),
-	}.Check(t, router)
-	assert.HTTPRequest{
-		Method:       "GET",
 		Path:         "/v1/clusters/current?rates=only",
 		ExpectStatus: 200,
 		ExpectBody:   assert.JSONFixtureFile("fixtures/cluster-get-west-only-rates.json"),

--- a/pkg/api/core.go
+++ b/pkg/api/core.go
@@ -112,8 +112,7 @@ func NewV1Router(cluster *core.Cluster, policyEnforcer gopherpolicy.Enforcer) (h
 
 func forbidClusterIDHeader(inner http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		clusterID := r.Header.Get("X-Limes-Cluster-Id")
-		if clusterID != "" && clusterID != "current" {
+		if len(r.Header[http.CanonicalHeaderKey("X-Limes-Cluster-Id")]) > 0 {
 			http.Error(w, "multi-cluster support is removed: the X-Limes-Cluster-Id header is not allowed anymore", http.StatusBadRequest)
 		} else {
 			inner.ServeHTTP(w, r)


### PR DESCRIPTION
Checklist:

- [ ] If this PR is about a plugin, I tested the plugin against an OpenStack cluster.
- [ ] I updated the documentation to describe the semantical or interface changes I introduced.
