### PR TITLE
move plugin-specific config types into the QuotaPlugins themselves

### DIFF
--- a/docs/operators/config.md
+++ b/docs/operators/config.md
@@ -242,11 +242,11 @@ The area for this service is `compute`.
 ```yaml
 services:
   - type: compute
-    compute:
+    params:
       bigvm_min_memory: 1048576
 ```
 
-Instances can be split into two price groups (regular and big VMs) by setting the `compute.bigvm_min_memory` key as
+Instances can be split into two price groups (regular and big VMs) by setting the `params.bigvm_min_memory` key as
 shown above. When enabled, the following extra resources become available:
 
 | Resource | Unit |
@@ -293,7 +293,7 @@ rules supplied in the configuration like this:
 ```yaml
 services:
   - type: compute
-    compute:
+    params:
       hypervisor_type_rules:
         - match: extra-spec:vmware:hv_enabled # match on extra spec with name "vmware:hv_enabled"
           pattern: '^True$'                   # regular expression
@@ -321,7 +321,7 @@ category.
 ```yaml
 services:
   - type: compute
-    compute:
+    params:
       separate_instance_quotas:
         flavor_name_pattern: ^bm_
         flavor_aliases:
@@ -331,11 +331,11 @@ services:
 
 Sometimes Tempest creates resource classes or flavors that Limes recognizes as requiring a separate instance quota,
 which may not be desired. To control which flavors get a separate instance quota, give the
-`compute.separate_instance_quotas.flavor_name_pattern` option as shown above. Only flavors with a name matching that
+`params.separate_instance_quotas.flavor_name_pattern` option as shown above. Only flavors with a name matching that
 regex will be considered.
 
 On some Nova installations, some flavors can have multiple names, either as permanent aliases or temporarily while
-moving to a new flavor naming scheme. The `compute.separate_instance_quotas.flavor_aliases` option configures Limes to
+moving to a new flavor naming scheme. The `params.separate_instance_quotas.flavor_aliases` option configures Limes to
 recognize flavor names that are aliased to each other, and decides which flavor name Limes prefers. For instance, in the
 config example above, the names `bm_newflavor2`, `bm_oldflavor2` and `bm_oldflavor3` are all aliases referring to the
 same flavor, and Limes prefers the name `bm_newflavor2`. The preferred name will be used when deriving a resource name
@@ -451,7 +451,7 @@ The area for this service is `storage`.
 ```yaml
 services:
   - type: sharev2
-    sharev2:
+    params:
       share_types:
         - name: default
           replication_enabled: true
@@ -479,7 +479,7 @@ The area for this service is `storage`. The following resources are always expos
 
 #### Multiple share types
 
-If the `sharev2.share_types` field lists more than one share type, the first
+If the `params.share_types` field lists more than one share type, the first
 four of the aforementioned five resources will refer to the quota for the first
 of these share types. (This peculiar rule exists for backwards-compatibility
 reasons.) For each other share type, the following resources are exposed:
@@ -521,7 +521,7 @@ following way: For each resource belonging to this share type,
 
 #### Physical usage
 
-Optionally, when the `sharev2.prometheus_api` configuration option is set,
+Optionally, when the `params.prometheus_api` configuration option is set,
 physical usage data will be scraped using the Prometheus metrics exported by
 the [netapp-api-exporter](https://github.com/sapcc/netapp-api-exporter).
 
@@ -535,7 +535,7 @@ will be used by the HTTP client to make requests to the Prometheus API.
 ```yaml
 services:
   - type: volumev2
