### PR TITLE
move capacity scrape timestamps from cluster_services to cluster_capacitors

### DIFF
--- a/internal/api/fixtures/cluster-get-west-no-resources.json
+++ b/internal/api/fixtures/cluster-get-west-no-resources.json
@@ -9,8 +9,6 @@
         "max_scraped_at": 66,
         "min_scraped_at": 22
       }
-    ],
-    "max_scraped_at": 1100,
-    "min_scraped_at": 1100
+    ]
   }
 }

--- a/internal/api/fixtures/cluster-get-west-with-overcommit.json
+++ b/internal/api/fixtures/cluster-get-west-with-overcommit.json
@@ -105,7 +105,7 @@
         "min_scraped_at": 11
       }
     ],
-    "max_scraped_at": 1200,
+    "max_scraped_at": 1100,
     "min_scraped_at": 1000
   }
 }

--- a/internal/api/fixtures/cluster-get-west.json
+++ b/internal/api/fixtures/cluster-get-west.json
@@ -101,7 +101,7 @@
         "min_scraped_at": 11
       }
     ],
-    "max_scraped_at": 1200,
+    "max_scraped_at": 1100,
     "min_scraped_at": 1000
   }
 }

--- a/internal/api/fixtures/start-data-minimal.sql
+++ b/internal/api/fixtures/start-data-minimal.sql
@@ -1,8 +1,8 @@
 CREATE OR REPLACE FUNCTION unix(i integer) RETURNS timestamp AS $$ SELECT TO_TIMESTAMP(i) AT TIME ZONE 'Etc/UTC' $$ LANGUAGE SQL;
 
 -- two services, one shared, one unshared
-INSERT INTO cluster_services (id, type, scraped_at) VALUES (1, 'unshared', UNIX(1000));
-INSERT INTO cluster_services (id, type, scraped_at) VALUES (2, 'shared',   UNIX(1100));
+INSERT INTO cluster_services (id, type) VALUES (1, 'unshared');
+INSERT INTO cluster_services (id, type) VALUES (2, 'shared');
 
 -- two domains
 INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');

--- a/internal/api/fixtures/start-data.sql
+++ b/internal/api/fixtures/start-data.sql
@@ -1,17 +1,18 @@
 CREATE OR REPLACE FUNCTION unix(i integer) RETURNS timestamp AS $$ SELECT TO_TIMESTAMP(i) AT TIME ZONE 'Etc/UTC' $$ LANGUAGE SQL;
 
--- one bogus capacitor
-INSERT INTO cluster_capacitors (capacitor_id, scraped_at, next_scrape_at) VALUES ('dummy-capacitor', UNIX(900), UNIX(1800));
+-- two capacitors matching the two services that have capacity values
+INSERT INTO cluster_capacitors (capacitor_id, scraped_at, next_scrape_at) VALUES ('scans-unshared', UNIX(1000), UNIX(2000));
+INSERT INTO cluster_capacitors (capacitor_id, scraped_at, next_scrape_at) VALUES ('scans-shared',   UNIX(1100), UNIX(2100));
 
 -- three services
-INSERT INTO cluster_services (id, type, scraped_at) VALUES (1, 'unshared',    UNIX(1000));
-INSERT INTO cluster_services (id, type, scraped_at) VALUES (2, 'shared',      UNIX(1100));
-INSERT INTO cluster_services (id, type, scraped_at) VALUES (3, 'centralized', UNIX(1200));
+INSERT INTO cluster_services (id, type) VALUES (1, 'unshared');
+INSERT INTO cluster_services (id, type) VALUES (2, 'shared');
+INSERT INTO cluster_services (id, type) VALUES (3, 'centralized');
 
 -- all services have the resources "things" and "capacity"
-INSERT INTO cluster_resources (service_id, name, capacity, subcapacities, capacity_per_az, capacitor_id) VALUES (1, 'things', 139, '[{"smaller_half":46},{"larger_half":93}]', '[{"name":"az-one","capacity":69,"usage":13},{"name":"az-two","capacity":69,"usage":13}]', 'dummy-capacitor');
-INSERT INTO cluster_resources (service_id, name, capacity, subcapacities, capacity_per_az, capacitor_id) VALUES (2, 'things', 246, '[{"smaller_half":82},{"larger_half":164}]', '', 'dummy-capacitor');
-INSERT INTO cluster_resources (service_id, name, capacity, subcapacities, capacity_per_az, capacitor_id) VALUES (2, 'capacity', 185, '', '', 'dummy-capacitor');
+INSERT INTO cluster_resources (service_id, name, capacity, subcapacities, capacity_per_az, capacitor_id) VALUES (1, 'things', 139, '[{"smaller_half":46},{"larger_half":93}]', '[{"name":"az-one","capacity":69,"usage":13},{"name":"az-two","capacity":69,"usage":13}]', 'scans-unshared');
+INSERT INTO cluster_resources (service_id, name, capacity, subcapacities, capacity_per_az, capacitor_id) VALUES (2, 'things', 246, '[{"smaller_half":82},{"larger_half":164}]', '', 'scans-shared');
+INSERT INTO cluster_resources (service_id, name, capacity, subcapacities, capacity_per_az, capacitor_id) VALUES (2, 'capacity', 185, '', '', 'scans-shared');
 
 -- two domains
 INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
