### PR TITLE
add config options for commitment API, show CommitmentConfig in project reports

### DIFF
--- a/docs/operators/config.md
+++ b/docs/operators/config.md
@@ -143,6 +143,8 @@ Some special behaviors for resources can be configured in the `resource_behavior
 | `resource_behavior[].scales_with` | no | If a resource is given, matching resources scales with this resource. The other resource may be specified by its name (for resources within the same service type), or by a slash-concatenated pair of service type and resource name, e.g. `compute/cores`. |
 | `resource_behavior[].scaling_factor` | yes, if `scales_with` is given | The scaling factor that will be reported for these resources' scaling relation. |
 | `resource_behavior[].min_nonzero_project_quota` | no | A lower boundary for project quota values that are not zero. |
+| `resource_behavior[].commitment_durations` | no | If given, commitments for this resource can be created with any of the given durations. The duration format is the same as in the `commitments[].duration` attribute that appears on the resource API. |
+| `resource_behavior[].commitment_min_confirm_date` | no | If given, commitments for this resource will always be created with `confirm_after` no earlier than this timestamp. This can be used to plan the introduction of commitments on a specific date. |
 | `resource_behavior[].annotations` | no | A map of extra key-value pairs that will be inserted into matching resources as-is in responses to GET requests, e.g. at `project.services[].resources[].annotations`. |
 
 For example:
@@ -159,6 +161,8 @@ resource_behavior:
   - { resource: .*, scope: foo/.*, max_burst_multiplier: 0 }
   # require each project to take at least 100 GB of object storage if they use it at all
   - { resource: object-store/capacity, min_nonzero_project_quota: 107374182400 }
+  # starting in 2024, offer commitments for Cinder storage
+  - { resource: volumev2/capacity, commitment_durations: [ 1 year, 2 years, 3 years ], commitment_min_confirm_date: 2024-01-01T00:00:00Z }
 ```
 
 ### Quota distribution models

--- a/docs/users/api-spec-resources.md
+++ b/docs/users/api-spec-resources.md
@@ -553,6 +553,8 @@ The objects at `projects[].services[].resources[]` may contain the following fie
 | `category` | string | The category of this resource (only shown when there is one). |
 | `contained_in` | string | The name of another resource (if any) within the same service that this resource is [contained in](#contained-resources). |
 | `quota_distribution_model` | string | The resource's [quota distribution model](#quota-distribution-model). Possible values are "hierarchical" and "centralized". |
+| `commitment_config` | object | Only present if commitments can be created for this resource. |
+| `commitment_config.durations` | list of strings | Acceptable durations for commitments on this resource, each expressed as a comma-separated sequence of positive integer multiples of time units like "1 year, 3 months". Acceptable time units include "second", "minute", "hour", "day", "month" and "year". |
 | `scales_with` | object | Only present when this resource is [scaling with](#scaling-relations) another resource. |
 | `scales_with.resource_name` | string | The name of the resource that this resource is scaling with. |
 | `scales_with.service_type` | string | The type name of the service containing the resource that this resource is scaling with. |

--- a/internal/reports/project.go
+++ b/internal/reports/project.go
@@ -179,6 +179,7 @@ func GetProjectResources(cluster *core.Cluster, domain db.Domain, project *db.Pr
 		if !resReport.NoQuota {
 			qdConfig := cluster.QuotaDistributionConfigForResource(*serviceType, *resourceName)
 			resReport.QuotaDistributionModel = qdConfig.Model
+			resReport.CommitmentConfig = behavior.ToCommitmentConfig()
 			if quota != nil {
 				resReport.Quota = quota
 				resReport.UsableQuota = quota


### PR DESCRIPTION
This is the very first piece of the commitments API. More stuff is ongoing in the `commitments` branch, but I will be splitting off small pieces like this to progressively unblock UI development.