-    volumev2:
+    params:
       volume_types: [ vmware, vmware_hdd ]
 ```
 
@@ -547,7 +547,7 @@ The area for this service is `storage`. The following resources are always expos
 | `snapshots` | countable |
 | `volumes` | countable |
 
-If the `volumev2.volume_types` field lists more than one volume type, the
+If the `params.volume_types` field lists more than one volume type, the
 aforementioned resources will refer to the quota for the first of these volume
 types. (This peculiar rule exists for backwards-compatibility reasons.) For
 each other volume type, the following resources are exposed:

--- a/pkg/collector/scrape_test.go
+++ b/pkg/collector/scrape_test.go
@@ -466,7 +466,7 @@ type autoApprovalTestPlugin struct {
 	StaticBackendQuota uint64
 }
 
-func (p *autoApprovalTestPlugin) Init(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, cfg core.ServiceConfiguration, scrapeSubresources map[string]bool) error {
+func (p *autoApprovalTestPlugin) Init(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, scrapeSubresources map[string]bool) error {
 	return nil
 }
 
@@ -562,7 +562,7 @@ func Test_AutoApproveInitialQuota(t *testing.T) {
 // A quota plugin with absolutely no resources and rates.
 type noopQuotaPlugin struct{}
 
-func (noopQuotaPlugin) Init(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, cfg core.ServiceConfiguration, scrapeSubresources map[string]bool) error {
+func (noopQuotaPlugin) Init(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, scrapeSubresources map[string]bool) error {
 	return nil
 }
 func (noopQuotaPlugin) PluginTypeID() string {

--- a/pkg/core/cluster.go
+++ b/pkg/core/cluster.go
@@ -171,7 +171,12 @@ func (c *Cluster) Connect() (err error) {
 			scrapeSubresources[resName] = true
 		}
 
-		err := c.QuotaPlugins[srv.Type].Init(provider, eo, srv, scrapeSubresources)
+		plugin := c.QuotaPlugins[srv.Type]
+		err = yaml.UnmarshalStrict([]byte(srv.Parameters), plugin)
+		if err != nil {
+			return fmt.Errorf("failed to supply params to service %s: %w", srv.Type, err)
+		}
+		err := plugin.Init(provider, eo, scrapeSubresources)
 		if err != nil {
 			return fmt.Errorf("failed to initialize service %s: %w", srv.Type, util.UnpackError(err))
 		}

--- a/pkg/core/config.go
+++ b/pkg/core/config.go
@@ -81,33 +81,7 @@ type ServiceConfiguration struct {
 	Auth   map[string]interface{} `yaml:"auth"`
 	// RateLimits describes the global rate limits (all requests for to a backend) and default project level rate limits.
 	RateLimits ServiceRateLimitConfiguration `yaml:"rate_limits"`
-	//for quota plugins that need configuration, add a field with the service type as
-	//name and put the config data in there (use a struct to be able to give
-	//config options meaningful names)
-	Compute struct {
-		BigVMMinMemoryMiB   uint64 `yaml:"bigvm_min_memory"`
-		HypervisorTypeRules []struct {
-			Key     string `yaml:"match"`
-			Pattern string `yaml:"pattern"`
-			Type    string `yaml:"type"`
-		} `yaml:"hypervisor_type_rules"`
-		SeparateInstanceQuotas struct {
-			FlavorNamePattern string              `yaml:"flavor_name_pattern"`
-			FlavorAliases     map[string][]string `yaml:"flavor_aliases"`
-		} `yaml:"separate_instance_quotas"`
-	} `yaml:"compute"`
-	CFM struct {
-		Authoritative bool `yaml:"authoritative"`
-		//TODO: remove this hidden feature flag when we have migrated to the new reporting style everywhere
-		ReportPhysicalUsage bool `yaml:"report_physical_usage"`
-	} `yaml:"database"`
-	ShareV2 struct {
-		ShareTypes          []ManilaShareTypeSpec       `yaml:"share_types"`
-		PrometheusAPIConfig *PrometheusAPIConfiguration `yaml:"prometheus_api"`
-	} `yaml:"sharev2"`
-	VolumeV2 struct {
-		VolumeTypes []string `yaml:"volume_types"`
-	} `yaml:"volumev2"`
+	Parameters util.YamlRawMessage           `yaml:"params"`
 }
 
 // ServiceRateLimitConfiguration describes the global and project-level default rate limit configurations for a service.

--- a/pkg/core/config.go
+++ b/pkg/core/config.go
@@ -76,9 +76,7 @@ type DiscoveryConfiguration struct {
 
 // ServiceConfiguration describes a service that is enabled for a certain cluster.
 type ServiceConfiguration struct {
-	Type   string                 `yaml:"type"`
-	Shared bool                   `yaml:"shared"`
-	Auth   map[string]interface{} `yaml:"auth"`
+	Type string `yaml:"type"`
 	// RateLimits describes the global rate limits (all requests for to a backend) and default project level rate limits.
 	RateLimits ServiceRateLimitConfiguration `yaml:"rate_limits"`
 	Parameters util.YamlRawMessage           `yaml:"params"`
@@ -111,22 +109,9 @@ type RateLimitConfiguration struct {
 // CapacitorConfiguration describes a capacity plugin that is enabled for a
 // certain cluster.
 type CapacitorConfiguration struct {
-	ID         string                 `yaml:"id"`
-	Type       string                 `yaml:"type"`
-	Auth       map[string]interface{} `yaml:"auth"`
-	Parameters util.YamlRawMessage    `yaml:"params"`
-}
-
-// ManilaMappingRule appears in both ServiceConfiguration and CapacitorConfiguration.
-// TODO move into pkg/plugins when ServiceConfiguration is converted to the Parameters pattern
-type ManilaShareTypeSpec struct {
-	Name               string `yaml:"name"`
-	ReplicationEnabled bool   `yaml:"replication_enabled"` //only used by QuotaPlugin
-	MappingRules       []*struct {
-		NamePattern string         `yaml:"name_pattern"`
-		NameRx      *regexp.Regexp `yaml:"-"`
-		ShareType   string         `yaml:"share_type"`
-	} `yaml:"mapping_rules"`
+	ID         string              `yaml:"id"`
+	Type       string              `yaml:"type"`
+	Parameters util.YamlRawMessage `yaml:"params"`
 }
 
 // LowPrivilegeRaiseConfiguration contains the configuration options for
@@ -199,16 +184,6 @@ func (b ResourceBehavior) ToScalingBehavior() *limesresources.ScalingBehavior {
 type BurstingConfiguration struct {
 	//If MaxMultiplier is zero, bursting is disabled.
 	MaxMultiplier limesresources.BurstingMultiplier `yaml:"max_multiplier"`
-}
-
-// PrometheusAPIConfiguration contains configuration parameters for a Prometheus API.
-// Only the URL field is required in the format: "http<s>://localhost<:9090>" (port is optional).
-// TODO move into pkg/plugins when ServiceConfiguration is converted to the Parameters pattern
-type PrometheusAPIConfiguration struct {
-	URL                      string `yaml:"url"`
-	ClientCertificatePath    string `yaml:"cert"`
-	ClientCertificateKeyPath string `yaml:"key"`
-	ServerCACertificatePath  string `yaml:"ca_cert"`
 }
 
 // QuotaDistributionConfiguration contains configuration options for specifying
@@ -296,16 +271,6 @@ func (cluster ClusterConfiguration) validateConfig() (success bool) {
 		if srv.Type == "" {
 			missing(fmt.Sprintf("services[%d].type", idx))
 		}
-		if srv.Shared {
-			//TODO remove this deprecation warning once the change was rolled out everywhere
-			logg.Error("services[%d].shared is true, which is not supported anymore", idx)
-			success = false
-		}
-		if len(srv.Auth) > 0 {
-			//TODO remove this deprecation warning once the change was rolled out everywhere
-			logg.Error("services[%d].auth was provided, but is not supported anymore", idx)
-			success = false
-		}
 	}
 	for idx, capa := range cluster.Capacitors {
 		if capa.ID == "" {
@@ -313,11 +278,6 @@ func (cluster ClusterConfiguration) validateConfig() (success bool) {
 		}
 		if capa.Type == "" {
 			missing(fmt.Sprintf("capacitors[%d].type", idx))
-		}
-		if len(capa.Auth) > 0 {
-			//TODO remove this deprecation warning once the change was rolled out everywhere
-			logg.Error("capacitors[%d].auth was provided, but is not supported anymore", idx)
-			success = false
 		}
 	}
 

--- a/pkg/core/constraints_test.go
+++ b/pkg/core/constraints_test.go
@@ -180,7 +180,7 @@ type quotaConstraintTestPlugin struct {
 	ServiceType string
 }
 
-func (p quotaConstraintTestPlugin) Init(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, cfg ServiceConfiguration, scrapeSubresources map[string]bool) error {
+func (p quotaConstraintTestPlugin) Init(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, scrapeSubresources map[string]bool) error {
 	return nil
 }
 func (p quotaConstraintTestPlugin) PluginTypeID() string {

--- a/pkg/core/plugin.go
+++ b/pkg/core/plugin.go
@@ -101,7 +101,10 @@ type QuotaPlugin interface {
 	//interface. Implementations can use it f.i. to discover the available
 	//Resources(). For plugins that support subresource scraping, the final
 	//argument indicates which resources to scrape (the keys are resource names).
-	Init(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, cfg ServiceConfiguration, scrapeSubresources map[string]bool) error
+	//
+	//Before Init is called, the `services[].params` provided in the config
+	//file will be yaml.Unmarshal()ed into the plugin object itself.
+	Init(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, scrapeSubresources map[string]bool) error
 	//ServiceInfo returns metadata for this service.
 	ServiceInfo() limes.ServiceInfo
 	//Resources returns metadata for all the resources that this plugin scrapes

--- a/pkg/plugins/capacity_manila.go
+++ b/pkg/plugins/capacity_manila.go
@@ -34,11 +34,11 @@ import (
 )
 
 type capacityManilaPlugin struct {
-	ShareTypes        []core.ManilaShareTypeSpec `yaml:"share_types"`
-	ShareNetworks     uint64                     `yaml:"share_networks"`
-	SharesPerPool     uint64                     `yaml:"shares_per_pool"`
-	SnapshotsPerShare uint64                     `yaml:"snapshots_per_share"`
-	CapacityBalance   float64                    `yaml:"capacity_balance"`
+	ShareTypes        []ManilaShareTypeSpec `yaml:"share_types"`
+	ShareNetworks     uint64                `yaml:"share_networks"`
+	SharesPerPool     uint64                `yaml:"shares_per_pool"`
+	SnapshotsPerShare uint64                `yaml:"snapshots_per_share"`
+	CapacityBalance   float64               `yaml:"capacity_balance"`
 }
 
 func init() {
@@ -71,7 +71,7 @@ func (p *capacityManilaPlugin) PluginTypeID() string {
 	return "manila"
 }
 
-func (p *capacityManilaPlugin) makeResourceName(kind string, shareType core.ManilaShareTypeSpec) string {
+func (p *capacityManilaPlugin) makeResourceName(kind string, shareType ManilaShareTypeSpec) string {
 	if p.ShareTypes[0].Name == shareType.Name {
 		//the resources for the first share type don't get the share type suffix
 		//for backwards compatibility reasons
@@ -144,7 +144,7 @@ type capacityForShareType struct {
 	SnapshotGigabytes core.CapacityData
 }
 
-func (p *capacityManilaPlugin) scrapeForShareType(shareType core.ManilaShareTypeSpec, client *gophercloud.ServiceClient, azForServiceHost map[string]string) (capacityForShareType, error) {
+func (p *capacityManilaPlugin) scrapeForShareType(shareType ManilaShareTypeSpec, client *gophercloud.ServiceClient, azForServiceHost map[string]string) (capacityForShareType, error) {
 	//list all pools for the Manila share types corresponding to this virtual share type
 	var allPools []schedulerstats.Pool
 	for _, stName := range getAllManilaShareTypes(shareType) {

--- a/pkg/plugins/capacity_prometheus.go
+++ b/pkg/plugins/capacity_prometheus.go
@@ -27,8 +27,8 @@ import (
 )
 
 type capacityPrometheusPlugin struct {
-	APIConfig core.PrometheusAPIConfiguration `yaml:"api"`
-	Queries   map[string]map[string]string    `yaml:"queries"`
+	APIConfig PrometheusAPIConfiguration   `yaml:"api"`
+	Queries   map[string]map[string]string `yaml:"queries"`
 }
 
 func init() {

--- a/pkg/plugins/client_prometheus.go
+++ b/pkg/plugins/client_prometheus.go
@@ -33,11 +33,18 @@ import (
 	prom_v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 	"github.com/sapcc/go-bits/logg"
-
-	"github.com/sapcc/limes/pkg/core"
 )
 
-func prometheusClient(cfg core.PrometheusAPIConfiguration) (prom_v1.API, error) {
+// PrometheusAPIConfiguration contains configuration parameters for a Prometheus API.
+// Only the URL field is required in the format: "http<s>://localhost<:9090>" (port is optional).
+type PrometheusAPIConfiguration struct {
+	URL                      string `yaml:"url"`
+	ClientCertificatePath    string `yaml:"cert"`
+	ClientCertificateKeyPath string `yaml:"key"`
+	ServerCACertificatePath  string `yaml:"ca_cert"`
+}
+
+func prometheusClient(cfg PrometheusAPIConfiguration) (prom_v1.API, error) {
 	if cfg.URL == "" {
 		return nil, errors.New("missing configuration parameter: url")
 	}

--- a/pkg/plugins/cronus.go
+++ b/pkg/plugins/cronus.go
@@ -35,9 +35,7 @@ import (
 	"github.com/sapcc/limes/pkg/core"
 )
 
-type cronusPlugin struct {
-	cfg core.ServiceConfiguration
-}
+type cronusPlugin struct{}
 
 var cronusRates = []limesrates.RateInfo{
 	{
@@ -63,8 +61,7 @@ func init() {
 }
 
 // Init implements the core.QuotaPlugin interface.
-func (p *cronusPlugin) Init(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, c core.ServiceConfiguration, scrapeSubresources map[string]bool) error {
-	p.cfg = c
+func (p *cronusPlugin) Init(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, scrapeSubresources map[string]bool) error {
 	return nil
 }
 

--- a/pkg/plugins/designate.go
+++ b/pkg/plugins/designate.go
@@ -34,9 +34,7 @@ import (
 	"github.com/sapcc/limes/pkg/core"
 )
 
-type designatePlugin struct {
-	cfg core.ServiceConfiguration
-}
+type designatePlugin struct{}
 
 var designateResources = []limesresources.ResourceInfo{
 	{
@@ -55,8 +53,7 @@ func init() {
 }
 
 // Init implements the core.QuotaPlugin interface.
-func (p *designatePlugin) Init(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, c core.ServiceConfiguration, scrapeSubresources map[string]bool) error {
-	p.cfg = c
+func (p *designatePlugin) Init(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, scrapeSubresources map[string]bool) error {
 	return nil
 }
 

--- a/pkg/plugins/keppel.go
+++ b/pkg/plugins/keppel.go
@@ -31,9 +31,7 @@ import (
 	"github.com/sapcc/limes/pkg/core"
 )
 
-type keppelPlugin struct {
-	cfg core.ServiceConfiguration
-}
+type keppelPlugin struct{}
 
 var keppelResources = []limesresources.ResourceInfo{
 	{
@@ -47,8 +45,7 @@ func init() {
 }
 
 // Init implements the core.QuotaPlugin interface.
-func (p *keppelPlugin) Init(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, c core.ServiceConfiguration, scrapeSubresources map[string]bool) error {
-	p.cfg = c
+func (p *keppelPlugin) Init(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, scrapeSubresources map[string]bool) error {
 	return nil
 }
 

--- a/pkg/plugins/manila.go
+++ b/pkg/plugins/manila.go
@@ -41,9 +41,9 @@ import (
 )
 
 type manilaPlugin struct {
-	ShareTypes          []core.ManilaShareTypeSpec       `yaml:"share_types"`
-	PrometheusAPIConfig *core.PrometheusAPIConfiguration `yaml:"prometheus_api"`
-	hasReplicaQuotas    bool                             `yaml:"-"`
+	ShareTypes          []ManilaShareTypeSpec       `yaml:"share_types"`
+	PrometheusAPIConfig *PrometheusAPIConfiguration `yaml:"prometheus_api"`
+	hasReplicaQuotas    bool                        `yaml:"-"`
 }
 
 func init() {
@@ -154,7 +154,7 @@ func (p *manilaPlugin) Rates() []limesrates.RateInfo {
 	return nil
 }
 
-func (p *manilaPlugin) makeResourceName(kind string, shareType core.ManilaShareTypeSpec) string {
+func (p *manilaPlugin) makeResourceName(kind string, shareType ManilaShareTypeSpec) string {
 	if p.ShareTypes[0].Name == shareType.Name {
 		//the resources for the first share type don't get the share type suffix
 		//for backwards compatibility reasons

--- a/pkg/plugins/neutron.go
+++ b/pkg/plugins/neutron.go
@@ -38,10 +38,9 @@ import (
 )
 
 type neutronPlugin struct {
-	cfg          core.ServiceConfiguration
-	resources    []limesresources.ResourceInfo
-	hasExtension map[string]bool
-	hasOctavia   bool
+	resources    []limesresources.ResourceInfo `yaml:"-"`
+	hasExtension map[string]bool               `yaml:"-"`
+	hasOctavia   bool                          `yaml:"-"`
 }
 
 var neutronResources = []limesresources.ResourceInfo{
@@ -144,9 +143,7 @@ func init() {
 }
 
 // Init implements the core.QuotaPlugin interface.
-func (p *neutronPlugin) Init(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, c core.ServiceConfiguration, scrapeSubresources map[string]bool) error {
-	p.cfg = c
-
+func (p *neutronPlugin) Init(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, scrapeSubresources map[string]bool) error {
 	client, err := openstack.NewNetworkV2(provider, eo)
 	if err != nil {
 		return err

--- a/pkg/plugins/swift.go
+++ b/pkg/plugins/swift.go
@@ -38,9 +38,7 @@ import (
 	"github.com/sapcc/limes/pkg/core"
 )
 
-type swiftPlugin struct {
-	cfg core.ServiceConfiguration
-}
+type swiftPlugin struct{}
 
 var swiftResources = []limesresources.ResourceInfo{
 	{
@@ -81,8 +79,7 @@ func init() {
 }
 
 // Init implements the core.QuotaPlugin interface.
-func (p *swiftPlugin) Init(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, c core.ServiceConfiguration, scrapeSubresources map[string]bool) error {
-	p.cfg = c
+func (p *swiftPlugin) Init(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, scrapeSubresources map[string]bool) error {
 	return nil
 }
 

--- a/pkg/test/plugin.go
+++ b/pkg/test/plugin.go
@@ -79,16 +79,8 @@ func NewPlugin(serviceType string, rates ...limesrates.RateInfo) *Plugin {
 	}
 }
 
-// NewPluginFactory creates a new PluginFactory for core.RegisterQuotaPlugin.
-func NewPluginFactory(serviceType string) func(core.ServiceConfiguration, map[string]bool) core.QuotaPlugin {
-	return func(cfg core.ServiceConfiguration, scrapeSubresources map[string]bool) core.QuotaPlugin {
-		//cfg and scrapeSubresources is ignored
-		return NewPlugin(serviceType)
-	}
-}
-
 // Init implements the core.QuotaPlugin interface.
-func (p *Plugin) Init(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, cfg core.ServiceConfiguration, scrapeSubresources map[string]bool) error {
+func (p *Plugin) Init(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, scrapeSubresources map[string]bool) error {
 	return nil
 }
 


### PR DESCRIPTION
Same approach and reasoning as in #275 and #279. Since this is the last PR in this series, I did some additional cleanup of old cruft from `pkg/core/config.go`.

Checklist:

- [x] If this PR is about a plugin, I tested the plugin against an OpenStack cluster.
- [x] I updated the documentation to describe the semantical or interface changes I introduced.