@@ -104,8 +105,8 @@ INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_big
 
 -- insert some bullshit data that should be filtered out by the internal/reports/ logic
 -- (cluster "north", service "weird", resource "items" and rate "frobnicate" are not configured)
-INSERT INTO cluster_services (id, type, scraped_at) VALUES (101, 'weird', UNIX(1100));
-INSERT INTO cluster_resources (service_id, name, capacity, capacitor_id) VALUES (101, 'things', 1, 'dummy-capacitor');
+INSERT INTO cluster_services (id, type) VALUES (101, 'weird');
+INSERT INTO cluster_resources (service_id, name, capacity, capacitor_id) VALUES (101, 'things', 1, 'scans-shared');
 INSERT INTO domain_services (id, domain_id, type) VALUES (101, 1, 'weird');
 INSERT INTO domain_resources (service_id, name, quota) VALUES (101, 'things', 1);
 INSERT INTO project_services (id, project_id, type) VALUES (101, 1, 'weird');

--- a/internal/collector/consistency.go
+++ b/internal/collector/consistency.go
@@ -71,7 +71,6 @@ func (c *Collector) checkConsistencyCluster(_ context.Context, _ prometheus.Labe
 		}
 	}
 
-	now := c.TimeNow()
 	//create missing service entries
 	for _, serviceType := range c.Cluster.ServiceTypesInAlphabeticalOrder() {
 		if seen[serviceType] {
@@ -79,10 +78,7 @@ func (c *Collector) checkConsistencyCluster(_ context.Context, _ prometheus.Labe
 		}
 
 		logg.Info("creating missing %s cluster service entry", serviceType)
-		err := c.DB.Insert(&db.ClusterService{
-			Type:      serviceType,
-			ScrapedAt: &now,
-		})
+		err := c.DB.Insert(&db.ClusterService{Type: serviceType})
 		if err != nil {
 			c.LogError(err.Error())
 		}

--- a/internal/collector/consistency_test.go
+++ b/internal/collector/consistency_test.go
@@ -101,11 +101,7 @@ func Test_Consistency(t *testing.T) {
 		t.Error(err)
 	}
 	//add some useless *_services entries
-	epoch := time.Unix(0, 0).UTC()
-	err = s.DB.Insert(&db.ClusterService{
-		Type:      "whatever",
-		ScrapedAt: &epoch,
-	})
+	err = s.DB.Insert(&db.ClusterService{Type: "whatever"})
 	if err != nil {
 		t.Error(err)
 	}

--- a/internal/collector/fixtures/checkconsistency0.sql
+++ b/internal/collector/fixtures/checkconsistency0.sql
@@ -1,6 +1,6 @@
-INSERT INTO cluster_services (id, type, scraped_at) VALUES (1, 'centralized', 3);
-INSERT INTO cluster_services (id, type, scraped_at) VALUES (2, 'shared', 3);
-INSERT INTO cluster_services (id, type, scraped_at) VALUES (3, 'unshared', 3);
+INSERT INTO cluster_services (id, type) VALUES (1, 'centralized');
+INSERT INTO cluster_services (id, type) VALUES (2, 'shared');
+INSERT INTO cluster_services (id, type) VALUES (3, 'unshared');
 
 INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'capacity', 0);
 INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'capacity_portion', 0);

--- a/internal/collector/fixtures/checkconsistency1.sql
+++ b/internal/collector/fixtures/checkconsistency1.sql
@@ -1,6 +1,6 @@
-INSERT INTO cluster_services (id, type, scraped_at) VALUES (1, 'centralized', 3);
-INSERT INTO cluster_services (id, type, scraped_at) VALUES (3, 'unshared', 3);
-INSERT INTO cluster_services (id, type, scraped_at) VALUES (4, 'whatever', 0);
+INSERT INTO cluster_services (id, type) VALUES (1, 'centralized');
+INSERT INTO cluster_services (id, type) VALUES (3, 'unshared');
+INSERT INTO cluster_services (id, type) VALUES (4, 'whatever');
 
 INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'capacity', 0);
 INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'capacity_portion', 0);

