### PR TITLE
parametrize QuotaPlugin interface by service type

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -64,12 +64,12 @@ func setupTest(t *testing.T, startData string) (*core.Cluster, *gorp.DbMap, http
 	}
 
 	quotaPlugins := map[string]core.QuotaPlugin{
-		"shared":   test.NewPlugin("shared", sharedRatesThatReportUsage...),
-		"unshared": test.NewPlugin("unshared", unsharedRatesThatReportUsage...),
+		"shared":   test.NewPlugin(sharedRatesThatReportUsage...),
+		"unshared": test.NewPlugin(unsharedRatesThatReportUsage...),
 	}
 	hasCentralizedService := startData == "fixtures/start-data.sql"
 	if hasCentralizedService {
-		quotaPlugins["centralized"] = test.NewPlugin("centralized")
+		quotaPlugins["centralized"] = test.NewPlugin()
 	}
 
 	westConstraintSet := core.QuotaConstraintSet{

--- a/internal/api/quota_updater.go
+++ b/internal/api/quota_updater.go
@@ -134,8 +134,8 @@ func (u *QuotaUpdater) ValidateInput(input limesresources.QuotaRequest, dbi db.I
 
 	//go through all services and resources and validate the requested quotas
 	u.Requests = make(map[string]map[string]QuotaRequest)
-	for _, quotaPlugin := range u.Cluster.QuotaPlugins {
-		srv := quotaPlugin.ServiceInfo()
+	for serviceType, quotaPlugin := range u.Cluster.QuotaPlugins {
+		srv := quotaPlugin.ServiceInfo(serviceType)
 		u.Requests[srv.Type] = map[string]QuotaRequest{}
 
 		for _, res := range quotaPlugin.Resources() {
@@ -276,7 +276,7 @@ func (u *QuotaUpdater) ValidateInput(input limesresources.QuotaRequest, dbi db.I
 			if plugin, exists := u.Cluster.QuotaPlugins[srvType]; exists {
 				domain := core.KeystoneDomainFromDB(*u.Domain)
 				project := core.KeystoneProjectFromDB(*u.Project, domain)
-				err := plugin.IsQuotaAcceptableForProject(project, quotaValues)
+				err := plugin.IsQuotaAcceptableForProject(project, quotaValues, u.Cluster.AllServiceInfos())
 				if err != nil {
 					for resName := range srvInput {
 						u.Requests[srvType][resName] = QuotaRequest{

--- a/internal/collector/capacity_test.go
+++ b/internal/collector/capacity_test.go
@@ -38,9 +38,9 @@ func Test_ScanCapacity(t *testing.T) {
 
 	cluster := &core.Cluster{
 		QuotaPlugins: map[string]core.QuotaPlugin{
-			"shared":    test.NewPlugin("shared"),
-			"unshared":  test.NewPlugin("unshared"),
-			"unshared2": test.NewPlugin("unshared2"),
+			"shared":    test.NewPlugin(),
+			"unshared":  test.NewPlugin(),
+			"unshared2": test.NewPlugin(),
 		},
 		CapacityPlugins: map[string]core.CapacityPlugin{
 			"unittest": test.NewCapacityPlugin("unittest",
@@ -68,7 +68,6 @@ func Test_ScanCapacity(t *testing.T) {
 	c := Collector{
 		Cluster:   cluster,
 		DB:        dbm,
-		Plugin:    nil,
 		LogError:  t.Errorf,
 		TimeNow:   test.TimeNow,
 		AddJitter: test.NoJitter,

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -37,7 +37,6 @@ import (
 type Collector struct {
 	Cluster *core.Cluster
 	DB      *gorp.DbMap
-	Plugin  core.QuotaPlugin
 	//Usually logg.Error, but can be changed inside unit tests.
 	LogError func(msg string, args ...interface{})
 	//Usually time.Now, but can be changed inside unit tests.
@@ -54,7 +53,6 @@ func NewCollector(cluster *core.Cluster, dbm *gorp.DbMap, plugin core.QuotaPlugi
 	return &Collector{
 		Cluster:   cluster,
 		DB:        dbm,
-		Plugin:    plugin,
 		LogError:  logg.Error,
 		TimeNow:   time.Now,
 		AddJitter: addJitter,

--- a/internal/collector/consistency_test.go
+++ b/internal/collector/consistency_test.go
@@ -36,7 +36,6 @@ func Test_Consistency(t *testing.T) {
 	c := Collector{
 		Cluster:   cluster,
 		DB:        dbm,
-		Plugin:    nil,
 		LogError:  t.Errorf,
 		TimeNow:   test.TimeNow,
 		AddJitter: test.NoJitter,

--- a/internal/collector/keystone_test.go
+++ b/internal/collector/keystone_test.go
@@ -54,9 +54,9 @@ func keystoneTestCluster(t *testing.T) (*core.Cluster, *gorp.DbMap) {
 		},
 		DiscoveryPlugin: test.NewDiscoveryPlugin(),
 		QuotaPlugins: map[string]core.QuotaPlugin{
-			"shared":      test.NewPlugin("shared"),
-			"unshared":    test.NewPlugin("unshared"),
-			"centralized": test.NewPlugin("centralized"),
+			"shared":      test.NewPlugin(),
+			"unshared":    test.NewPlugin(),
+			"centralized": test.NewPlugin(),
 		},
 		CapacityPlugins: map[string]core.CapacityPlugin{},
 	}, dbm

--- a/internal/collector/metrics.go
+++ b/internal/collector/metrics.go
@@ -217,7 +217,7 @@ func (c *AggregateMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 		if plugin == nil {
 			return nil
 		}
-		serviceName := plugin.ServiceInfo().ProductName
+		serviceName := plugin.ServiceInfo(serviceType).ProductName
 
 		if len(plugin.Resources()) > 0 {
 			ch <- prometheus.MustNewConstMetric(

--- a/internal/core/constraints_test.go
+++ b/internal/core/constraints_test.go
@@ -119,9 +119,9 @@ func TestQuotaConstraintParsingSuccess(t *testing.T) {
 func clusterForQuotaConstraintTest() *Cluster {
 	return &Cluster{
 		QuotaPlugins: map[string]QuotaPlugin{
-			"service-one": quotaConstraintTestPlugin{"service-one"},
-			"service-two": quotaConstraintTestPlugin{"service-two"},
-			"centralized": quotaConstraintTestPlugin{"centralized"},
+			"service-one": quotaConstraintTestPlugin{},
+			"service-two": quotaConstraintTestPlugin{},
+			"centralized": quotaConstraintTestPlugin{},
 		},
 		Config: ClusterConfiguration{
 			QuotaDistributionConfigs: []*QuotaDistributionConfiguration{{
@@ -174,18 +174,16 @@ func expectQuotaConstraintInvalid(t *testing.T, path string, expectedErrors ...s
 	}
 }
 
-type quotaConstraintTestPlugin struct {
-	ServiceType string
-}
+type quotaConstraintTestPlugin struct{}
 
 func (p quotaConstraintTestPlugin) Init(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, scrapeSubresources map[string]bool) error {
 	return nil
 }
 func (p quotaConstraintTestPlugin) PluginTypeID() string {
-	return p.ServiceType
+	return "--test-quota-constraints"
 }
-func (p quotaConstraintTestPlugin) ServiceInfo() limes.ServiceInfo {
-	return limes.ServiceInfo{Type: p.ServiceType}
+func (p quotaConstraintTestPlugin) ServiceInfo(serviceType string) limes.ServiceInfo {
+	return limes.ServiceInfo{Type: serviceType}
 }
 func (p quotaConstraintTestPlugin) Rates() []limesrates.RateInfo {
 	return nil
@@ -193,7 +191,7 @@ func (p quotaConstraintTestPlugin) Rates() []limesrates.RateInfo {
 func (p quotaConstraintTestPlugin) Scrape(project KeystoneProject) (result map[string]ResourceData, serializedMetrics string, err error) {
 	return nil, "", nil
 }
-func (p quotaConstraintTestPlugin) IsQuotaAcceptableForProject(project KeystoneProject, fullQuotas map[string]map[string]uint64) error {
+func (p quotaConstraintTestPlugin) IsQuotaAcceptableForProject(project KeystoneProject, fullQuotas map[string]map[string]uint64, allServiceInfos []limes.ServiceInfo) error {
 	return nil
 }
 func (p quotaConstraintTestPlugin) SetQuota(project KeystoneProject, quotas map[string]uint64) error {

--- a/internal/core/plugin.go
+++ b/internal/core/plugin.go
@@ -113,7 +113,12 @@ type QuotaPlugin interface {
 	Init(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, scrapeSubresources map[string]bool) error
 
 	//ServiceInfo returns metadata for this service.
-	ServiceInfo() limes.ServiceInfo
+	//
+	//This receives the `serviceType` as an argument because it needs to appear
+	//in the ServiceInfo struct. But in general, a plugin cannot know which
+	//serviceType it was instantiated for (esp. in unit tests, where the generic
+	//test plugin is instantiated multiple times for different service types).
+	ServiceInfo(serviceType string) limes.ServiceInfo
 
 	//Resources returns metadata for all the resources that this plugin scrapes
 	//from the backend service.
@@ -133,7 +138,12 @@ type QuotaPlugin interface {
 	//to the quotas of other services. (For example, Keppel uses Swift as a
 	//storage backend, so nonzero Keppel quota requires nonzero Swift quota in
 	//Limes, to catch a common misconfiguration that confuses users.)
-	IsQuotaAcceptableForProject(project KeystoneProject, fullQuotas map[string]map[string]uint64) error
+	//
+	//The `fullQuotas` map uses service type strings as the first key. Since
+	//quota plugins can be instantiated under arbitrary service types,
+	//implementations should inspect `allServiceInfos` to locate the service type
+	//names that they are interested in.
+	IsQuotaAcceptableForProject(project KeystoneProject, fullQuotas map[string]map[string]uint64, allServiceInfos []limes.ServiceInfo) error
 	//SetQuota updates the backend service's quotas for the given project in the
 	//given domain to the values specified here. The map is guaranteed to contain
 	//values for all resources defined by Resources().

--- a/internal/plugins/cinder.go
+++ b/internal/plugins/cinder.go
@@ -70,9 +70,9 @@ func (p *cinderPlugin) PluginTypeID() string {
 }
 
 // ServiceInfo implements the core.QuotaPlugin interface.
-func (p *cinderPlugin) ServiceInfo() limes.ServiceInfo {
+func (p *cinderPlugin) ServiceInfo(serviceType string) limes.ServiceInfo {
 	return limes.ServiceInfo{
-		Type:        "volumev2",
+		Type:        serviceType,
 		ProductName: "cinder",
 		Area:        "storage",
 	}
@@ -292,7 +292,7 @@ func (p *cinderPlugin) collectSnapshotSubresources(project core.KeystoneProject,
 }
 
 // IsQuotaAcceptableForProject implements the core.QuotaPlugin interface.
-func (p *cinderPlugin) IsQuotaAcceptableForProject(project core.KeystoneProject, fullQuotas map[string]map[string]uint64) error {
+func (p *cinderPlugin) IsQuotaAcceptableForProject(project core.KeystoneProject, fullQuotas map[string]map[string]uint64, allServiceInfos []limes.ServiceInfo) error {
 	//not required for this plugin
 	return nil
 }

--- a/internal/plugins/cronus.go
+++ b/internal/plugins/cronus.go
@@ -75,9 +75,9 @@ func (p *cronusPlugin) PluginTypeID() string {
 }
 
 // ServiceInfo implements the core.QuotaPlugin interface.
-func (p *cronusPlugin) ServiceInfo() limes.ServiceInfo {
+func (p *cronusPlugin) ServiceInfo(serviceType string) limes.ServiceInfo {
 	return limes.ServiceInfo{
-		Type:        "email-aws",
+		Type:        serviceType,
 		ProductName: "cronus",
 		Area:        "email",
 	}
@@ -99,7 +99,7 @@ func (p *cronusPlugin) Scrape(project core.KeystoneProject) (result map[string]c
 }
 
 // IsQuotaAcceptableForProject implements the core.QuotaPlugin interface.
-func (p *cronusPlugin) IsQuotaAcceptableForProject(project core.KeystoneProject, fullQuotas map[string]map[string]uint64) error {
+func (p *cronusPlugin) IsQuotaAcceptableForProject(project core.KeystoneProject, fullQuotas map[string]map[string]uint64, allServiceInfos []limes.ServiceInfo) error {
 	//not required for this plugin
 	return nil
 }

--- a/internal/plugins/designate.go
+++ b/internal/plugins/designate.go
@@ -67,9 +67,9 @@ func (p *designatePlugin) PluginTypeID() string {
 }
 
 // ServiceInfo implements the core.QuotaPlugin interface.
-func (p *designatePlugin) ServiceInfo() limes.ServiceInfo {
+func (p *designatePlugin) ServiceInfo(serviceType string) limes.ServiceInfo {
 	return limes.ServiceInfo{
-		Type:        "dns",
+		Type:        serviceType,
 		ProductName: "designate",
 		Area:        "dns",
 	}
@@ -131,7 +131,7 @@ func (p *designatePlugin) Scrape(project core.KeystoneProject) (result map[strin
 }
 
 // IsQuotaAcceptableForProject implements the core.QuotaPlugin interface.
-func (p *designatePlugin) IsQuotaAcceptableForProject(project core.KeystoneProject, fullQuotas map[string]map[string]uint64) error {
+func (p *designatePlugin) IsQuotaAcceptableForProject(project core.KeystoneProject, fullQuotas map[string]map[string]uint64, allServiceInfos []limes.ServiceInfo) error {
 	//not required for this plugin
 	return nil
 }

--- a/internal/plugins/manila.go
+++ b/internal/plugins/manila.go
@@ -113,9 +113,9 @@ func (p *manilaPlugin) PluginTypeID() string {
 }
 
 // ServiceInfo implements the core.QuotaPlugin interface.
-func (p *manilaPlugin) ServiceInfo() limes.ServiceInfo {
+func (p *manilaPlugin) ServiceInfo(serviceType string) limes.ServiceInfo {
 	return limes.ServiceInfo{
-		Type:        "sharev2",
+		Type:        serviceType,
 		ProductName: "manila",
 		Area:        "storage",
 	}
@@ -302,8 +302,14 @@ func (p *manilaPlugin) rejectInaccessibleShareType(project core.KeystoneProject,
 }
 
 // IsQuotaAcceptableForProject implements the core.QuotaPlugin interface.
-func (p *manilaPlugin) IsQuotaAcceptableForProject(project core.KeystoneProject, fullQuotas map[string]map[string]uint64) error {
-	return p.rejectInaccessibleShareType(project, fullQuotas[p.ServiceInfo().Type])
+func (p *manilaPlugin) IsQuotaAcceptableForProject(project core.KeystoneProject, fullQuotas map[string]map[string]uint64, allServiceInfos []limes.ServiceInfo) error {
+	var ourQuotas map[string]uint64
+	for _, srv := range allServiceInfos {
+		if srv.ProductName == "manila" {
+			ourQuotas = fullQuotas[srv.Type]
+		}
+	}
+	return p.rejectInaccessibleShareType(project, ourQuotas)
 }
 
 // SetQuota implements the core.QuotaPlugin interface.

--- a/internal/plugins/neutron.go
+++ b/internal/plugins/neutron.go
@@ -209,9 +209,9 @@ func (p *neutronPlugin) PluginTypeID() string {
 }
 
 // ServiceInfo implements the core.QuotaPlugin interface.
-func (p *neutronPlugin) ServiceInfo() limes.ServiceInfo {
+func (p *neutronPlugin) ServiceInfo(serviceType string) limes.ServiceInfo {
 	return limes.ServiceInfo{
-		Type:        "network",
+		Type:        serviceType,
 		ProductName: "neutron",
 		Area:        "network",
 	}
@@ -432,7 +432,7 @@ func (q neutronOrOctaviaQuotaSet) ToQuotaUpdateMap() (map[string]interface{}, er
 }
 
 // IsQuotaAcceptableForProject implements the core.QuotaPlugin interface.
-func (p *neutronPlugin) IsQuotaAcceptableForProject(project core.KeystoneProject, fullQuotas map[string]map[string]uint64) error {
+func (p *neutronPlugin) IsQuotaAcceptableForProject(project core.KeystoneProject, fullQuotas map[string]map[string]uint64, allServiceInfos []limes.ServiceInfo) error {
 	//not required for this plugin
 	return nil
 }

--- a/internal/plugins/nova.go
+++ b/internal/plugins/nova.go
@@ -246,9 +246,9 @@ func (p *novaPlugin) PluginTypeID() string {
 }
 
 // ServiceInfo implements the core.QuotaPlugin interface.
-func (p *novaPlugin) ServiceInfo() limes.ServiceInfo {
+func (p *novaPlugin) ServiceInfo(serviceType string) limes.ServiceInfo {
 	return limes.ServiceInfo{
-		Type:        "compute",
+		Type:        serviceType,
 		ProductName: "nova",
 		Area:        "compute",
 	}
@@ -548,7 +548,7 @@ func derefSlicePtrOrEmpty(val *[]string) []string {
 }
 
 // IsQuotaAcceptableForProject implements the core.QuotaPlugin interface.
-func (p *novaPlugin) IsQuotaAcceptableForProject(project core.KeystoneProject, fullQuotas map[string]map[string]uint64) error {
+func (p *novaPlugin) IsQuotaAcceptableForProject(project core.KeystoneProject, fullQuotas map[string]map[string]uint64, allServiceInfos []limes.ServiceInfo) error {
 	//not required for this plugin
 	return nil
 }

--- a/internal/plugins/swift.go
+++ b/internal/plugins/swift.go
@@ -97,9 +97,9 @@ func (p *swiftPlugin) PluginTypeID() string {
 }
 
 // ServiceInfo implements the core.QuotaPlugin interface.
-func (p *swiftPlugin) ServiceInfo() limes.ServiceInfo {
+func (p *swiftPlugin) ServiceInfo(serviceType string) limes.ServiceInfo {
 	return limes.ServiceInfo{
-		Type:        "object-store",
+		Type:        serviceType,
 		ProductName: "swift",
 		Area:        "storage",
 	}
@@ -174,7 +174,7 @@ func (p *swiftPlugin) Scrape(project core.KeystoneProject) (result map[string]co
 }
 
 // IsQuotaAcceptableForProject implements the core.QuotaPlugin interface.
-func (p *swiftPlugin) IsQuotaAcceptableForProject(project core.KeystoneProject, fullQuotas map[string]map[string]uint64) error {
+func (p *swiftPlugin) IsQuotaAcceptableForProject(project core.KeystoneProject, fullQuotas map[string]map[string]uint64, allServiceInfos []limes.ServiceInfo) error {
 	//not required for this plugin
 	return nil
 }

--- a/internal/test/discovery.go
+++ b/internal/test/discovery.go
@@ -53,7 +53,7 @@ func NewDiscoveryPlugin() *DiscoveryPlugin {
 
 // PluginTypeID implements the core.DiscoveryPlugin interface.
 func (p *DiscoveryPlugin) PluginTypeID() string {
-	return "unittest"
+	return "--test-static"
 }
 
 // Init implements the core.DiscoveryPlugin interface.

--- a/internal/test/plugin.go
+++ b/internal/test/plugin.go
@@ -38,7 +38,6 @@ import (
 
 // Plugin is a core.QuotaPlugin implementation for unit tests.
 type Plugin struct {
-	StaticServiceType  string
 	StaticRateInfos    []limesrates.RateInfo
 	StaticResourceData map[string]*core.ResourceData
 	StaticCapacity     map[string]uint64
@@ -67,10 +66,9 @@ var resources = []limesresources.ResourceInfo{
 }
 
 // NewPlugin creates a new Plugin for the given service type.
-func NewPlugin(serviceType string, rates ...limesrates.RateInfo) *Plugin {
+func NewPlugin(rates ...limesrates.RateInfo) *Plugin {
 	return &Plugin{
-		StaticServiceType: serviceType,
-		StaticRateInfos:   rates,
+		StaticRateInfos: rates,
 		StaticResourceData: map[string]*core.ResourceData{
 			"things":   {Quota: 42, Usage: 2},
 			"capacity": {Quota: 100, Usage: 0},
@@ -86,14 +84,14 @@ func (p *Plugin) Init(provider *gophercloud.ProviderClient, eo gophercloud.Endpo
 
 // PluginTypeID implements the core.QuotaPlugin interface.
 func (p *Plugin) PluginTypeID() string {
-	return p.StaticServiceType
+	return "--test-generic"
 }
 
 // ServiceInfo implements the core.QuotaPlugin interface.
-func (p *Plugin) ServiceInfo() limes.ServiceInfo {
+func (p *Plugin) ServiceInfo(serviceType string) limes.ServiceInfo {
 	return limes.ServiceInfo{
-		Type: p.StaticServiceType,
-		Area: p.StaticServiceType,
+		Type: serviceType,
+		Area: serviceType,
 	}
 }
 
@@ -196,7 +194,7 @@ func (p *Plugin) Scrape(project core.KeystoneProject) (result map[string]core.Re
 }
 
 // IsQuotaAcceptableForProject implements the core.QuotaPlugin interface.
-func (p *Plugin) IsQuotaAcceptableForProject(project core.KeystoneProject, fullQuotas map[string]map[string]uint64) error {
+func (p *Plugin) IsQuotaAcceptableForProject(project core.KeystoneProject, fullQuotas map[string]map[string]uint64, allServiceInfos []limes.ServiceInfo) error {
 	if p.QuotaIsNotAcceptable {
 		var quotasStr []string
 		for srvType, srvQuotas := range fullQuotas {

--- a/main.go
+++ b/main.go
@@ -144,10 +144,10 @@ func taskCollect(cluster *core.Cluster, args []string) {
 	//that for now, and instead construct worker threads in such a way that they
 	//can be terminated at any time without leaving the system in an inconsistent
 	//state, mostly through usage of DB transactions.)
-	for _, plugin := range cluster.QuotaPlugins {
+	for serviceType, plugin := range cluster.QuotaPlugins {
 		c := collector.NewCollector(cluster, dbm, plugin)
-		go c.Scrape()
-		go c.ScrapeRates()
+		go c.Scrape(serviceType)
+		go c.ScrapeRates(serviceType)
 	}
 
 	//start those collector threads which operate over all services simultaneously


### PR DESCRIPTION
The QuotaPlugin interface used to be built on the assumption that `pluginTypeID == serviceType` for each plugin. This assumption is broken in the tests, where the same generic plugin gets instantiated multiple times to test different subvariants in the same test.

The plugin loading code is already aware of the distinction between `pluginTypeID` and `serviceType`, but while trying to convert the testcases to load plugins from config, I ran into some places where the plugin implementations themselves rely on `pluginTypeID == serviceType`. This commit removes this assumption, by passing in `serviceType` or `allServiceInfos` from outside where required.
