### PR TITLE
rewrite reports.GetProjects() into a streaming style to limit peak memory usage

### DIFF
--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -2108,3 +2108,22 @@ func Test_QuotaBursting(t *testing.T) {
 		Body:         body,
 	}.Check(t, router)
 }
+
+func Test_EmptyProjectList(t *testing.T) {
+	clusterName, pathtoData := "west", "fixtures/start-data.sql"
+	_, router, _ := setupTest(t, clusterName, pathtoData)
+
+	_, err := db.DB.Exec(`DELETE FROM projects`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//This warrants its own unit test since the rendering of empty project lists
+	//uses a different code path than the rendering of non-empty project lists.
+	assert.HTTPRequest{
+		Method:       "GET",
+		Path:         "/v1/domains/uuid-for-germany/projects",
+		ExpectStatus: 200,
+		ExpectBody:   assert.JSONObject{"projects": []assert.JSONObject{}},
+	}.Check(t, router)
+}

--- a/pkg/api/clusters.go
+++ b/pkg/api/clusters.go
@@ -22,6 +22,7 @@ package api
 import (
 	"net/http"
 
+	"github.com/sapcc/go-bits/logg"
 	"github.com/sapcc/go-bits/respondwith"
 	"github.com/sapcc/go-bits/sre"
 	"github.com/sapcc/limes/pkg/db"
@@ -38,6 +39,9 @@ func (p *v1Provider) GetCluster(w http.ResponseWriter, r *http.Request) {
 	showBasic := !token.Check("cluster:show")
 
 	filter := reports.ReadFilter(r)
+	if filter.WithRates {
+		logg.Info("rate data on resource endpoint is deprecated: GET %s by user %s@%s with UA %q requests WithRates = true, OnlyRates = %t", r.URL.Path, token.UserName(), token.UserDomainName(), r.Header.Get("User-Agent"), filter.OnlyRates)
+	}
 	if showBasic {
 		filter.IsSubcapacityAllowed = func(serviceType, resourceName string) bool {
 			token.Context.Request["service"] = serviceType

--- a/pkg/api/core.go
+++ b/pkg/api/core.go
@@ -221,12 +221,16 @@ func GetDomainReport(cluster *core.Cluster, dbDomain db.Domain, dbi db.Interface
 
 //GetProjectReport is a convenience wrapper around reports.GetProjects() for getting a single project report.
 func GetProjectReport(cluster *core.Cluster, dbDomain db.Domain, dbProject db.Project, dbi db.Interface, filter reports.Filter) (*limes.ProjectReport, error) {
-	projectReports, err := reports.GetProjects(cluster, dbDomain, &dbProject.ID, dbi, filter)
+	var result *limes.ProjectReport
+	err := reports.GetProjects(cluster, dbDomain, &dbProject, dbi, filter, func(r *limes.ProjectReport) error {
+		result = r
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
-	if len(projectReports) == 0 {
+	if result == nil {
 		return nil, errors.New("no resource data found for project")
 	}
-	return projectReports[0], nil
+	return result, nil
 }

--- a/pkg/api/domains.go
+++ b/pkg/api/domains.go
@@ -25,6 +25,7 @@ import (
 
 	gorp "gopkg.in/gorp.v2"
 
+	"github.com/sapcc/go-bits/logg"
 	"github.com/sapcc/go-bits/respondwith"
 	"github.com/sapcc/go-bits/sre"
 	"github.com/sapcc/limes"
@@ -42,7 +43,12 @@ func (p *v1Provider) ListDomains(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	domains, err := reports.GetDomains(p.Cluster, nil, db.DB, reports.ReadFilter(r))
+	filter := reports.ReadFilter(r)
+	if filter.WithRates {
+		logg.Info("rate data on resource endpoint is deprecated: GET %s by user %s@%s with UA %q requests WithRates = true, OnlyRates = %t", r.URL.Path, token.UserName(), token.UserDomainName(), r.Header.Get("User-Agent"), filter.OnlyRates)
+	}
+
+	domains, err := reports.GetDomains(p.Cluster, nil, db.DB, filter)
 	if respondwith.ErrorText(w, err) {
 		return
 	}
@@ -62,7 +68,12 @@ func (p *v1Provider) GetDomain(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	domain, err := GetDomainReport(p.Cluster, *dbDomain, db.DB, reports.ReadFilter(r))
+	filter := reports.ReadFilter(r)
+	if filter.WithRates {
+		logg.Info("rate data on resource endpoint is deprecated: GET %s by user %s@%s with UA %q requests WithRates = true, OnlyRates = %t", r.URL.Path, token.UserName(), token.UserDomainName(), r.Header.Get("User-Agent"), filter.OnlyRates)
+	}
+
+	domain, err := GetDomainReport(p.Cluster, *dbDomain, db.DB, filter)
 	if respondwith.ErrorText(w, err) {
 		return
 	}

--- a/pkg/api/fixtures/project-get-berlin-only-rates.json
+++ b/pkg/api/fixtures/project-get-berlin-only-rates.json
@@ -36,6 +36,7 @@
             "default_window": "1s"
           }
         ],
+        "scraped_at": 22,
         "rates_scraped_at": 23
       },
       {
@@ -64,6 +65,7 @@
             "default_window": "1s"
           }
         ],
+        "scraped_at": 11,
         "rates_scraped_at": 12
       }
     ]

--- a/pkg/api/fixtures/project-get-paris-only-default-rates.json
+++ b/pkg/api/fixtures/project-get-paris-only-default-rates.json
@@ -30,7 +30,8 @@
             "limit": 2,
             "window": "1s"
           }
-        ]
+        ],
+        "scraped_at": 66
       },
       {
         "type": "unshared",
@@ -52,7 +53,8 @@
             "limit": 2,
             "window": "1s"
           }
-        ]
+        ],
+        "scraped_at": 55
       }
     ]
   }

