### PR TITLE
sharev2: add "snapmirror_capacity" resource (usage reporting only)

### DIFF
--- a/docs/operators/config.md
+++ b/docs/operators/config.md
@@ -459,6 +459,7 @@ The area for this service is `storage`. The following resources are always expos
 | `share_snapshots` | countable | |
 | `snapshot_capacity` | GiB | |
 | `share_networks` | countable | |
+| `snapmirror_capacity` | GiB | Only if `prometheus_api` is given. A SAP-specific extension that reports disk space consumed by Snapmirror backups. |
 
 #### Multiple share types
 

--- a/internal/plugins/manila.go
+++ b/internal/plugins/manila.go
@@ -511,7 +511,7 @@ func (p *manilaPlugin) collectSnapmirrorUsage(project core.KeystoneProject, shar
 	//Manila itself, so we have to collect usage from NetApp metrics instead
 	defaultValue := float64(0)
 	queryStr := fmt.Sprintf(
-		`sum(max by (volume) (netapp_volume_total_bytes{project_id=%q,share_type=%q,volume_type="dp",volume_state="online",volume=~".*EC2BKP"}))`,
+		`sum(max by (share_id) (netapp_volume_total_bytes{project_id=%q,volume_type!="dp",share_type=%q,volume_state="online",snapshot_policy="EC2_Backups"}))`,
 		project.UUID, shareTypeName,
 	)
 	bytesTotal, err := client.GetSingleValue(queryStr, &defaultValue)
@@ -520,7 +520,7 @@ func (p *manilaPlugin) collectSnapmirrorUsage(project core.KeystoneProject, shar
 	}
 
 	queryStr = fmt.Sprintf(
-		`sum(max by (volume) (netapp_volume_used_bytes{project_id=%q,share_type=%q,volume_type="dp",volume_state="online",volume=~".*EC2BKP"}))`,
+		`sum(max by (share_id) (netapp_volume_used_bytes{project_id=%q,volume_type!="dp",share_type=%q,volume_state="online",snapshot_policy="EC2_Backups"}))`,
 		project.UUID, shareTypeName,
 	)
 	bytesUsed, err := client.GetSingleValue(queryStr, &defaultValue)

--- a/internal/plugins/manila.go
+++ b/internal/plugins/manila.go
@@ -478,7 +478,7 @@ func (p *manilaPlugin) collectPhysicalUsage(project core.KeystoneProject) (manil
 		//NOTE: The `max by (share_id)` is necessary for when a share is being
 		//migrated to another shareserver and thus appears in the metrics twice.
 		queryStr := fmt.Sprintf(
-			`sum(max by (share_id) (netapp_volume_used_bytes{project_id=%q,volume_type!="dp",share_type=%q}))`,
+			`sum(max by (share_id) (netapp_volume_used_bytes{project_id=%q,volume_type!="dp",share_type=%q,volume_state="online"}))`,
 			project.UUID, stName,
 		)
 		bytesPhysical, err := client.GetSingleValue(queryStr, &defaultValue)
@@ -488,7 +488,7 @@ func (p *manilaPlugin) collectPhysicalUsage(project core.KeystoneProject) (manil
 		usage.Gigabytes[stName] = roundUpIntoGigabytes(bytesPhysical)
 
 		queryStr = fmt.Sprintf(
-			`sum(max by (share_id) (netapp_volume_snapshot_used_bytes{project_id=%q,volume_type!="dp",share_type=%q}))`,
+			`sum(max by (share_id) (netapp_volume_snapshot_used_bytes{project_id=%q,volume_type!="dp",share_type=%q,volume_state="online"}))`,
 			project.UUID, stName,
 		)
 		snapshotBytesPhysical, err := client.GetSingleValue(queryStr, &defaultValue)
@@ -511,7 +511,7 @@ func (p *manilaPlugin) collectSnapmirrorUsage(project core.KeystoneProject, shar
 	//Manila itself, so we have to collect usage from NetApp metrics instead
 	defaultValue := float64(0)
 	queryStr := fmt.Sprintf(
-		`sum(max by (volume) (netapp_volume_total_bytes{project_id=%q,share_type=%q,volume_type="dp",volume=~".*EC2BKP"}))`,
+		`sum(max by (volume) (netapp_volume_total_bytes{project_id=%q,share_type=%q,volume_type="dp",volume_state="online",volume=~".*EC2BKP"}))`,
 		project.UUID, shareTypeName,
 	)
 	bytesTotal, err := client.GetSingleValue(queryStr, &defaultValue)
@@ -520,7 +520,7 @@ func (p *manilaPlugin) collectSnapmirrorUsage(project core.KeystoneProject, shar
 	}
 
 	queryStr = fmt.Sprintf(
-		`sum(max by (volume) (netapp_volume_used_bytes{project_id=%q,share_type=%q,volume_type="dp",volume=~".*EC2BKP"}))`,
+		`sum(max by (volume) (netapp_volume_used_bytes{project_id=%q,share_type=%q,volume_type="dp",volume_state="online",volume=~".*EC2BKP"}))`,
 		project.UUID, shareTypeName,
 	)
 	bytesUsed, err := client.GetSingleValue(queryStr, &defaultValue)

--- a/internal/plugins/manila.go
+++ b/internal/plugins/manila.go
@@ -511,7 +511,7 @@ func (p *manilaPlugin) collectSnapmirrorUsage(project core.KeystoneProject, shar
 	//Manila itself, so we have to collect usage from NetApp metrics instead
 	defaultValue := float64(0)
 	queryStr := fmt.Sprintf(
-		`sum(max by (volume) (netapp_volume_total_bytes{project_id="%s",share_type="%s",volume_type="dp",volume=~".*EC2BKP"}))`,
+		`sum(max by (volume) (netapp_volume_total_bytes{project_id=%q,share_type=%q,volume_type="dp",volume=~".*EC2BKP"}))`,
 		project.UUID, shareTypeName,
 	)
 	bytesTotal, err := client.GetSingleValue(queryStr, &defaultValue)
@@ -520,7 +520,7 @@ func (p *manilaPlugin) collectSnapmirrorUsage(project core.KeystoneProject, shar
 	}
 
 	queryStr = fmt.Sprintf(
-		`sum(max by (volume) (netapp_volume_used_bytes{project_id="%s",share_type="%s",volume_type="dp",volume=~".*EC2BKP"}))`,
+		`sum(max by (volume) (netapp_volume_used_bytes{project_id=%q,share_type=%q,volume_type="dp",volume=~".*EC2BKP"}))`,
 		project.UUID, shareTypeName,
 	)
 	bytesUsed, err := client.GetSingleValue(queryStr, &defaultValue)


### PR DESCRIPTION
@Carthaca Can you please check whether I understood the requirement correctly? Especially the part where I'm assuming that shares managed by Manila are _never_ tagged as `volume_type="dp"` and that Snapmirror backups are _always_ tagged as `volume_type="dp"`. Also, is `snapmirror_capacity` ok as a user-facing resource name? I'm willing to take your suggestions if you have a better idea.