### PR TITLE
move plugin-specific config types into the CapacityPlugins themselves

### DIFF
--- a/pkg/core/cluster.go
+++ b/pkg/core/cluster.go
@@ -187,7 +187,12 @@ func (c *Cluster) Connect() (err error) {
 		scrapeSubcapacities[serviceType] = m
 	}
 	for _, capa := range c.Config.Capacitors {
-		err := c.CapacityPlugins[capa.ID].Init(provider, eo, capa, scrapeSubcapacities)
+		plugin := c.CapacityPlugins[capa.ID]
+		err = yaml.UnmarshalStrict([]byte(capa.Parameters), plugin)
+		if err != nil {
+			return fmt.Errorf("failed to supply params to capacitor %s: %w", capa.ID, err)
+		}
+		err := plugin.Init(provider, eo, scrapeSubcapacities)
 		if err != nil {
 			return fmt.Errorf("failed to initialize capacitor %s: %w", capa.ID, util.UnpackError(err))
 		}

--- a/pkg/core/config.go
+++ b/pkg/core/config.go
@@ -137,42 +137,14 @@ type RateLimitConfiguration struct {
 // CapacitorConfiguration describes a capacity plugin that is enabled for a
 // certain cluster.
 type CapacitorConfiguration struct {
-	ID   string                 `yaml:"id"`
-	Type string                 `yaml:"type"`
-	Auth map[string]interface{} `yaml:"auth"`
-	//for capacitors that need configuration, add a field with the plugin's ID as
-	//name and put the config data in there (use a struct to be able to give
-	//config options meaningful names)
-	Nova struct {
-		AggregateNamePattern     string            `yaml:"aggregate_name_pattern"`
-		MaxInstancesPerAggregate uint64            `yaml:"max_instances_per_aggregate"`
-		ExtraSpecs               map[string]string `yaml:"extra_specs"`
-		HypervisorTypePattern    string            `yaml:"hypervisor_type_pattern"`
-	} `yaml:"nova"`
-	Prometheus struct {
-		APIConfig PrometheusAPIConfiguration   `yaml:"api"`
-		Queries   map[string]map[string]string `yaml:"queries"`
-	} `yaml:"prometheus"`
-	Cinder struct {
-		VolumeTypes map[string]struct {
-			VolumeBackendName string `yaml:"volume_backend_name"`
-			IsDefault         bool   `yaml:"default"`
-		} `yaml:"volume_types"`
-	} `yaml:"cinder"`
-	Manila struct {
-		ShareTypes        []ManilaShareTypeSpec `yaml:"share_types"`
-		ShareNetworks     uint64                `yaml:"share_networks"`
-		SharesPerPool     uint64                `yaml:"shares_per_pool"`
-		SnapshotsPerShare uint64                `yaml:"snapshots_per_share"`
-		CapacityBalance   float64               `yaml:"capacity_balance"`
-	} `yaml:"manila"`
-	Manual      map[string]map[string]uint64 `yaml:"manual"`
-	SAPCCIronic struct {
-		FlavorAliases map[string][]string `yaml:"flavor_aliases"`
-	} `yaml:"sapcc_ironic"`
+	ID         string                 `yaml:"id"`
+	Type       string                 `yaml:"type"`
+	Auth       map[string]interface{} `yaml:"auth"`
+	Parameters util.YamlRawMessage    `yaml:"params"`
 }
 
 // ManilaMappingRule appears in both ServiceConfiguration and CapacitorConfiguration.
+// TODO move into pkg/plugins when ServiceConfiguration is converted to the Parameters pattern
 type ManilaShareTypeSpec struct {
 	Name               string `yaml:"name"`
 	ReplicationEnabled bool   `yaml:"replication_enabled"` //only used by QuotaPlugin
@@ -257,6 +229,7 @@ type BurstingConfiguration struct {
 
 // PrometheusAPIConfiguration contains configuration parameters for a Prometheus API.
 // Only the URL field is required in the format: "http<s>://localhost<:9090>" (port is optional).
+// TODO move into pkg/plugins when ServiceConfiguration is converted to the Parameters pattern
 type PrometheusAPIConfiguration struct {
 	URL                      string `yaml:"url"`
 	ClientCertificatePath    string `yaml:"cert"`

--- a/pkg/core/plugin.go
+++ b/pkg/core/plugin.go
@@ -193,7 +193,10 @@ type CapacityPlugin interface {
 	pluggable.Plugin
 	//Init is guaranteed to be called before all other methods exposed by the
 	//interface.
-	Init(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, cfg CapacitorConfiguration, scrapeSubcapacities map[string]map[string]bool) error
+	//
+	//Before Init is called, the `capacitors[].params` provided in the config
+	//file will be yaml.Unmarshal()ed into the plugin object itself.
+	Init(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, scrapeSubcapacities map[string]map[string]bool) error
 	//Scrape queries the backend service(s) for the capacities of the resources
 	//that this plugin is concerned with. The result is a two-dimensional map,
 	//with the first key being the service type, and the second key being the

--- a/pkg/plugins/capacity_manual.go
+++ b/pkg/plugins/capacity_manual.go
@@ -29,7 +29,7 @@ import (
 )
 
 type capacityManualPlugin struct {
-	cfg core.CapacitorConfiguration
+	Values map[string]map[string]uint64 `yaml:"values"`
 }
 
 func init() {
@@ -37,8 +37,7 @@ func init() {
 }
 
 // Init implements the core.CapacityPlugin interface.
-func (p *capacityManualPlugin) Init(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, c core.CapacitorConfiguration, scrapeSubcapacities map[string]map[string]bool) error {
-	p.cfg = c
+func (p *capacityManualPlugin) Init(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, scrapeSubcapacities map[string]map[string]bool) error {
 	return nil
 }
 
@@ -51,12 +50,12 @@ var errNoManualData = errors.New(`missing values for capacitor plugin "manual"`)
 
 // Scrape implements the core.CapacityPlugin interface.
 func (p *capacityManualPlugin) Scrape(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (result map[string]map[string]core.CapacityData, _ string, err error) {
-	if p.cfg.Manual == nil {
+	if p.Values == nil {
 		return nil, "", errNoManualData
 	}
 
 	result = make(map[string]map[string]core.CapacityData)
-	for serviceType, serviceData := range p.cfg.Manual {
+	for serviceType, serviceData := range p.Values {
 		serviceResult := make(map[string]core.CapacityData)
 		for resourceName, capacity := range serviceData {
 			serviceResult[resourceName] = core.CapacityData{Capacity: capacity}

--- a/pkg/plugins/capacity_sapcc_cfm.go
+++ b/pkg/plugins/capacity_sapcc_cfm.go
@@ -31,8 +31,7 @@ import (
 )
 
 type capacityCFMPlugin struct {
-	cfg       core.CapacitorConfiguration
-	projectID string
+	projectID string `yaml:"-"`
 }
 
 func init() {
@@ -40,8 +39,7 @@ func init() {
 }
 
 // Init implements the core.CapacityPlugin interface.
-func (p *capacityCFMPlugin) Init(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, c core.CapacitorConfiguration, scrapeSubcapacities map[string]map[string]bool) (err error) {
-	p.cfg = c
+func (p *capacityCFMPlugin) Init(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, scrapeSubcapacities map[string]map[string]bool) (err error) {
 	p.projectID, err = getProjectIDForToken(provider, eo)
 	return err
 }

--- a/pkg/plugins/capacity_sapcc_ironic.go
+++ b/pkg/plugins/capacity_sapcc_ironic.go
@@ -37,8 +37,9 @@ import (
 )
 
 type capacitySapccIronicPlugin struct {
-	ftt                 novaFlavorTranslationTable
-	reportSubcapacities bool
+	FlavorAliases       map[string][]string        `yaml:"flavor_aliases"`
+	ftt                 novaFlavorTranslationTable `yaml:"-"`
+	reportSubcapacities bool                       `yaml:"-"`
 }
 
 type capacitySapccIronicSerializedMetrics struct {
@@ -50,8 +51,8 @@ func init() {
 }
 
 // Init implements the core.CapacityPlugin interface.
-func (p *capacitySapccIronicPlugin) Init(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, c core.CapacitorConfiguration, scrapeSubcapacities map[string]map[string]bool) error {
-	p.ftt = newNovaFlavorTranslationTable(c.SAPCCIronic.FlavorAliases)
+func (p *capacitySapccIronicPlugin) Init(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, scrapeSubcapacities map[string]map[string]bool) error {
+	p.ftt = newNovaFlavorTranslationTable(p.FlavorAliases)
 	p.reportSubcapacities = scrapeSubcapacities["compute"]["instances-baremetal"]
 	return nil
 }

--- a/pkg/test/discovery.go
+++ b/pkg/test/discovery.go
@@ -28,8 +28,8 @@ import (
 // DiscoveryPlugin is a core.DiscoveryPlugin implementation for unit tests that
 // reports a static set of domains and projects.
 type DiscoveryPlugin struct {
-	StaticDomains  []core.KeystoneDomain
-	StaticProjects map[string][]core.KeystoneProject
+	StaticDomains  []core.KeystoneDomain             `yaml:"-"`
+	StaticProjects map[string][]core.KeystoneProject `yaml:"-"`
 }
 
 // NewDiscoveryPlugin creates a DiscoveryPlugin instance.

--- a/pkg/test/plugin.go
+++ b/pkg/test/plugin.go
@@ -276,11 +276,11 @@ func (p *Plugin) CollectMetrics(ch chan<- prometheus.Metric, clusterID string, p
 
 // CapacityPlugin is a core.CapacityPlugin implementation for unit tests.
 type CapacityPlugin struct {
-	PluginType        string
-	Resources         []string //each formatted as "servicetype/resourcename"
-	Capacity          uint64
-	WithAZCapData     bool
-	WithSubcapacities bool
+	PluginType        string   `yaml:"-"`
+	Resources         []string `yaml:"-"` //each formatted as "servicetype/resourcename"
+	Capacity          uint64   `yaml:"-"`
+	WithAZCapData     bool     `yaml:"-"`
+	WithSubcapacities bool     `yaml:"-"`
 }
 
 // NewCapacityPlugin creates a new CapacityPlugin.
@@ -289,7 +289,7 @@ func NewCapacityPlugin(pluginType string, resources ...string) *CapacityPlugin {
 }
 
 // Init implements the core.CapacityPlugin interface.
-func (p *CapacityPlugin) Init(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, cfg core.CapacitorConfiguration, scrapeSubcapacities map[string]map[string]bool) error {
+func (p *CapacityPlugin) Init(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, scrapeSubcapacities map[string]map[string]bool) error {
 	return nil
 }
 


### PR DESCRIPTION
Same approach and reasoning as in #275.

Checklist:

- [x] If this PR is about a plugin, I tested the plugin against an OpenStack cluster.
- [x] I updated the documentation to describe the semantical or interface changes I introduced.