--- a/pkg/api/fixtures/start-data-minimal.sql
+++ b/pkg/api/fixtures/start-data-minimal.sql
@@ -1,0 +1,15 @@
+CREATE OR REPLACE FUNCTION unix(i integer) RETURNS timestamp AS $$ SELECT TO_TIMESTAMP(i) AT TIME ZONE 'Etc/UTC' $$ LANGUAGE SQL;
+
+-- two services, one shared, one unshared
+INSERT INTO cluster_services (id, cluster_id, type, scraped_at) VALUES (1, 'west', 'unshared', UNIX(1000));
+INSERT INTO cluster_services (id, cluster_id, type, scraped_at) VALUES (2, 'west', 'shared',   UNIX(1100));
+
+-- cluster "west" has two domains
+INSERT INTO domains (id, cluster_id, name, uuid) VALUES (1, 'west', 'germany', 'uuid-for-germany');
+INSERT INTO domains (id, cluster_id, name, uuid) VALUES (2, 'west', 'france',  'uuid-for-france');
+
+-- domain_services is fully populated (as ensured by the collector's consistency check)
+INSERT INTO domain_services (id, domain_id, type) VALUES (1, 1, 'unshared');
+INSERT INTO domain_services (id, domain_id, type) VALUES (2, 1, 'shared');
+INSERT INTO domain_services (id, domain_id, type) VALUES (3, 2, 'unshared');
+INSERT INTO domain_services (id, domain_id, type) VALUES (4, 2, 'shared');

--- a/pkg/api/fixtures/start-data.sql
+++ b/pkg/api/fixtures/start-data.sql
@@ -80,7 +80,7 @@ INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_big
 INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_bigint) VALUES (3, 'service/unshared/instances:delete', NULL, NULL, '0');
 INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_bigint) VALUES (4, 'service/shared/objects:delete', NULL, NULL, '0');
 INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_bigint) VALUES (4, 'service/shared/objects:unlimited', NULL, NULL, '1048576');
--- not pictures: paris has no records at all, so the API will only display the default rate limits
+-- not pictured: paris has no records at all, so the API will only display the default rate limits
 
 -- insert some bullshit data that should be filtered out by the pkg/reports/ logic
 -- (cluster "north", service "weird", resource "items" and rate "frobnicate" are not configured)

