### PR TITLE
provide a stub implementation for a separate rate data API

### DIFF
--- a/docs/users/api-v1-specification.md
+++ b/docs/users/api-v1-specification.md
@@ -6,32 +6,6 @@ catalog under the service type `resources`.
 Where permission requirements are indicated, they refer to the default policy. Limes operators can configure their
 policy differently, so that certain requests may require other roles or token scopes.
 
-* [Request headers](#request-headers)
-  * [X\-Auth\-Token](#x-auth-token)
-* [GET /v1/clusters/current](#get-v1clusterscurrent)
-  * [Subcapacities](#subcapacities)
-* [GET /v1/domains](#get-v1domains)
-* [GET /v1/domains/:domain\_id](#get-v1domainsdomain_id)
-* [PUT /v1/domains/:domain\_id](#put-v1domainsdomain_id)
-* [POST /v1/domains/:domain\_id/simulate\-put](#post-v1domainsdomain_idsimulate-put)
-* [POST /v1/domains/discover](#post-v1domainsdiscover)
-* [GET /v1/domains/:domain\_id/projects](#get-v1domainsdomain_idprojects)
-* [GET /v1/domains/:domain\_id/projects/:project\_id](#get-v1domainsdomain_idprojectsproject_id)
-  * [Quota/usage for resources](#quotausage-for-resources)
-  * [Subresources](#subresources)
-  * [Quota bursting details](#quota-bursting-details)
-  * [Rate limits and throughput tracking](#rate-limits-and-throughput-tracking)
-    * [Default rate limits](#default-rate-limits)
-* [PUT /v1/domains/:domain\_id/projects/:project\_id](#put-v1domainsdomain_idprojectsproject_id)
-* [POST /v1/domains/:domain\_id/projects/:project\_id/simulate\-put](#post-v1domainsdomain_idprojectsproject_idsimulate-put)
-* [POST /v1/domains/:domain\_id/projects/discover](#post-v1domainsdomain_idprojectsdiscover)
-* [POST /v1/domains/:domain\_id/projects/:project\_id/sync](#post-v1domainsdomain_idprojectsproject_idsync)
-* [GET /v1/inconsistencies](#get-v1inconsistencies)
-* [GET /v1/admin/scrape\-errors](#get-v1adminscrape-errors)
-* [GET /v1/admin/rate\-scrape\-errors](#get-v1adminrate-scrape-errors)
-
----
-
 ## Request headers
 
 ### X-Auth-Token
@@ -56,7 +30,7 @@ Returns 200 (OK) on success. Result is a JSON document like:
 ```json
 {
   "cluster": {
-    "id": "example-cluster",
+    "id": "current",
     "services": [
       {
         "type": "compute",
@@ -743,6 +717,49 @@ If the project does not exist in Limes' database yet, query Keystone to see if t
 *Rationale:* When a project administrator wants to adjust her project's quotas, she might discover that the usage data
 shown by Limes is out-of-date. She can then use this call to refresh the usage data in order to make a more informed
 decision about how to adjust her quotas.
+
+## GET /rates/v1/clusters/current
+
+Query global rate limits for the cluster level. These rate limits apply to all users in aggregate. Arguments:
+
+* `service`: Limit query to resources in this service. May be given multiple times.
+* `area`: Limit query to resources in services in this area. May be given multiple times.
+* `resource`: When combined, with `?service=`, limit query to that resource.
+
+Returns 200 (OK) on success. Result is a JSON document like:
+
+```json
+{
+  "cluster": {
+    "id": "current",
+    "services": [
+      {
+        "type": "object-store",
+        "area": "storage",
+        "rates": [
+          {
+            "name": "service/shared/objects:create",
+            "limit": 5000,
+            "window": "1s"
+          },
+          {
+            "name": "service/shared/objects:update",
+            "limit": 10000,
+            "window": "1s"
+          },
+          {
+            "name": "service/shared/objects:delete",
+            "limit": 5000,
+            "window": "1s"
+          },
+          ...
+        ]
+      },
+      ...
+    ]
+  }
+}
+```
 
 ## GET /v1/inconsistencies
 

--- a/docs/users/api-v1-specification.md
+++ b/docs/users/api-v1-specification.md
@@ -768,7 +768,7 @@ Returns 200 (OK) on success. Result is a JSON document like:
 ## GET /rates/v1/domains/:domain\_id/projects/:project\_id
 
 Same behavior as the respective endpoints without the `/rates` prefix, but always implies `?rates=only` and therefore
-shows only rate data. Specifiying the `rates` query parameter explicitly is an error.
+shows only rate data. Specifying the `rates` query parameter explicitly is an error.
 
 ## GET /v1/inconsistencies
 

--- a/docs/users/api-v1-specification.md
+++ b/docs/users/api-v1-specification.md
@@ -391,6 +391,9 @@ projects in that token's domain. With project member permission, shows that toke
   Use `rates=only` to only list rates (instead of resources).
   When combined with `?service=`, limit query to these rates (e.g. `?service=compute&rates`). May be given multiple times.
 
+  **Warning:** Usage of `?rates` on these endpoints is deprecated. Use the new
+  `GET /rates/v1/domains/:domain_id/projects` and `GET /rates/v1/domains/:domain_id/projects/:project_id` endpoints instead.
+
 Returns 200 (OK) on success. Result is a JSON document like:
 
 ```json
@@ -760,6 +763,12 @@ Returns 200 (OK) on success. Result is a JSON document like:
   }
 }
 ```
+
+## GET /rates/v1/domains/:domain\_id/projects
+## GET /rates/v1/domains/:domain\_id/projects/:project\_id
+
+Same behavior as the respective endpoints without the `/rates` prefix, but always implies `?rates=only` and therefore
+shows only rate data. Specifiying the `rates` query parameter explicitly is an error.
 
 ## GET /v1/inconsistencies
 

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -436,6 +436,20 @@ func Test_ClusterOperations(t *testing.T) {
 		ExpectBody:   assert.JSONFixtureFile("fixtures/cluster-get-west-filtered.json"),
 	}.Check(t, router)
 
+	//check GetClusterRates
+	assert.HTTPRequest{
+		Method:       "GET",
+		Path:         "/rates/v1/clusters/current",
+		ExpectStatus: 200,
+		ExpectBody:   assert.JSONFixtureFile("fixtures/cluster-get-west-only-rates.json"),
+	}.Check(t, router)
+	assert.HTTPRequest{
+		Method:       "GET",
+		Path:         "/rates/v1/clusters/current?rates",
+		ExpectStatus: 400,
+		ExpectBody:   assert.StringData("the `rates` query parameter is not allowed here\n"),
+	}.Check(t, router)
+
 	//check rendering of overcommit factors
 	cluster.Config.ResourceBehaviors = []*core.ResourceBehaviorConfiguration{
 		{

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -1099,6 +1099,12 @@ func Test_ProjectOperations(t *testing.T) {
 		ExpectStatus: 200,
 		ExpectBody:   assert.JSONFixtureFile("./fixtures/project-get-dresden-with-rates.json"),
 	}.Check(t, router)
+	assert.HTTPRequest{
+		Method:       "GET",
+		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-dresden?rates=only",
+		ExpectStatus: 200,
+		ExpectBody:   assert.JSONFixtureFile("./fixtures/project-get-dresden-only-rates.json"),
+	}.Check(t, router)
 	//paris has a case of infinite backend quota
 	assert.HTTPRequest{
 		Method:       "GET",
@@ -1112,6 +1118,20 @@ func Test_ProjectOperations(t *testing.T) {
 		Path:         "/v1/domains/uuid-for-france/projects/uuid-for-paris?rates=only",
 		ExpectStatus: 200,
 		ExpectBody:   assert.JSONFixtureFile("./fixtures/project-get-paris-only-default-rates.json"),
+	}.Check(t, router)
+
+	//check GetProjectRates
+	assert.HTTPRequest{
+		Method:       "GET",
+		Path:         "/rates/v1/domains/uuid-for-germany/projects/uuid-for-berlin",
+		ExpectStatus: 200,
+		ExpectBody:   assert.JSONFixtureFile("./fixtures/project-get-berlin-only-rates.json"),
+	}.Check(t, router)
+	assert.HTTPRequest{
+		Method:       "GET",
+		Path:         "/rates/v1/domains/uuid-for-germany/projects/uuid-for-dresden",
+		ExpectStatus: 200,
+		ExpectBody:   assert.JSONFixtureFile("./fixtures/project-get-dresden-only-rates.json"),
 	}.Check(t, router)
 
 	//check non-existent domains/projects
@@ -1137,6 +1157,12 @@ func Test_ProjectOperations(t *testing.T) {
 	}.Check(t, router)
 	assert.HTTPRequest{
 		Method:       "GET",
+		Path:         "/v1/domains/uuid-for-germany/projects?rates=only",
+		ExpectStatus: 200,
+		ExpectBody:   assert.JSONFixtureFile("./fixtures/project-list-only-rates.json"),
+	}.Check(t, router)
+	assert.HTTPRequest{
+		Method:       "GET",
 		Path:         "/v1/domains/uuid-for-germany/projects?service=unknown",
 		ExpectStatus: 200,
 		ExpectBody:   assert.JSONFixtureFile("./fixtures/project-list-no-services.json"),
@@ -1152,6 +1178,14 @@ func Test_ProjectOperations(t *testing.T) {
 		Path:         "/v1/domains/uuid-for-germany/projects?service=shared&resource=things",
 		ExpectStatus: 200,
 		ExpectBody:   assert.JSONFixtureFile("./fixtures/project-list-filtered.json"),
+	}.Check(t, router)
+
+	//check ListProjectRates
+	assert.HTTPRequest{
+		Method:       "GET",
+		Path:         "/rates/v1/domains/uuid-for-germany/projects",
+		ExpectStatus: 200,
+		ExpectBody:   assert.JSONFixtureFile("./fixtures/project-list-only-rates.json"),
 	}.Check(t, router)
 
 	//check ?area= filter (esp. interaction with ?service= filter)

--- a/pkg/api/core.go
+++ b/pkg/api/core.go
@@ -93,9 +93,9 @@ func NewV1Router(cluster *core.Cluster, policyEnforcer gopherpolicy.Enforcer) (h
 	})
 
 	r.Methods("GET").Path("/v1/clusters/current").HandlerFunc(p.GetCluster)
+	r.Methods("GET").Path("/rates/v1/clusters/current").HandlerFunc(p.GetClusterRates)
 
 	r.Methods("GET").Path("/v1/inconsistencies").HandlerFunc(p.ListInconsistencies)
-
 	r.Methods("GET").Path("/v1/admin/scrape-errors").HandlerFunc(p.ListScrapeErrors)
 	r.Methods("GET").Path("/v1/admin/rate-scrape-errors").HandlerFunc(p.ListRateScrapeErrors)
 

--- a/pkg/api/core.go
+++ b/pkg/api/core.go
@@ -111,6 +111,8 @@ func NewV1Router(cluster *core.Cluster, policyEnforcer gopherpolicy.Enforcer) (h
 	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/sync").HandlerFunc(p.SyncProject)
 	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/simulate-put").HandlerFunc(p.SimulatePutProject)
 	r.Methods("PUT").Path("/v1/domains/{domain_id}/projects/{project_id}").HandlerFunc(p.PutProject)
+	r.Methods("GET").Path("/rates/v1/domains/{domain_id}/projects").HandlerFunc(p.ListProjectRates)
+	r.Methods("GET").Path("/rates/v1/domains/{domain_id}/projects/{project_id}").HandlerFunc(p.GetProjectRates)
 
 	return sre.Instrument(forbidClusterIDHeader(r)), p.VersionData
 }

--- a/pkg/api/fixtures/cluster-get-west-filtered.json
+++ b/pkg/api/fixtures/cluster-get-west-filtered.json
@@ -14,9 +14,7 @@
           }
         ],
         "max_scraped_at": 66,
-        "min_scraped_at": 22,
-        "max_rates_scraped_at": 45,
-        "min_rates_scraped_at": 23
+        "min_scraped_at": 22
       }
     ],
     "max_scraped_at": 1100,

--- a/pkg/api/fixtures/cluster-get-west-no-resources.json
+++ b/pkg/api/fixtures/cluster-get-west-no-resources.json
@@ -7,9 +7,7 @@
         "area": "shared",
         "resources": [],
         "max_scraped_at": 66,
-        "min_scraped_at": 22,
-        "max_rates_scraped_at": 45,
-        "min_rates_scraped_at": 23
+        "min_scraped_at": 22
       }
     ],
     "max_scraped_at": 1100,

--- a/pkg/api/fixtures/cluster-get-west-with-overcommit.json
+++ b/pkg/api/fixtures/cluster-get-west-with-overcommit.json
@@ -35,9 +35,7 @@
           }
         ],
         "max_scraped_at": 66,
-        "min_scraped_at": 22,
-        "max_rates_scraped_at": 45,
-        "min_rates_scraped_at": 23
+        "min_scraped_at": 22
       },
       {
         "type": "unshared",
@@ -79,9 +77,7 @@
           }
         ],
         "max_scraped_at": 55,
-        "min_scraped_at": 11,
-        "max_rates_scraped_at": 34,
-        "min_rates_scraped_at": 12
+        "min_scraped_at": 11
       }
     ],
     "max_scraped_at": 1100,

--- a/pkg/api/fixtures/cluster-get-west.json
+++ b/pkg/api/fixtures/cluster-get-west.json
@@ -34,9 +34,7 @@
           }
         ],
         "max_scraped_at": 66,
-        "min_scraped_at": 22,
-        "max_rates_scraped_at": 45,
-        "min_rates_scraped_at": 23
+        "min_scraped_at": 22
       },
       {
         "type": "unshared",
@@ -75,9 +73,7 @@
           }
         ],
         "max_scraped_at": 55,
-        "min_scraped_at": 11,
-        "max_rates_scraped_at": 34,
-        "min_rates_scraped_at": 12
+        "min_scraped_at": 11
       }
     ],
     "max_scraped_at": 1100,

--- a/pkg/api/fixtures/project-get-berlin-only-rates.json
+++ b/pkg/api/fixtures/project-get-berlin-only-rates.json
@@ -36,7 +36,6 @@
             "default_window": "1s"
           }
         ],
-        "scraped_at": 22,
         "rates_scraped_at": 23
       },
       {
@@ -65,7 +64,6 @@
             "default_window": "1s"
           }
         ],
-        "scraped_at": 11,
         "rates_scraped_at": 12
       }
     ]

--- a/pkg/api/fixtures/project-get-dresden-only-rates.json
+++ b/pkg/api/fixtures/project-get-dresden-only-rates.json
@@ -37,7 +37,6 @@
             "window": "1s"
           }
         ],
-        "scraped_at": 44,
         "rates_scraped_at": 45
       },
       {
@@ -62,7 +61,6 @@
             "window": "1s"
           }
         ],
-        "scraped_at": 33,
         "rates_scraped_at": 34
       }
     ]

--- a/pkg/api/fixtures/project-get-dresden-only-rates.json
+++ b/pkg/api/fixtures/project-get-dresden-only-rates.json
@@ -1,0 +1,70 @@
+{
+  "project": {
+    "id": "uuid-for-dresden",
+    "name": "dresden",
+    "parent_id": "uuid-for-berlin",
+    "services": [
+      {
+        "type": "shared",
+        "area": "shared",
+        "resources": [],
+        "rates": [
+          {
+            "name": "service/shared/objects:create",
+            "limit": 5,
+            "window": "1m"
+          },
+          {
+            "name": "service/shared/objects:delete",
+            "unit": "MiB",
+            "limit": 1,
+            "window": "1m",
+            "usage_as_bigint": "0"
+          },
+          {
+            "name": "service/shared/objects:read/list",
+            "limit": 3,
+            "window": "1s"
+          },
+          {
+            "name": "service/shared/objects:unlimited",
+            "unit": "KiB",
+            "usage_as_bigint": "1048576"
+          },
+          {
+            "name": "service/shared/objects:update",
+            "limit": 2,
+            "window": "1s"
+          }
+        ],
+        "scraped_at": 44,
+        "rates_scraped_at": 45
+      },
+      {
+        "type": "unshared",
+        "area": "unshared",
+        "resources": [],
+        "rates": [
+          {
+            "name": "service/unshared/instances:create",
+            "limit": 5,
+            "window": "1m"
+          },
+          {
+            "name": "service/unshared/instances:delete",
+            "limit": 1,
+            "window": "1m",
+            "usage_as_bigint": "0"
+          },
+          {
+            "name": "service/unshared/instances:update",
+            "limit": 2,
+            "window": "1s"
+          }
+        ],
+        "scraped_at": 33,
+        "rates_scraped_at": 34
+      }
+    ]
+  }
+}

--- a/pkg/api/fixtures/project-get-paris-only-default-rates.json
+++ b/pkg/api/fixtures/project-get-paris-only-default-rates.json
@@ -30,8 +30,7 @@
             "limit": 2,
             "window": "1s"
           }
-        ],
-        "scraped_at": 66
+        ]
       },
       {
         "type": "unshared",
@@ -53,8 +52,7 @@
             "limit": 2,
             "window": "1s"
           }
-        ],
-        "scraped_at": 55
+        ]
       }
     ]
   }

--- a/pkg/api/fixtures/project-list-only-rates.json
+++ b/pkg/api/fixtures/project-list-only-rates.json
@@ -37,7 +37,6 @@
               "default_window": "1s"
             }
           ],
-          "scraped_at": 22,
           "rates_scraped_at": 23
         },
         {
@@ -66,7 +65,6 @@
               "default_window": "1s"
             }
           ],
-          "scraped_at": 11,
           "rates_scraped_at": 12
         }
       ]
@@ -109,7 +107,6 @@
               "window": "1s"
             }
           ],
-          "scraped_at": 44,
           "rates_scraped_at": 45
         },
         {
@@ -134,7 +131,6 @@
               "window": "1s"
             }
           ],
-          "scraped_at": 33,
           "rates_scraped_at": 34
         }
       ]

--- a/pkg/api/fixtures/project-list-only-rates.json
+++ b/pkg/api/fixtures/project-list-only-rates.json
@@ -1,0 +1,143 @@
+{
+  "projects": [
+    {
+      "id": "uuid-for-berlin",
+      "name": "berlin",
+      "parent_id": "uuid-for-germany",
+      "services": [
+        {
+          "type": "shared",
+          "area": "shared",
+          "resources": [],
+          "rates": [
+            {
+              "name": "service/shared/objects:create",
+              "limit": 5,
+              "window": "1m"
+            },
+            {
+              "name": "service/shared/objects:delete",
+              "unit": "MiB",
+              "limit": 2,
+              "window": "1m",
+              "default_limit": 1,
+              "default_window": "1m",
+              "usage_as_bigint": "23456"
+            },
+            {
+              "name": "service/shared/objects:read/list",
+              "limit": 3,
+              "window": "1s"
+            },
+            {
+              "name": "service/shared/objects:update",
+              "limit": 2,
+              "window": "1m",
+              "default_limit": 2,
+              "default_window": "1s"
+            }
+          ],
+          "scraped_at": 22,
+          "rates_scraped_at": 23
+        },
+        {
+          "type": "unshared",
+          "area": "unshared",
+          "resources": [],
+          "rates": [
+            {
+              "name": "service/unshared/instances:create",
+              "limit": 5,
+              "window": "1m"
+            },
+            {
+              "name": "service/unshared/instances:delete",
+              "limit": 2,
+              "window": "1m",
+              "default_limit": 1,
+              "default_window": "1m",
+              "usage_as_bigint": "12345"
+            },
+            {
+              "name": "service/unshared/instances:update",
+              "limit": 2,
+              "window": "1m",
+              "default_limit": 2,
+              "default_window": "1s"
+            }
+          ],
+          "scraped_at": 11,
+          "rates_scraped_at": 12
+        }
+      ]
+    },
+    {
+      "id": "uuid-for-dresden",
+      "name": "dresden",
+      "parent_id": "uuid-for-berlin",
+      "services": [
+        {
+          "type": "shared",
+          "area": "shared",
+          "resources": [],
+          "rates": [
+            {
+              "name": "service/shared/objects:create",
+              "limit": 5,
+              "window": "1m"
+            },
+            {
+              "name": "service/shared/objects:delete",
+              "unit": "MiB",
+              "limit": 1,
+              "window": "1m",
+              "usage_as_bigint": "0"
+            },
+            {
+              "name": "service/shared/objects:read/list",
+              "limit": 3,
+              "window": "1s"
+            },
+            {
+              "name": "service/shared/objects:unlimited",
+              "unit": "KiB",
+              "usage_as_bigint": "1048576"
+            },
+            {
+              "name": "service/shared/objects:update",
+              "limit": 2,
+              "window": "1s"
+            }
+          ],
+          "scraped_at": 44,
+          "rates_scraped_at": 45
+        },
+        {
+          "type": "unshared",
+          "area": "unshared",
+          "resources": [],
+          "rates": [
+            {
+              "name": "service/unshared/instances:create",
+              "limit": 5,
+              "window": "1m"
+            },
+            {
+              "name": "service/unshared/instances:delete",
+              "limit": 1,
+              "window": "1m",
+              "usage_as_bigint": "0"
+            },
+            {
+              "name": "service/unshared/instances:update",
+              "limit": 2,
+              "window": "1s"
+            }
+          ],
+          "scraped_at": 33,
+          "rates_scraped_at": 34
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/reports/cluster.go
+++ b/pkg/reports/cluster.go
@@ -115,16 +115,18 @@ func GetCluster(cluster *core.Cluster, dbi db.Interface, filter Filter) (*limes.
 						service.MinScrapedAt = &val
 					}
 				}
-				if maxRatesScrapedAt != nil {
-					val := maxRatesScrapedAt.Unix()
-					if service.MaxRatesScrapedAt == nil || *service.MaxRatesScrapedAt < val {
-						service.MaxRatesScrapedAt = &val
+				if filter.WithRates {
+					if maxRatesScrapedAt != nil {
+						val := maxRatesScrapedAt.Unix()
+						if service.MaxRatesScrapedAt == nil || *service.MaxRatesScrapedAt < val {
+							service.MaxRatesScrapedAt = &val
+						}
 					}
-				}
-				if minRatesScrapedAt != nil {
-					val := minRatesScrapedAt.Unix()
-					if service.MinRatesScrapedAt == nil || *service.MinRatesScrapedAt > val {
-						service.MinRatesScrapedAt = &val
+					if minRatesScrapedAt != nil {
+						val := minRatesScrapedAt.Unix()
+						if service.MinRatesScrapedAt == nil || *service.MinRatesScrapedAt > val {
+							service.MinRatesScrapedAt = &val
+						}
 					}
 				}
 			}

--- a/pkg/reports/project.go
+++ b/pkg/reports/project.go
@@ -125,7 +125,7 @@ func GetProjects(cluster *core.Cluster, domain db.Domain, project *db.Project, d
 				return err
 			}
 
-			_, srvReport, _ := projects.Find(cluster, projectUUID, projectName, projectParentUUID, serviceType, nil, scrapedAt, ratesScrapedAt, onCreateService)
+			_, srvReport, _ := projects.Find(cluster, projectUUID, projectName, projectParentUUID, serviceType, nil, timeIf(scrapedAt, !filter.OnlyRates), timeIf(ratesScrapedAt, filter.WithRates), onCreateService)
 			if srvReport != nil && rateName != nil {
 				rateReport := srvReport.Rates[*rateName]
 


### PR DESCRIPTION
During #135, I realized that having two types of differently-shaped data coming from different data sources (resource data and rate data) in the same API leads to an unnecessarily complex implementation and a lot of pain in general. Since the only user for the rate data is CBR (who collect Cronus rate usage data for billing purposes), we still have an opportunity to remake this API into something more maintainable.

As a first step, this PR provides new endpoints below `/rates/v1/` that implement reading of rate data via the existing report logic, but with `?rates=only` implied. This is not exactly what we want to have here in the end (there are still lots of `"resources": []` in the JSON outputs of these new endpoints), but it's enough to migrate CBR over to these new endpoints for their usecase. This will then enable a second step where we remove rate data support from the original endpoints and restructure the implementation accordingly.