--- a/internal/collector/fixtures/checkconsistency2.sql
+++ b/internal/collector/fixtures/checkconsistency2.sql
@@ -1,6 +1,6 @@
-INSERT INTO cluster_services (id, type, scraped_at) VALUES (1, 'centralized', 3);
-INSERT INTO cluster_services (id, type, scraped_at) VALUES (3, 'unshared', 3);
-INSERT INTO cluster_services (id, type, scraped_at) VALUES (5, 'shared', 6);
+INSERT INTO cluster_services (id, type) VALUES (1, 'centralized');
+INSERT INTO cluster_services (id, type) VALUES (3, 'unshared');
+INSERT INTO cluster_services (id, type) VALUES (5, 'shared');
 
 INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'capacity', 0);
 INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'capacity_portion', 0);
@@ -32,9 +32,9 @@ INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
 INSERT INTO domains (id, name, uuid) VALUES (2, 'france', 'uuid-for-france');
 
 INSERT INTO project_services (id, project_id, type, next_scrape_at, rates_next_scrape_at) VALUES (1, 1, 'centralized', 0, 0);
-INSERT INTO project_services (id, project_id, type, next_scrape_at, rates_next_scrape_at) VALUES (11, 1, 'shared', 7, 7);
-INSERT INTO project_services (id, project_id, type, next_scrape_at, rates_next_scrape_at) VALUES (12, 2, 'shared', 7, 7);
-INSERT INTO project_services (id, project_id, type, next_scrape_at, rates_next_scrape_at) VALUES (13, 3, 'shared', 8, 8);
+INSERT INTO project_services (id, project_id, type, next_scrape_at, rates_next_scrape_at) VALUES (11, 1, 'shared', 5, 5);
+INSERT INTO project_services (id, project_id, type, next_scrape_at, rates_next_scrape_at) VALUES (12, 2, 'shared', 5, 5);
+INSERT INTO project_services (id, project_id, type, next_scrape_at, rates_next_scrape_at) VALUES (13, 3, 'shared', 6, 6);
 INSERT INTO project_services (id, project_id, type, next_scrape_at, rates_next_scrape_at) VALUES (3, 1, 'unshared', 0, 0);
 INSERT INTO project_services (id, project_id, type, next_scrape_at, rates_next_scrape_at) VALUES (4, 2, 'centralized', 1, 1);
 INSERT INTO project_services (id, project_id, type, next_scrape_at, rates_next_scrape_at) VALUES (6, 2, 'unshared', 1, 1);

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -161,4 +161,20 @@ var sqlMigrations = map[string]string{
 		ALTER TABLE cluster_resources
 			DROP COLUMN capacitor_id;
 	`,
+	"024_move_capacity_scrape_timestamps.up.sql": `
+		ALTER TABLE cluster_capacitors
+			ALTER COLUMN scraped_at SET DEFAULT NULL; -- null if scraping did not happen yet
+		ALTER TABLE cluster_services
+			DROP COLUMN scraped_at;
+		ALTER TABLE cluster_resources
+			ALTER COLUMN capacitor_id DROP DEFAULT;
+	`,
+	"024_move_capacity_scrape_timestamps.down.sql": `
+		ALTER TABLE cluster_capacitors
+			ALTER COLUMN scraped_at DROP DEFAULT;
+		ALTER TABLE cluster_services
+			ADD COLUMN scraped_at TIMESTAMP NOT NULL DEFAULT NOW();
+		ALTER TABLE cluster_resources
+			ALTER COLUMN capacitor_id SET DEFAULT NULL;
+	`,
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -37,19 +37,18 @@ type ClusterCapacitor struct {
 
 // ClusterService contains a record from the `cluster_services` table.
 type ClusterService struct {
-	ID        int64      `db:"id"`
-	Type      string     `db:"type"`
-	ScrapedAt *time.Time `db:"scraped_at"` //pointer type to allow for NULL value
+	ID   int64  `db:"id"`
+	Type string `db:"type"`
 }
 
 // ClusterResource contains a record from the `cluster_resources` table.
 type ClusterResource struct {
-	ServiceID         int64   `db:"service_id"`
-	Name              string  `db:"name"`
-	RawCapacity       uint64  `db:"capacity"`
-	CapacityPerAZJSON string  `db:"capacity_per_az"`
-	SubcapacitiesJSON string  `db:"subcapacities"`
-	CapacitorID       *string `db:"capacitor_id"` //can be NULL during transition period (TODO: remove after migration 24)
+	ServiceID         int64  `db:"service_id"`
+	Name              string `db:"name"`
+	RawCapacity       uint64 `db:"capacity"`
+	CapacityPerAZJSON string `db:"capacity_per_az"`
+	SubcapacitiesJSON string `db:"subcapacities"`
+	CapacitorID       string `db:"capacitor_id"`
 }
 
 // Domain contains a record from the `domains` table.


### PR DESCRIPTION
In preparation for splitting the capacity scrape job into separate tasks for each capacitor.

The changes in the API response fixtures emerge because we now only report those scrape timestamps that are actually relevant to the data displayed, instead of just all the timestamps all the time.