--- a/pkg/api/projects.go
+++ b/pkg/api/projects.go
@@ -121,8 +121,12 @@ func (p *v1Provider) ListProjects(w http.ResponseWriter, r *http.Request) {
 	}
 	if err != nil {
 		if outputStarted {
-			//we are already writing a 200 response, so we can only log the error,
-			//but we cannot send it to the client
+			//deliberately destroy the ongoing JSON document to make it clear to the
+			//client that an error occurred
+			fmt.Fprintf(w, "\naborting because of error: %s\n", err.Error())
+			//usually we don't need to log errors in handlers because the
+			//logg.Middleware does it for us, but since this is a 200 response, we
+			//need to do it ourselves
 			logg.Error("late error during GET %s: %s", r.URL.String(), err.Error())
 		} else {
 			//the callback was never called, so we can properly report the error to the client

--- a/pkg/reports/project.go
+++ b/pkg/reports/project.go
@@ -31,19 +31,22 @@ import (
 	"github.com/sapcc/limes/pkg/db"
 )
 
+//NOTE: Both queries use LEFT OUTER JOIN to generate at least one result row
+//per known project, to ensure that each project gets a report even if its
+//resource data and/or rate data is incomplete.
 var (
+	projectRateLimitReportQuery = db.SimplifyWhitespaceInSQL(`
+	SELECT p.uuid, p.name, COALESCE(p.parent_uuid, ''), ps.type, ps.scraped_at, ps.rates_scraped_at, pra.name, pra.rate_limit, pra.window_ns, pra.usage_as_bigint
+	  FROM projects p
+	  LEFT OUTER JOIN project_services ps ON ps.project_id = p.id {{AND ps.type = $service_type}}
+	  LEFT OUTER JOIN project_rates pra ON pra.service_id = ps.id
+	 WHERE %s
+`)
 	projectReportQuery = db.SimplifyWhitespaceInSQL(`
 	SELECT p.uuid, p.name, COALESCE(p.parent_uuid, ''), p.has_bursting, ps.type, ps.scraped_at, ps.rates_scraped_at, pr.name, pr.quota, pr.usage, pr.physical_usage, pr.backend_quota, pr.subresources
 	  FROM projects p
 	  LEFT OUTER JOIN project_services ps ON ps.project_id = p.id {{AND ps.type = $service_type}}
 	  LEFT OUTER JOIN project_resources pr ON pr.service_id = ps.id {{AND pr.name = $resource_name}}
-	 WHERE %s
-`)
-	projectRateLimitReportQuery = db.SimplifyWhitespaceInSQL(`
-	SELECT p.uuid, p.name, COALESCE(p.parent_uuid, ''), ps.type, ps.scraped_at, ps.rates_scraped_at, pra.name, pra.rate_limit, pra.window_ns, pra.usage_as_bigint
-	  FROM projects p
-	  JOIN project_services ps ON ps.project_id = p.id {{AND ps.type = $service_type}}
-	  JOIN project_rates pra ON pra.service_id = ps.id
 	 WHERE %s
 `)
 )
@@ -65,112 +68,30 @@ func GetProjects(cluster *core.Cluster, domain db.Domain, project *db.Project, d
 
 	projects := make(projects)
 
-	//avoid collecting the potentially large subresources strings when possible
-	queryStr := projectReportQuery
-	if !filter.WithSubresources {
-		queryStr = strings.Replace(queryStr, "pr.subresources", "''", 1)
-	}
-	var joinArgs []interface{}
-	if filter.OnlyRates {
-		//run the query only to collect all projects and project services, skip resource data by using a resource name filter that never match
-		filter2 := filter
-		filter2.ResourceNames = []string{"does-not-match-anything"}
-		queryStr, joinArgs = filter2.PrepareQuery(queryStr)
-	} else {
-		queryStr, joinArgs = filter.PrepareQuery(queryStr)
-	}
-	whereStr, whereArgs := db.BuildSimpleWhereClause(fields, len(joinArgs))
-	err := db.ForeachRow(dbi, fmt.Sprintf(queryStr, whereStr), append(joinArgs, whereArgs...), func(rows *sql.Rows) error {
-		var (
-			projectUUID        string
-			projectName        string
-			projectParentUUID  string
-			projectHasBursting bool
-			serviceType        *string
-			scrapedAt          *time.Time
-			ratesScrapedAt     *time.Time
-			resourceName       *string
-			quota              *uint64
-			usage              *uint64
-			physicalUsage      *uint64
-			backendQuota       *int64
-			subresources       *string
-		)
-		err := rows.Scan(
-			&projectUUID, &projectName, &projectParentUUID, &projectHasBursting,
-			&serviceType, &scrapedAt, &ratesScrapedAt, &resourceName,
-			&quota, &usage, &physicalUsage, &backendQuota, &subresources,
-		)
-		if err != nil {
-			return err
-		}
-
-		projectReport, _, resReport := projects.Find(cluster, projectUUID, projectName, projectParentUUID, serviceType, resourceName, timeIf(scrapedAt, !filter.OnlyRates), timeIf(ratesScrapedAt, filter.WithRates))
-		if projectReport != nil && clusterCanBurst {
-			projectReport.Bursting = &limes.ProjectBurstingInfo{
-				Enabled:    projectHasBursting,
-				Multiplier: cluster.Config.Bursting.MaxMultiplier,
-			}
-		}
-
-		if resReport != nil {
-			subresourcesValue := ""
-			if subresources != nil {
-				subresourcesValue = *subresources
-			}
-			resReport.PhysicalUsage = physicalUsage
-			resReport.BackendQuota = nil //See below.
-			resReport.Subresources = limes.JSONString(subresourcesValue)
-
-			behavior := cluster.BehaviorForResource(*serviceType, *resourceName, domain.Name+"/"+projectName)
-			resReport.Scaling = behavior.ToScalingBehavior()
-			resReport.Annotations = behavior.Annotations
-
-			if usage != nil {
-				resReport.Usage = *usage
-			}
-			if quota != nil && !resReport.NoQuota {
-				resReport.Quota = quota
-				resReport.UsableQuota = quota
-				if projectHasBursting && clusterCanBurst {
-					usableQuota := behavior.MaxBurstMultiplier.ApplyTo(*quota)
-					resReport.UsableQuota = &usableQuota
-				}
-				if backendQuota != nil && (*backendQuota < 0 || uint64(*backendQuota) != *resReport.UsableQuota) {
-					resReport.BackendQuota = backendQuota
-				}
-			}
-			if projectHasBursting && clusterCanBurst && quota != nil && usage != nil {
-				if *usage > *quota {
-					resReport.BurstUsage = *usage - *quota
-				}
-			}
-		}
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-
-	if filter.WithRates {
-		//pre-fill the report with the default rate limits
-		for _, projectReport := range projects {
-			for _, serviceReport := range projectReport.Services {
-				if svcConfig, err := cluster.Config.GetServiceConfigurationForType(serviceReport.Type); err == nil {
-					if len(svcConfig.RateLimits.ProjectDefault) > 0 {
-						serviceReport.Rates = make(limes.ProjectRateLimitReports, len(svcConfig.RateLimits.ProjectDefault))
-						for _, rateLimit := range svcConfig.RateLimits.ProjectDefault {
-							serviceReport.Rates[rateLimit.Name] = &limes.ProjectRateLimitReport{
-								RateInfo: cluster.InfoForRate(serviceReport.Type, rateLimit.Name),
-								Limit:    rateLimit.Limit,
-								Window:   p2window(rateLimit.Window),
-							}
+	//if rates are requested, fill default rate limits into ProjectServiceReport
+	//instances as they are created
+	onCreateService := func(serviceReport *limes.ProjectServiceReport) {
+		if filter.WithRates {
+			if svcConfig, err := cluster.Config.GetServiceConfigurationForType(serviceReport.Type); err == nil {
+				if len(svcConfig.RateLimits.ProjectDefault) > 0 {
+					serviceReport.Rates = make(limes.ProjectRateLimitReports, len(svcConfig.RateLimits.ProjectDefault))
+					for _, rateLimit := range svcConfig.RateLimits.ProjectDefault {
+						serviceReport.Rates[rateLimit.Name] = &limes.ProjectRateLimitReport{
+							RateInfo: cluster.InfoForRate(serviceReport.Type, rateLimit.Name),
+							Limit:    rateLimit.Limit,
+							Window:   p2window(rateLimit.Window),
 						}
 					}
 				}
 			}
 		}
+	}
 
+	//phase 1: collect rate data
+	//
+	//We do this phase first because this data is small enough to easily fit in RAM.
+
+	if filter.WithRates {
 		queryStr, joinArgs := filter.PrepareQuery(projectRateLimitReportQuery)
 		whereStr, whereArgs := db.BuildSimpleWhereClause(fields, len(joinArgs))
 		err := db.ForeachRow(dbi, fmt.Sprintf(queryStr, whereStr), append(joinArgs, whereArgs...), func(rows *sql.Rows) error {
@@ -181,10 +102,10 @@ func GetProjects(cluster *core.Cluster, domain db.Domain, project *db.Project, d
 				serviceType       *string
 				scrapedAt         *time.Time
 				ratesScrapedAt    *time.Time
-				rateName          string
+				rateName          *string
 				limit             *uint64
 				window            *limes.Window
-				usageAsBigint     string
+				usageAsBigint     *string
 			)
 			err := rows.Scan(
 				&projectUUID, &projectName, &projectParentUUID,
@@ -195,22 +116,24 @@ func GetProjects(cluster *core.Cluster, domain db.Domain, project *db.Project, d
 				return err
 			}
 
-			_, srvReport, _ := projects.Find(cluster, projectUUID, projectName, projectParentUUID, serviceType, nil, scrapedAt, ratesScrapedAt)
-			if srvReport != nil {
-				rateReport := srvReport.Rates[rateName]
+			_, srvReport, _ := projects.Find(cluster, projectUUID, projectName, projectParentUUID, serviceType, nil, scrapedAt, ratesScrapedAt, onCreateService)
+			if srvReport != nil && rateName != nil {
+				rateReport := srvReport.Rates[*rateName]
 
 				//we previously created report entries for all rates that have a
 				//default limit; create missing report entries for rates that only have
 				//a usage
-				if rateReport == nil && usageAsBigint != "" && cluster.HasUsageForRate(*serviceType, rateName) {
+				if rateReport == nil && usageAsBigint != nil && *usageAsBigint != "" && cluster.HasUsageForRate(*serviceType, *rateName) {
 					rateReport = &limes.ProjectRateLimitReport{
-						RateInfo: cluster.InfoForRate(*serviceType, rateName),
+						RateInfo: cluster.InfoForRate(*serviceType, *rateName),
 					}
-					srvReport.Rates[rateName] = rateReport
+					srvReport.Rates[*rateName] = rateReport
 				}
 
 				if rateReport != nil {
-					rateReport.UsageAsBigint = usageAsBigint
+					if usageAsBigint != nil {
+						rateReport.UsageAsBigint = *usageAsBigint
+					}
 
 					//overwrite the default limit if a different custom limit is
 					//configured, but ignore custom limits where there is no default
@@ -226,6 +149,92 @@ func GetProjects(cluster *core.Cluster, domain db.Domain, project *db.Project, d
 				}
 			}
 
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	//phase 2: collect resource data
+	//
+	//Data collected in this phase can be very large if subresources are requested.
+	//TODO: send reports as soon as they are finished
+
+	if !filter.OnlyRates {
+		//avoid collecting the potentially large subresources strings when possible
+		queryStr := projectReportQuery
+		if !filter.WithSubresources {
+			queryStr = strings.Replace(queryStr, "pr.subresources", "''", 1)
+		}
+		queryStr, joinArgs := filter.PrepareQuery(queryStr)
+		whereStr, whereArgs := db.BuildSimpleWhereClause(fields, len(joinArgs))
+		err := db.ForeachRow(dbi, fmt.Sprintf(queryStr, whereStr), append(joinArgs, whereArgs...), func(rows *sql.Rows) error {
+			var (
+				projectUUID        string
+				projectName        string
+				projectParentUUID  string
+				projectHasBursting bool
+				serviceType        *string
+				scrapedAt          *time.Time
+				ratesScrapedAt     *time.Time
+				resourceName       *string
+				quota              *uint64
+				usage              *uint64
+				physicalUsage      *uint64
+				backendQuota       *int64
+				subresources       *string
+			)
+			err := rows.Scan(
+				&projectUUID, &projectName, &projectParentUUID, &projectHasBursting,
+				&serviceType, &scrapedAt, &ratesScrapedAt, &resourceName,
+				&quota, &usage, &physicalUsage, &backendQuota, &subresources,
+			)
+			if err != nil {
+				return err
+			}
+
+			projectReport, _, resReport := projects.Find(cluster, projectUUID, projectName, projectParentUUID, serviceType, resourceName, timeIf(scrapedAt, !filter.OnlyRates), timeIf(ratesScrapedAt, filter.WithRates), onCreateService)
+			if projectReport != nil && clusterCanBurst {
+				projectReport.Bursting = &limes.ProjectBurstingInfo{
+					Enabled:    projectHasBursting,
+					Multiplier: cluster.Config.Bursting.MaxMultiplier,
+				}
+			}
+
+			if resReport != nil {
+				subresourcesValue := ""
+				if subresources != nil {
+					subresourcesValue = *subresources
+				}
+				resReport.PhysicalUsage = physicalUsage
+				resReport.BackendQuota = nil //See below.
+				resReport.Subresources = limes.JSONString(subresourcesValue)
+
+				behavior := cluster.BehaviorForResource(*serviceType, *resourceName, domain.Name+"/"+projectName)
+				resReport.Scaling = behavior.ToScalingBehavior()
+				resReport.Annotations = behavior.Annotations
+
+				if usage != nil {
+					resReport.Usage = *usage
+				}
+				if quota != nil && !resReport.NoQuota {
+					resReport.Quota = quota
+					resReport.UsableQuota = quota
+					if projectHasBursting && clusterCanBurst {
+						usableQuota := behavior.MaxBurstMultiplier.ApplyTo(*quota)
+						resReport.UsableQuota = &usableQuota
+					}
+					if backendQuota != nil && (*backendQuota < 0 || uint64(*backendQuota) != *resReport.UsableQuota) {
+						resReport.BackendQuota = backendQuota
+					}
+				}
+				if projectHasBursting && clusterCanBurst && quota != nil && usage != nil {
+					if *usage > *quota {
+						resReport.BurstUsage = *usage - *quota
+					}
+				}
+			}
 			return nil
 		})
 		if err != nil {
@@ -255,7 +264,7 @@ func p2window(val limes.Window) *limes.Window {
 
 type projects map[string]*limes.ProjectReport
 
-func (p projects) Find(cluster *core.Cluster, projectUUID, projectName, projectParentUUID string, serviceType, resourceName *string, scrapedAt, ratesScrapedAt *time.Time) (*limes.ProjectReport, *limes.ProjectServiceReport, *limes.ProjectResourceReport) {
+func (p projects) Find(cluster *core.Cluster, projectUUID, projectName, projectParentUUID string, serviceType, resourceName *string, scrapedAt, ratesScrapedAt *time.Time, onCreateService func(*limes.ProjectServiceReport)) (*limes.ProjectReport, *limes.ProjectServiceReport, *limes.ProjectResourceReport) {
 	//Ensure the ProjectReport exists.
 	project, exists := p[projectUUID]
 	if !exists {
@@ -289,6 +298,9 @@ func (p projects) Find(cluster *core.Cluster, projectUUID, projectName, projectP
 		if ratesScrapedAt != nil {
 			ratesScrapedAtUnix := ratesScrapedAt.Unix()
 			service.RatesScrapedAt = &ratesScrapedAtUnix
+		}
+		if onCreateService != nil {
+			onCreateService(service)
 		}
 		project.Services[*serviceType] = service
 	}


### PR DESCRIPTION
As explained in the commit messages and code comments.

Checklist:

- [ ] ~If this PR is about a plugin, I tested the plugin against an OpenStack cluster.~
- [ ] ~I updated the documentation to describe the semantical or interface changes I introduced.~
