### PR TITLE
remove the cluster_id from config, database records, and metric labels

### DIFF
--- a/docs/operators/config.md
+++ b/docs/operators/config.md
@@ -56,7 +56,6 @@ Limes logs all quota changes at the domain and project level in an Open Standard
 A configuration file in YAML format must be provided that describes things like the set of available backend services and the quota/capacity scraping behavior. A minimal config file could look like this:
 
 ```yaml
-cluster_id: staging
 services:
   - type: compute
   - type: network
@@ -78,7 +77,6 @@ The following fields and sections are supported:
 
 | Field | Required | Description |
 | --- | --- | --- |
-| `cluster_id` | yes | Must be given for historical reasons. May be chosen freely, but should not be changed afterwards. (It *can* be changed, but that requires a shutdown of all Limes components and manual editing of the database.) |
 | `catalog_url` | no | URL of Limes API service as it appears in the Keystone service catalog for this cluster. This is only used for version advertisements, and can be omitted if no client relies on the URLs in these version advertisements. |
 | `discovery.method` | no | Defines which method to use to discover Keystone domains and projects in this cluster. If not given, the default value is `list`. |
 | `discovery.except_domains` | no | May contain a regex. Domains whose names match the regex will not be considered by Limes. |
@@ -115,7 +113,6 @@ Both `limits.projects` and `limits.domains` contain two-level maps, first by ser
 For example:
 
 ```yaml
-cluster_id: example
 lowpriv_raise:
   limits:
     projects:
@@ -148,7 +145,6 @@ Some special behaviors for resources can be configured in the `resource_behavior
 For example:
 
 ```yaml
-cluster_id: example
 resource_behavior:
   - { resource: network/healthmonitors, scales_with: network/loadbalancers, scaling_factor: 1 }
   - { resource: network/listeners,      scales_with: network/loadbalancers, scaling_factor: 2 }
