### PR TITLE
add full AZ awareness to plugin scraping interfaces

### DIFF
--- a/internal/collector/capacity_scrape_test.go
+++ b/internal/collector/capacity_scrape_test.go
@@ -161,7 +161,7 @@ func Test_ScanCapacity(t *testing.T) {
 		UPDATE cluster_capacitors SET scraped_at = %d, next_scrape_at = %d WHERE capacitor_id = 'unittest';
 		UPDATE cluster_capacitors SET scraped_at = %d, next_scrape_at = %d WHERE capacitor_id = 'unittest2';
 		INSERT INTO cluster_capacitors (capacitor_id, scraped_at, scrape_duration_secs, serialized_metrics, next_scrape_at) VALUES ('unittest4', %d, 5, '{"smaller_half":14,"larger_half":28}', %d);
-		INSERT INTO cluster_resources (service_id, name, capacity, subcapacities, capacitor_id) VALUES (2, 'things', 42, '[{"smaller_half":14},{"larger_half":28}]', 'unittest4');
+		INSERT INTO cluster_resources (service_id, name, capacity, subcapacities, capacitor_id) VALUES (2, 'things', 42, '[{"az":"az-one","smaller_half":7},{"az":"az-one","larger_half":14},{"az":"az-two","smaller_half":7},{"az":"az-two","larger_half":14}]', 'unittest4');
 	`,
 		scrapedAt1.Unix(), scrapedAt1.Add(15*time.Minute).Unix(),
 		scrapedAt2.Unix(), scrapedAt2.Add(15*time.Minute).Unix(),
@@ -180,7 +180,7 @@ func Test_ScanCapacity(t *testing.T) {
 		UPDATE cluster_capacitors SET scraped_at = %d, next_scrape_at = %d WHERE capacitor_id = 'unittest';
 		UPDATE cluster_capacitors SET scraped_at = %d, next_scrape_at = %d WHERE capacitor_id = 'unittest2';
 		UPDATE cluster_capacitors SET scraped_at = %d, serialized_metrics = '{"smaller_half":3,"larger_half":7}', next_scrape_at = %d WHERE capacitor_id = 'unittest4';
-		UPDATE cluster_resources SET capacity = 10, subcapacities = '[{"smaller_half":3},{"larger_half":7}]' WHERE service_id = 2 AND name = 'things';
+		UPDATE cluster_resources SET capacity = 10, subcapacities = '[{"az":"az-one","smaller_half":1},{"az":"az-one","larger_half":4},{"az":"az-two","smaller_half":1},{"az":"az-two","larger_half":4}]' WHERE service_id = 2 AND name = 'things';
 	`,
 		scrapedAt1.Unix(), scrapedAt1.Add(15*time.Minute).Unix(),
 		scrapedAt2.Unix(), scrapedAt2.Add(15*time.Minute).Unix(),

--- a/internal/collector/scrape_test.go
+++ b/internal/collector/scrape_test.go
@@ -173,7 +173,7 @@ func Test_ScrapeSuccess(t *testing.T) {
 	//change the data that is reported by the plugin
 	s.Clock.StepBy(scrapeInterval)
 	plugin.StaticResourceData["capacity"].Quota = 110
-	plugin.StaticResourceData["things"].Usage = 5
+	plugin.StaticResourceData["things"].UsageData.Regional.Usage = 5
 	//Scrape should pick up the changed resource data
 	mustT(t, job.ProcessOne(s.Ctx, withLabel))
 	mustT(t, job.ProcessOne(s.Ctx, withLabel))
@@ -269,7 +269,7 @@ func Test_ScrapeSuccess(t *testing.T) {
 	//"capacity_portion" (otherwise this resource has been all zeroes this entire
 	//time)
 	s.Clock.StepBy(scrapeInterval)
-	plugin.StaticResourceData["capacity"].Usage = 20
+	plugin.StaticResourceData["capacity"].UsageData.Regional.Usage = 20
 	mustT(t, job.ProcessOne(s.Ctx, withLabel))
 	mustT(t, job.ProcessOne(s.Ctx, withLabel))
 

--- a/internal/core/data.go
+++ b/internal/core/data.go
@@ -1,0 +1,94 @@
+/*******************************************************************************
+*
+* Copyright 2023 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package core
+
+import (
+	"slices"
+	"sort"
+)
+
+// Topological is a container for data that can either be reported for
+// the entire region at once, or separately by AZ.
+// Exactly one field shall be non-nil.
+type Topological[D TopologicalData[D]] struct {
+	Regional *D
+	PerAZ    map[string]*D
+}
+
+// Regional is a shorthand to construct a Topological instance with the Regional member filled.
+func Regional[D TopologicalData[D]](data D) Topological[D] {
+	return Topological[D]{Regional: &data}
+}
+
+// PerAZ is a shorthand to construct a Topological instance with the PerAZ member filled.
+func PerAZ[D TopologicalData[D]](data map[string]*D) Topological[D] {
+	return Topological[D]{PerAZ: data}
+}
+
+// Sum returns a sum of all data in this container.
+// If the Regional field is filled, that data is returned directly.
+// Otherwise, all entries in the PerAZ field are summed together.
+func (t Topological[D]) Sum() D {
+	if t.PerAZ == nil {
+		return *t.Regional
+	}
+
+	//fold AZ data in a well-defined order for deterministic test result
+	azNames := make([]string, 0, len(t.PerAZ))
+	for az := range t.PerAZ {
+		azNames = append(azNames, az)
+	}
+	sort.Strings(azNames)
+
+	var result D
+	for _, az := range azNames {
+		result = result.add(*t.PerAZ[az])
+	}
+	return result
+}
+
+// TopologicalData is an interfaces for types that can be put into the Topological container.
+type TopologicalData[Self any] interface {
+	// List of permitted types. This is required for type inference, as explained here:
+	// <https://stackoverflow.com/a/73851453>
+	CapacityData
+
+	// Computes the sum of this structure and `other`.
+	// This is used to implement Topological.Sum().
+	add(other Self) Self
+}
+
+// CapacityData contains capacity data for a single project resource.
+type CapacityData struct {
+	Capacity      uint64
+	Usage         uint64 //NOTE: currently only relevant on AZ level, regional level uses the aggregation of project usages
+	Subcapacities []any  //only if supported by plugin and enabled in config
+}
+
+// add implements the TopologicalData interface.
+//
+//nolint:unused // looks like a linter bug
+func (d CapacityData) add(other CapacityData) CapacityData {
+	return CapacityData{
+		Capacity:      d.Capacity + other.Capacity,
+		Usage:         d.Usage + other.Usage,
+		Subcapacities: append(slices.Clone(d.Subcapacities), other.Subcapacities...),
+	}
+}

--- a/internal/core/plugin.go
+++ b/internal/core/plugin.go
@@ -182,24 +182,6 @@ type QuotaPlugin interface {
 	CollectMetrics(ch chan<- prometheus.Metric, project KeystoneProject, serializedMetrics string) error
 }
 
-// CapacityData contains the total and per-availability-zone capacity data for a
-// single resource.
-//
-// The Subcapacities field may optionally be populated with subcapacities, if the
-// capacity plugin providing this CapacityData instance has been instructed to (and
-// is able to) scrape subcapacities for this resource.
-type CapacityData struct {
-	Capacity      uint64
-	CapacityPerAZ map[string]*CapacityDataForAZ
-	Subcapacities []any
-}
-
-// CapacityDataForAZ is the capacity data for a single resource in a single AZ.
-type CapacityDataForAZ struct {
-	Capacity uint64
-	Usage    uint64
-}
-
 // CapacityPlugin is the interface that all capacity collector plugins must
 // implement.
 //
@@ -231,7 +213,7 @@ type CapacityPlugin interface {
 	//
 	//The serializedMetrics return value is persisted in the Limes DB and
 	//supplied to all subsequent RenderMetrics calls.
-	Scrape() (result map[string]map[string]CapacityData, serializedMetrics string, err error)
+	Scrape() (result map[string]map[string]Topological[CapacityData], serializedMetrics string, err error)
 
 	//DescribeMetrics is called when Prometheus is scraping metrics from
 	//limes-collect, to provide an opportunity to the plugin to emit its own

--- a/internal/core/plugin.go
+++ b/internal/core/plugin.go
@@ -82,18 +82,6 @@ type DiscoveryPlugin interface {
 	ListProjects(domain KeystoneDomain) ([]KeystoneProject, error)
 }
 
-// ResourceData contains quota and usage data for a single resource.
-//
-// The Subresources field may optionally be populated with subresources, if the
-// quota plugin providing this ResourceData instance has been instructed to (and
-// is able to) scrape subresources for this resource.
-type ResourceData struct {
-	Quota         int64 //negative values indicate infinite quota
-	Usage         uint64
-	PhysicalUsage *uint64 //only supported by some plugins
-	Subresources  []any
-}
-
 // QuotaPlugin is the interface that the quota/usage collector plugins for all
 // backend services must implement. There can only be one QuotaPlugin for each
 // backend service.

--- a/internal/plugins/archer.go
+++ b/internal/plugins/archer.go
@@ -113,11 +113,15 @@ func (p *archerPlugin) Scrape(project core.KeystoneProject) (result map[string]c
 	result = map[string]core.ResourceData{
 		"endpoints": {
 			Quota: archerQuota.Endpoint,
-			Usage: archerQuota.InUseEndpoint,
+			UsageData: core.Regional(core.UsageData{
+				Usage: archerQuota.InUseEndpoint,
+			}),
 		},
 		"services": {
 			Quota: archerQuota.Service,
-			Usage: archerQuota.InUseService,
+			UsageData: core.Regional(core.UsageData{
+				Usage: archerQuota.InUseService,
+			}),
 		},
 	}
 	return result, "", nil

--- a/internal/plugins/capacity_manual.go
+++ b/internal/plugins/capacity_manual.go
@@ -49,16 +49,16 @@ func (p *capacityManualPlugin) PluginTypeID() string {
 var errNoManualData = errors.New(`missing values for capacitor plugin "manual"`)
 
 // Scrape implements the core.CapacityPlugin interface.
-func (p *capacityManualPlugin) Scrape() (result map[string]map[string]core.CapacityData, _ string, err error) {
+func (p *capacityManualPlugin) Scrape() (result map[string]map[string]core.Topological[core.CapacityData], _ string, err error) {
 	if p.Values == nil {
 		return nil, "", errNoManualData
 	}
 
-	result = make(map[string]map[string]core.CapacityData)
+	result = make(map[string]map[string]core.Topological[core.CapacityData])
 	for serviceType, serviceData := range p.Values {
-		serviceResult := make(map[string]core.CapacityData)
+		serviceResult := make(map[string]core.Topological[core.CapacityData])
 		for resourceName, capacity := range serviceData {
-			serviceResult[resourceName] = core.CapacityData{Capacity: capacity}
+			serviceResult[resourceName] = core.Regional(core.CapacityData{Capacity: capacity})
 		}
 		result[serviceType] = serviceResult
 	}

--- a/internal/plugins/capacity_prometheus.go
+++ b/internal/plugins/capacity_prometheus.go
@@ -47,21 +47,21 @@ func (p *capacityPrometheusPlugin) PluginTypeID() string {
 }
 
 // Scrape implements the core.CapacityPlugin interface.
-func (p *capacityPrometheusPlugin) Scrape() (result map[string]map[string]core.CapacityData, _ string, err error) {
+func (p *capacityPrometheusPlugin) Scrape() (result map[string]map[string]core.Topological[core.CapacityData], _ string, err error) {
 	client, err := p.APIConfig.Connect()
 	if err != nil {
 		return nil, "", err
 	}
 
-	result = make(map[string]map[string]core.CapacityData)
+	result = make(map[string]map[string]core.Topological[core.CapacityData])
 	for serviceType, queries := range p.Queries {
-		serviceResult := make(map[string]core.CapacityData)
+		serviceResult := make(map[string]core.Topological[core.CapacityData])
 		for resourceName, query := range queries {
 			value, err := client.GetSingleValue(query, nil)
 			if err != nil {
 				return nil, "", err
 			}
-			serviceResult[resourceName] = core.CapacityData{Capacity: uint64(value)}
+			serviceResult[resourceName] = core.Regional(core.CapacityData{Capacity: uint64(value)})
 		}
 		result[serviceType] = serviceResult
 	}

--- a/internal/plugins/cinder.go
+++ b/internal/plugins/cinder.go
@@ -118,7 +118,10 @@ func (p *cinderPlugin) makeResourceName(kind, volumeType string) string {
 	return kind + "_" + volumeType
 }
 
-type quotaSetField core.ResourceData
+type quotaSetField struct {
+	Quota int64
+	Usage uint64
+}
 
 func (f *quotaSetField) UnmarshalJSON(buf []byte) error {
 	//The `quota_set` field in the os-quota-sets response is mostly
@@ -142,9 +145,11 @@ func (f *quotaSetField) UnmarshalJSON(buf []byte) error {
 
 func (f quotaSetField) ToResourceData(subresources []any) core.ResourceData {
 	return core.ResourceData{
-		Quota:        f.Quota,
-		Usage:        f.Usage,
-		Subresources: subresources,
+		Quota: f.Quota,
+		UsageData: core.Regional(core.UsageData{
+			Usage:        f.Usage,
+			Subresources: subresources,
+		}),
 	}
 }
 

--- a/internal/plugins/designate.go
+++ b/internal/plugins/designate.go
@@ -121,11 +121,15 @@ func (p *designatePlugin) Scrape(project core.KeystoneProject) (result map[strin
 	return map[string]core.ResourceData{
 		"zones": {
 			Quota: quotas.Zones,
-			Usage: uint64(len(zoneIDs)),
+			UsageData: core.Regional(core.UsageData{
+				Usage: uint64(len(zoneIDs)),
+			}),
 		},
 		"recordsets": {
 			Quota: quotas.ZoneRecordsets,
-			Usage: maxRecordsetsPerZone,
+			UsageData: core.Regional(core.UsageData{
+				Usage: maxRecordsetsPerZone,
+			}),
 		},
 	}, "", nil
 }

--- a/internal/plugins/keppel.go
+++ b/internal/plugins/keppel.go
@@ -92,7 +92,9 @@ func (p *keppelPlugin) Scrape(project core.KeystoneProject) (result map[string]c
 	return map[string]core.ResourceData{
 		"images": {
 			Quota: quotas.Manifests.Quota,
-			Usage: quotas.Manifests.Usage,
+			UsageData: core.Regional(core.UsageData{
+				Usage: quotas.Manifests.Usage,
+			}),
 		},
 	}, "", nil
 }

--- a/internal/plugins/neutron.go
+++ b/internal/plugins/neutron.go
@@ -365,7 +365,9 @@ func (p *neutronPlugin) scrapeNeutronInto(result map[string]core.ResourceData, p
 		values := quotas.Values[res.NeutronName]
 		result[res.LimesName] = core.ResourceData{
 			Quota: values.Quota,
-			Usage: values.Usage,
+			UsageData: core.Regional(core.UsageData{
+				Usage: values.Usage,
+			}),
 		}
 	}
 	return nil
@@ -394,7 +396,9 @@ func (p *neutronPlugin) scrapeOctaviaInto(result map[string]core.ResourceData, p
 		}
 		result[res.LimesName] = core.ResourceData{
 			Quota: quota,
-			Usage: usage[res.OctaviaName],
+			UsageData: core.Regional(core.UsageData{
+				Usage: usage[res.OctaviaName],
+			}),
 		}
 	}
 	return nil

--- a/internal/plugins/nova.go
+++ b/internal/plugins/nova.go
@@ -311,23 +311,33 @@ func (p *novaPlugin) Scrape(project core.KeystoneProject) (result map[string]cor
 	resultPtr := map[string]*core.ResourceData{
 		"cores": {
 			Quota: limitsData.Limits.Absolute.MaxTotalCores,
-			Usage: limitsData.Limits.Absolute.TotalCoresUsed,
+			UsageData: core.Regional(core.UsageData{
+				Usage: limitsData.Limits.Absolute.TotalCoresUsed,
+			}),
 		},
 		"instances": {
 			Quota: limitsData.Limits.Absolute.MaxTotalInstances,
-			Usage: limitsData.Limits.Absolute.TotalInstancesUsed,
+			UsageData: core.Regional(core.UsageData{
+				Usage: limitsData.Limits.Absolute.TotalInstancesUsed,
+			}),
 		},
 		"ram": {
 			Quota: limitsData.Limits.Absolute.MaxTotalRAMSize,
-			Usage: limitsData.Limits.Absolute.TotalRAMUsed,
+			UsageData: core.Regional(core.UsageData{
+				Usage: limitsData.Limits.Absolute.TotalRAMUsed,
+			}),
 		},
 		"server_groups": {
 			Quota: limitsData.Limits.Absolute.MaxServerGroups,
-			Usage: limitsData.Limits.Absolute.TotalServerGroupsUsed,
+			UsageData: core.Regional(core.UsageData{
+				Usage: limitsData.Limits.Absolute.TotalServerGroupsUsed,
+			}),
 		},
 		"server_group_members": {
 			Quota: limitsData.Limits.Absolute.MaxServerGroupMembers,
-			Usage: totalServerGroupMembersUsed,
+			UsageData: core.Regional(core.UsageData{
+				Usage: totalServerGroupMembersUsed,
+			}),
 		},
 	}
 
@@ -337,7 +347,9 @@ func (p *novaPlugin) Scrape(project core.KeystoneProject) (result map[string]cor
 			if p.SeparateInstanceQuotas.FlavorNameRx.MatchString(flavorName) {
 				resultPtr[p.ftt.LimesResourceNameForFlavor(flavorName)] = &core.ResourceData{
 					Quota: flavorLimits.MaxTotalInstances,
-					Usage: flavorLimits.TotalInstancesUsed,
+					UsageData: core.Regional(core.UsageData{
+						Usage: flavorLimits.TotalInstancesUsed,
+					}),
 				}
 			}
 		}
@@ -350,8 +362,8 @@ func (p *novaPlugin) Scrape(project core.KeystoneProject) (result map[string]cor
 	for _, res := range p.resources {
 		if _, exists := resultPtr[res.Name]; !exists {
 			resultPtr[res.Name] = &core.ResourceData{
-				Quota: 0,
-				Usage: 0,
+				Quota:     0,
+				UsageData: core.Regional(core.UsageData{}),
 			}
 		}
 	}
@@ -432,9 +444,9 @@ func (p *novaPlugin) Scrape(project core.KeystoneProject) (result map[string]cor
 
 						//do not count baremetal instances into `{cores,instances,ram}_{bigvm,regular}`
 						if _, exists := resultPtr[p.ftt.LimesResourceNameForFlavor(flavorName)]; !exists {
-							resultPtr["cores_"+class].Usage += flavor.VCPUs
-							resultPtr["instances_"+class].Usage++
-							resultPtr["ram_"+class].Usage += flavor.MemoryMiB
+							resultPtr["cores_"+class].UsageData.Regional.Usage += flavor.VCPUs
+							resultPtr["instances_"+class].UsageData.Regional.Usage++
+							resultPtr["ram_"+class].UsageData.Regional.Usage += flavor.MemoryMiB
 						}
 					}
 				}
@@ -468,7 +480,7 @@ func (p *novaPlugin) Scrape(project core.KeystoneProject) (result map[string]cor
 				if !exists {
 					resource = resultPtr["instances"]
 				}
-				resource.Subresources = append(resource.Subresources, subResource)
+				resource.UsageData.Regional.Subresources = append(resource.UsageData.Regional.Subresources, subResource)
 			}
 			return true, nil
 		})

--- a/internal/plugins/swift.go
+++ b/internal/plugins/swift.go
@@ -129,11 +129,11 @@ func (p *swiftPlugin) Scrape(project core.KeystoneProject) (result map[string]co
 	account := p.Account(project.UUID)
 	headers, err := account.Headers()
 	if schwift.Is(err, http.StatusNotFound) || schwift.Is(err, http.StatusGone) {
-		//Swift account does not exist or was deleted and not yet reaped, but the keystone project exist
+		//Swift account does not exist or was deleted and not yet reaped, but the keystone project exists
 		return map[string]core.ResourceData{
 			"capacity": {
-				Quota: 0,
-				Usage: 0,
+				Quota:     0,
+				UsageData: core.Regional(core.UsageData{Usage: 0}),
 			},
 		}, "", nil
 	} else if err != nil {
@@ -164,8 +164,10 @@ func (p *swiftPlugin) Scrape(project core.KeystoneProject) (result map[string]co
 	}
 
 	data := core.ResourceData{
-		Usage: headers.BytesUsed().Get(),
 		Quota: int64(headers.BytesUsedQuota().Get()),
+		UsageData: core.Regional(core.UsageData{
+			Usage: headers.BytesUsed().Get(),
+		}),
 	}
 	if !headers.BytesUsedQuota().Exists() {
 		data.Quota = -1

--- a/internal/test/plugins/quota_autoapproval.go
+++ b/internal/test/plugins/quota_autoapproval.go
@@ -97,8 +97,8 @@ func (p *AutoApprovalQuotaPlugin) CollectMetrics(ch chan<- prometheus.Metric, pr
 // Scrape implements the core.QuotaPlugin interface.
 func (p *AutoApprovalQuotaPlugin) Scrape(project core.KeystoneProject) (result map[string]core.ResourceData, serializedMetrics string, err error) {
 	return map[string]core.ResourceData{
-		"approve":   {Usage: 0, Quota: int64(p.StaticBackendQuota)},
-		"noapprove": {Usage: 0, Quota: int64(p.StaticBackendQuota) + 10},
+		"approve":   {UsageData: core.Regional(core.UsageData{Usage: 0}), Quota: int64(p.StaticBackendQuota)},
+		"noapprove": {UsageData: core.Regional(core.UsageData{Usage: 0}), Quota: int64(p.StaticBackendQuota) + 10},
 	}, "", nil
 }
 


### PR DESCRIPTION
Depending on the resource, scraping can now return capacity and usage data either for the entire region, or broken down by AZs. This distinction is represented by the enum type `core.Topological`. Quota stays affixed to the regional level for now (i.e. one number that applies across all AZs), since there is no committed requirement to support AZ quota in the backend.

The frontend does not change in any way at this point. This change is specifically about enhancing the interface between Limes internals and plugins to the point that whatever changes end up being done in the frontend can be supported.

Some more details are in the commit messages.

**Update:** I have tested that the new plugin implementations yield the same results. There are some exceptions for `sharev2/share_capacity` and `compute/instances`, where, because of rounding errors, computing the total capacity from raw values (as we did before) is different from computing the capacity per AZ from raw values and then summing over all AZs. These are literal rounding errors, though.