### PR TITLE
move plugin-specific config types into the DiscoveryPlugins themselves

### DIFF
--- a/docs/operators/config.md
+++ b/docs/operators/config.md
@@ -83,6 +83,7 @@ The following fields and sections are supported:
 | `discovery.method` | no | Defines which method to use to discover Keystone domains and projects in this cluster. If not given, the default value is `list`. |
 | `discovery.except_domains` | no | May contain a regex. Domains whose names match the regex will not be considered by Limes. |
 | `discovery.only_domains` | no | May contain a regex. If given, only domains whose names match the regex will be considered by Limes. If `except_domains` is also given, it takes precedence over `only_domains`. |
+| `discovery.params` | yes/no | A subsection containing additional parameters for the specific discovery method. Whether this is required depends on the discovery method; see [*Supported discovery methods*](#supported-discovery-methods) for details. |
 | `services` | yes | List of backend services for which to scrape quota/usage data. Service types for which Limes does not include a suitable *quota plugin* will be ignored. See below for supported service types. |
 | `subresources` | no | List of resources where subresource scraping is requested. This is an object with service types as keys, and a list of resource names as values. |
 | `subcapacities` | no | List of resources where subcapacity scraping is requested. This is an object with service types as keys, and a list of resource names as values. |
@@ -203,7 +204,7 @@ When this method is configured, Limes will simply list all Keystone domains and 
 ```yaml
 discovery:
   method: static
-  static:
+  params:
     domains:
     - id: 455080d9-6699-4f46-a755-2b2f8459c147
       name: Default

--- a/pkg/core/cluster.go
+++ b/pkg/core/cluster.go
@@ -36,6 +36,7 @@ import (
 	"github.com/sapcc/go-bits/logg"
 	"github.com/sapcc/go-bits/must"
 	"github.com/sapcc/go-bits/osext"
+	yaml "gopkg.in/yaml.v2"
 
 	"github.com/sapcc/limes/pkg/util"
 )
@@ -154,7 +155,11 @@ func (c *Cluster) Connect() (err error) {
 	eo := c.Auth.EndpointOpts
 
 	//initialize discovery plugin
-	err = c.DiscoveryPlugin.Init(provider, eo, c.Config.Discovery)
+	err = yaml.Unmarshal([]byte(c.Config.Discovery.Parameters), c.DiscoveryPlugin)
+	if err != nil {
+		return fmt.Errorf("failed to supply params to discovery method: %w", err)
+	}
+	err = c.DiscoveryPlugin.Init(provider, eo)
 	if err != nil {
 		return fmt.Errorf("failed to initialize discovery method: %w", util.UnpackError(err))
 	}

--- a/pkg/core/config.go
+++ b/pkg/core/config.go
@@ -31,6 +31,8 @@ import (
 	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
 	"github.com/sapcc/go-bits/logg"
 	yaml "gopkg.in/yaml.v2"
+
+	"github.com/sapcc/limes/pkg/util"
 )
 
 // ClusterConfiguration contains all the configuration data for a single cluster.
@@ -64,28 +66,12 @@ func (cluster *ClusterConfiguration) GetServiceConfigurationForType(serviceType 
 // DiscoveryConfiguration describes the method of discovering Keystone domains
 // and projects.
 type DiscoveryConfiguration struct {
-	Method               string         `yaml:"method"`
-	ExcludeDomainPattern string         `yaml:"except_domains"`
-	IncludeDomainPattern string         `yaml:"only_domains"`
-	ExcludeDomainRx      *regexp.Regexp `yaml:"-"`
-	IncludeDomainRx      *regexp.Regexp `yaml:"-"`
-	//for discovery methods that need configuration, add a field with the method
-	//as name and put the config data in there (use a struct to be able to give
-	//config options meaningful names)
-	RoleAssignment struct {
-		RoleName string `yaml:"role"`
-	} `yaml:"role-assignment"`
-	Static struct {
-		Domains []struct {
-			UUID     string `yaml:"id"`
-			Name     string `yaml:"name"`
-			Projects []struct {
-				UUID       string `yaml:"id"`
-				Name       string `yaml:"name"`
-				ParentUUID string `yaml:"parent_id"`
-			} `yaml:"projects"`
-		} `yaml:"domains"`
-	} `yaml:"static"`
+	Method               string              `yaml:"method"`
+	ExcludeDomainPattern string              `yaml:"except_domains"`
+	IncludeDomainPattern string              `yaml:"only_domains"`
+	ExcludeDomainRx      *regexp.Regexp      `yaml:"-"`
+	IncludeDomainRx      *regexp.Regexp      `yaml:"-"`
+	Parameters           util.YamlRawMessage `yaml:"params"`
 }
 
 // ServiceConfiguration describes a service that is enabled for a certain cluster.

--- a/pkg/core/plugin.go
+++ b/pkg/core/plugin.go
@@ -68,8 +68,12 @@ func KeystoneProjectFromDB(dbProject db.Project, domain KeystoneDomain) Keystone
 // projects and domains in a cluster.
 type DiscoveryPlugin interface {
 	pluggable.Plugin
-	//Init is called before any other interface methods, and allows the plugin to perform first-time initialization.
-	Init(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, cfg DiscoveryConfiguration) error
+	//Init is called before any other interface methods, and allows the plugin to
+	//perform first-time initialization.
+	//
+	//Before Init is called, the `discovery.params` provided in the configuration
+	//file will be yaml.Unmarshal()ed into the plugin object itself.
+	Init(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) error
 	//ListDomains returns all Keystone domains in the cluster.
 	ListDomains(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) ([]KeystoneDomain, error)
 	//ListProjects returns all Keystone projects in the given domain.

--- a/pkg/plugins/discovery_list.go
+++ b/pkg/plugins/discovery_list.go
@@ -40,7 +40,7 @@ func (p *listDiscoveryPlugin) PluginTypeID() string {
 }
 
 // Init implements the core.DiscoveryPlugin interface.
-func (p *listDiscoveryPlugin) Init(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, cfg core.DiscoveryConfiguration) error {
+func (p *listDiscoveryPlugin) Init(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) error {
 	return nil //not used
 }
 

--- a/pkg/plugins/discovery_static.go
+++ b/pkg/plugins/discovery_static.go
@@ -29,7 +29,15 @@ import (
 )
 
 type staticDiscoveryPlugin struct {
-	cfg core.DiscoveryConfiguration
+	Domains []struct {
+		UUID     string `yaml:"id"`
+		Name     string `yaml:"name"`
+		Projects []struct {
+			UUID       string `yaml:"id"`
+			Name       string `yaml:"name"`
+			ParentUUID string `yaml:"parent_id"`
+		} `yaml:"projects"`
+	} `yaml:"domains"`
 }
 
 func init() {
@@ -42,18 +50,17 @@ func (p *staticDiscoveryPlugin) PluginTypeID() string {
 }
 
 // Init implements the core.DiscoveryPlugin interface.
-func (p *staticDiscoveryPlugin) Init(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, cfg core.DiscoveryConfiguration) error {
-	p.cfg = cfg
+func (p *staticDiscoveryPlugin) Init(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) error {
 	return nil
 }
 
 // ListDomains implements the core.DiscoveryPlugin interface.
 func (p *staticDiscoveryPlugin) ListDomains(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) ([]core.KeystoneDomain, error) {
 	var result []core.KeystoneDomain
-	if len(p.cfg.Static.Domains) == 0 {
+	if len(p.Domains) == 0 {
 		return nil, errors.New("no domains configured")
 	}
-	for _, domain := range p.cfg.Static.Domains {
+	for _, domain := range p.Domains {
 		if domain.UUID == "" {
 			return nil, fmt.Errorf("missing ID for preconfigured domain %q", domain.Name)
 		}
@@ -71,10 +78,10 @@ func (p *staticDiscoveryPlugin) ListDomains(provider *gophercloud.ProviderClient
 // ListProjects implements the core.DiscoveryPlugin interface.
 func (p *staticDiscoveryPlugin) ListProjects(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, queryDomain core.KeystoneDomain) ([]core.KeystoneProject, error) {
 	var result []core.KeystoneProject
-	if len(p.cfg.Static.Domains) == 0 {
+	if len(p.Domains) == 0 {
 		return nil, errors.New("no domains configured")
 	}
-	for _, domain := range p.cfg.Static.Domains {
+	for _, domain := range p.Domains {
 		if domain.UUID == queryDomain.UUID {
 			if len(domain.Projects) == 0 {
 				return nil, fmt.Errorf("no projects configured for domain %s", queryDomain.UUID)

--- a/pkg/test/discovery.go
+++ b/pkg/test/discovery.go
@@ -57,7 +57,7 @@ func (p *DiscoveryPlugin) PluginTypeID() string {
 }
 
 // Init implements the core.DiscoveryPlugin interface.
-func (p *DiscoveryPlugin) Init(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, cfg core.DiscoveryConfiguration) error {
+func (p *DiscoveryPlugin) Init(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) error {
 	return nil //not used
 }
 

--- a/pkg/util/datatypes.go
+++ b/pkg/util/datatypes.go
@@ -21,6 +21,8 @@ package util
 
 import (
 	"encoding/json"
+
+	"gopkg.in/yaml.v2"
 )
 
 // Float64OrUnknown extracts a value of type float64 or unknown from a json
@@ -36,5 +38,22 @@ func (f *Float64OrUnknown) UnmarshalJSON(buffer []byte) error {
 	var x float64
 	err := json.Unmarshal(buffer, &x)
 	*f = Float64OrUnknown(x)
+	return err
+}
+
+// YamlRawMessage is like json.RawMessage: During yaml.Unmarshal(), it will
+// just collect the provided YAML representation instead of parsing it into a
+// specific datatype. It can be used to defer parsing when the concrete target
+// type is not yet known when the YAML input is initially unmarshalled.
+type YamlRawMessage []byte
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (m *YamlRawMessage) UnmarshalYAML(unmarshal func(any) error) error {
+	var data any
+	err := unmarshal(&data)
+	if err != nil {
+		return err
+	}
+	*m, err = yaml.Marshal(data)
 	return err
 }


### PR DESCRIPTION
On its surface, this is just cleaner separation of concerns. The pkg/core module should not have to know any types that are only relevant to the internals of individual plugin implementations.

The bigger picture is that I want to get test coverage for the config loading and cluster assembling code, by also using it to set up test scenarios. This means constructing test plugins in the usual way, from configuration. Without this change, we would have to bleed test-only types into pkg/core, which I find excessively ugly.

This change is a proof-of-concept for the approach. If this proves to work, I will also adjust the QuotaPlugin and CapacityPlugin interfaces in the same way.