@@ -837,7 +833,6 @@ For further details see the [rate limits API specification](../users/api-v1-spec
 Example configuration:
 
 ```yaml
-cluster_id: staging
 services:
   - type: object-store
     rates:

--- a/docs/operators/index.md
+++ b/docs/operators/index.md
@@ -31,22 +31,6 @@ Limes consists of two basic services:
 - Both services emit Prometheus metrics. See [List of metrics](./metrics.md) for details.
 - Persistence is provided by a PostgreSQL database which is accessible to both services.
 
-## Support for shared services
-
-Limes includes support for services that are shared across *OpenStack clusters* (i.e. separate OpenStack installations
-with separate service catalogs). In this case, multiple instances of the API service and the collector service (one each
-per cluster) will share the same Postgres database, but use different *cluster IDs* to identify their cluster's data
-within the database.
-
-A *shared service* is a backend service which is available in multiple clusters. For example, a Swift object storage
-setup can have multiple proxy deployments which each authenticate against a different cluster's Keystone. In this case,
-the total capacity which is reported by the shared service needs to be distributed among all clusters using the shared
-service.
-
-When one of the clusters uses Limes only for the shared service, not for its local resources, Limes can be configured to
-only collect and manage the resources provided by shared services. Please refer to the [configuration
-guide](./config.md) for details.
-
 # Building
 
 This repository contains a `Makefile` with an `install` target that understands the conventional `DESTDIR` and `PREFIX`
@@ -87,7 +71,7 @@ If you're using Kubernetes, you can use our team's [Helm chart for Limes][chart]
    ```
 
    There should be only one instance of the collector service. The API service can be scaled out by simply starting
-   additional instances with the same configuration and cluster ID.
+   additional instances with the same configuration.
 
 6. Register the public URL of the API service in the Keystone service catalog: A service with type `resources` shall
    point to the base path of the public URL, e.g. `https://limes.example.com/`. A service with type `limes-rates` shall

--- a/docs/operators/metrics.md
+++ b/docs/operators/metrics.md
@@ -20,22 +20,20 @@ The collector service exposes the following metrics by default:
 
 | Type | Metric | Labels |
 | --- | --- | --- |
-| Counter | `limes_successful_scrapes` | `os_cluster`, `service`, `service_name` (counts projects) |
-| Counter | `limes_failed_scrapes` | `os_cluster`, `service`, `service_name` (counts projects) |
-| Counter | `limes_successful_domain_discoveries` | `os_cluster` |
-| Counter | `limes_failed_domain_discoveries` | `os_cluster` |
-| Counter | `limes_successful_project_discoveries` | `os_cluster`, `domain`, `domain_id` |
-| Counter | `limes_failed_project_discoveries` | `os_cluster`, `domain`, `domain_id` |
-| Counter | `limes_successful_capacity_scrapes` | `os_cluster`, `capacitor` |
-| Counter | `limes_failed_capacity_scrapes` | `os_cluster`, `capacitor` |
-| Counter | `limes_successful_auditevent_publish` | `os_cluster` |
-| Counter | `limes_failed_auditevent_publish` | `os_cluster` |
+| Counter | `limes_successful_scrapes` | `service`, `service_name` (counts projects) |
+| Counter | `limes_failed_scrapes` | `service`, `service_name` (counts projects) |
+| Counter | `limes_successful_domain_discoveries` | none |
+| Counter | `limes_failed_domain_discoveries` | none |
+| Counter | `limes_successful_project_discoveries` | `domain`, `domain_id` |
+| Counter | `limes_failed_project_discoveries` | `domain`, `domain_id` |
+| Counter | `limes_successful_capacity_scrapes` | `capacitor` |
+| Counter | `limes_failed_capacity_scrapes` | `capacitor` |
+| Counter | `limes_successful_auditevent_publish` | none |
+| Counter | `limes_failed_auditevent_publish` | none |
 
 The `limes_failed_scrapes` metric is particularly useful for assessing the continued operation of backend services
 (specifically their API parts). If you can do only one alert on Limes metrics, alert on `limes_failed_scrapes`.
 Alerts on `limes_failed_{domain,project}_discoveries` are very useful, too, but less important.
-
-`os_cluster` represents the OpenStack cluster configured in the [clusters configuration section](config.md#section-clusters)
 
 For the scraping metrics, the `service` label contains the type of the backend service in question (as stated in the Keystone
 service catalog), and the `service_name` label contains the product name (in lower case) of the reference implementation
@@ -48,13 +46,11 @@ additional metrics:
 
 | Type | Metric | Labels |
 | --- | --- | --- |
-| Gauge | `limes_cluster_capacity` | `os_cluster`, `service`, `resource` |
-| Gauge | `limes_domain_quota` | `os_cluster`, `service`, `resource`, `domain`, `domain_id` |
-| Gauge | `limes_project_backendquota` | `os_cluster`, `service`, `resource`, `domain`, `domain_id`, `project`, `project_id` |
-| Gauge | `limes_project_quota` | `os_cluster`, `service`, `resource`, `domain`, `domain_id`, `project`, `project_id` |
-| Gauge | `limes_project_usage` | `os_cluster`, `service`, `resource`, `domain`, `domain_id`, `project`, `project_id` |
-
-`os_cluster` represents the OpenStack cluster configured in the [clusters configuration section](config.md#section-clusters)
+| Gauge | `limes_cluster_capacity` | `service`, `resource` |
+| Gauge | `limes_domain_quota` | `service`, `resource`, `domain`, `domain_id` |
+| Gauge | `limes_project_backendquota` | `service`, `resource`, `domain`, `domain_id`, `project`, `project_id` |
+| Gauge | `limes_project_quota` | `service`, `resource`, `domain`, `domain_id`, `project`, `project_id` |
+| Gauge | `limes_project_usage` | `service`, `resource`, `domain`, `domain_id`, `project`, `project_id` |
 
 ### Quota/capacity plugins
 

--- a/main.go
+++ b/main.go
@@ -73,7 +73,7 @@ func main() {
 	//load configuration and connect to cluster
 	cluster := core.NewConfiguration(configPath)
 	must.Succeed(cluster.Connect())
-	api.StartAuditTrail(cluster.ID)
+	api.StartAuditTrail()
 
 	//select task
 	switch taskName {

--- a/pkg/api/audit.go
+++ b/pkg/api/audit.go
@@ -27,7 +27,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sapcc/go-api-declarations/cadf"
 	"github.com/sapcc/go-api-declarations/limes"
 	limesrates "github.com/sapcc/go-api-declarations/limes/rates"
@@ -44,19 +43,16 @@ var eventSink chan<- cadf.Event
 
 // StartAuditTrail starts the audit trail by initializing the event sink and
 // starting a Commit() goroutine.
-func StartAuditTrail(clusterID string) {
+func StartAuditTrail() {
 	if osext.GetenvBool("LIMES_AUDIT_ENABLE") {
-		labels := prometheus.Labels{
-			"os_cluster": clusterID,
-		}
-		auditEventPublishSuccessCounter.With(labels).Add(0)
-		auditEventPublishFailedCounter.With(labels).Add(0)
+		auditEventPublishSuccessCounter.Add(0)
+		auditEventPublishFailedCounter.Add(0)
 
 		onSuccessFunc := func() {
-			auditEventPublishSuccessCounter.With(labels).Inc()
+			auditEventPublishSuccessCounter.Inc()
 		}
 		onFailFunc := func() {
-			auditEventPublishFailedCounter.With(labels).Inc()
+			auditEventPublishFailedCounter.Inc()
 		}
 		s := make(chan cadf.Event, 20)
 		eventSink = s

--- a/pkg/api/core.go
+++ b/pkg/api/core.go
@@ -173,9 +173,7 @@ func (p *v1Provider) FindDomainFromRequest(w http.ResponseWriter, r *http.Reques
 	}
 
 	var domain db.Domain
-	err := p.DB.SelectOne(&domain, `SELECT * FROM domains WHERE uuid = $1 AND cluster_id = $2`,
-		domainUUID, p.Cluster.ID,
-	)
+	err := p.DB.SelectOne(&domain, `SELECT * FROM domains WHERE uuid = $1`, domainUUID)
 	switch {
 	case err == sql.ErrNoRows:
 		http.Error(w, "no such domain (if it was just created, try to POST /domains/discover)", http.StatusNotFound)

--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -36,7 +36,7 @@ func (p *v1Provider) ListScrapeErrors(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	scrapeErrors, err := reports.GetScrapeErrors(p.Cluster, p.DB, reports.ReadFilter(r, p.Cluster.GetServiceTypesForArea))
+	scrapeErrors, err := reports.GetScrapeErrors(p.DB, reports.ReadFilter(r, p.Cluster.GetServiceTypesForArea))
 	if respondwith.ErrorText(w, err) {
 		return
 	}
@@ -52,7 +52,7 @@ func (p *v1Provider) ListRateScrapeErrors(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	scrapeErrors, err := reports.GetRateScrapeErrors(p.Cluster, p.DB, reports.ReadFilter(r, p.Cluster.GetServiceTypesForArea))
+	scrapeErrors, err := reports.GetRateScrapeErrors(p.DB, reports.ReadFilter(r, p.Cluster.GetServiceTypesForArea))
 	if respondwith.ErrorText(w, err) {
 		return
 	}

--- a/pkg/api/fixtures/start-data-inconsistencies.sql
+++ b/pkg/api/fixtures/start-data-inconsistencies.sql
@@ -1,7 +1,7 @@
 -- start data for inconsistencies test
 -- "cloud" cluster has two domains
-INSERT INTO domains (id, cluster_id, name, uuid) VALUES (1, 'cloud', 'germany',  'uuid-for-germany');
-INSERT INTO domains (id, cluster_id, name, uuid) VALUES (2, 'cloud', 'pakistan', 'uuid-for-pakistan');
+INSERT INTO domains (id, name, uuid) VALUES (1, 'germany',  'uuid-for-germany');
+INSERT INTO domains (id, name, uuid) VALUES (2, 'pakistan', 'uuid-for-pakistan');
 
 -- domain_services is fully populated (as ensured by the collector's consistency check)
 INSERT INTO domain_services (id, domain_id, type) VALUES (1, 1, 'compute');

--- a/pkg/api/fixtures/start-data-minimal.sql
+++ b/pkg/api/fixtures/start-data-minimal.sql
@@ -1,12 +1,12 @@
 CREATE OR REPLACE FUNCTION unix(i integer) RETURNS timestamp AS $$ SELECT TO_TIMESTAMP(i) AT TIME ZONE 'Etc/UTC' $$ LANGUAGE SQL;
 
 -- two services, one shared, one unshared
-INSERT INTO cluster_services (id, cluster_id, type, scraped_at) VALUES (1, 'west', 'unshared', UNIX(1000));
-INSERT INTO cluster_services (id, cluster_id, type, scraped_at) VALUES (2, 'west', 'shared',   UNIX(1100));
+INSERT INTO cluster_services (id, type, scraped_at) VALUES (1, 'unshared', UNIX(1000));
+INSERT INTO cluster_services (id, type, scraped_at) VALUES (2, 'shared',   UNIX(1100));
 
--- cluster "west" has two domains
-INSERT INTO domains (id, cluster_id, name, uuid) VALUES (1, 'west', 'germany', 'uuid-for-germany');
-INSERT INTO domains (id, cluster_id, name, uuid) VALUES (2, 'west', 'france',  'uuid-for-france');
+-- two domains
+INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
+INSERT INTO domains (id, name, uuid) VALUES (2, 'france',  'uuid-for-france');
 
 -- domain_services is fully populated (as ensured by the collector's consistency check)
 INSERT INTO domain_services (id, domain_id, type) VALUES (1, 1, 'unshared');

--- a/pkg/api/fixtures/start-data-opa.sql
+++ b/pkg/api/fixtures/start-data-opa.sql
@@ -1,17 +1,17 @@
 CREATE OR REPLACE FUNCTION unix(i integer) RETURNS timestamp AS $$ SELECT TO_TIMESTAMP(i) AT TIME ZONE 'Etc/UTC' $$ LANGUAGE SQL;
 
 -- two services, one shared, one unshared
-INSERT INTO cluster_services (id, cluster_id, type, scraped_at) VALUES (1, 'west', 'unshared', UNIX(1000));
-INSERT INTO cluster_services (id, cluster_id, type, scraped_at) VALUES (2, 'west', 'shared',   UNIX(1100));
+INSERT INTO cluster_services (id, type, scraped_at) VALUES (1, 'unshared', UNIX(1000));
+INSERT INTO cluster_services (id, type, scraped_at) VALUES (2, 'shared',   UNIX(1100));
 
 -- both services have the resources "things" and "capacity"
 INSERT INTO cluster_resources (service_id, name, capacity, subcapacities, capacity_per_az) VALUES (1, 'things', 139, '[{"smaller_half":46},{"larger_half":93}]', '[{"name":"az-one","capacity":69,"usage":13},{"name":"az-two","capacity":69,"usage":13}]');
 INSERT INTO cluster_resources (service_id, name, capacity, subcapacities, capacity_per_az) VALUES (2, 'things', 246, '[{"smaller_half":82},{"larger_half":164}]', '');
 INSERT INTO cluster_resources (service_id, name, capacity, subcapacities, capacity_per_az) VALUES (2, 'capacity', 185, '', '');
 
--- cluster "west" has two domains
-INSERT INTO domains (id, cluster_id, name, uuid) VALUES (1, 'west', 'germany', 'uuid-for-germany');
-INSERT INTO domains (id, cluster_id, name, uuid) VALUES (2, 'west', 'france',  'uuid-for-france');
+-- two domains
+INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
+INSERT INTO domains (id, name, uuid) VALUES (2, 'france',  'uuid-for-france');
 
 -- domain_services is fully populated (as ensured by the collector's consistency check)
 INSERT INTO domain_services (id, domain_id, type) VALUES (1, 1, 'unshared');
@@ -80,12 +80,9 @@ INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, su
 -- -- not pictures: paris has no records at all, so the API will only display the default rate limits
 
 -- -- insert some bullshit data that should be filtered out by the pkg/reports/ logic
--- -- (cluster "north", service "weird", resource "items" and rate "frobnicate" are not configured)
--- INSERT INTO cluster_services (id, cluster_id, type, scraped_at) VALUES (101, 'north', 'unshared', UNIX(1000));
--- INSERT INTO cluster_services (id, cluster_id, type, scraped_at) VALUES (102, 'north', 'shared',   UNIX(1100));
+-- -- (service "weird", resource "items" and rate "frobnicate" are not configured)
+-- INSERT INTO cluster_services (id, type, scraped_at) VALUES (101, 'weird', UNIX(1100));
 -- INSERT INTO cluster_resources (service_id, name, capacity) VALUES (101, 'things', 1);
--- INSERT INTO cluster_resources (service_id, name, capacity) VALUES (102, 'things', 1);
-
 -- INSERT INTO domain_services (id, domain_id, type) VALUES (101, 1, 'weird');
 -- INSERT INTO domain_resources (service_id, name, quota) VALUES (101, 'things', 1);
 -- INSERT INTO project_services (id, project_id, type) VALUES (101, 1, 'weird');

--- a/pkg/api/fixtures/start-data.sql
+++ b/pkg/api/fixtures/start-data.sql
@@ -1,18 +1,18 @@
 CREATE OR REPLACE FUNCTION unix(i integer) RETURNS timestamp AS $$ SELECT TO_TIMESTAMP(i) AT TIME ZONE 'Etc/UTC' $$ LANGUAGE SQL;
 
 -- three services
-INSERT INTO cluster_services (id, cluster_id, type, scraped_at) VALUES (1, 'west', 'unshared',    UNIX(1000));
-INSERT INTO cluster_services (id, cluster_id, type, scraped_at) VALUES (2, 'west', 'shared',      UNIX(1100));
-INSERT INTO cluster_services (id, cluster_id, type, scraped_at) VALUES (3, 'west', 'centralized', UNIX(1200));
+INSERT INTO cluster_services (id, type, scraped_at) VALUES (1, 'unshared',    UNIX(1000));
+INSERT INTO cluster_services (id, type, scraped_at) VALUES (2, 'shared',      UNIX(1100));
+INSERT INTO cluster_services (id, type, scraped_at) VALUES (3, 'centralized', UNIX(1200));
 
 -- all services have the resources "things" and "capacity"
 INSERT INTO cluster_resources (service_id, name, capacity, subcapacities, capacity_per_az) VALUES (1, 'things', 139, '[{"smaller_half":46},{"larger_half":93}]', '[{"name":"az-one","capacity":69,"usage":13},{"name":"az-two","capacity":69,"usage":13}]');
 INSERT INTO cluster_resources (service_id, name, capacity, subcapacities, capacity_per_az) VALUES (2, 'things', 246, '[{"smaller_half":82},{"larger_half":164}]', '');
 INSERT INTO cluster_resources (service_id, name, capacity, subcapacities, capacity_per_az) VALUES (2, 'capacity', 185, '', '');
 
--- cluster "west" has two domains
-INSERT INTO domains (id, cluster_id, name, uuid) VALUES (1, 'west', 'germany', 'uuid-for-germany');
-INSERT INTO domains (id, cluster_id, name, uuid) VALUES (2, 'west', 'france',  'uuid-for-france');
+-- two domains
+INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
+INSERT INTO domains (id, name, uuid) VALUES (2, 'france',  'uuid-for-france');
 
 -- domain_services is fully populated (as ensured by the collector's consistency check)
 INSERT INTO domain_services (id, domain_id, type) VALUES (1, 1, 'unshared');
@@ -101,11 +101,8 @@ INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_big
 
 -- insert some bullshit data that should be filtered out by the pkg/reports/ logic
 -- (cluster "north", service "weird", resource "items" and rate "frobnicate" are not configured)
-INSERT INTO cluster_services (id, cluster_id, type, scraped_at) VALUES (101, 'north', 'unshared', UNIX(1000));
-INSERT INTO cluster_services (id, cluster_id, type, scraped_at) VALUES (102, 'north', 'shared',   UNIX(1100));
+INSERT INTO cluster_services (id, type, scraped_at) VALUES (101, 'weird', UNIX(1100));
 INSERT INTO cluster_resources (service_id, name, capacity) VALUES (101, 'things', 1);
-INSERT INTO cluster_resources (service_id, name, capacity) VALUES (102, 'things', 1);
-
 INSERT INTO domain_services (id, domain_id, type) VALUES (101, 1, 'weird');
 INSERT INTO domain_resources (service_id, name, quota) VALUES (101, 'things', 1);
 INSERT INTO project_services (id, project_id, type) VALUES (101, 1, 'weird');

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -23,7 +23,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-var lowPrivilegeRaiseMetricLabels = []string{"os_cluster", "service", "resource"}
+var lowPrivilegeRaiseMetricLabels = []string{"service", "resource"}
 
 var lowPrivilegeRaiseDomainSuccessCounter = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
@@ -49,19 +49,17 @@ var lowPrivilegeRaiseProjectFailureCounter = prometheus.NewCounterVec(
 		Help: "Counter for failed quota auto approval for some service/resource per project.",
 	}, lowPrivilegeRaiseMetricLabels)
 
-var auditEventPublishSuccessCounter = prometheus.NewCounterVec(
+var auditEventPublishSuccessCounter = prometheus.NewCounter(
 	prometheus.CounterOpts{
 		Name: "limes_successful_auditevent_publish",
 		Help: "Counter for successful audit event publish to RabbitMQ server.",
-	},
-	[]string{"os_cluster"})
+	})
 
-var auditEventPublishFailedCounter = prometheus.NewCounterVec(
+var auditEventPublishFailedCounter = prometheus.NewCounter(
 	prometheus.CounterOpts{
 		Name: "limes_failed_auditevent_publish",
 		Help: "Counter for failed audit event publish to RabbitMQ server.",
-	},
-	[]string{"os_cluster"})
+	})
 
 func init() {
 	prometheus.MustRegister(lowPrivilegeRaiseDomainSuccessCounter)

--- a/pkg/api/quota_updater.go
+++ b/pkg/api/quota_updater.go
@@ -735,9 +735,8 @@ func (u QuotaUpdater) CommitAuditTrail(token *gopherpolicy.Token, r *http.Reques
 			// low-privilege-raise metrics
 			if qdConfig.Model != limesresources.CentralizedQuotaDistribution && u.CanRaiseLP(srvType) && !u.CanRaise(srvType) {
 				labels := prometheus.Labels{
-					"os_cluster": u.Cluster.ID,
-					"service":    srvType,
-					"resource":   resName,
+					"service":  srvType,
+					"resource": resName,
 				}
 				if u.ScopeType() == "domain" {
 					if invalid {

--- a/pkg/api/rates.go
+++ b/pkg/api/rates.go
@@ -35,7 +35,7 @@ import (
 	"github.com/sapcc/limes/pkg/reports"
 )
 
-// GetClusterRates handles GET /v1/clusters/:cluster_id.
+// GetClusterRates handles GET /rates/v1/clusters/current.
 func (p *v1Provider) GetClusterRates(w http.ResponseWriter, r *http.Request) {
 	httpapi.IdentifyEndpoint(r, "/rates/v1/clusters/current")
 	token := p.CheckToken(r)

--- a/pkg/collector/consistency_test.go
+++ b/pkg/collector/consistency_test.go
@@ -99,7 +99,6 @@ func Test_Consistency(t *testing.T) {
 	//add some useless *_services entries
 	epoch := time.Unix(0, 0).UTC()
 	err = dbm.Insert(&db.ClusterService{
-		ClusterID: "west",
 		Type:      "whatever",
 		ScrapedAt: &epoch,
 	})

--- a/pkg/collector/fixtures/capacity_metrics.prom
+++ b/pkg/collector/fixtures/capacity_metrics.prom
@@ -1,25 +1,25 @@
 # HELP limes_capacity_plugin_metrics_ok Whether capacity plugin metrics were rendered successfully for a particular capacitor. Only present when the capacitor emits metrics.
 # TYPE limes_capacity_plugin_metrics_ok gauge
-limes_capacity_plugin_metrics_ok{capacitor="unittest4",os_cluster="west"} 1
+limes_capacity_plugin_metrics_ok{capacitor="unittest4"} 1
 # HELP limes_cluster_capacity Reported capacity of a Limes resource for an OpenStack cluster.
 # TYPE limes_cluster_capacity gauge
-limes_cluster_capacity{os_cluster="west",resource="capacity",service="shared"} 0
-limes_cluster_capacity{os_cluster="west",resource="capacity",service="unshared"} 42
-limes_cluster_capacity{os_cluster="west",resource="capacity",service="unshared2"} 0
-limes_cluster_capacity{os_cluster="west",resource="capacity_portion",service="shared"} 0
-limes_cluster_capacity{os_cluster="west",resource="capacity_portion",service="unshared"} 0
-limes_cluster_capacity{os_cluster="west",resource="capacity_portion",service="unshared2"} 0
-limes_cluster_capacity{os_cluster="west",resource="things",service="shared"} 23
-limes_cluster_capacity{os_cluster="west",resource="things",service="unshared"} 10
-limes_cluster_capacity{os_cluster="west",resource="things",service="unshared2"} 30
+limes_cluster_capacity{resource="capacity",service="shared"} 0
+limes_cluster_capacity{resource="capacity",service="unshared"} 42
+limes_cluster_capacity{resource="capacity",service="unshared2"} 0
+limes_cluster_capacity{resource="capacity_portion",service="shared"} 0
+limes_cluster_capacity{resource="capacity_portion",service="unshared"} 0
+limes_cluster_capacity{resource="capacity_portion",service="unshared2"} 0
+limes_cluster_capacity{resource="things",service="shared"} 23
+limes_cluster_capacity{resource="things",service="unshared"} 10
+limes_cluster_capacity{resource="things",service="unshared2"} 30
 # HELP limes_cluster_capacity_per_az Reported capacity of a Limes resource for an OpenStack cluster in a specific availability zone.
 # TYPE limes_cluster_capacity_per_az gauge
-limes_cluster_capacity_per_az{availability_zone="az-one",os_cluster="west",resource="things",service="unshared2"} 15
-limes_cluster_capacity_per_az{availability_zone="az-two",os_cluster="west",resource="things",service="unshared2"} 15
+limes_cluster_capacity_per_az{availability_zone="az-one",resource="things",service="unshared2"} 15
+limes_cluster_capacity_per_az{availability_zone="az-two",resource="things",service="unshared2"} 15
 # HELP limes_cluster_usage_per_az Actual usage of a Limes resource for an OpenStack cluster in a specific availability zone.
 # TYPE limes_cluster_usage_per_az gauge
-limes_cluster_usage_per_az{availability_zone="az-one",os_cluster="west",resource="things",service="unshared2"} 3
-limes_cluster_usage_per_az{availability_zone="az-two",os_cluster="west",resource="things",service="unshared2"} 3
+limes_cluster_usage_per_az{availability_zone="az-one",resource="things",service="unshared2"} 3
+limes_cluster_usage_per_az{availability_zone="az-two",resource="things",service="unshared2"} 3
 # HELP limes_unit_multiplier Conversion factor that a value of this resource must be multiplied with to obtain the base unit (e.g. bytes). For use with Grafana when only the base unit can be configured because of templating.
 # TYPE limes_unit_multiplier gauge
 limes_unit_multiplier{resource="capacity",service="shared"} 1
@@ -33,7 +33,7 @@ limes_unit_multiplier{resource="things",service="unshared"} 1
 limes_unit_multiplier{resource="things",service="unshared2"} 1
 # HELP limes_unittest_capacity_larger_half 
 # TYPE limes_unittest_capacity_larger_half gauge
-limes_unittest_capacity_larger_half{os_cluster="west"} 7
+limes_unittest_capacity_larger_half 7
 # HELP limes_unittest_capacity_smaller_half 
 # TYPE limes_unittest_capacity_smaller_half gauge
-limes_unittest_capacity_smaller_half{os_cluster="west"} 3
+limes_unittest_capacity_smaller_half 3

--- a/pkg/collector/fixtures/checkconsistency-pre.sql
+++ b/pkg/collector/fixtures/checkconsistency-pre.sql
@@ -24,8 +24,8 @@ INSERT INTO domain_services (id, domain_id, type) VALUES (4, 2, 'centralized');
 INSERT INTO domain_services (id, domain_id, type) VALUES (5, 2, 'shared');
 INSERT INTO domain_services (id, domain_id, type) VALUES (6, 2, 'unshared');
 
-INSERT INTO domains (id, cluster_id, name, uuid) VALUES (1, 'west', 'germany', 'uuid-for-germany');
-INSERT INTO domains (id, cluster_id, name, uuid) VALUES (2, 'west', 'france', 'uuid-for-france');
+INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
+INSERT INTO domains (id, name, uuid) VALUES (2, 'france', 'uuid-for-france');
 
 INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state, serialized_metrics, checked_at, scrape_error_message, rates_checked_at, rates_scrape_error_message) VALUES (1, 1, 'centralized', NULL, FALSE, 0, NULL, FALSE, 0, '', '', NULL, '', NULL, '');
 INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state, serialized_metrics, checked_at, scrape_error_message, rates_checked_at, rates_scrape_error_message) VALUES (2, 1, 'shared', NULL, FALSE, 0, NULL, FALSE, 0, '', '', NULL, '', NULL, '');

--- a/pkg/collector/fixtures/checkconsistency0.sql
+++ b/pkg/collector/fixtures/checkconsistency0.sql
@@ -1,6 +1,6 @@
-INSERT INTO cluster_services (id, cluster_id, type, scraped_at) VALUES (1, 'west', 'centralized', 0);
-INSERT INTO cluster_services (id, cluster_id, type, scraped_at) VALUES (2, 'west', 'shared', 0);
-INSERT INTO cluster_services (id, cluster_id, type, scraped_at) VALUES (3, 'west', 'unshared', 0);
+INSERT INTO cluster_services (id, type, scraped_at) VALUES (1, 'centralized', 0);
+INSERT INTO cluster_services (id, type, scraped_at) VALUES (2, 'shared', 0);
+INSERT INTO cluster_services (id, type, scraped_at) VALUES (3, 'unshared', 0);
 
 INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'capacity', 0);
 INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'capacity_portion', 0);
@@ -28,8 +28,8 @@ INSERT INTO domain_services (id, domain_id, type) VALUES (4, 2, 'centralized');
 INSERT INTO domain_services (id, domain_id, type) VALUES (5, 2, 'shared');
 INSERT INTO domain_services (id, domain_id, type) VALUES (6, 2, 'unshared');
 
-INSERT INTO domains (id, cluster_id, name, uuid) VALUES (1, 'west', 'germany', 'uuid-for-germany');
-INSERT INTO domains (id, cluster_id, name, uuid) VALUES (2, 'west', 'france', 'uuid-for-france');
+INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
+INSERT INTO domains (id, name, uuid) VALUES (2, 'france', 'uuid-for-france');
 
 INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state, serialized_metrics, checked_at, scrape_error_message, rates_checked_at, rates_scrape_error_message) VALUES (1, 1, 'centralized', NULL, FALSE, 0, NULL, FALSE, 0, '', '', NULL, '', NULL, '');
 INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state, serialized_metrics, checked_at, scrape_error_message, rates_checked_at, rates_scrape_error_message) VALUES (2, 1, 'shared', NULL, FALSE, 0, NULL, FALSE, 0, '', '', NULL, '', NULL, '');

--- a/pkg/collector/fixtures/checkconsistency1.sql
+++ b/pkg/collector/fixtures/checkconsistency1.sql
@@ -1,6 +1,6 @@
-INSERT INTO cluster_services (id, cluster_id, type, scraped_at) VALUES (1, 'west', 'centralized', 0);
-INSERT INTO cluster_services (id, cluster_id, type, scraped_at) VALUES (3, 'west', 'unshared', 0);
-INSERT INTO cluster_services (id, cluster_id, type, scraped_at) VALUES (4, 'west', 'whatever', 0);
+INSERT INTO cluster_services (id, type, scraped_at) VALUES (1, 'centralized', 0);
+INSERT INTO cluster_services (id, type, scraped_at) VALUES (3, 'unshared', 0);
+INSERT INTO cluster_services (id, type, scraped_at) VALUES (4, 'whatever', 0);
 
 INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'capacity', 0);
 INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'capacity_portion', 0);
@@ -21,8 +21,8 @@ INSERT INTO domain_services (id, domain_id, type) VALUES (4, 2, 'centralized');
 INSERT INTO domain_services (id, domain_id, type) VALUES (5, 2, 'shared');
 INSERT INTO domain_services (id, domain_id, type) VALUES (7, 1, 'whatever');
 
-INSERT INTO domains (id, cluster_id, name, uuid) VALUES (1, 'west', 'germany', 'uuid-for-germany');
-INSERT INTO domains (id, cluster_id, name, uuid) VALUES (2, 'west', 'france', 'uuid-for-france');
+INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
+INSERT INTO domains (id, name, uuid) VALUES (2, 'france', 'uuid-for-france');
 
 INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state, serialized_metrics, checked_at, scrape_error_message, rates_checked_at, rates_scrape_error_message) VALUES (1, 1, 'centralized', NULL, FALSE, 0, NULL, FALSE, 0, '', '', NULL, '', NULL, '');
 INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state, serialized_metrics, checked_at, scrape_error_message, rates_checked_at, rates_scrape_error_message) VALUES (10, 1, 'whatever', NULL, FALSE, 0, NULL, FALSE, 0, '', '', NULL, '', NULL, '');

--- a/pkg/collector/fixtures/checkconsistency2.sql
+++ b/pkg/collector/fixtures/checkconsistency2.sql
@@ -1,6 +1,6 @@
-INSERT INTO cluster_services (id, cluster_id, type, scraped_at) VALUES (1, 'west', 'centralized', 0);
-INSERT INTO cluster_services (id, cluster_id, type, scraped_at) VALUES (3, 'west', 'unshared', 0);
-INSERT INTO cluster_services (id, cluster_id, type, scraped_at) VALUES (5, 'west', 'shared', 1);
+INSERT INTO cluster_services (id, type, scraped_at) VALUES (1, 'centralized', 0);
+INSERT INTO cluster_services (id, type, scraped_at) VALUES (3, 'unshared', 0);
+INSERT INTO cluster_services (id, type, scraped_at) VALUES (5, 'shared', 1);
 
 INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'capacity', 0);
 INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'capacity_portion', 0);
@@ -28,8 +28,8 @@ INSERT INTO domain_services (id, domain_id, type) VALUES (5, 2, 'shared');
 INSERT INTO domain_services (id, domain_id, type) VALUES (8, 1, 'unshared');
 INSERT INTO domain_services (id, domain_id, type) VALUES (9, 2, 'unshared');
 
-INSERT INTO domains (id, cluster_id, name, uuid) VALUES (1, 'west', 'germany', 'uuid-for-germany');
-INSERT INTO domains (id, cluster_id, name, uuid) VALUES (2, 'west', 'france', 'uuid-for-france');
+INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
+INSERT INTO domains (id, name, uuid) VALUES (2, 'france', 'uuid-for-france');
 
 INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state, serialized_metrics, checked_at, scrape_error_message, rates_checked_at, rates_scrape_error_message) VALUES (1, 1, 'centralized', NULL, FALSE, 0, NULL, FALSE, 0, '', '', NULL, '', NULL, '');
 INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state, serialized_metrics, checked_at, scrape_error_message, rates_checked_at, rates_scrape_error_message) VALUES (11, 1, 'shared', NULL, FALSE, 0, NULL, FALSE, 0, '', '', NULL, '', NULL, '');

--- a/pkg/collector/fixtures/ratescrape_metrics.prom
+++ b/pkg/collector/fixtures/ratescrape_metrics.prom
@@ -1,19 +1,19 @@
 # HELP limes_cluster_capacity Reported capacity of a Limes resource for an OpenStack cluster.
 # TYPE limes_cluster_capacity gauge
-limes_cluster_capacity{os_cluster="west",resource="capacity",service="unittest"} 0
-limes_cluster_capacity{os_cluster="west",resource="capacity_portion",service="unittest"} 0
-limes_cluster_capacity{os_cluster="west",resource="things",service="unittest"} 0
+limes_cluster_capacity{resource="capacity",service="unittest"} 0
+limes_cluster_capacity{resource="capacity_portion",service="unittest"} 0
+limes_cluster_capacity{resource="things",service="unittest"} 0
 # HELP limes_domain_quota Assigned quota of a Limes resource for an OpenStack domain.
 # TYPE limes_domain_quota gauge
-limes_domain_quota{domain="germany",domain_id="uuid-for-germany",os_cluster="west",resource="capacity",service="unittest"} 0
-limes_domain_quota{domain="germany",domain_id="uuid-for-germany",os_cluster="west",resource="capacity_portion",service="unittest"} 0
-limes_domain_quota{domain="germany",domain_id="uuid-for-germany",os_cluster="west",resource="things",service="unittest"} 0
+limes_domain_quota{domain="germany",domain_id="uuid-for-germany",resource="capacity",service="unittest"} 0
+limes_domain_quota{domain="germany",domain_id="uuid-for-germany",resource="capacity_portion",service="unittest"} 0
+limes_domain_quota{domain="germany",domain_id="uuid-for-germany",resource="things",service="unittest"} 0
 # HELP limes_project_rate_usage Usage of a Limes rate for an OpenStack project. These are counters that never reset.
 # TYPE limes_project_rate_usage gauge
-limes_project_rate_usage{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="berlin",project_id="uuid-for-berlin",rate="firstrate",service="unittest"} 5129
-limes_project_rate_usage{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="berlin",project_id="uuid-for-berlin",rate="secondrate",service="unittest"} 1034
-limes_project_rate_usage{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="dresden",project_id="uuid-for-dresden",rate="firstrate",service="unittest"} 1033
-limes_project_rate_usage{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="dresden",project_id="uuid-for-dresden",rate="secondrate",service="unittest"} 1034
+limes_project_rate_usage{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",rate="firstrate",service="unittest"} 5129
+limes_project_rate_usage{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",rate="secondrate",service="unittest"} 1034
+limes_project_rate_usage{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",rate="firstrate",service="unittest"} 1033
+limes_project_rate_usage{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",rate="secondrate",service="unittest"} 1034
 # HELP limes_unit_multiplier Conversion factor that a value of this resource must be multiplied with to obtain the base unit (e.g. bytes). For use with Grafana when only the base unit can be configured because of templating.
 # TYPE limes_unit_multiplier gauge
 limes_unit_multiplier{resource="capacity",service="unittest"} 1

--- a/pkg/collector/fixtures/ratescrape_metrics_skipzero.prom
+++ b/pkg/collector/fixtures/ratescrape_metrics_skipzero.prom
@@ -1,19 +1,19 @@
 # HELP limes_cluster_capacity Reported capacity of a Limes resource for an OpenStack cluster.
 # TYPE limes_cluster_capacity gauge
-limes_cluster_capacity{os_cluster="west",resource="capacity",service="unittest"} 0
-limes_cluster_capacity{os_cluster="west",resource="capacity_portion",service="unittest"} 0
-limes_cluster_capacity{os_cluster="west",resource="things",service="unittest"} 0
+limes_cluster_capacity{resource="capacity",service="unittest"} 0
+limes_cluster_capacity{resource="capacity_portion",service="unittest"} 0
+limes_cluster_capacity{resource="things",service="unittest"} 0
 # HELP limes_domain_quota Assigned quota of a Limes resource for an OpenStack domain.
 # TYPE limes_domain_quota gauge
-limes_domain_quota{domain="germany",domain_id="uuid-for-germany",os_cluster="west",resource="capacity",service="unittest"} 0
-limes_domain_quota{domain="germany",domain_id="uuid-for-germany",os_cluster="west",resource="capacity_portion",service="unittest"} 0
-limes_domain_quota{domain="germany",domain_id="uuid-for-germany",os_cluster="west",resource="things",service="unittest"} 0
+limes_domain_quota{domain="germany",domain_id="uuid-for-germany",resource="capacity",service="unittest"} 0
+limes_domain_quota{domain="germany",domain_id="uuid-for-germany",resource="capacity_portion",service="unittest"} 0
+limes_domain_quota{domain="germany",domain_id="uuid-for-germany",resource="things",service="unittest"} 0
 # HELP limes_project_rate_usage Usage of a Limes rate for an OpenStack project. These are counters that never reset.
 # TYPE limes_project_rate_usage gauge
-limes_project_rate_usage{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="berlin",project_id="uuid-for-berlin",rate="firstrate",service="unittest"} 5129
-limes_project_rate_usage{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="berlin",project_id="uuid-for-berlin",rate="secondrate",service="unittest"} 1034
-limes_project_rate_usage{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="dresden",project_id="uuid-for-dresden",rate="firstrate",service="unittest"} 1033
-limes_project_rate_usage{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="dresden",project_id="uuid-for-dresden",rate="secondrate",service="unittest"} 1034
+limes_project_rate_usage{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",rate="firstrate",service="unittest"} 5129
+limes_project_rate_usage{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",rate="secondrate",service="unittest"} 1034
+limes_project_rate_usage{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",rate="firstrate",service="unittest"} 1033
+limes_project_rate_usage{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",rate="secondrate",service="unittest"} 1034
 # HELP limes_unit_multiplier Conversion factor that a value of this resource must be multiplied with to obtain the base unit (e.g. bytes). For use with Grafana when only the base unit can be configured because of templating.
 # TYPE limes_unit_multiplier gauge
 limes_unit_multiplier{resource="capacity",service="unittest"} 1

--- a/pkg/collector/fixtures/scandomains1.sql
+++ b/pkg/collector/fixtures/scandomains1.sql
@@ -24,8 +24,8 @@ INSERT INTO domain_services (id, domain_id, type) VALUES (4, 2, 'centralized');
 INSERT INTO domain_services (id, domain_id, type) VALUES (5, 2, 'shared');
 INSERT INTO domain_services (id, domain_id, type) VALUES (6, 2, 'unshared');
 
-INSERT INTO domains (id, cluster_id, name, uuid) VALUES (1, 'west', 'germany', 'uuid-for-germany');
-INSERT INTO domains (id, cluster_id, name, uuid) VALUES (2, 'west', 'france', 'uuid-for-france');
+INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
+INSERT INTO domains (id, name, uuid) VALUES (2, 'france', 'uuid-for-france');
 
 INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state, serialized_metrics, checked_at, scrape_error_message, rates_checked_at, rates_scrape_error_message) VALUES (1, 1, 'centralized', NULL, FALSE, 0, NULL, FALSE, 0, '', '', NULL, '', NULL, '');
 INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state, serialized_metrics, checked_at, scrape_error_message, rates_checked_at, rates_scrape_error_message) VALUES (2, 1, 'shared', NULL, FALSE, 0, NULL, FALSE, 0, '', '', NULL, '', NULL, '');

--- a/pkg/collector/fixtures/scrape-centralized0.sql
+++ b/pkg/collector/fixtures/scrape-centralized0.sql
@@ -4,7 +4,7 @@ INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'things', 0);
 
 INSERT INTO domain_services (id, domain_id, type) VALUES (1, 1, 'centralized');
 
-INSERT INTO domains (id, cluster_id, name, uuid) VALUES (1, 'west', 'germany', 'uuid-for-germany');
+INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
 
 INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state, serialized_metrics, checked_at, scrape_error_message, rates_checked_at, rates_scrape_error_message) VALUES (1, 1, 'centralized', NULL, FALSE, 0, NULL, FALSE, 0, '', '', NULL, '', NULL, '');
 

--- a/pkg/collector/fixtures/scrape0.sql
+++ b/pkg/collector/fixtures/scrape0.sql
@@ -4,7 +4,7 @@ INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'things', 0);
 
 INSERT INTO domain_services (id, domain_id, type) VALUES (1, 1, 'unittest');
 
-INSERT INTO domains (id, cluster_id, name, uuid) VALUES (1, 'west', 'germany', 'uuid-for-germany');
+INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
 
 INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state, serialized_metrics, checked_at, scrape_error_message, rates_checked_at, rates_scrape_error_message) VALUES (1, 1, 'unittest', NULL, FALSE, 0, NULL, FALSE, 0, '', '', NULL, '', NULL, '');
 INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state, serialized_metrics, checked_at, scrape_error_message, rates_checked_at, rates_scrape_error_message) VALUES (2, 2, 'unittest', NULL, FALSE, 0, NULL, FALSE, 0, '', '', NULL, '', NULL, '');

--- a/pkg/collector/fixtures/scrape_metrics.prom
+++ b/pkg/collector/fixtures/scrape_metrics.prom
@@ -1,47 +1,47 @@
 # HELP limes_cluster_capacity Reported capacity of a Limes resource for an OpenStack cluster.
 # TYPE limes_cluster_capacity gauge
-limes_cluster_capacity{os_cluster="west",resource="capacity",service="unittest"} 0
-limes_cluster_capacity{os_cluster="west",resource="capacity_portion",service="unittest"} 0
-limes_cluster_capacity{os_cluster="west",resource="things",service="unittest"} 0
+limes_cluster_capacity{resource="capacity",service="unittest"} 0
+limes_cluster_capacity{resource="capacity_portion",service="unittest"} 0
+limes_cluster_capacity{resource="things",service="unittest"} 0
 # HELP limes_domain_quota Assigned quota of a Limes resource for an OpenStack domain.
 # TYPE limes_domain_quota gauge
-limes_domain_quota{domain="germany",domain_id="uuid-for-germany",os_cluster="west",resource="capacity",service="unittest"} 0
-limes_domain_quota{domain="germany",domain_id="uuid-for-germany",os_cluster="west",resource="capacity_portion",service="unittest"} 0
-limes_domain_quota{domain="germany",domain_id="uuid-for-germany",os_cluster="west",resource="things",service="unittest"} 0
+limes_domain_quota{domain="germany",domain_id="uuid-for-germany",resource="capacity",service="unittest"} 0
+limes_domain_quota{domain="germany",domain_id="uuid-for-germany",resource="capacity_portion",service="unittest"} 0
+limes_domain_quota{domain="germany",domain_id="uuid-for-germany",resource="things",service="unittest"} 0
 # HELP limes_newest_scraped_at Newest (i.e. largest) scraped_at timestamp for any project given a certain service in a certain OpenStack cluster.
 # TYPE limes_newest_scraped_at gauge
-limes_newest_scraped_at{os_cluster="west",service="unittest",service_name=""} 24
+limes_newest_scraped_at{service="unittest",service_name=""} 24
 # HELP limes_oldest_scraped_at Oldest (i.e. smallest) scraped_at timestamp for any project given a certain service in a certain OpenStack cluster.
 # TYPE limes_oldest_scraped_at gauge
-limes_oldest_scraped_at{os_cluster="west",service="unittest",service_name=""} 22
+limes_oldest_scraped_at{service="unittest",service_name=""} 22
 # HELP limes_plugin_metrics_ok Whether quota plugin metrics were rendered successfully for a particular project service. Only present when the project service emits metrics.
 # TYPE limes_plugin_metrics_ok gauge
-limes_plugin_metrics_ok{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="berlin",project_id="uuid-for-berlin",service="unittest"} 1
-limes_plugin_metrics_ok{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="dresden",project_id="uuid-for-dresden",service="unittest"} 1
+limes_plugin_metrics_ok{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",service="unittest"} 1
+limes_plugin_metrics_ok{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",service="unittest"} 1
 # HELP limes_project_backendquota Actual quota of a Limes resource for an OpenStack project.
 # TYPE limes_project_backendquota gauge
-limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest"} 40
-limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest"} 13
-limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest"} 48
-limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest"} 15
+limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest"} 40
+limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest"} 13
+limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest"} 48
+limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest"} 15
 # HELP limes_project_physical_usage Actual (physical) usage of a Limes resource for an OpenStack project.
 # TYPE limes_project_physical_usage gauge
-limes_project_physical_usage{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest"} 10
-limes_project_physical_usage{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest"} 10
+limes_project_physical_usage{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest"} 10
+limes_project_physical_usage{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest"} 10
 # HELP limes_project_quota Assigned quota of a Limes resource for an OpenStack project.
 # TYPE limes_project_quota gauge
-limes_project_quota{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest"} 40
-limes_project_quota{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest"} 13
-limes_project_quota{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest"} 40
-limes_project_quota{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest"} 13
+limes_project_quota{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest"} 40
+limes_project_quota{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest"} 13
+limes_project_quota{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest"} 40
+limes_project_quota{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest"} 13
 # HELP limes_project_usage Actual (logical) usage of a Limes resource for an OpenStack project.
 # TYPE limes_project_usage gauge
-limes_project_usage{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest"} 20
-limes_project_usage{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="berlin",project_id="uuid-for-berlin",resource="capacity_portion",service="unittest"} 5
-limes_project_usage{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest"} 5
-limes_project_usage{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest"} 20
-limes_project_usage{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="dresden",project_id="uuid-for-dresden",resource="capacity_portion",service="unittest"} 5
-limes_project_usage{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest"} 5
+limes_project_usage{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest"} 20
+limes_project_usage{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity_portion",service="unittest"} 5
+limes_project_usage{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest"} 5
+limes_project_usage{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest"} 20
+limes_project_usage{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity_portion",service="unittest"} 5
+limes_project_usage{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest"} 5
 # HELP limes_unit_multiplier Conversion factor that a value of this resource must be multiplied with to obtain the base unit (e.g. bytes). For use with Grafana when only the base unit can be configured because of templating.
 # TYPE limes_unit_multiplier gauge
 limes_unit_multiplier{resource="capacity",service="unittest"} 1
@@ -49,9 +49,9 @@ limes_unit_multiplier{resource="capacity_portion",service="unittest"} 1
 limes_unit_multiplier{resource="things",service="unittest"} 1
 # HELP limes_unittest_capacity_usage 
 # TYPE limes_unittest_capacity_usage gauge
-limes_unittest_capacity_usage{domain_id="uuid-for-germany",os_cluster="west",project_id="uuid-for-berlin"} 20
-limes_unittest_capacity_usage{domain_id="uuid-for-germany",os_cluster="west",project_id="uuid-for-dresden"} 20
+limes_unittest_capacity_usage{domain_id="uuid-for-germany",project_id="uuid-for-berlin"} 20
+limes_unittest_capacity_usage{domain_id="uuid-for-germany",project_id="uuid-for-dresden"} 20
 # HELP limes_unittest_things_usage 
 # TYPE limes_unittest_things_usage gauge
-limes_unittest_things_usage{domain_id="uuid-for-germany",os_cluster="west",project_id="uuid-for-berlin"} 5
-limes_unittest_things_usage{domain_id="uuid-for-germany",os_cluster="west",project_id="uuid-for-dresden"} 5
+limes_unittest_things_usage{domain_id="uuid-for-germany",project_id="uuid-for-berlin"} 5
+limes_unittest_things_usage{domain_id="uuid-for-germany",project_id="uuid-for-dresden"} 5

--- a/pkg/collector/fixtures/scrape_metrics_skipzero.prom
+++ b/pkg/collector/fixtures/scrape_metrics_skipzero.prom
@@ -1,47 +1,47 @@
 # HELP limes_cluster_capacity Reported capacity of a Limes resource for an OpenStack cluster.
 # TYPE limes_cluster_capacity gauge
-limes_cluster_capacity{os_cluster="west",resource="capacity",service="unittest"} 0
-limes_cluster_capacity{os_cluster="west",resource="capacity_portion",service="unittest"} 0
-limes_cluster_capacity{os_cluster="west",resource="things",service="unittest"} 0
+limes_cluster_capacity{resource="capacity",service="unittest"} 0
+limes_cluster_capacity{resource="capacity_portion",service="unittest"} 0
+limes_cluster_capacity{resource="things",service="unittest"} 0
 # HELP limes_domain_quota Assigned quota of a Limes resource for an OpenStack domain.
 # TYPE limes_domain_quota gauge
-limes_domain_quota{domain="germany",domain_id="uuid-for-germany",os_cluster="west",resource="capacity",service="unittest"} 0
-limes_domain_quota{domain="germany",domain_id="uuid-for-germany",os_cluster="west",resource="capacity_portion",service="unittest"} 0
-limes_domain_quota{domain="germany",domain_id="uuid-for-germany",os_cluster="west",resource="things",service="unittest"} 0
+limes_domain_quota{domain="germany",domain_id="uuid-for-germany",resource="capacity",service="unittest"} 0
+limes_domain_quota{domain="germany",domain_id="uuid-for-germany",resource="capacity_portion",service="unittest"} 0
+limes_domain_quota{domain="germany",domain_id="uuid-for-germany",resource="things",service="unittest"} 0
 # HELP limes_newest_scraped_at Newest (i.e. largest) scraped_at timestamp for any project given a certain service in a certain OpenStack cluster.
 # TYPE limes_newest_scraped_at gauge
-limes_newest_scraped_at{os_cluster="west",service="unittest",service_name=""} 24
+limes_newest_scraped_at{service="unittest",service_name=""} 24
 # HELP limes_oldest_scraped_at Oldest (i.e. smallest) scraped_at timestamp for any project given a certain service in a certain OpenStack cluster.
 # TYPE limes_oldest_scraped_at gauge
-limes_oldest_scraped_at{os_cluster="west",service="unittest",service_name=""} 22
+limes_oldest_scraped_at{service="unittest",service_name=""} 22
 # HELP limes_plugin_metrics_ok Whether quota plugin metrics were rendered successfully for a particular project service. Only present when the project service emits metrics.
 # TYPE limes_plugin_metrics_ok gauge
-limes_plugin_metrics_ok{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="berlin",project_id="uuid-for-berlin",service="unittest"} 1
-limes_plugin_metrics_ok{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="dresden",project_id="uuid-for-dresden",service="unittest"} 1
+limes_plugin_metrics_ok{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",service="unittest"} 1
+limes_plugin_metrics_ok{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",service="unittest"} 1
 # HELP limes_project_backendquota Actual quota of a Limes resource for an OpenStack project.
 # TYPE limes_project_backendquota gauge
-limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest"} 40
-limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest"} 13
-limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest"} 48
-limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest"} 15
+limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest"} 40
+limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest"} 13
+limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest"} 48
+limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest"} 15
 # HELP limes_project_physical_usage Actual (physical) usage of a Limes resource for an OpenStack project.
 # TYPE limes_project_physical_usage gauge
-limes_project_physical_usage{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest"} 10
-limes_project_physical_usage{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest"} 10
+limes_project_physical_usage{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest"} 10
+limes_project_physical_usage{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest"} 10
 # HELP limes_project_quota Assigned quota of a Limes resource for an OpenStack project.
 # TYPE limes_project_quota gauge
-limes_project_quota{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest"} 40
-limes_project_quota{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest"} 13
-limes_project_quota{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest"} 40
-limes_project_quota{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest"} 13
+limes_project_quota{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest"} 40
+limes_project_quota{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest"} 13
+limes_project_quota{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest"} 40
+limes_project_quota{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest"} 13
 # HELP limes_project_usage Actual (logical) usage of a Limes resource for an OpenStack project.
 # TYPE limes_project_usage gauge
-limes_project_usage{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest"} 20
-limes_project_usage{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="berlin",project_id="uuid-for-berlin",resource="capacity_portion",service="unittest"} 5
-limes_project_usage{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest"} 5
-limes_project_usage{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest"} 20
-limes_project_usage{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="dresden",project_id="uuid-for-dresden",resource="capacity_portion",service="unittest"} 5
-limes_project_usage{domain="germany",domain_id="uuid-for-germany",os_cluster="west",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest"} 5
+limes_project_usage{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest"} 20
+limes_project_usage{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity_portion",service="unittest"} 5
+limes_project_usage{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest"} 5
+limes_project_usage{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest"} 20
+limes_project_usage{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity_portion",service="unittest"} 5
+limes_project_usage{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest"} 5
 # HELP limes_unit_multiplier Conversion factor that a value of this resource must be multiplied with to obtain the base unit (e.g. bytes). For use with Grafana when only the base unit can be configured because of templating.
 # TYPE limes_unit_multiplier gauge
 limes_unit_multiplier{resource="capacity",service="unittest"} 1
@@ -49,9 +49,9 @@ limes_unit_multiplier{resource="capacity_portion",service="unittest"} 1
 limes_unit_multiplier{resource="things",service="unittest"} 1
 # HELP limes_unittest_capacity_usage 
 # TYPE limes_unittest_capacity_usage gauge
-limes_unittest_capacity_usage{domain_id="uuid-for-germany",os_cluster="west",project_id="uuid-for-berlin"} 20
-limes_unittest_capacity_usage{domain_id="uuid-for-germany",os_cluster="west",project_id="uuid-for-dresden"} 20
+limes_unittest_capacity_usage{domain_id="uuid-for-germany",project_id="uuid-for-berlin"} 20
+limes_unittest_capacity_usage{domain_id="uuid-for-germany",project_id="uuid-for-dresden"} 20
 # HELP limes_unittest_things_usage 
 # TYPE limes_unittest_things_usage gauge
-limes_unittest_things_usage{domain_id="uuid-for-germany",os_cluster="west",project_id="uuid-for-berlin"} 5
-limes_unittest_things_usage{domain_id="uuid-for-germany",os_cluster="west",project_id="uuid-for-dresden"} 5
+limes_unittest_things_usage{domain_id="uuid-for-germany",project_id="uuid-for-berlin"} 5
+limes_unittest_things_usage{domain_id="uuid-for-germany",project_id="uuid-for-dresden"} 5

--- a/pkg/collector/keystone_test.go
+++ b/pkg/collector/keystone_test.go
@@ -38,7 +38,6 @@ func keystoneTestCluster(t *testing.T) (*core.Cluster, *gorp.DbMap) {
 	dbm := test.InitDatabase(t, nil)
 
 	return &core.Cluster{
-		ID: "west",
 		Config: core.ClusterConfiguration{
 			QuotaDistributionConfigs: []*core.QuotaDistributionConfiguration{
 				{
@@ -192,7 +191,7 @@ func Test_ScanDomains(t *testing.T) {
 		DELETE FROM domain_services WHERE id = 4 AND domain_id = 2 AND type = 'centralized';
 		DELETE FROM domain_services WHERE id = 5 AND domain_id = 2 AND type = 'shared';
 		DELETE FROM domain_services WHERE id = 6 AND domain_id = 2 AND type = 'unshared';
-		DELETE FROM domains WHERE id = 2 AND cluster_id = 'west' AND uuid = 'uuid-for-france';
+		DELETE FROM domains WHERE id = 2 AND uuid = 'uuid-for-france';
 		DELETE FROM project_services WHERE id = 7 AND project_id = 3 AND type = 'centralized';
 		DELETE FROM project_services WHERE id = 8 AND project_id = 3 AND type = 'shared';
 		DELETE FROM project_services WHERE id = 9 AND project_id = 3 AND type = 'unshared';
@@ -210,7 +209,7 @@ func Test_ScanDomains(t *testing.T) {
 	}
 	assert.DeepEqual(t, "new domains after ScanDomains #8", actualNewDomains, []string(nil))
 	tr.DBChanges().AssertEqualf(`
-		UPDATE domains SET name = 'germany-changed' WHERE id = 1 AND cluster_id = 'west' AND uuid = 'uuid-for-germany';
+		UPDATE domains SET name = 'germany-changed' WHERE id = 1 AND uuid = 'uuid-for-germany';
 		UPDATE projects SET name = 'berlin-changed' WHERE id = 1 AND uuid = 'uuid-for-berlin';
 	`)
 }

--- a/pkg/collector/metrics.go
+++ b/pkg/collector/metrics.go
@@ -42,7 +42,7 @@ var scrapeSuccessCounter = prometheus.NewCounterVec(
 		Name: "limes_successful_scrapes",
 		Help: "Counter for successful quota scrape operations per Keystone project.",
 	},
-	[]string{"os_cluster", "service", "service_name"},
+	[]string{"service", "service_name"},
 )
 
 var scrapeFailedCounter = prometheus.NewCounterVec(
@@ -50,7 +50,7 @@ var scrapeFailedCounter = prometheus.NewCounterVec(
 		Name: "limes_failed_scrapes",
 		Help: "Counter for failed quota scrape operations per Keystone project.",
 	},
-	[]string{"os_cluster", "service", "service_name"},
+	[]string{"service", "service_name"},
 )
 
 var scrapeSuspendedCounter = prometheus.NewCounterVec(
@@ -58,7 +58,7 @@ var scrapeSuspendedCounter = prometheus.NewCounterVec(
 		Name: "limes_suspended_scrapes",
 		Help: "Counter for suspended quota scrape operations per Keystone project.",
 	},
-	[]string{"os_cluster", "service", "service_name"},
+	[]string{"service", "service_name"},
 )
 
 var projectDiscoverySuccessCounter = prometheus.NewCounterVec(
@@ -66,7 +66,7 @@ var projectDiscoverySuccessCounter = prometheus.NewCounterVec(
 		Name: "limes_successful_project_discoveries",
 		Help: "Counter for successful project discovery operations per Keystone domain.",
 	},
-	[]string{"os_cluster", "domain", "domain_id"},
+	[]string{"domain", "domain_id"},
 )
 
 var projectDiscoveryFailedCounter = prometheus.NewCounterVec(
@@ -74,23 +74,21 @@ var projectDiscoveryFailedCounter = prometheus.NewCounterVec(
 		Name: "limes_failed_project_discoveries",
 		Help: "Counter for failed project discovery operations per Keystone domain.",
 	},
-	[]string{"os_cluster", "domain", "domain_id"},
+	[]string{"domain", "domain_id"},
 )
 
-var domainDiscoverySuccessCounter = prometheus.NewCounterVec(
+var domainDiscoverySuccessCounter = prometheus.NewCounter(
 	prometheus.CounterOpts{
 		Name: "limes_successful_domain_discoveries",
 		Help: "Counter for successful domain discovery operations.",
 	},
-	[]string{"os_cluster"},
 )
 
-var domainDiscoveryFailedCounter = prometheus.NewCounterVec(
+var domainDiscoveryFailedCounter = prometheus.NewCounter(
 	prometheus.CounterOpts{
 		Name: "limes_failed_domain_discoveries",
 		Help: "Counter for failed domain discovery operations.",
 	},
-	[]string{"os_cluster"},
 )
 
 var clusterCapacitorSuccessCounter = prometheus.NewCounterVec(
@@ -98,7 +96,7 @@ var clusterCapacitorSuccessCounter = prometheus.NewCounterVec(
 		Name: "limes_successful_capacity_scrapes",
 		Help: "Counter for successful cluster capacity scrapes.",
 	},
-	[]string{"os_cluster", "capacitor"},
+	[]string{"capacitor"},
 )
 
 var clusterCapacitorFailedCounter = prometheus.NewCounterVec(
@@ -106,7 +104,7 @@ var clusterCapacitorFailedCounter = prometheus.NewCounterVec(
 		Name: "limes_failed_capacity_scrapes",
 		Help: "Counter for failed cluster capacity scrapes.",
 	},
-	[]string{"os_cluster", "capacitor"},
+	[]string{"capacitor"},
 )
 
 var ratesScrapeSuccessCounter = prometheus.NewCounterVec(
@@ -114,7 +112,7 @@ var ratesScrapeSuccessCounter = prometheus.NewCounterVec(
 		Name: "limes_successful_rate_scrapes",
 		Help: "Counter for successful rate scrape operations per Keystone project.",
 	},
-	[]string{"os_cluster", "service", "service_name"},
+	[]string{"service", "service_name"},
 )
 
 var ratesScrapeFailedCounter = prometheus.NewCounterVec(
@@ -122,7 +120,7 @@ var ratesScrapeFailedCounter = prometheus.NewCounterVec(
 		Name: "limes_failed_rate_scrapes",
 		Help: "Counter for failed rate scrape operations per Keystone project.",
 	},
-	[]string{"os_cluster", "service", "service_name"},
+	[]string{"service", "service_name"},
 )
 
 var ratesScrapeSuspendedCounter = prometheus.NewCounterVec(
@@ -130,7 +128,7 @@ var ratesScrapeSuspendedCounter = prometheus.NewCounterVec(
 		Name: "limes_suspended_rate_scrapes",
 		Help: "Counter for suspended rate scrape operations per Keystone project.",
 	},
-	[]string{"os_cluster", "service", "service_name"},
+	[]string{"service", "service_name"},
 )
 
 func init() {
@@ -156,7 +154,7 @@ var minScrapedAtGauge = prometheus.NewGaugeVec(
 		Name: "limes_oldest_scraped_at",
 		Help: "Oldest (i.e. smallest) scraped_at timestamp for any project given a certain service in a certain OpenStack cluster.",
 	},
-	[]string{"os_cluster", "service", "service_name"},
+	[]string{"service", "service_name"},
 )
 
 var maxScrapedAtGauge = prometheus.NewGaugeVec(
@@ -164,7 +162,7 @@ var maxScrapedAtGauge = prometheus.NewGaugeVec(
 		Name: "limes_newest_scraped_at",
 		Help: "Newest (i.e. largest) scraped_at timestamp for any project given a certain service in a certain OpenStack cluster.",
 	},
-	[]string{"os_cluster", "service", "service_name"},
+	[]string{"service", "service_name"},
 )
 
 var minRatesScrapedAtGauge = prometheus.NewGaugeVec(
@@ -172,7 +170,7 @@ var minRatesScrapedAtGauge = prometheus.NewGaugeVec(
 		Name: "limes_oldest_rates_scraped_at",
 		Help: "Oldest (i.e. smallest) rates_scraped_at timestamp for any project given a certain service in a certain OpenStack cluster.",
 	},
-	[]string{"os_cluster", "service", "service_name"},
+	[]string{"service", "service_name"},
 )
 
 var maxRatesScrapedAtGauge = prometheus.NewGaugeVec(
@@ -180,7 +178,7 @@ var maxRatesScrapedAtGauge = prometheus.NewGaugeVec(
 		Name: "limes_newest_rates_scraped_at",
 		Help: "Newest (i.e. largest) rates_scraped_at timestamp for any project given a certain service in a certain OpenStack cluster.",
 	},
-	[]string{"os_cluster", "service", "service_name"},
+	[]string{"service", "service_name"},
 )
 
 // AggregateMetricsCollector is a prometheus.Collector that submits
@@ -199,12 +197,10 @@ func (c *AggregateMetricsCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 var scrapedAtAggregateQuery = sqlext.SimplifyWhitespace(`
-	SELECT ps.type, MIN(ps.scraped_at), MAX(ps.scraped_at), MIN(ps.rates_scraped_at), MAX(ps.rates_scraped_at)
-	  FROM domains d
-	  JOIN projects p ON p.domain_id = d.id
-	  JOIN project_services ps ON ps.project_id = p.id
-	 WHERE d.cluster_id = $1 AND ps.scraped_at IS NOT NULL
-	 GROUP BY ps.type
+	SELECT type, MIN(scraped_at), MAX(scraped_at), MIN(rates_scraped_at), MAX(rates_scraped_at)
+	  FROM project_services
+	 WHERE scraped_at IS NOT NULL
+	 GROUP BY type
 `)
 
 // Collect implements the prometheus.Collector interface.
@@ -222,8 +218,7 @@ func (c *AggregateMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 	maxRatesScrapedAtGauge.Describe(descCh)
 	maxRatesScrapedAtDesc := <-descCh
 
-	queryArgs := []interface{}{c.Cluster.ID}
-	err := sqlext.ForeachRow(c.DB, scrapedAtAggregateQuery, queryArgs, func(rows *sql.Rows) error {
+	err := sqlext.ForeachRow(c.DB, scrapedAtAggregateQuery, nil, func(rows *sql.Rows) error {
 		var (
 			serviceType       string
 			minScrapedAt      *time.Time
@@ -246,24 +241,24 @@ func (c *AggregateMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 			ch <- prometheus.MustNewConstMetric(
 				minScrapedAtDesc,
 				prometheus.GaugeValue, timeAsUnixOrZero(minScrapedAt),
-				c.Cluster.ID, serviceType, serviceName,
+				serviceType, serviceName,
 			)
 			ch <- prometheus.MustNewConstMetric(
 				maxScrapedAtDesc,
 				prometheus.GaugeValue, timeAsUnixOrZero(maxScrapedAt),
-				c.Cluster.ID, serviceType, serviceName,
+				serviceType, serviceName,
 			)
 		}
 		if len(plugin.Rates()) > 0 {
 			ch <- prometheus.MustNewConstMetric(
 				minRatesScrapedAtDesc,
 				prometheus.GaugeValue, timeAsUnixOrZero(minRatesScrapedAt),
-				c.Cluster.ID, serviceType, serviceName,
+				serviceType, serviceName,
 			)
 			ch <- prometheus.MustNewConstMetric(
 				maxRatesScrapedAtDesc,
 				prometheus.GaugeValue, timeAsUnixOrZero(maxRatesScrapedAt),
-				c.Cluster.ID, serviceType, serviceName,
+				serviceType, serviceName,
 			)
 		}
 		return nil
@@ -288,7 +283,7 @@ var capacityPluginMetricsOkGauge = prometheus.NewGaugeVec(
 		Name: "limes_capacity_plugin_metrics_ok",
 		Help: "Whether capacity plugin metrics were rendered successfully for a particular capacitor. Only present when the capacitor emits metrics.",
 	},
-	[]string{"os_cluster", "capacitor"},
+	[]string{"capacitor"},
 )
 
 // CapacityPluginMetricsCollector is a prometheus.Collector that submits metrics
@@ -319,7 +314,7 @@ func (c *CapacityPluginMetricsCollector) Describe(ch chan<- *prometheus.Desc) {
 var capacitySerializedMetricsGetQuery = sqlext.SimplifyWhitespace(`
 	SELECT capacitor_id, serialized_metrics
 	  FROM cluster_capacitors
-	 WHERE cluster_id = $1 AND serialized_metrics != ''
+	 WHERE serialized_metrics != ''
 `)
 
 // Collect implements the prometheus.Collector interface.
@@ -335,8 +330,7 @@ func (c *CapacityPluginMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 		return
 	}
 
-	queryArgs := []interface{}{c.Cluster.ID}
-	err := sqlext.ForeachRow(c.DB, capacitySerializedMetricsGetQuery, queryArgs, func(rows *sql.Rows) error {
+	err := sqlext.ForeachRow(c.DB, capacitySerializedMetricsGetQuery, nil, func(rows *sql.Rows) error {
 		var i CapacityPluginMetricsInstance
 		err := rows.Scan(&i.CapacitorID, &i.SerializedMetrics)
 		if err == nil {
@@ -354,7 +348,7 @@ func (c *CapacityPluginMetricsCollector) collectOneCapacitor(ch chan<- prometheu
 	if plugin == nil {
 		return
 	}
-	err := plugin.CollectMetrics(ch, c.Cluster.ID, instance.SerializedMetrics)
+	err := plugin.CollectMetrics(ch, instance.SerializedMetrics)
 	successAsFloat := 1.0
 	if err != nil {
 		successAsFloat = 0.0
@@ -366,7 +360,7 @@ func (c *CapacityPluginMetricsCollector) collectOneCapacitor(ch chan<- prometheu
 	ch <- prometheus.MustNewConstMetric(
 		pluginMetricsOkDesc,
 		prometheus.GaugeValue, successAsFloat,
-		c.Cluster.ID, instance.CapacitorID,
+		instance.CapacitorID,
 	)
 }
 
@@ -378,7 +372,7 @@ var quotaPluginMetricsOkGauge = prometheus.NewGaugeVec(
 		Name: "limes_plugin_metrics_ok",
 		Help: "Whether quota plugin metrics were rendered successfully for a particular project service. Only present when the project service emits metrics.",
 	},
-	[]string{"os_cluster", "domain", "domain_id", "project", "project_id", "service"},
+	[]string{"domain", "domain_id", "project", "project_id", "service"},
 )
 
 // QuotaPluginMetricsCollector is a prometheus.Collector that submits metrics
@@ -412,7 +406,7 @@ var quotaSerializedMetricsGetQuery = sqlext.SimplifyWhitespace(`
 	  FROM domains d
 	  JOIN projects p ON p.domain_id = d.id
 	  JOIN project_services ps ON ps.project_id = p.id
-	 WHERE d.cluster_id = $1 AND ps.serialized_metrics != ''
+	 WHERE ps.serialized_metrics != ''
 `)
 
 // Collect implements the prometheus.Collector interface.
@@ -428,8 +422,7 @@ func (c *QuotaPluginMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 		return
 	}
 
-	queryArgs := []interface{}{c.Cluster.ID}
-	err := sqlext.ForeachRow(c.DB, quotaSerializedMetricsGetQuery, queryArgs, func(rows *sql.Rows) error {
+	err := sqlext.ForeachRow(c.DB, quotaSerializedMetricsGetQuery, nil, func(rows *sql.Rows) error {
 		var i QuotaPluginMetricsInstance
 		err := rows.Scan(
 			&i.Project.Domain.Name, &i.Project.Domain.UUID,
@@ -450,7 +443,7 @@ func (c *QuotaPluginMetricsCollector) collectOneProjectService(ch chan<- prometh
 	if plugin == nil {
 		return
 	}
-	err := plugin.CollectMetrics(ch, c.Cluster.ID, instance.Project, instance.SerializedMetrics)
+	err := plugin.CollectMetrics(ch, instance.Project, instance.SerializedMetrics)
 	successAsFloat := 1.0
 	if err != nil {
 		successAsFloat = 0.0
@@ -462,7 +455,7 @@ func (c *QuotaPluginMetricsCollector) collectOneProjectService(ch chan<- prometh
 	ch <- prometheus.MustNewConstMetric(
 		pluginMetricsOkDesc,
 		prometheus.GaugeValue, successAsFloat,
-		c.Cluster.ID, instance.Project.Domain.Name, instance.Project.Domain.UUID, instance.Project.Name, instance.Project.UUID, instance.ServiceType,
+		instance.Project.Domain.Name, instance.Project.Domain.UUID, instance.Project.Name, instance.Project.UUID, instance.ServiceType,
 	)
 }
 
@@ -474,7 +467,7 @@ var clusterCapacityGauge = prometheus.NewGaugeVec(
 		Name: "limes_cluster_capacity",
 		Help: "Reported capacity of a Limes resource for an OpenStack cluster.",
 	},
-	[]string{"os_cluster", "service", "resource"},
+	[]string{"service", "resource"},
 )
 
 var clusterCapacityPerAZGauge = prometheus.NewGaugeVec(
@@ -482,7 +475,7 @@ var clusterCapacityPerAZGauge = prometheus.NewGaugeVec(
 		Name: "limes_cluster_capacity_per_az",
 		Help: "Reported capacity of a Limes resource for an OpenStack cluster in a specific availability zone.",
 	},
-	[]string{"os_cluster", "availability_zone", "service", "resource"},
+	[]string{"availability_zone", "service", "resource"},
 )
 
 var clusterUsagePerAZGauge = prometheus.NewGaugeVec(
@@ -490,7 +483,7 @@ var clusterUsagePerAZGauge = prometheus.NewGaugeVec(
 		Name: "limes_cluster_usage_per_az",
 		Help: "Actual usage of a Limes resource for an OpenStack cluster in a specific availability zone.",
 	},
-	[]string{"os_cluster", "availability_zone", "service", "resource"},
+	[]string{"availability_zone", "service", "resource"},
 )
 
 var domainQuotaGauge = prometheus.NewGaugeVec(
@@ -498,7 +491,7 @@ var domainQuotaGauge = prometheus.NewGaugeVec(
 		Name: "limes_domain_quota",
 		Help: "Assigned quota of a Limes resource for an OpenStack domain.",
 	},
-	[]string{"os_cluster", "domain", "domain_id", "service", "resource"},
+	[]string{"domain", "domain_id", "service", "resource"},
 )
 
 var projectQuotaGauge = prometheus.NewGaugeVec(
@@ -506,7 +499,7 @@ var projectQuotaGauge = prometheus.NewGaugeVec(
 		Name: "limes_project_quota",
 		Help: "Assigned quota of a Limes resource for an OpenStack project.",
 	},
-	[]string{"os_cluster", "domain", "domain_id", "project", "project_id", "service", "resource"},
+	[]string{"domain", "domain_id", "project", "project_id", "service", "resource"},
 )
 
 var projectBackendQuotaGauge = prometheus.NewGaugeVec(
@@ -514,7 +507,7 @@ var projectBackendQuotaGauge = prometheus.NewGaugeVec(
 		Name: "limes_project_backendquota",
 		Help: "Actual quota of a Limes resource for an OpenStack project.",
 	},
-	[]string{"os_cluster", "domain", "domain_id", "project", "project_id", "service", "resource"},
+	[]string{"domain", "domain_id", "project", "project_id", "service", "resource"},
 )
 
 var projectUsageGauge = prometheus.NewGaugeVec(
@@ -522,7 +515,7 @@ var projectUsageGauge = prometheus.NewGaugeVec(
 		Name: "limes_project_usage",
 		Help: "Actual (logical) usage of a Limes resource for an OpenStack project.",
 	},
-	[]string{"os_cluster", "domain", "domain_id", "project", "project_id", "service", "resource"},
+	[]string{"domain", "domain_id", "project", "project_id", "service", "resource"},
 )
 
 var projectPhysicalUsageGauge = prometheus.NewGaugeVec(
@@ -530,7 +523,7 @@ var projectPhysicalUsageGauge = prometheus.NewGaugeVec(
 		Name: "limes_project_physical_usage",
 		Help: "Actual (physical) usage of a Limes resource for an OpenStack project.",
 	},
-	[]string{"os_cluster", "domain", "domain_id", "project", "project_id", "service", "resource"},
+	[]string{"domain", "domain_id", "project", "project_id", "service", "resource"},
 )
 
 var projectRateUsageGauge = prometheus.NewGaugeVec(
@@ -538,7 +531,7 @@ var projectRateUsageGauge = prometheus.NewGaugeVec(
 		Name: "limes_project_rate_usage",
 		Help: "Usage of a Limes rate for an OpenStack project. These are counters that never reset.",
 	},
-	[]string{"os_cluster", "domain", "domain_id", "project", "project_id", "service", "rate"},
+	[]string{"domain", "domain_id", "project", "project_id", "service", "rate"},
 )
 
 var unitConversionGauge = prometheus.NewGaugeVec(
@@ -577,7 +570,6 @@ var clusterMetricsQuery = sqlext.SimplifyWhitespace(`
 	SELECT cs.type, cr.name, cr.capacity, cr.capacity_per_az
 	  FROM cluster_services cs
 	  JOIN cluster_resources cr ON cr.service_id = cs.id
-	 WHERE cs.cluster_id = $1
 `)
 
 var domainMetricsQuery = sqlext.SimplifyWhitespace(`
@@ -585,7 +577,6 @@ var domainMetricsQuery = sqlext.SimplifyWhitespace(`
 	  FROM domains d
 	  JOIN domain_services ds ON ds.domain_id = d.id
 	  JOIN domain_resources dr ON dr.service_id = ds.id
-	 WHERE d.cluster_id = $1
 `)
 
 var projectMetricsQuery = sqlext.SimplifyWhitespace(`
@@ -594,7 +585,6 @@ var projectMetricsQuery = sqlext.SimplifyWhitespace(`
 	  JOIN projects p ON p.domain_id = d.id
 	  JOIN project_services ps ON ps.project_id = p.id
 	  JOIN project_resources pr ON pr.service_id = ps.id
-	 WHERE d.cluster_id = $1
 `)
 
 var projectRateMetricsQuery = sqlext.SimplifyWhitespace(`
@@ -603,7 +593,7 @@ var projectRateMetricsQuery = sqlext.SimplifyWhitespace(`
 	  JOIN projects p ON p.domain_id = d.id
 	  JOIN project_services ps ON ps.project_id = p.id
 	  JOIN project_rates pra ON pra.service_id = ps.id
-	 WHERE d.cluster_id = $1 AND pra.usage_as_bigint != ''
+	 WHERE pra.usage_as_bigint != ''
 `)
 
 // Collect implements the prometheus.Collector interface.
@@ -640,8 +630,7 @@ func (c *DataMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 
 	//fetch values for cluster level
 	capacityReported := make(map[string]map[string]bool)
-	queryArgs := []interface{}{c.Cluster.ID}
-	err := sqlext.ForeachRow(c.DB, clusterMetricsQuery, queryArgs, func(rows *sql.Rows) error {
+	err := sqlext.ForeachRow(c.DB, clusterMetricsQuery, nil, func(rows *sql.Rows) error {
 		var (
 			serviceType   string
 			resourceName  string
@@ -669,13 +658,13 @@ func (c *DataMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 				ch <- prometheus.MustNewConstMetric(
 					clusterCapacityPerAZDesc,
 					prometheus.GaugeValue, float64(report.Capacity)*overcommitFactor,
-					c.Cluster.ID, report.Name, serviceType, resourceName,
+					report.Name, serviceType, resourceName,
 				)
 				if report.Usage != 0 {
 					ch <- prometheus.MustNewConstMetric(
 						clusterUsagePerAZDesc,
 						prometheus.GaugeValue, float64(report.Usage),
-						c.Cluster.ID, report.Name, serviceType, resourceName,
+						report.Name, serviceType, resourceName,
 					)
 				}
 			}
@@ -684,7 +673,7 @@ func (c *DataMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(
 			clusterCapacityDesc,
 			prometheus.GaugeValue, float64(capacity)*overcommitFactor,
-			c.Cluster.ID, serviceType, resourceName,
+			serviceType, resourceName,
 		)
 
 		_, exists := capacityReported[serviceType]
@@ -711,13 +700,13 @@ func (c *DataMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 			ch <- prometheus.MustNewConstMetric(
 				clusterCapacityDesc,
 				prometheus.GaugeValue, 0,
-				c.Cluster.ID, serviceType, res.Name,
+				serviceType, res.Name,
 			)
 		}
 	}
 
 	//fetch values for domain level
-	err = sqlext.ForeachRow(c.DB, domainMetricsQuery, queryArgs, func(rows *sql.Rows) error {
+	err = sqlext.ForeachRow(c.DB, domainMetricsQuery, nil, func(rows *sql.Rows) error {
 		var (
 			domainName   string
 			domainUUID   string
@@ -732,7 +721,7 @@ func (c *DataMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(
 			domainQuotaDesc,
 			prometheus.GaugeValue, float64(quota),
-			c.Cluster.ID, domainName, domainUUID, serviceType, resourceName,
+			domainName, domainUUID, serviceType, resourceName,
 		)
 		return nil
 	})
@@ -741,7 +730,7 @@ func (c *DataMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 
 	//fetch values for project level (quota/usage)
-	err = sqlext.ForeachRow(c.DB, projectMetricsQuery, queryArgs, func(rows *sql.Rows) error {
+	err = sqlext.ForeachRow(c.DB, projectMetricsQuery, nil, func(rows *sql.Rows) error {
 		var (
 			domainName    string
 			domainUUID    string
@@ -764,7 +753,7 @@ func (c *DataMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 				ch <- prometheus.MustNewConstMetric(
 					projectQuotaDesc,
 					prometheus.GaugeValue, float64(*quota),
-					c.Cluster.ID, domainName, domainUUID, projectName, projectUUID, serviceType, resourceName,
+					domainName, domainUUID, projectName, projectUUID, serviceType, resourceName,
 				)
 			}
 		}
@@ -773,7 +762,7 @@ func (c *DataMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 				ch <- prometheus.MustNewConstMetric(
 					projectBackendQuotaDesc,
 					prometheus.GaugeValue, float64(*backendQuota),
-					c.Cluster.ID, domainName, domainUUID, projectName, projectUUID, serviceType, resourceName,
+					domainName, domainUUID, projectName, projectUUID, serviceType, resourceName,
 				)
 			}
 		}
@@ -781,7 +770,7 @@ func (c *DataMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 			ch <- prometheus.MustNewConstMetric(
 				projectUsageDesc,
 				prometheus.GaugeValue, float64(usage),
-				c.Cluster.ID, domainName, domainUUID, projectName, projectUUID, serviceType, resourceName,
+				domainName, domainUUID, projectName, projectUUID, serviceType, resourceName,
 			)
 		}
 		if physicalUsage != nil {
@@ -789,7 +778,7 @@ func (c *DataMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 				ch <- prometheus.MustNewConstMetric(
 					projectPhysicalUsageDesc,
 					prometheus.GaugeValue, float64(*physicalUsage),
-					c.Cluster.ID, domainName, domainUUID, projectName, projectUUID, serviceType, resourceName,
+					domainName, domainUUID, projectName, projectUUID, serviceType, resourceName,
 				)
 			}
 		}
@@ -812,7 +801,7 @@ func (c *DataMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 
 	//fetch values for project level (rate usage)
-	err = sqlext.ForeachRow(c.DB, projectRateMetricsQuery, queryArgs, func(rows *sql.Rows) error {
+	err = sqlext.ForeachRow(c.DB, projectRateMetricsQuery, nil, func(rows *sql.Rows) error {
 		var (
 			domainName    string
 			domainUUID    string
@@ -836,7 +825,7 @@ func (c *DataMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 			ch <- prometheus.MustNewConstMetric(
 				projectRateUsageDesc,
 				prometheus.GaugeValue, usageAsFloat,
-				c.Cluster.ID, domainName, domainUUID, projectName, projectUUID, serviceType, rateName,
+				domainName, domainUUID, projectName, projectUUID, serviceType, rateName,
 			)
 		}
 		return nil

--- a/pkg/collector/ratescrape_test.go
+++ b/pkg/collector/ratescrape_test.go
@@ -82,7 +82,7 @@ func Test_RateScrapeSuccess(t *testing.T) {
 		INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'capacity_portion', 0);
 		INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'things', 0);
 		INSERT INTO domain_services (id, domain_id, type) VALUES (1, 1, 'unittest');
-		INSERT INTO domains (id, cluster_id, name, uuid) VALUES (1, 'west', 'germany', 'uuid-for-germany');
+		INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
 		INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_bigint) VALUES (1, 'otherrate', 42, 120000000000, '');
 		INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_bigint) VALUES (1, 'secondrate', 10, 1000000000, '');
 		INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state, serialized_metrics, checked_at, scrape_error_message, rates_checked_at, rates_scrape_error_message) VALUES (1, 1, 'unittest', NULL, FALSE, 0, NULL, FALSE, 0, '', '', NULL, '', NULL, '');
@@ -230,7 +230,7 @@ func Test_ScrapeRatesButNoRates(t *testing.T) {
 	_, tr0 := easypg.NewTracker(t, dbm.Db)
 	tr0.AssertEqualf(`
 		INSERT INTO domain_services (id, domain_id, type) VALUES (1, 1, 'noop');
-		INSERT INTO domains (id, cluster_id, name, uuid) VALUES (1, 'west', 'germany', 'uuid-for-germany');
+		INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
 		INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state, serialized_metrics, checked_at, scrape_error_message, rates_checked_at, rates_scrape_error_message) VALUES (1, 1, 'noop', NULL, FALSE, 0, 1, FALSE, 1, '', '', NULL, '', 1, '');
 		INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany', FALSE);
 	`)

--- a/pkg/collector/scrape.go
+++ b/pkg/collector/scrape.go
@@ -51,7 +51,7 @@ const (
 // query that finds the next project that needs to have resources scraped
 var findProjectForResourceScrapeQuery = sqlext.SimplifyWhitespace(`
 	SELECT * FROM project_services
-	-- filter by service type (NOTE: no filtering by cluster ID necessary anymore since there is only one, TODO: remove cluster ID from the DB entirely)
+	-- filter by service type
 	WHERE type = $1
 	-- filter by need to be updated (because of user request, because of missing data, or because of outdated data)
 	AND (stale OR scraped_at IS NULL OR scraped_at < $2 OR (scraped_at != checked_at AND checked_at < $3))
@@ -73,7 +73,6 @@ func (c *Collector) Scrape() {
 
 	//make sure that the counters are reported
 	labels := prometheus.Labels{
-		"os_cluster":   c.Cluster.ID,
 		"service":      serviceType,
 		"service_name": serviceInfo.ProductName,
 	}

--- a/pkg/collector/scrape_test.go
+++ b/pkg/collector/scrape_test.go
@@ -50,7 +50,6 @@ func prepareScrapeTest(t *testing.T, numProjects int, quotaPlugins ...core.Quota
 	dbm := test.InitDatabase(t, nil)
 
 	cluster := &core.Cluster{
-		ID:              "west",
 		DiscoveryPlugin: test.NewDiscoveryPlugin(),
 		QuotaPlugins:    map[string]core.QuotaPlugin{},
 		CapacityPlugins: map[string]core.CapacityPlugin{},
@@ -475,7 +474,7 @@ func (p *autoApprovalTestPlugin) ScrapeRates(provider *gophercloud.ProviderClien
 }
 func (p *autoApprovalTestPlugin) DescribeMetrics(ch chan<- *prometheus.Desc) {
 }
-func (p *autoApprovalTestPlugin) CollectMetrics(ch chan<- prometheus.Metric, clusterID string, project core.KeystoneProject, serializedMetrics string) error {
+func (p *autoApprovalTestPlugin) CollectMetrics(ch chan<- prometheus.Metric, project core.KeystoneProject, serializedMetrics string) error {
 	return nil
 }
 
@@ -564,7 +563,7 @@ func (noopQuotaPlugin) ScrapeRates(client *gophercloud.ProviderClient, eo gopher
 }
 func (noopQuotaPlugin) DescribeMetrics(ch chan<- *prometheus.Desc) {
 }
-func (noopQuotaPlugin) CollectMetrics(ch chan<- prometheus.Metric, clusterID string, project core.KeystoneProject, serializedMetrics string) error {
+func (noopQuotaPlugin) CollectMetrics(ch chan<- prometheus.Metric, project core.KeystoneProject, serializedMetrics string) error {
 	return nil
 }
 
@@ -587,7 +586,7 @@ func Test_ScrapeButNoResources(t *testing.T) {
 	_, tr0 := easypg.NewTracker(t, dbm.Db)
 	tr0.AssertEqualf(`
 		INSERT INTO domain_services (id, domain_id, type) VALUES (1, 1, 'noop');
-		INSERT INTO domains (id, cluster_id, name, uuid) VALUES (1, 'west', 'germany', 'uuid-for-germany');
+		INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
 		INSERT INTO project_services (id, project_id, type, scraped_at, stale, scrape_duration_secs, rates_scraped_at, rates_stale, rates_scrape_duration_secs, rates_scrape_state, serialized_metrics, checked_at, scrape_error_message, rates_checked_at, rates_scrape_error_message) VALUES (1, 1, 'noop', 1, FALSE, 1, NULL, FALSE, 0, '', '', 1, '', NULL, '');
 		INSERT INTO projects (id, domain_id, name, uuid, parent_uuid, has_bursting) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany', FALSE);
 	`)

--- a/pkg/core/cluster.go
+++ b/pkg/core/cluster.go
@@ -41,11 +41,9 @@ import (
 	"github.com/sapcc/limes/pkg/util"
 )
 
-// Cluster contains all configuration and runtime information about a single
-// cluster. It is passed around a lot in Limes code, mostly for the cluster ID,
-// the list of enabled services, and access to the quota and capacity plugins.
+// Cluster contains all configuration and runtime information for the target
+// cluster.
 type Cluster struct {
-	ID                string
 	Auth              *AuthSession
 	Config            ClusterConfiguration
 	DiscoveryPlugin   DiscoveryPlugin
@@ -68,7 +66,6 @@ type Cluster struct {
 // will be logged when some of the requested plugins cannot be found.
 func NewCluster(config ClusterConfiguration) *Cluster {
 	c := &Cluster{
-		ID:              config.ClusterID,
 		Config:          config,
 		QuotaPlugins:    make(map[string]QuotaPlugin),
 		CapacityPlugins: make(map[string]CapacityPlugin),
@@ -77,7 +74,7 @@ func NewCluster(config ClusterConfiguration) *Cluster {
 
 	c.DiscoveryPlugin = DiscoveryPluginRegistry.Instantiate(config.Discovery.Method)
 	if c.DiscoveryPlugin == nil {
-		logg.Fatal("setup for cluster %s failed: no suitable discovery plugin found", config.ClusterID)
+		logg.Fatal("setup for discovery method %s failed: no suitable discovery plugin found", config.Discovery.Method)
 	}
 
 	for _, srv := range config.Services {

--- a/pkg/core/config.go
+++ b/pkg/core/config.go
@@ -35,11 +35,10 @@ import (
 	"github.com/sapcc/limes/pkg/util"
 )
 
-// ClusterConfiguration contains all the configuration data for a single cluster.
-// It is passed around in a lot of Limes code, mostly for the cluster ID and the
-// list of enabled services.
+// ClusterConfiguration contains all the configuration data for a single
+// cluster. It is instantiated from YAML and then transformed into type
+// Cluster during the startup phase.
 type ClusterConfiguration struct {
-	ClusterID  string                   `yaml:"cluster_id"`
 	CatalogURL string                   `yaml:"catalog_url"`
 	Discovery  DiscoveryConfiguration   `yaml:"discovery"`
 	Services   []ServiceConfiguration   `yaml:"services"`
@@ -244,9 +243,6 @@ func (cluster ClusterConfiguration) validateConfig() (success bool) {
 	missing := func(key string) {
 		logg.Error("missing %s configuration value", key)
 		success = false
-	}
-	if cluster.ClusterID == "" {
-		missing("cluster_id")
 	}
 
 	compileOptionalRx := func(pattern string) *regexp.Regexp {

--- a/pkg/core/constraints_test.go
+++ b/pkg/core/constraints_test.go
@@ -206,7 +206,7 @@ func (p quotaConstraintTestPlugin) ScrapeRates(client *gophercloud.ProviderClien
 }
 func (p quotaConstraintTestPlugin) DescribeMetrics(ch chan<- *prometheus.Desc) {
 }
-func (p quotaConstraintTestPlugin) CollectMetrics(ch chan<- prometheus.Metric, clusterID string, project KeystoneProject, serializedMetrics string) error {
+func (p quotaConstraintTestPlugin) CollectMetrics(ch chan<- prometheus.Metric, project KeystoneProject, serializedMetrics string) error {
 	return nil
 }
 

--- a/pkg/core/plugin.go
+++ b/pkg/core/plugin.go
@@ -154,12 +154,10 @@ type QuotaPlugin interface {
 	//metrics. The serializedMetrics argument contains the respective value
 	//returned from the last Scrape call on the same project.
 	//
-	//The clusterID should be given as a label to all emitted metrics.
-	//
 	//Some plugins also emit metrics directly within Scrape. This newer interface
 	//should be preferred since metrics emitted here won't be lost between
 	//restarts of limes-collect.
-	CollectMetrics(ch chan<- prometheus.Metric, clusterID string, project KeystoneProject, serializedMetrics string) error
+	CollectMetrics(ch chan<- prometheus.Metric, project KeystoneProject, serializedMetrics string) error
 }
 
 // CapacityData contains the total and per-availability-zone capacity data for a
@@ -223,12 +221,10 @@ type CapacityPlugin interface {
 	//metrics. The serializedMetrics argument contains the respective value
 	//returned from the last Scrape call on the same project.
 	//
-	//The clusterID should be given as a label to all emitted metrics.
-	//
 	//Some plugins also emit metrics directly within Scrape. This newer interface
 	//should be preferred since metrics emitted here won't be lost between
 	//restarts of limes-collect.
-	CollectMetrics(ch chan<- prometheus.Metric, clusterID, serializedMetrics string) error
+	CollectMetrics(ch chan<- prometheus.Metric, serializedMetrics string) error
 }
 
 var (

--- a/pkg/db/models.go
+++ b/pkg/db/models.go
@@ -28,7 +28,6 @@ import (
 
 // ClusterCapacitor contains a record from the `cluster_capacitors` table.
 type ClusterCapacitor struct {
-	ClusterID          string     `db:"cluster_id"`
 	CapacitorID        string     `db:"capacitor_id"`
 	ScrapedAt          *time.Time `db:"scraped_at"` //pointer type to allow for NULL value
 	ScrapeDurationSecs float64    `db:"scrape_duration_secs"`
@@ -38,7 +37,6 @@ type ClusterCapacitor struct {
 // ClusterService contains a record from the `cluster_services` table.
 type ClusterService struct {
 	ID        int64      `db:"id"`
-	ClusterID string     `db:"cluster_id"`
 	Type      string     `db:"type"`
 	ScrapedAt *time.Time `db:"scraped_at"` //pointer type to allow for NULL value
 }
@@ -54,10 +52,9 @@ type ClusterResource struct {
 
 // Domain contains a record from the `domains` table.
 type Domain struct {
-	ID        int64  `db:"id"`
-	ClusterID string `db:"cluster_id"`
-	Name      string `db:"name"`
-	UUID      string `db:"uuid"`
+	ID   int64  `db:"id"`
+	Name string `db:"name"`
+	UUID string `db:"uuid"`
 }
 
 // DomainService contains a record from the `domain_services` table.
@@ -143,7 +140,7 @@ type ProjectRate struct {
 
 // initGorp is used by Init() to setup the ORM part of the database connection.
 func initGorp(db *gorp.DbMap) {
-	db.AddTableWithName(ClusterCapacitor{}, "cluster_capacitors").SetKeys(false, "cluster_id", "capacitor_id")
+	db.AddTableWithName(ClusterCapacitor{}, "cluster_capacitors").SetKeys(false, "capacitor_id")
 	db.AddTableWithName(ClusterService{}, "cluster_services").SetKeys(true, "id")
 	db.AddTableWithName(ClusterResource{}, "cluster_resources").SetKeys(false, "service_id", "name")
 	db.AddTableWithName(Domain{}, "domains").SetKeys(true, "id")

--- a/pkg/plugins/capacity_cinder.go
+++ b/pkg/plugins/capacity_cinder.go
@@ -163,7 +163,7 @@ func (p *capacityCinderPlugin) DescribeMetrics(ch chan<- *prometheus.Desc) {
 }
 
 // CollectMetrics implements the core.CapacityPlugin interface.
-func (p *capacityCinderPlugin) CollectMetrics(ch chan<- prometheus.Metric, clusterID, serializedMetrics string) error {
+func (p *capacityCinderPlugin) CollectMetrics(ch chan<- prometheus.Metric, serializedMetrics string) error {
 	//not used by this plugin
 	return nil
 }

--- a/pkg/plugins/capacity_manila.go
+++ b/pkg/plugins/capacity_manila.go
@@ -132,7 +132,7 @@ func (p *capacityManilaPlugin) DescribeMetrics(ch chan<- *prometheus.Desc) {
 }
 
 // CollectMetrics implements the core.CapacityPlugin interface.
-func (p *capacityManilaPlugin) CollectMetrics(ch chan<- prometheus.Metric, clusterID, serializedMetrics string) error {
+func (p *capacityManilaPlugin) CollectMetrics(ch chan<- prometheus.Metric, serializedMetrics string) error {
 	//not used by this plugin
 	return nil
 }

--- a/pkg/plugins/capacity_manual.go
+++ b/pkg/plugins/capacity_manual.go
@@ -72,7 +72,7 @@ func (p *capacityManualPlugin) DescribeMetrics(ch chan<- *prometheus.Desc) {
 }
 
 // CollectMetrics implements the core.CapacityPlugin interface.
-func (p *capacityManualPlugin) CollectMetrics(ch chan<- prometheus.Metric, clusterID, serializedMetrics string) error {
+func (p *capacityManualPlugin) CollectMetrics(ch chan<- prometheus.Metric, serializedMetrics string) error {
 	//not used by this plugin
 	return nil
 }

--- a/pkg/plugins/capacity_nova.go
+++ b/pkg/plugins/capacity_nova.go
@@ -302,7 +302,7 @@ var novaHypervisorWellformedGauge = prometheus.NewGaugeVec(
 		Name: "limes_nova_hypervisor_is_wellformed",
 		Help: "One metric per Nova hypervisor that was discovered by Limes's capacity scanner. Value is 1 for wellformed hypervisors that could be uniquely matched to an aggregate and an AZ, 0 otherwise.",
 	},
-	[]string{"os_cluster", "hypervisor", "hostname", "aggregate", "az"},
+	[]string{"hypervisor", "hostname", "aggregate", "az"},
 )
 
 // DescribeMetrics implements the core.CapacityPlugin interface.
@@ -311,7 +311,7 @@ func (p *capacityNovaPlugin) DescribeMetrics(ch chan<- *prometheus.Desc) {
 }
 
 // CollectMetrics implements the core.CapacityPlugin interface.
-func (p *capacityNovaPlugin) CollectMetrics(ch chan<- prometheus.Metric, clusterID, serializedMetrics string) error {
+func (p *capacityNovaPlugin) CollectMetrics(ch chan<- prometheus.Metric, serializedMetrics string) error {
 	var metrics capacityNovaSerializedMetrics
 	err := json.Unmarshal([]byte(serializedMetrics), &metrics)
 	if err != nil {
@@ -333,7 +333,7 @@ func (p *capacityNovaPlugin) CollectMetrics(ch chan<- prometheus.Metric, cluster
 		ch <- prometheus.MustNewConstMetric(
 			novaHypervisorWellformedDesc,
 			prometheus.GaugeValue, isWellformed,
-			clusterID, hv.Name, hv.Hostname, aggrList, azList,
+			hv.Name, hv.Hostname, aggrList, azList,
 		)
 	}
 	return nil

--- a/pkg/plugins/capacity_prometheus.go
+++ b/pkg/plugins/capacity_prometheus.go
@@ -73,7 +73,7 @@ func (p *capacityPrometheusPlugin) DescribeMetrics(ch chan<- *prometheus.Desc) {
 }
 
 // CollectMetrics implements the core.CapacityPlugin interface.
-func (p *capacityPrometheusPlugin) CollectMetrics(ch chan<- prometheus.Metric, clusterID, serializedMetrics string) error {
+func (p *capacityPrometheusPlugin) CollectMetrics(ch chan<- prometheus.Metric, serializedMetrics string) error {
 	//not used by this plugin
 	return nil
 }

--- a/pkg/plugins/capacity_sapcc_cfm.go
+++ b/pkg/plugins/capacity_sapcc_cfm.go
@@ -103,7 +103,7 @@ func (p *capacityCFMPlugin) DescribeMetrics(ch chan<- *prometheus.Desc) {
 }
 
 // CollectMetrics implements the core.CapacityPlugin interface.
-func (p *capacityCFMPlugin) CollectMetrics(ch chan<- prometheus.Metric, clusterID, serializedMetrics string) error {
+func (p *capacityCFMPlugin) CollectMetrics(ch chan<- prometheus.Metric, serializedMetrics string) error {
 	//not used by this plugin
 	return nil
 }

--- a/pkg/plugins/capacity_sapcc_ironic.go
+++ b/pkg/plugins/capacity_sapcc_ironic.go
@@ -296,12 +296,11 @@ func (p *capacitySapccIronicPlugin) Scrape(provider *gophercloud.ProviderClient,
 	return map[string]map[string]core.CapacityData{"compute": result2}, string(serializedMetricsBytes), nil
 }
 
-var ironicUnmatchedNodesGauge = prometheus.NewGaugeVec(
+var ironicUnmatchedNodesGauge = prometheus.NewGauge(
 	prometheus.GaugeOpts{
 		Name: "limes_unmatched_ironic_nodes",
 		Help: "Number of available/active Ironic nodes without matching flavor.",
 	},
-	[]string{"os_cluster"},
 )
 
 // DescribeMetrics implements the core.CapacityPlugin interface.
@@ -310,7 +309,7 @@ func (p *capacitySapccIronicPlugin) DescribeMetrics(ch chan<- *prometheus.Desc) 
 }
 
 // CollectMetrics implements the core.CapacityPlugin interface.
-func (p *capacitySapccIronicPlugin) CollectMetrics(ch chan<- prometheus.Metric, clusterID, serializedMetrics string) error {
+func (p *capacitySapccIronicPlugin) CollectMetrics(ch chan<- prometheus.Metric, serializedMetrics string) error {
 	if serializedMetrics == "" {
 		return nil
 	}
@@ -327,7 +326,6 @@ func (p *capacitySapccIronicPlugin) CollectMetrics(ch chan<- prometheus.Metric, 
 	ch <- prometheus.MustNewConstMetric(
 		ironicUnmatchedNodesDesc,
 		prometheus.GaugeValue, float64(metrics.UnmatchedNodeCount),
-		clusterID,
 	)
 	return nil
 }

--- a/pkg/plugins/cfm.go
+++ b/pkg/plugins/cfm.go
@@ -153,7 +153,7 @@ func (p *cfmPlugin) DescribeMetrics(ch chan<- *prometheus.Desc) {
 }
 
 // CollectMetrics implements the core.QuotaPlugin interface.
-func (p *cfmPlugin) CollectMetrics(ch chan<- prometheus.Metric, clusterID string, project core.KeystoneProject, serializedMetrics string) error {
+func (p *cfmPlugin) CollectMetrics(ch chan<- prometheus.Metric, project core.KeystoneProject, serializedMetrics string) error {
 	//not used by this plugin
 	return nil
 }

--- a/pkg/plugins/cinder.go
+++ b/pkg/plugins/cinder.go
@@ -255,7 +255,7 @@ func (p *cinderPlugin) DescribeMetrics(ch chan<- *prometheus.Desc) {
 }
 
 // CollectMetrics implements the core.QuotaPlugin interface.
-func (p *cinderPlugin) CollectMetrics(ch chan<- prometheus.Metric, clusterID string, project core.KeystoneProject, serializedMetrics string) error {
+func (p *cinderPlugin) CollectMetrics(ch chan<- prometheus.Metric, project core.KeystoneProject, serializedMetrics string) error {
 	//not used by this plugin
 	return nil
 }

--- a/pkg/plugins/cronus.go
+++ b/pkg/plugins/cronus.go
@@ -200,7 +200,7 @@ func (p *cronusPlugin) DescribeMetrics(ch chan<- *prometheus.Desc) {
 }
 
 // CollectMetrics implements the core.QuotaPlugin interface.
-func (p *cronusPlugin) CollectMetrics(ch chan<- prometheus.Metric, clusterID string, project core.KeystoneProject, serializedMetrics string) error {
+func (p *cronusPlugin) CollectMetrics(ch chan<- prometheus.Metric, project core.KeystoneProject, serializedMetrics string) error {
 	//not used by this plugin
 	return nil
 }

--- a/pkg/plugins/designate.go
+++ b/pkg/plugins/designate.go
@@ -160,7 +160,7 @@ func (p *designatePlugin) DescribeMetrics(ch chan<- *prometheus.Desc) {
 }
 
 // CollectMetrics implements the core.QuotaPlugin interface.
-func (p *designatePlugin) CollectMetrics(ch chan<- prometheus.Metric, clusterID string, project core.KeystoneProject, serializedMetrics string) error {
+func (p *designatePlugin) CollectMetrics(ch chan<- prometheus.Metric, project core.KeystoneProject, serializedMetrics string) error {
 	//not used by this plugin
 	return nil
 }

--- a/pkg/plugins/keppel.go
+++ b/pkg/plugins/keppel.go
@@ -120,7 +120,7 @@ func (p *keppelPlugin) DescribeMetrics(ch chan<- *prometheus.Desc) {
 }
 
 // CollectMetrics implements the core.QuotaPlugin interface.
-func (p *keppelPlugin) CollectMetrics(ch chan<- prometheus.Metric, clusterID string, project core.KeystoneProject, serializedMetrics string) error {
+func (p *keppelPlugin) CollectMetrics(ch chan<- prometheus.Metric, project core.KeystoneProject, serializedMetrics string) error {
 	//not used by this plugin
 	return nil
 }

--- a/pkg/plugins/manila.go
+++ b/pkg/plugins/manila.go
@@ -386,7 +386,7 @@ func (p *manilaPlugin) DescribeMetrics(ch chan<- *prometheus.Desc) {
 }
 
 // CollectMetrics implements the core.QuotaPlugin interface.
-func (p *manilaPlugin) CollectMetrics(ch chan<- prometheus.Metric, clusterID string, project core.KeystoneProject, serializedMetrics string) error {
+func (p *manilaPlugin) CollectMetrics(ch chan<- prometheus.Metric, project core.KeystoneProject, serializedMetrics string) error {
 	//not used by this plugin
 	return nil
 }

--- a/pkg/plugins/neutron.go
+++ b/pkg/plugins/neutron.go
@@ -500,7 +500,7 @@ func (p *neutronPlugin) DescribeMetrics(ch chan<- *prometheus.Desc) {
 }
 
 // CollectMetrics implements the core.QuotaPlugin interface.
-func (p *neutronPlugin) CollectMetrics(ch chan<- prometheus.Metric, clusterID string, project core.KeystoneProject, serializedMetrics string) error {
+func (p *neutronPlugin) CollectMetrics(ch chan<- prometheus.Metric, project core.KeystoneProject, serializedMetrics string) error {
 	//not used by this plugin
 	return nil
 }

--- a/pkg/plugins/nova.go
+++ b/pkg/plugins/nova.go
@@ -585,7 +585,7 @@ var novaInstanceCountGauge = prometheus.NewGaugeVec(
 		Name: "limes_instance_counts",
 		Help: "Number of Nova instances per project and hypervisor type.",
 	},
-	[]string{"os_cluster", "domain_id", "project_id", "hypervisor"},
+	[]string{"domain_id", "project_id", "hypervisor"},
 )
 
 // DescribeMetrics implements the core.QuotaPlugin interface.
@@ -594,7 +594,7 @@ func (p *novaPlugin) DescribeMetrics(ch chan<- *prometheus.Desc) {
 }
 
 // CollectMetrics implements the core.QuotaPlugin interface.
-func (p *novaPlugin) CollectMetrics(ch chan<- prometheus.Metric, clusterID string, project core.KeystoneProject, serializedMetrics string) error {
+func (p *novaPlugin) CollectMetrics(ch chan<- prometheus.Metric, project core.KeystoneProject, serializedMetrics string) error {
 	if serializedMetrics == "" {
 		return nil
 	}
@@ -612,7 +612,7 @@ func (p *novaPlugin) CollectMetrics(ch chan<- prometheus.Metric, clusterID strin
 		ch <- prometheus.MustNewConstMetric(
 			novaInstanceCountDesc,
 			prometheus.GaugeValue, float64(instanceCount),
-			clusterID, project.Domain.UUID, project.UUID, hypervisorName,
+			project.Domain.UUID, project.UUID, hypervisorName,
 		)
 	}
 	return nil

--- a/pkg/plugins/swift.go
+++ b/pkg/plugins/swift.go
@@ -53,14 +53,14 @@ var (
 			Name: "limes_swift_objects_per_container",
 			Help: "Number of objects for each Swift container.",
 		},
-		[]string{"os_cluster", "domain_id", "project_id", "container_name"},
+		[]string{"domain_id", "project_id", "container_name"},
 	)
 	swiftBytesUsedGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "limes_swift_size_bytes_per_container",
 			Help: "Total object size in bytes for each Swift container.",
 		},
-		[]string{"os_cluster", "domain_id", "project_id", "container_name"},
+		[]string{"domain_id", "project_id", "container_name"},
 	)
 )
 
@@ -213,7 +213,7 @@ func (p *swiftPlugin) DescribeMetrics(ch chan<- *prometheus.Desc) {
 }
 
 // CollectMetrics implements the core.QuotaPlugin interface.
-func (p *swiftPlugin) CollectMetrics(ch chan<- prometheus.Metric, clusterID string, project core.KeystoneProject, serializedMetrics string) error {
+func (p *swiftPlugin) CollectMetrics(ch chan<- prometheus.Metric, project core.KeystoneProject, serializedMetrics string) error {
 	if serializedMetrics == "" {
 		return nil
 	}
@@ -233,12 +233,12 @@ func (p *swiftPlugin) CollectMetrics(ch chan<- prometheus.Metric, clusterID stri
 		ch <- prometheus.MustNewConstMetric(
 			swiftObjectsCountDesc,
 			prometheus.GaugeValue, float64(containerMetrics.ObjectCount),
-			clusterID, project.Domain.UUID, project.UUID, containerName,
+			project.Domain.UUID, project.UUID, containerName,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			swiftBytesUsedDesc,
 			prometheus.GaugeValue, float64(containerMetrics.BytesUsed),
-			clusterID, project.Domain.UUID, project.UUID, containerName,
+			project.Domain.UUID, project.UUID, containerName,
 		)
 	}
 

--- a/pkg/reports/domain.go
+++ b/pkg/reports/domain.go
@@ -59,9 +59,9 @@ var domainReportQuery2 = sqlext.SimplifyWhitespace(`
 func GetDomains(cluster *core.Cluster, domainID *int64, dbi db.Interface, filter Filter) ([]*limesresources.DomainReport, error) {
 	clusterCanBurst := cluster.Config.Bursting.MaxMultiplier > 0
 
-	fields := map[string]interface{}{"d.cluster_id": cluster.ID}
+	var fields map[string]any
 	if domainID != nil {
-		fields["d.id"] = *domainID
+		fields = map[string]any{"d.id": *domainID}
 	}
 
 	//first query: data for projects in this domain

--- a/pkg/test/plugin.go
+++ b/pkg/test/plugin.go
@@ -220,11 +220,11 @@ func (p *Plugin) SetQuota(provider *gophercloud.ProviderClient, eo gophercloud.E
 var (
 	unittestCapacityUsageMetric = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{Name: "limes_unittest_capacity_usage"},
-		[]string{"os_cluster", "domain_id", "project_id"},
+		[]string{"domain_id", "project_id"},
 	)
 	unittestThingsUsageMetric = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{Name: "limes_unittest_things_usage"},
-		[]string{"os_cluster", "domain_id", "project_id"},
+		[]string{"domain_id", "project_id"},
 	)
 )
 
@@ -235,7 +235,7 @@ func (p *Plugin) DescribeMetrics(ch chan<- *prometheus.Desc) {
 }
 
 // CollectMetrics implements the core.QuotaPlugin interface.
-func (p *Plugin) CollectMetrics(ch chan<- prometheus.Metric, clusterID string, project core.KeystoneProject, serializedMetrics string) error {
+func (p *Plugin) CollectMetrics(ch chan<- prometheus.Metric, project core.KeystoneProject, serializedMetrics string) error {
 	if serializedMetrics == "" {
 		return nil
 	}
@@ -257,11 +257,11 @@ func (p *Plugin) CollectMetrics(ch chan<- prometheus.Metric, clusterID string, p
 
 	ch <- prometheus.MustNewConstMetric(
 		unittestCapacityUsageDesc, prometheus.GaugeValue, float64(data.CapacityUsage),
-		clusterID, project.Domain.UUID, project.UUID,
+		project.Domain.UUID, project.UUID,
 	)
 	ch <- prometheus.MustNewConstMetric(
 		unittestThingsUsageDesc, prometheus.GaugeValue, float64(data.ThingsUsage),
-		clusterID, project.Domain.UUID, project.UUID,
+		project.Domain.UUID, project.UUID,
 	)
 	return nil
 }
@@ -331,13 +331,11 @@ func (p *CapacityPlugin) Scrape(provider *gophercloud.ProviderClient, eo gopherc
 }
 
 var (
-	unittestCapacitySmallerHalfMetric = prometheus.NewGaugeVec(
+	unittestCapacitySmallerHalfMetric = prometheus.NewGauge(
 		prometheus.GaugeOpts{Name: "limes_unittest_capacity_smaller_half"},
-		[]string{"os_cluster"},
 	)
-	unittestCapacityLargerHalfMetric = prometheus.NewGaugeVec(
+	unittestCapacityLargerHalfMetric = prometheus.NewGauge(
 		prometheus.GaugeOpts{Name: "limes_unittest_capacity_larger_half"},
-		[]string{"os_cluster"},
 	)
 )
 
@@ -350,7 +348,7 @@ func (p *CapacityPlugin) DescribeMetrics(ch chan<- *prometheus.Desc) {
 }
 
 // CollectMetrics implements the core.CapacityPlugin interface.
-func (p *CapacityPlugin) CollectMetrics(ch chan<- prometheus.Metric, clusterID, serializedMetrics string) error {
+func (p *CapacityPlugin) CollectMetrics(ch chan<- prometheus.Metric, serializedMetrics string) error {
 	if !p.WithSubcapacities {
 		return nil
 	}
@@ -372,11 +370,9 @@ func (p *CapacityPlugin) CollectMetrics(ch chan<- prometheus.Metric, clusterID, 
 
 	ch <- prometheus.MustNewConstMetric(
 		unittestCapacitySmallerHalfDesc, prometheus.GaugeValue, float64(data.SmallerHalf),
-		clusterID,
 	)
 	ch <- prometheus.MustNewConstMetric(
 		unittestCapacityLargerHalfDesc, prometheus.GaugeValue, float64(data.LargerHalf),
-		clusterID,
 	)
 	return nil
 }


### PR DESCRIPTION
It only remains in the API for backwards-compatibility reasons (where it has already been hardcoded to the dummy value "current" months ago).