### PR TITLE
capacity-nova: expose hypervisors as subcapacities (instead of aggregates)

### DIFF
--- a/pkg/core/config.go
+++ b/pkg/core/config.go
@@ -155,9 +155,10 @@ type CapacitorConfiguration struct {
 	//name and put the config data in there (use a struct to be able to give
 	//config options meaningful names)
 	Nova struct {
-		ExtraSpecs            map[string]string `yaml:"extra_specs"`
-		HypervisorTypePattern string            `yaml:"hypervisor_type_pattern"`
-		UsePlacementAPI       bool              `yaml:"use_placement_api"`
+		AggregateNamePattern     string            `yaml:"aggregate_name_pattern"`
+		MaxInstancesPerAggregate uint64            `yaml:"max_instances_per_aggregate"`
+		ExtraSpecs               map[string]string `yaml:"extra_specs"`
+		HypervisorTypePattern    string            `yaml:"hypervisor_type_pattern"`
 	} `yaml:"nova"`
 	Prometheus struct {
 		APIConfig PrometheusAPIConfiguration   `yaml:"api"`


### PR DESCRIPTION
This more fine-grained reporting is required because billing/controlling wants to match capacity reported by us with the data in our DCIM tooling. The only active user of the aggregate-level subcapacities is Elektra; I will make sure that the respective change in Elektra gets deployed in synchrony.

This commit also changes the upper limit for instance capacity from `10000 * az_count` to `10000 * matching_aggregate_count`, since in our deployment the assumed hard limit of 10000 applies at the vCenter level, i.e. at the level of matching aggregates.

Checklist:

- [x] If this PR is about a plugin, I tested the plugin against an OpenStack cluster.
- [x] I updated the documentation to describe the semantical or interface changes I introduced.

**Please do not merge this without my approval.** We need to land the respective UI change in Elektra first.