### PR TITLE
retain gophercloud.ServiceClient instances in plugins

### DIFF
--- a/internal/api/quota_updater.go
+++ b/internal/api/quota_updater.go
@@ -320,10 +320,9 @@ func (u *QuotaUpdater) ValidateInput(input limesresources.QuotaRequest, dbi db.I
 
 			//perform validation
 			if plugin, exists := u.Cluster.QuotaPlugins[srvType]; exists {
-				provider, eo := u.Cluster.ProviderClient()
 				domain := core.KeystoneDomainFromDB(*u.Domain)
 				project := core.KeystoneProjectFromDB(*u.Project, domain)
-				err := plugin.IsQuotaAcceptableForProject(provider, eo, project, quotaValues)
+				err := plugin.IsQuotaAcceptableForProject(project, quotaValues)
 				if err != nil {
 					for resName := range srvInput {
 						u.Requests[srvType][resName] = QuotaRequest{

--- a/internal/collector/capacity.go
+++ b/internal/collector/capacity.go
@@ -73,9 +73,8 @@ func (c *Collector) scanCapacity() {
 		clusterCapacitorSuccessCounter.With(labels).Add(0)
 		clusterCapacitorFailedCounter.With(labels).Add(0)
 
-		provider, eo := c.Cluster.ProviderClient()
 		scrapeStart := c.TimeNow()
-		capacities, serializedMetrics, err := plugin.Scrape(provider, eo)
+		capacities, serializedMetrics, err := plugin.Scrape()
 		scrapeDuration := c.TimeNow().Sub(scrapeStart)
 		if err != nil {
 			c.LogError("scan capacity with capacitor %s failed: %s", capacitorID, util.UnpackError(err).Error())

--- a/internal/collector/keystone.go
+++ b/internal/collector/keystone.go
@@ -39,7 +39,7 @@ type ScanDomainsOpts struct {
 // This extends ListDomains() by handling of the {Include,Exclude}DomainRx. It's
 // a separate function for unit test accessibility.
 func (c *Collector) listDomainsFiltered() ([]core.KeystoneDomain, error) {
-	domains, err := c.Cluster.DiscoveryPlugin.ListDomains(c.Cluster.ProviderClient())
+	domains, err := c.Cluster.DiscoveryPlugin.ListDomains()
 	if err != nil {
 		return nil, err
 	}
@@ -203,8 +203,7 @@ func (c *Collector) ScanProjects(domain *db.Domain) (result []string, resultErr 
 	}()
 
 	//list projects in Keystone
-	provider, eo := c.Cluster.ProviderClient()
-	projects, err := c.Cluster.DiscoveryPlugin.ListProjects(provider, eo, core.KeystoneDomainFromDB(*domain))
+	projects, err := c.Cluster.DiscoveryPlugin.ListProjects(core.KeystoneDomainFromDB(*domain))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/collector/metrics.go
+++ b/internal/collector/metrics.go
@@ -53,14 +53,6 @@ var scrapeFailedCounter = prometheus.NewCounterVec(
 	[]string{"service", "service_name"},
 )
 
-var scrapeSuspendedCounter = prometheus.NewCounterVec(
-	prometheus.CounterOpts{
-		Name: "limes_suspended_scrapes",
-		Help: "Counter for suspended quota scrape operations per Keystone project.",
-	},
-	[]string{"service", "service_name"},
-)
-
 var projectDiscoverySuccessCounter = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Name: "limes_successful_project_discoveries",
@@ -123,18 +115,9 @@ var ratesScrapeFailedCounter = prometheus.NewCounterVec(
 	[]string{"service", "service_name"},
 )
 
-var ratesScrapeSuspendedCounter = prometheus.NewCounterVec(
-	prometheus.CounterOpts{
-		Name: "limes_suspended_rate_scrapes",
-		Help: "Counter for suspended rate scrape operations per Keystone project.",
-	},
-	[]string{"service", "service_name"},
-)
-
 func init() {
 	prometheus.MustRegister(scrapeSuccessCounter)
 	prometheus.MustRegister(scrapeFailedCounter)
-	prometheus.MustRegister(scrapeSuspendedCounter)
 	prometheus.MustRegister(projectDiscoverySuccessCounter)
 	prometheus.MustRegister(projectDiscoveryFailedCounter)
 	prometheus.MustRegister(domainDiscoverySuccessCounter)
@@ -143,7 +126,6 @@ func init() {
 	prometheus.MustRegister(clusterCapacitorFailedCounter)
 	prometheus.MustRegister(ratesScrapeSuccessCounter)
 	prometheus.MustRegister(ratesScrapeFailedCounter)
-	prometheus.MustRegister(ratesScrapeSuspendedCounter)
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/internal/collector/scrape_test.go
+++ b/internal/collector/scrape_test.go
@@ -474,7 +474,7 @@ func (p *autoApprovalTestPlugin) Resources() []limesresources.ResourceInfo {
 func (p *autoApprovalTestPlugin) Rates() []limesrates.RateInfo {
 	return nil
 }
-func (p *autoApprovalTestPlugin) ScrapeRates(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, project core.KeystoneProject, prevSerializedState string) (result map[string]*big.Int, serializedState string, err error) {
+func (p *autoApprovalTestPlugin) ScrapeRates(project core.KeystoneProject, prevSerializedState string) (result map[string]*big.Int, serializedState string, err error) {
 	return nil, "", nil
 }
 func (p *autoApprovalTestPlugin) DescribeMetrics(ch chan<- *prometheus.Desc) {
@@ -483,18 +483,18 @@ func (p *autoApprovalTestPlugin) CollectMetrics(ch chan<- prometheus.Metric, pro
 	return nil
 }
 
-func (p *autoApprovalTestPlugin) Scrape(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, project core.KeystoneProject) (result map[string]core.ResourceData, serializedMetrics string, err error) {
+func (p *autoApprovalTestPlugin) Scrape(project core.KeystoneProject) (result map[string]core.ResourceData, serializedMetrics string, err error) {
 	return map[string]core.ResourceData{
 		"approve":   {Usage: 0, Quota: int64(p.StaticBackendQuota)},
 		"noapprove": {Usage: 0, Quota: int64(p.StaticBackendQuota) + 10},
 	}, "", nil
 }
 
-func (p *autoApprovalTestPlugin) IsQuotaAcceptableForProject(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, project core.KeystoneProject, quotas map[string]uint64) error {
+func (p *autoApprovalTestPlugin) IsQuotaAcceptableForProject(project core.KeystoneProject, quotas map[string]uint64) error {
 	return errors.New("unimplemented")
 }
 
-func (p *autoApprovalTestPlugin) SetQuota(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, project core.KeystoneProject, quotas map[string]uint64) error {
+func (p *autoApprovalTestPlugin) SetQuota(project core.KeystoneProject, quotas map[string]uint64) error {
 	return errors.New("unimplemented")
 }
 
@@ -552,19 +552,19 @@ func (noopQuotaPlugin) ServiceInfo() limes.ServiceInfo {
 func (noopQuotaPlugin) Resources() []limesresources.ResourceInfo {
 	return nil
 }
-func (noopQuotaPlugin) Scrape(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, project core.KeystoneProject) (result map[string]core.ResourceData, serializedMetrics string, err error) {
+func (noopQuotaPlugin) Scrape(project core.KeystoneProject) (result map[string]core.ResourceData, serializedMetrics string, err error) {
 	return nil, "", nil
 }
-func (noopQuotaPlugin) IsQuotaAcceptableForProject(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, project core.KeystoneProject, quotas map[string]uint64) error {
+func (noopQuotaPlugin) IsQuotaAcceptableForProject(project core.KeystoneProject, quotas map[string]uint64) error {
 	return nil
 }
-func (noopQuotaPlugin) SetQuota(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, project core.KeystoneProject, quotas map[string]uint64) error {
+func (noopQuotaPlugin) SetQuota(project core.KeystoneProject, quotas map[string]uint64) error {
 	return nil
 }
 func (noopQuotaPlugin) Rates() []limesrates.RateInfo {
 	return nil
 }
-func (noopQuotaPlugin) ScrapeRates(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, project core.KeystoneProject, prevSerializedState string) (result map[string]*big.Int, serializedState string, err error) {
+func (noopQuotaPlugin) ScrapeRates(project core.KeystoneProject, prevSerializedState string) (result map[string]*big.Int, serializedState string, err error) {
 	return nil, "", nil
 }
 func (noopQuotaPlugin) DescribeMetrics(ch chan<- *prometheus.Desc) {

--- a/internal/core/cluster.go
+++ b/internal/core/cluster.go
@@ -28,7 +28,6 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/gophercloud/gophercloud"
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/sapcc/go-api-declarations/limes"
 	limesrates "github.com/sapcc/go-api-declarations/limes/rates"
@@ -295,16 +294,6 @@ func (c Cluster) parseLowPrivilegeRaiseLimits(inputs map[string]map[string]strin
 		}
 	}
 	return result, nil
-}
-
-// ProviderClient returns the gophercloud.ProviderClient for this cluster. This
-// returns nil unless Connect() is called first. (This usually happens at
-// program startup time for the current cluster.)
-func (c *Cluster) ProviderClient() (*gophercloud.ProviderClient, gophercloud.EndpointOpts) {
-	if c.Auth == nil {
-		return nil, gophercloud.EndpointOpts{}
-	}
-	return c.Auth.ProviderClient, c.Auth.EndpointOpts
 }
 
 // ServiceTypesInAlphabeticalOrder can be used when service types need to be

--- a/internal/core/constraints_test.go
+++ b/internal/core/constraints_test.go
@@ -190,16 +190,16 @@ func (p quotaConstraintTestPlugin) ServiceInfo() limes.ServiceInfo {
 func (p quotaConstraintTestPlugin) Rates() []limesrates.RateInfo {
 	return nil
 }
-func (p quotaConstraintTestPlugin) Scrape(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, project KeystoneProject) (result map[string]ResourceData, serializedMetrics string, err error) {
+func (p quotaConstraintTestPlugin) Scrape(project KeystoneProject) (result map[string]ResourceData, serializedMetrics string, err error) {
 	return nil, "", nil
 }
-func (p quotaConstraintTestPlugin) IsQuotaAcceptableForProject(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, project KeystoneProject, quotas map[string]uint64) error {
+func (p quotaConstraintTestPlugin) IsQuotaAcceptableForProject(project KeystoneProject, quotas map[string]uint64) error {
 	return nil
 }
-func (p quotaConstraintTestPlugin) SetQuota(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, project KeystoneProject, quotas map[string]uint64) error {
+func (p quotaConstraintTestPlugin) SetQuota(project KeystoneProject, quotas map[string]uint64) error {
 	return nil
 }
-func (p quotaConstraintTestPlugin) ScrapeRates(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, project KeystoneProject, prevSerializedState string) (result map[string]*big.Int, serializedState string, err error) {
+func (p quotaConstraintTestPlugin) ScrapeRates(project KeystoneProject, prevSerializedState string) (result map[string]*big.Int, serializedState string, err error) {
 	return nil, "", nil
 }
 func (p quotaConstraintTestPlugin) DescribeMetrics(ch chan<- *prometheus.Desc) {

--- a/internal/datamodel/apply_backend_quota.go
+++ b/internal/datamodel/apply_backend_quota.go
@@ -97,8 +97,7 @@ func ApplyBackendQuota(dbi db.Interface, cluster *core.Cluster, domain core.Keys
 	}
 
 	//apply quotas in backend
-	provider, eo := cluster.ProviderClient()
-	err = plugin.SetQuota(provider, eo, core.KeystoneProjectFromDB(project, domain), targetQuotasForBackend)
+	err = plugin.SetQuota(core.KeystoneProjectFromDB(project, domain), targetQuotasForBackend)
 	if err != nil {
 		return err
 	}

--- a/internal/plugins/capacity_manual.go
+++ b/internal/plugins/capacity_manual.go
@@ -49,7 +49,7 @@ func (p *capacityManualPlugin) PluginTypeID() string {
 var errNoManualData = errors.New(`missing values for capacitor plugin "manual"`)
 
 // Scrape implements the core.CapacityPlugin interface.
-func (p *capacityManualPlugin) Scrape(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (result map[string]map[string]core.CapacityData, _ string, err error) {
+func (p *capacityManualPlugin) Scrape() (result map[string]map[string]core.CapacityData, _ string, err error) {
 	if p.Values == nil {
 		return nil, "", errNoManualData
 	}

--- a/internal/plugins/capacity_prometheus.go
+++ b/internal/plugins/capacity_prometheus.go
@@ -47,7 +47,7 @@ func (p *capacityPrometheusPlugin) PluginTypeID() string {
 }
 
 // Scrape implements the core.CapacityPlugin interface.
-func (p *capacityPrometheusPlugin) Scrape(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (result map[string]map[string]core.CapacityData, _ string, err error) {
+func (p *capacityPrometheusPlugin) Scrape() (result map[string]map[string]core.CapacityData, _ string, err error) {
 	client, err := p.APIConfig.Connect()
 	if err != nil {
 		return nil, "", err

--- a/internal/plugins/capacity_sapcc_ironic.go
+++ b/internal/plugins/capacity_sapcc_ironic.go
@@ -68,7 +68,7 @@ func (p *capacitySapccIronicPlugin) Init(provider *gophercloud.ProviderClient, e
 	if err != nil {
 		return err
 	}
-	p.IronicV1.Microversion = "1.22"
+	p.IronicV1.Microversion = "1.22" //for node attributes "provision_state" and "target_provision_state"
 	return nil
 }
 

--- a/internal/plugins/discovery_static.go
+++ b/internal/plugins/discovery_static.go
@@ -55,7 +55,7 @@ func (p *staticDiscoveryPlugin) Init(client *gophercloud.ProviderClient, eo goph
 }
 
 // ListDomains implements the core.DiscoveryPlugin interface.
-func (p *staticDiscoveryPlugin) ListDomains(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) ([]core.KeystoneDomain, error) {
+func (p *staticDiscoveryPlugin) ListDomains() ([]core.KeystoneDomain, error) {
 	var result []core.KeystoneDomain
 	if len(p.Domains) == 0 {
 		return nil, errors.New("no domains configured")
@@ -76,7 +76,7 @@ func (p *staticDiscoveryPlugin) ListDomains(provider *gophercloud.ProviderClient
 }
 
 // ListProjects implements the core.DiscoveryPlugin interface.
-func (p *staticDiscoveryPlugin) ListProjects(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, queryDomain core.KeystoneDomain) ([]core.KeystoneProject, error) {
+func (p *staticDiscoveryPlugin) ListProjects(queryDomain core.KeystoneDomain) ([]core.KeystoneProject, error) {
 	var result []core.KeystoneProject
 	if len(p.Domains) == 0 {
 		return nil, errors.New("no domains configured")

--- a/internal/test/discovery.go
+++ b/internal/test/discovery.go
@@ -62,12 +62,12 @@ func (p *DiscoveryPlugin) Init(client *gophercloud.ProviderClient, eo gopherclou
 }
 
 // ListDomains implements the core.DiscoveryPlugin interface.
-func (p *DiscoveryPlugin) ListDomains(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) ([]core.KeystoneDomain, error) {
+func (p *DiscoveryPlugin) ListDomains() ([]core.KeystoneDomain, error) {
 	return p.StaticDomains, nil
 }
 
 // ListProjects implements the core.DiscoveryPlugin interface.
-func (p *DiscoveryPlugin) ListProjects(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, domain core.KeystoneDomain) ([]core.KeystoneProject, error) {
+func (p *DiscoveryPlugin) ListProjects(domain core.KeystoneDomain) ([]core.KeystoneProject, error) {
 	//the domain is not duplicated in each StaticProjects entry, so it must be
 	//added now
 	result := make([]core.KeystoneProject, len(p.StaticProjects[domain.UUID]))

--- a/internal/test/plugin.go
+++ b/internal/test/plugin.go
@@ -108,7 +108,7 @@ func (p *Plugin) Rates() []limesrates.RateInfo {
 }
 
 // ScrapeRates implements the core.QuotaPlugin interface.
-func (p *Plugin) ScrapeRates(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, project core.KeystoneProject, prevSerializedState string) (result map[string]*big.Int, serializedState string, err error) {
+func (p *Plugin) ScrapeRates(project core.KeystoneProject, prevSerializedState string) (result map[string]*big.Int, serializedState string, err error) {
 	if p.ScrapeFails {
 		return nil, "", errors.New("ScrapeRates failed as requested")
 	}
@@ -138,7 +138,7 @@ func (p *Plugin) ScrapeRates(client *gophercloud.ProviderClient, eo gophercloud.
 }
 
 // Scrape implements the core.QuotaPlugin interface.
-func (p *Plugin) Scrape(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, project core.KeystoneProject) (result map[string]core.ResourceData, serializedMetrics string, err error) {
+func (p *Plugin) Scrape(project core.KeystoneProject) (result map[string]core.ResourceData, serializedMetrics string, err error) {
 	if p.ScrapeFails {
 		return nil, "", errors.New("Scrape failed as requested")
 	}
@@ -196,7 +196,7 @@ func (p *Plugin) Scrape(provider *gophercloud.ProviderClient, eo gophercloud.End
 }
 
 // IsQuotaAcceptableForProject implements the core.QuotaPlugin interface.
-func (p *Plugin) IsQuotaAcceptableForProject(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, project core.KeystoneProject, quotas map[string]uint64) error {
+func (p *Plugin) IsQuotaAcceptableForProject(project core.KeystoneProject, quotas map[string]uint64) error {
 	if p.QuotaIsNotAcceptable {
 		var quotasStr []string
 		for resName, quota := range quotas {
@@ -209,7 +209,7 @@ func (p *Plugin) IsQuotaAcceptableForProject(client *gophercloud.ProviderClient,
 }
 
 // SetQuota implements the core.QuotaPlugin interface.
-func (p *Plugin) SetQuota(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, project core.KeystoneProject, quotas map[string]uint64) error {
+func (p *Plugin) SetQuota(project core.KeystoneProject, quotas map[string]uint64) error {
 	if p.SetQuotaFails {
 		return errors.New("SetQuota failed as requested")
 	}
@@ -291,7 +291,7 @@ func (p *CapacityPlugin) PluginTypeID() string {
 }
 
 // Scrape implements the core.CapacityPlugin interface.
-func (p *CapacityPlugin) Scrape(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (result map[string]map[string]core.CapacityData, serializedMetrics string, err error) {
+func (p *CapacityPlugin) Scrape() (result map[string]map[string]core.CapacityData, serializedMetrics string, err error) {
 	var capacityPerAZ map[string]*core.CapacityDataForAZ
 	if p.WithAZCapData {
 		capacityPerAZ = map[string]*core.CapacityDataForAZ{

--- a/main.go
+++ b/main.go
@@ -32,7 +32,6 @@ import (
 	"time"
 
 	"github.com/dlmiddlecote/sqlstats"
-	"github.com/gophercloud/gophercloud"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/cors"
@@ -204,14 +203,13 @@ func taskTestGetQuota(cluster *core.Cluster, args []string) {
 	}
 
 	serviceType := args[1]
-	provider, eo := cluster.ProviderClient()
-	project := must.Return(findProjectForTesting(cluster, provider, eo, args[0]))
+	project := must.Return(findProjectForTesting(cluster, args[0]))
 
 	if _, ok := cluster.QuotaPlugins[serviceType]; !ok {
 		logg.Fatal("unknown service type: %s", serviceType)
 	}
 
-	result, serializedMetrics, err := cluster.QuotaPlugins[serviceType].Scrape(provider, eo, project)
+	result, serializedMetrics, err := cluster.QuotaPlugins[serviceType].Scrape(project)
 	must.Succeed(err)
 
 	for resourceName := range result {
@@ -247,10 +245,9 @@ func taskTestGetRates(cluster *core.Cluster, args []string) {
 	}
 
 	serviceType := args[1]
-	provider, eo := cluster.ProviderClient()
-	project := must.Return(findProjectForTesting(cluster, provider, eo, args[0]))
+	project := must.Return(findProjectForTesting(cluster, args[0]))
 
-	result, serializedState, err := cluster.QuotaPlugins[serviceType].ScrapeRates(provider, eo, project, prevSerializedState)
+	result, serializedState, err := cluster.QuotaPlugins[serviceType].ScrapeRates(project, prevSerializedState)
 	must.Succeed(err)
 	if serializedState != "" {
 		logg.Info("scrape returned new serialized state: %s", serializedState)
@@ -269,13 +266,13 @@ func taskTestGetRates(cluster *core.Cluster, args []string) {
 	must.Succeed(enc.Encode(result))
 }
 
-func findProjectForTesting(cluster *core.Cluster, client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, projectUUID string) (core.KeystoneProject, error) {
-	domains, err := cluster.DiscoveryPlugin.ListDomains(client, eo)
+func findProjectForTesting(cluster *core.Cluster, projectUUID string) (core.KeystoneProject, error) {
+	domains, err := cluster.DiscoveryPlugin.ListDomains()
 	if err != nil {
 		return core.KeystoneProject{}, util.UnpackError(err)
 	}
 	for _, d := range domains {
-		projects, err := cluster.DiscoveryPlugin.ListProjects(client, eo, d)
+		projects, err := cluster.DiscoveryPlugin.ListProjects(d)
 		if err != nil {
 			return core.KeystoneProject{}, util.UnpackError(err)
 		}
@@ -329,8 +326,7 @@ func taskTestSetQuota(cluster *core.Cluster, args []string) {
 	}
 
 	serviceType := args[1]
-	provider, eo := cluster.ProviderClient()
-	project := must.Return(findProjectForTesting(cluster, provider, eo, args[0]))
+	project := must.Return(findProjectForTesting(cluster, args[0]))
 
 	quotaValueRx := regexp.MustCompile(`^([^=]+)=(\d+)$`)
 	quotaValues := make(map[string]uint64)
@@ -346,7 +342,7 @@ func taskTestSetQuota(cluster *core.Cluster, args []string) {
 		quotaValues[match[1]] = val
 	}
 
-	must.Succeed(cluster.QuotaPlugins[serviceType].SetQuota(provider, eo, project, quotaValues))
+	must.Succeed(cluster.QuotaPlugins[serviceType].SetQuota(project, quotaValues))
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -363,8 +359,7 @@ func taskTestScanCapacity(cluster *core.Cluster, args []string) {
 		logg.Fatal("unknown capacitor: %s", capacitorID)
 	}
 
-	provider, eo := cluster.ProviderClient()
-	capacities, serializedMetrics, err := plugin.Scrape(provider, eo)
+	capacities, serializedMetrics, err := plugin.Scrape()
 	if err != nil {
 		logg.Error("Scrape failed: %s", util.UnpackError(err).Error())
 		capacities = nil


### PR DESCRIPTION
With this change, we only need the ProviderClient/EndpointOpts pair once during initialization. Afterwards, the plugins maintain their connections to the respective OpenStack services independently. (Note that the underlying ProviderClient is still shared between all ServiceClient instances so constructed, so this does not affect token rotation and such.)

The motivation for this change is that it will enable me to move `AuthToOpenstack` out of `Cluster.Connect`, which then makes the rest of that function testable.

The main reason why I did not do it like this from the start is that, very early on, Limes was intended to function with only a partial set of backend services present (which can happen during buildup of a new OpenStack cluster). This capability is long since gone, since there are so many cases now where we query backend services during Init() to do critical computations like the set of available resources. This change therefores removed the specific support for missing backend services from the scrape loops.