### PR TITLE
add ID columns to *_resources tables

### DIFF
--- a/internal/api/fixtures/start-data-commitments.sql
+++ b/internal/api/fixtures/start-data-commitments.sql
@@ -32,25 +32,25 @@ INSERT INTO project_services (id, project_id, type, scraped_at, checked_at) VALU
 
 -- project_resources contains only boring placeholder values
 -- berlin
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (1, 'things',   10, 2, 10, 10);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (1, 'capacity', 10, 2, 10, 10);
-INSERT INTO project_resources (service_id, name, usage) VALUES (1, 'capacity_portion', 1);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (2, 'things',   10, 2, 10, 10);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (2, 'capacity', 10, 2, 10, 10);
-INSERT INTO project_resources (service_id, name, usage) VALUES (2, 'capacity_portion', 1);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (1,  1, 'things',   10, 2, 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (2,  1, 'capacity', 10, 2, 10, 10);
+INSERT INTO project_resources (id, service_id, name, usage) VALUES (3,  1, 'capacity_portion', 1);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (4,  2, 'things',   10, 2, 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (5,  2, 'capacity', 10, 2, 10, 10);
+INSERT INTO project_resources (id, service_id, name, usage) VALUES (6,  2, 'capacity_portion', 1);
 -- dresden
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (3, 'things',   10, 2, 10, 10);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (3, 'capacity', 10, 2, 10, 10);
-INSERT INTO project_resources (service_id, name, usage) VALUES (3, 'capacity_portion', 1);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (4, 'things',   10, 2, 10, 10);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (4, 'capacity', 10, 2, 10, 10);
-INSERT INTO project_resources (service_id, name, usage) VALUES (4, 'capacity_portion', 1);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (7,  3, 'things',   10, 2, 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (8,  3, 'capacity', 10, 2, 10, 10);
+INSERT INTO project_resources (id, service_id, name, usage) VALUES (9,  3, 'capacity_portion', 1);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (10, 4, 'things',   10, 2, 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (11, 4, 'capacity', 10, 2, 10, 10);
+INSERT INTO project_resources (id, service_id, name, usage) VALUES (12, 4, 'capacity_portion', 1);
 -- paris
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (5, 'things',   10, 2, 10, 10);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (5, 'capacity', 10, 2, 10, 10);
-INSERT INTO project_resources (service_id, name, usage) VALUES (5, 'capacity_portion', 1);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (6, 'things',   10, 2, 10, 10);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (6, 'capacity', 10, 2, 10, 10);
-INSERT INTO project_resources (service_id, name, usage) VALUES (6, 'capacity_portion', 1);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (13, 5, 'things',   10, 2, 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (14, 5, 'capacity', 10, 2, 10, 10);
+INSERT INTO project_resources (id, service_id, name, usage) VALUES (15, 5, 'capacity_portion', 1);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (16, 6, 'things',   10, 2, 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (17, 6, 'capacity', 10, 2, 10, 10);
+INSERT INTO project_resources (id, service_id, name, usage) VALUES (18, 6, 'capacity_portion', 1);
 
 -- project_rates is empty: no rates configured

--- a/internal/api/fixtures/start-data-inconsistencies.sql
+++ b/internal/api/fixtures/start-data-inconsistencies.sql
@@ -10,11 +10,11 @@ INSERT INTO domain_services (id, domain_id, type) VALUES (3, 2, 'compute');
 INSERT INTO domain_services (id, domain_id, type) VALUES (4, 2, 'network');
 
 -- domain_resources has a hole where no domain quota (pakistan: loadbalancers) has been set yet
-INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'cores',         100);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'ram',           1000);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (2, 'loadbalancers', 20);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (3, 'cores',         30);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (3, 'ram',           250);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (1, 1, 'cores',         100);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (2, 1, 'ram',           1000);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (3, 2, 'loadbalancers', 20);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (4, 3, 'cores',         30);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (5, 3, 'ram',           250);
 
 -- "germany" has one project, and "pakistan" has two (lahore is a child project of karachi in order to check
 -- correct rendering of the parent_uuid field)
@@ -31,12 +31,12 @@ INSERT INTO project_services (id, project_id, type, scraped_at, checked_at) VALU
 INSERT INTO project_services (id, project_id, type, scraped_at, checked_at) VALUES (6, 3, 'network', '2018-06-13 15:06:37', '2018-06-13 15:06:37');
 
 -- project_resources contains some pathological cases
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'cores',         30,  14, 10,  '', 30, NULL);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'ram',           100, 88, 100, '', 100, 92);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'loadbalancers', 10,  5,  10,  '', 10, NULL);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (3, 'cores',         14,  18, 14,  '', 14, NULL);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (3, 'ram',           60,  45, 60,  '', 60, 40);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (4, 'loadbalancers', 5,   2,  5,   '', 5, NULL);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (5, 'cores',         30,  20,  30,  '', 30, NULL);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (5, 'ram',           62,  48, 62,  '', 62, 43);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (6, 'loadbalancers', 10,  4,  10,  '', 10, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 1, 'cores',         30,  14, 10,  '', 30, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 1, 'ram',           100, 88, 100, '', 100, 92);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (3, 2, 'loadbalancers', 10,  5,  10,  '', 10, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (4, 3, 'cores',         14,  18, 14,  '', 14, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (5, 3, 'ram',           60,  45, 60,  '', 60, 40);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (6, 4, 'loadbalancers', 5,   2,  5,   '', 5, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (7, 5, 'cores',         30,  20,  30,  '', 30, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (8, 5, 'ram',           62,  48, 62,  '', 62, 43);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (9, 6, 'loadbalancers', 10,  4,  10,  '', 10, NULL);

--- a/internal/api/fixtures/start-data.sql
+++ b/internal/api/fixtures/start-data.sql
@@ -9,9 +9,9 @@ INSERT INTO cluster_services (id, type) VALUES (1, 'unshared');
 INSERT INTO cluster_services (id, type) VALUES (2, 'shared');
 
 -- all services have the resources "things" and "capacity"
-INSERT INTO cluster_resources (service_id, name, capacity, subcapacities, capacity_per_az, capacitor_id) VALUES (1, 'things', 139, '[{"smaller_half":46},{"larger_half":93}]', '[{"name":"az-one","capacity":69,"usage":13},{"name":"az-two","capacity":69,"usage":13}]', 'scans-unshared');
-INSERT INTO cluster_resources (service_id, name, capacity, subcapacities, capacity_per_az, capacitor_id) VALUES (2, 'things', 246, '[{"smaller_half":82},{"larger_half":164}]', '', 'scans-shared');
-INSERT INTO cluster_resources (service_id, name, capacity, subcapacities, capacity_per_az, capacitor_id) VALUES (2, 'capacity', 185, '', '', 'scans-shared');
+INSERT INTO cluster_resources (id, service_id, name, capacity, subcapacities, capacity_per_az, capacitor_id) VALUES (1, 1, 'things', 139, '[{"smaller_half":46},{"larger_half":93}]', '[{"name":"az-one","capacity":69,"usage":13},{"name":"az-two","capacity":69,"usage":13}]', 'scans-unshared');
+INSERT INTO cluster_resources (id, service_id, name, capacity, subcapacities, capacity_per_az, capacitor_id) VALUES (2, 2, 'things', 246, '[{"smaller_half":82},{"larger_half":164}]', '', 'scans-shared');
+INSERT INTO cluster_resources (id, service_id, name, capacity, subcapacities, capacity_per_az, capacitor_id) VALUES (3, 2, 'capacity', 185, '', '', 'scans-shared');
 
 -- two domains
 INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
@@ -24,12 +24,12 @@ INSERT INTO domain_services (id, domain_id, type) VALUES (3, 2, 'unshared');
 INSERT INTO domain_services (id, domain_id, type) VALUES (4, 2, 'shared');
 
 -- domain_resources has some holes where no domain quotas have been set yet (and we don't have anything for "capacity_portion" since it's NoQuota)
-INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'things',   50);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'capacity', 45);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (2, 'things',   30);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (2, 'capacity', 25);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (3, 'things',   20);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (3, 'capacity', 55);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (1, 1, 'things',   50);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (2, 1, 'capacity', 45);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (3, 2, 'things',   30);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (4, 2, 'capacity', 25);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (5, 3, 'things',   20);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (6, 3, 'capacity', 55);
 
 -- "germany" has two projects, the other domains have one each (Dresden is a child project of Berlin in order to check
 -- correct rendering of the parent_uuid field)
@@ -47,26 +47,26 @@ INSERT INTO project_services (id, project_id, type, scraped_at, rates_scraped_at
 
 -- project_resources contains some pathological cases
 -- berlin (also used for test cases concerning subresources)
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'things',   10, 2, 10, '[{"id":"firstthing","value":23},{"id":"secondthing","value":42}]', 10, NULL);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'capacity', 10, 2, 10, '', 10, NULL);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'capacity_portion', NULL, 1, NULL, '', NULL, NULL);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'things',   10, 2, 10, '[{"id":"thirdthing","value":5},{"id":"fourththing","value":123}]', 10, NULL);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'capacity', 10, 2, 10, '', 10, NULL);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 'capacity_portion', NULL, 1, NULL, '', NULL, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1,  1, 'things',   10, 2, 10, '[{"id":"firstthing","value":23},{"id":"secondthing","value":42}]', 10, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2,  1, 'capacity', 10, 2, 10, '', 10, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (3,  1, 'capacity_portion', NULL, 1, NULL, '', NULL, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (4,  2, 'things',   10, 2, 10, '[{"id":"thirdthing","value":5},{"id":"fourththing","value":123}]', 10, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (5,  2, 'capacity', 10, 2, 10, '', 10, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (6,  2, 'capacity_portion', NULL, 1, NULL, '', NULL, NULL);
 -- dresden (backend quota for shared/capacity mismatches approved quota and exceeds domain quota)
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (3, 'things',   10, 2, 10, '', 10, NULL);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (3, 'capacity', 10, 2, 10, '', 10, NULL);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (3, 'capacity_portion', NULL, 1, NULL, '', NULL, NULL);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (4, 'things',   10, 2, 10, '', 10, NULL);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (4, 'capacity', 10, 2, 100, '', 10, NULL);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (4, 'capacity_portion', NULL, 1, NULL, '', NULL, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (7,  3, 'things',   10, 2, 10, '', 10, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (8,  3, 'capacity', 10, 2, 10, '', 10, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (9,  3, 'capacity_portion', NULL, 1, NULL, '', NULL, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (10, 4, 'things',   10, 2, 10, '', 10, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (11, 4, 'capacity', 10, 2, 100, '', 10, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (12, 4, 'capacity_portion', NULL, 1, NULL, '', NULL, NULL);
 -- paris (infinite backend quota for unshared/things; non-null physical_usage for */capacity, all other project resources should report physical_usage = usage in aggregations)
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (5, 'things',   10, 2, -1, '', 10, NULL);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (5, 'capacity', 10, 2, 10, '', 10, 1);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (5, 'capacity_portion', NULL, 1, NULL, '', NULL, NULL);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (6, 'things',   10, 2, 10, '', 10, NULL);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (6, 'capacity', 10, 2, 10, '', 10, 1);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (6, 'capacity_portion', NULL, 1, NULL, '', NULL, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (13, 5, 'things',   10, 2, -1, '', 10, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (14, 5, 'capacity', 10, 2, 10, '', 10, 1);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (15, 5, 'capacity_portion', NULL, 1, NULL, '', NULL, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (16, 6, 'things',   10, 2, 10, '', 10, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (17, 6, 'capacity', 10, 2, 10, '', 10, 1);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (18, 6, 'capacity_portion', NULL, 1, NULL, '', NULL, NULL);
 
 -- project_rates also has multiple different setups to test different cases
 -- berlin has custom rate limits
@@ -86,15 +86,15 @@ INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_big
 -- insert some bullshit data that should be filtered out by the internal/reports/ logic
 -- (cluster "north", service "weird", resource "items" and rate "frobnicate" are not configured)
 INSERT INTO cluster_services (id, type) VALUES (101, 'weird');
-INSERT INTO cluster_resources (service_id, name, capacity, capacitor_id) VALUES (101, 'things', 1, 'scans-shared');
+INSERT INTO cluster_resources (id, service_id, name, capacity, capacitor_id) VALUES (101, 101, 'things', 1, 'scans-shared');
 INSERT INTO domain_services (id, domain_id, type) VALUES (101, 1, 'weird');
-INSERT INTO domain_resources (service_id, name, quota) VALUES (101, 'things', 1);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (101, 101, 'things', 1);
 INSERT INTO project_services (id, project_id, type) VALUES (101, 1, 'weird');
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (101, 'things', 2, 1, 2, '', 2, 1);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (101, 101, 'things', 2, 1, 2, '', 2, 1);
 
-INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'items', 1);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'items', 2, 1, 2, '', 2, 1);
-INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 'items_portion', NULL, 1, NULL, '', NULL, NULL);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (102, 1, 'items', 1);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (102, 1, 'items', 2, 1, 2, '', 2, 1);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (103, 1, 'items_portion', NULL, 1, NULL, '', NULL, NULL);
 
 INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_bigint) VALUES (1, 'service/unshared/instances:frobnicate', 5, 1000000000, '');
 INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_bigint) VALUES (2, 'service/shared/objects:frobnicate', 5, 1000000000, '');

--- a/internal/collector/consistency_test.go
+++ b/internal/collector/consistency_test.go
@@ -116,11 +116,7 @@ func Test_Consistency(t *testing.T) {
 
 	//add a domain_resource that contradicts the cluster.QuotaConstraints; this
 	//should be fixed by CheckConsistency()
-	_, err = s.DB.Update(&db.DomainResource{
-		ServiceID: 1,
-		Name:      "capacity",
-		Quota:     200,
-	})
+	_, err = s.DB.Exec(`UPDATE domain_resources SET quota = 200 WHERE service_id = $1 AND name = $2`, 1, "capacity")
 	if err != nil {
 		t.Error(err)
 	}

--- a/internal/collector/fixtures/checkconsistency-pre.sql
+++ b/internal/collector/fixtures/checkconsistency-pre.sql
@@ -1,15 +1,15 @@
-INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'capacity', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'capacity_portion', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'things', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (2, 'capacity', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (2, 'capacity_portion', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (2, 'things', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (3, 'capacity', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (3, 'capacity_portion', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (3, 'things', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (4, 'capacity', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (4, 'capacity_portion', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (4, 'things', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (1, 1, 'capacity', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (10, 4, 'capacity', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (11, 4, 'capacity_portion', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (12, 4, 'things', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (2, 1, 'capacity_portion', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (3, 1, 'things', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (4, 2, 'capacity', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (5, 2, 'capacity_portion', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (6, 2, 'things', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (7, 3, 'capacity', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (8, 3, 'capacity_portion', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (9, 3, 'things', 0);
 
 INSERT INTO domain_services (id, domain_id, type) VALUES (1, 1, 'shared');
 INSERT INTO domain_services (id, domain_id, type) VALUES (2, 1, 'unshared');

--- a/internal/collector/fixtures/checkconsistency0.sql
+++ b/internal/collector/fixtures/checkconsistency0.sql
@@ -1,18 +1,18 @@
 INSERT INTO cluster_services (id, type) VALUES (1, 'shared');
 INSERT INTO cluster_services (id, type) VALUES (2, 'unshared');
 
-INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'capacity', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'capacity_portion', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'things', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (2, 'capacity', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (2, 'capacity_portion', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (2, 'things', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (3, 'capacity', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (3, 'capacity_portion', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (3, 'things', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (4, 'capacity', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (4, 'capacity_portion', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (4, 'things', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (1, 1, 'capacity', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (10, 4, 'capacity', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (11, 4, 'capacity_portion', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (12, 4, 'things', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (2, 1, 'capacity_portion', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (3, 1, 'things', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (4, 2, 'capacity', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (5, 2, 'capacity_portion', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (6, 2, 'things', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (7, 3, 'capacity', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (8, 3, 'capacity_portion', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (9, 3, 'things', 0);
 
 INSERT INTO domain_services (id, domain_id, type) VALUES (1, 1, 'shared');
 INSERT INTO domain_services (id, domain_id, type) VALUES (2, 1, 'unshared');

--- a/internal/collector/fixtures/checkconsistency1.sql
+++ b/internal/collector/fixtures/checkconsistency1.sql
@@ -1,12 +1,12 @@
 INSERT INTO cluster_services (id, type) VALUES (2, 'unshared');
 INSERT INTO cluster_services (id, type) VALUES (3, 'whatever');
 
-INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'capacity', 200);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'capacity_portion', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'things', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (3, 'capacity', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (3, 'capacity_portion', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (3, 'things', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (1, 1, 'capacity', 200);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (2, 1, 'capacity_portion', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (3, 1, 'things', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (7, 3, 'capacity', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (8, 3, 'capacity_portion', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (9, 3, 'things', 0);
 
 INSERT INTO domain_services (id, domain_id, type) VALUES (1, 1, 'shared');
 INSERT INTO domain_services (id, domain_id, type) VALUES (3, 2, 'shared');

--- a/internal/collector/fixtures/checkconsistency2.sql
+++ b/internal/collector/fixtures/checkconsistency2.sql
@@ -1,18 +1,18 @@
 INSERT INTO cluster_services (id, type) VALUES (2, 'unshared');
 INSERT INTO cluster_services (id, type) VALUES (4, 'shared');
 
-INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'capacity', 100);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'capacity_portion', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'things', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (3, 'capacity', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (3, 'capacity_portion', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (3, 'things', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (6, 'capacity', 10);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (6, 'capacity_portion', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (6, 'things', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (7, 'capacity', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (7, 'capacity_portion', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (7, 'things', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (1, 1, 'capacity', 100);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (13, 6, 'capacity', 10);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (14, 6, 'capacity_portion', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (15, 6, 'things', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (16, 7, 'capacity', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (17, 7, 'capacity_portion', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (18, 7, 'things', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (2, 1, 'capacity_portion', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (3, 1, 'things', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (7, 3, 'capacity', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (8, 3, 'capacity_portion', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (9, 3, 'things', 0);
 
 INSERT INTO domain_services (id, domain_id, type) VALUES (1, 1, 'shared');
 INSERT INTO domain_services (id, domain_id, type) VALUES (3, 2, 'shared');

--- a/internal/collector/fixtures/scandomains1.sql
+++ b/internal/collector/fixtures/scandomains1.sql
@@ -1,15 +1,15 @@
-INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'capacity', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'capacity_portion', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'things', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (2, 'capacity', 20);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (2, 'capacity_portion', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (2, 'things', 10);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (3, 'capacity', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (3, 'capacity_portion', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (3, 'things', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (4, 'capacity', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (4, 'capacity_portion', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (4, 'things', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (1, 1, 'capacity', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (10, 4, 'capacity', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (11, 4, 'capacity_portion', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (12, 4, 'things', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (2, 1, 'capacity_portion', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (3, 1, 'things', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (4, 2, 'capacity', 20);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (5, 2, 'capacity_portion', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (6, 2, 'things', 10);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (7, 3, 'capacity', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (8, 3, 'capacity_portion', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (9, 3, 'things', 0);
 
 INSERT INTO domain_services (id, domain_id, type) VALUES (1, 1, 'shared');
 INSERT INTO domain_services (id, domain_id, type) VALUES (2, 1, 'unshared');

--- a/internal/collector/fixtures/scrape0.sql
+++ b/internal/collector/fixtures/scrape0.sql
@@ -1,6 +1,6 @@
-INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'capacity', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'capacity_portion', 0);
-INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'things', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (1, 1, 'capacity', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (2, 1, 'capacity_portion', 0);
+INSERT INTO domain_resources (id, service_id, name, quota) VALUES (3, 1, 'things', 0);
 
 INSERT INTO domain_services (id, domain_id, type) VALUES (1, 1, 'unittest');
 

--- a/internal/collector/keystone_test.go
+++ b/internal/collector/keystone_test.go
@@ -168,12 +168,12 @@ func Test_ScanDomains(t *testing.T) {
 	}
 	assert.DeepEqual(t, "new domains after ScanDomains #7", actualNewDomains, []string(nil))
 	tr.DBChanges().AssertEqualf(`
-		DELETE FROM domain_resources WHERE service_id = 3 AND name = 'capacity';
-		DELETE FROM domain_resources WHERE service_id = 3 AND name = 'capacity_portion';
-		DELETE FROM domain_resources WHERE service_id = 3 AND name = 'things';
-		DELETE FROM domain_resources WHERE service_id = 4 AND name = 'capacity';
-		DELETE FROM domain_resources WHERE service_id = 4 AND name = 'capacity_portion';
-		DELETE FROM domain_resources WHERE service_id = 4 AND name = 'things';
+		DELETE FROM domain_resources WHERE id = 10 AND service_id = 4 AND name = 'capacity';
+		DELETE FROM domain_resources WHERE id = 11 AND service_id = 4 AND name = 'capacity_portion';
+		DELETE FROM domain_resources WHERE id = 12 AND service_id = 4 AND name = 'things';
+		DELETE FROM domain_resources WHERE id = 7 AND service_id = 3 AND name = 'capacity';
+		DELETE FROM domain_resources WHERE id = 8 AND service_id = 3 AND name = 'capacity_portion';
+		DELETE FROM domain_resources WHERE id = 9 AND service_id = 3 AND name = 'things';
 		DELETE FROM domain_services WHERE id = 3 AND domain_id = 2 AND type = 'shared';
 		DELETE FROM domain_services WHERE id = 4 AND domain_id = 2 AND type = 'unshared';
 		DELETE FROM domains WHERE id = 2 AND uuid = 'uuid-for-france';

--- a/internal/collector/ratescrape_test.go
+++ b/internal/collector/ratescrape_test.go
@@ -98,9 +98,9 @@ func Test_RateScrapeSuccess(t *testing.T) {
 	//we set up our initial rates correctly
 	tr, tr0 := easypg.NewTracker(t, s.DB.Db)
 	tr0.AssertEqualf(`
-		INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'capacity', 0);
-		INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'capacity_portion', 0);
-		INSERT INTO domain_resources (service_id, name, quota) VALUES (1, 'things', 0);
+		INSERT INTO domain_resources (id, service_id, name, quota) VALUES (1, 1, 'capacity', 0);
+		INSERT INTO domain_resources (id, service_id, name, quota) VALUES (2, 1, 'capacity_portion', 0);
+		INSERT INTO domain_resources (id, service_id, name, quota) VALUES (3, 1, 'things', 0);
 		INSERT INTO domain_services (id, domain_id, type) VALUES (1, 1, 'unittest');
 		INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
 		INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_bigint) VALUES (1, 'otherrate', 42, 120000000000, '');

--- a/internal/collector/scrape_test.go
+++ b/internal/collector/scrape_test.go
@@ -153,12 +153,12 @@ func Test_ScrapeSuccess(t *testing.T) {
 	scrapedAt1 := s.Clock.Now().Add(-5 * time.Second)
 	scrapedAt2 := s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`
-		INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, desired_backend_quota, physical_usage) VALUES (1, 'capacity', 10, 0, 100, 10, 0);
-		INSERT INTO project_resources (service_id, name, usage) VALUES (1, 'capacity_portion', 0);
-		INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (1, 'things', 0, 2, 42, '[{"index":0},{"index":1}]', 0);
-		INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, desired_backend_quota, physical_usage) VALUES (2, 'capacity', 10, 0, 100, 12, 0);
-		INSERT INTO project_resources (service_id, name, usage) VALUES (2, 'capacity_portion', 0);
-		INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (2, 'things', 0, 2, 42, '[{"index":0},{"index":1}]', 0);
+		INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota, physical_usage) VALUES (1, 1, 'capacity', 10, 0, 100, 10, 0);
+		INSERT INTO project_resources (id, service_id, name, usage) VALUES (2, 1, 'capacity_portion', 0);
+		INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (3, 1, 'things', 0, 2, 42, '[{"index":0},{"index":1}]', 0);
+		INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota, physical_usage) VALUES (4, 2, 'capacity', 10, 0, 100, 12, 0);
+		INSERT INTO project_resources (id, service_id, name, usage) VALUES (5, 2, 'capacity_portion', 0);
+		INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (6, 2, 'things', 0, 2, 42, '[{"index":0},{"index":1}]', 0);
 		UPDATE project_services SET scraped_at = %[1]d, scrape_duration_secs = 5, serialized_metrics = '{"capacity_usage":0,"things_usage":2}', checked_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND type = 'unittest';
 		UPDATE project_services SET scraped_at = %[3]d, scrape_duration_secs = 5, serialized_metrics = '{"capacity_usage":0,"things_usage":2}', checked_at = %[3]d, next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND type = 'unittest';
 	`,
@@ -182,10 +182,10 @@ func Test_ScrapeSuccess(t *testing.T) {
 	scrapedAt1 = s.Clock.Now().Add(-5 * time.Second)
 	scrapedAt2 = s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`
-		UPDATE project_resources SET backend_quota = 110 WHERE service_id = 1 AND name = 'capacity';
-		UPDATE project_resources SET usage = 5, subresources = '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]' WHERE service_id = 1 AND name = 'things';
-		UPDATE project_resources SET backend_quota = 110 WHERE service_id = 2 AND name = 'capacity';
-		UPDATE project_resources SET usage = 5, subresources = '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]' WHERE service_id = 2 AND name = 'things';
+		UPDATE project_resources SET backend_quota = 110 WHERE id = 1 AND service_id = 1 AND name = 'capacity';
+		UPDATE project_resources SET usage = 5, subresources = '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]' WHERE id = 3 AND service_id = 1 AND name = 'things';
+		UPDATE project_resources SET backend_quota = 110 WHERE id = 4 AND service_id = 2 AND name = 'capacity';
+		UPDATE project_resources SET usage = 5, subresources = '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]' WHERE id = 6 AND service_id = 2 AND name = 'things';
 		UPDATE project_services SET scraped_at = %[1]d, serialized_metrics = '{"capacity_usage":0,"things_usage":5}', checked_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND type = 'unittest';
 		UPDATE project_services SET scraped_at = %[3]d, serialized_metrics = '{"capacity_usage":0,"things_usage":5}', checked_at = %[3]d, next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND type = 'unittest';
 	`,
@@ -214,10 +214,10 @@ func Test_ScrapeSuccess(t *testing.T) {
 	scrapedAt1 = s.Clock.Now().Add(-5 * time.Second)
 	scrapedAt2 = s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`
-		UPDATE project_resources SET quota = 20, backend_quota = 20, desired_backend_quota = 20 WHERE service_id = 1 AND name = 'capacity';
-		UPDATE project_resources SET quota = 13, backend_quota = 13, desired_backend_quota = 13 WHERE service_id = 1 AND name = 'things';
-		UPDATE project_resources SET quota = 20, backend_quota = 24, desired_backend_quota = 24 WHERE service_id = 2 AND name = 'capacity';
-		UPDATE project_resources SET quota = 13, backend_quota = 15, desired_backend_quota = 15 WHERE service_id = 2 AND name = 'things';
+		UPDATE project_resources SET quota = 20, backend_quota = 20, desired_backend_quota = 20 WHERE id = 1 AND service_id = 1 AND name = 'capacity';
+		UPDATE project_resources SET quota = 13, backend_quota = 13, desired_backend_quota = 13 WHERE id = 3 AND service_id = 1 AND name = 'things';
+		UPDATE project_resources SET quota = 20, backend_quota = 24, desired_backend_quota = 24 WHERE id = 4 AND service_id = 2 AND name = 'capacity';
+		UPDATE project_resources SET quota = 13, backend_quota = 15, desired_backend_quota = 15 WHERE id = 6 AND service_id = 2 AND name = 'things';
 		UPDATE project_services SET scraped_at = %[1]d, checked_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND type = 'unittest';
 		UPDATE project_services SET scraped_at = %[3]d, checked_at = %[3]d, next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND type = 'unittest';
 	`,
@@ -257,8 +257,8 @@ func Test_ScrapeSuccess(t *testing.T) {
 	scrapedAt1 = s.Clock.Now().Add(-5 * time.Second)
 	scrapedAt2 = s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`
-		UPDATE project_resources SET quota = 40, backend_quota = 40, desired_backend_quota = 40 WHERE service_id = 1 AND name = 'capacity';
-		UPDATE project_resources SET quota = 40, backend_quota = 48, desired_backend_quota = 48 WHERE service_id = 2 AND name = 'capacity';
+		UPDATE project_resources SET quota = 40, backend_quota = 40, desired_backend_quota = 40 WHERE id = 1 AND service_id = 1 AND name = 'capacity';
+		UPDATE project_resources SET quota = 40, backend_quota = 48, desired_backend_quota = 48 WHERE id = 4 AND service_id = 2 AND name = 'capacity';
 		UPDATE project_services SET scraped_at = %[1]d, checked_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND type = 'unittest';
 		UPDATE project_services SET scraped_at = %[3]d, checked_at = %[3]d, next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND type = 'unittest';
 	`,
@@ -277,10 +277,10 @@ func Test_ScrapeSuccess(t *testing.T) {
 	scrapedAt1 = s.Clock.Now().Add(-5 * time.Second)
 	scrapedAt2 = s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`
-		UPDATE project_resources SET usage = 20, physical_usage = 10 WHERE service_id = 1 AND name = 'capacity';
-		UPDATE project_resources SET usage = 5 WHERE service_id = 1 AND name = 'capacity_portion';
-		UPDATE project_resources SET usage = 20, physical_usage = 10 WHERE service_id = 2 AND name = 'capacity';
-		UPDATE project_resources SET usage = 5 WHERE service_id = 2 AND name = 'capacity_portion';
+		UPDATE project_resources SET usage = 20, physical_usage = 10 WHERE id = 1 AND service_id = 1 AND name = 'capacity';
+		UPDATE project_resources SET usage = 5 WHERE id = 2 AND service_id = 1 AND name = 'capacity_portion';
+		UPDATE project_resources SET usage = 20, physical_usage = 10 WHERE id = 4 AND service_id = 2 AND name = 'capacity';
+		UPDATE project_resources SET usage = 5 WHERE id = 5 AND service_id = 2 AND name = 'capacity_portion';
 		UPDATE project_services SET scraped_at = %[1]d, serialized_metrics = '{"capacity_usage":20,"things_usage":5}', checked_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND type = 'unittest';
 		UPDATE project_services SET scraped_at = %[3]d, serialized_metrics = '{"capacity_usage":20,"things_usage":5}', checked_at = %[3]d, next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND type = 'unittest';
 	`,
@@ -368,12 +368,12 @@ func Test_ScrapeFailure(t *testing.T) {
 	checkedAt1 := s.Clock.Now().Add(-5 * time.Second)
 	checkedAt2 := s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`
-		INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (1, 'capacity', 10, 0, -1, 10);
-		INSERT INTO project_resources (service_id, name, usage) VALUES (1, 'capacity_portion', 0);
-		INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (1, 'things', 0, 0, -1, 0);
-		INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (2, 'capacity', 10, 0, -1, 12);
-		INSERT INTO project_resources (service_id, name, usage) VALUES (2, 'capacity_portion', 0);
-		INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (2, 'things', 0, 0, -1, 0);
+		INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (1, 1, 'capacity', 10, 0, -1, 10);
+		INSERT INTO project_resources (id, service_id, name, usage) VALUES (2, 1, 'capacity_portion', 0);
+		INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (3, 1, 'things', 0, 0, -1, 0);
+		INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (4, 2, 'capacity', 10, 0, -1, 12);
+		INSERT INTO project_resources (id, service_id, name, usage) VALUES (5, 2, 'capacity_portion', 0);
+		INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (6, 2, 'things', 0, 0, -1, 0);
 		UPDATE project_services SET scraped_at = 0, checked_at = %[1]d, scrape_error_message = 'Scrape failed as requested', next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND type = 'unittest';
 		UPDATE project_services SET scraped_at = 0, checked_at = %[3]d, scrape_error_message = 'Scrape failed as requested', next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND type = 'unittest';
 	`,
@@ -405,10 +405,10 @@ func Test_ScrapeFailure(t *testing.T) {
 	scrapedAt1 := s.Clock.Now().Add(-5 * time.Second)
 	scrapedAt2 := s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`
-		UPDATE project_resources SET backend_quota = 100, physical_usage = 0 WHERE service_id = 1 AND name = 'capacity';
-		UPDATE project_resources SET usage = 2, backend_quota = 42, subresources = '[{"index":0},{"index":1}]' WHERE service_id = 1 AND name = 'things';
-		UPDATE project_resources SET backend_quota = 100, physical_usage = 0 WHERE service_id = 2 AND name = 'capacity';
-		UPDATE project_resources SET usage = 2, backend_quota = 42, subresources = '[{"index":0},{"index":1}]' WHERE service_id = 2 AND name = 'things';
+		UPDATE project_resources SET backend_quota = 100, physical_usage = 0 WHERE id = 1 AND service_id = 1 AND name = 'capacity';
+		UPDATE project_resources SET usage = 2, backend_quota = 42, subresources = '[{"index":0},{"index":1}]' WHERE id = 3 AND service_id = 1 AND name = 'things';
+		UPDATE project_resources SET backend_quota = 100, physical_usage = 0 WHERE id = 4 AND service_id = 2 AND name = 'capacity';
+		UPDATE project_resources SET usage = 2, backend_quota = 42, subresources = '[{"index":0},{"index":1}]' WHERE id = 6 AND service_id = 2 AND name = 'things';
 		UPDATE project_services SET scraped_at = %[1]d, scrape_duration_secs = 5, serialized_metrics = '{"capacity_usage":0,"things_usage":2}', checked_at = %[1]d, scrape_error_message = '', next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND type = 'unittest';
 		UPDATE project_services SET scraped_at = %[3]d, scrape_duration_secs = 5, serialized_metrics = '{"capacity_usage":0,"things_usage":2}', checked_at = %[3]d, scrape_error_message = '', next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND type = 'unittest';
 	`,
@@ -478,8 +478,8 @@ func Test_AutoApproveInitialQuota(t *testing.T) {
 
 	scrapedAt := s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`
-		INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (1, 'approve', 10, 0, 10, 10);
-		INSERT INTO project_resources (service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (1, 'noapprove', 0, 0, 20, 0);
+		INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (1, 1, 'approve', 10, 0, 10, 10);
+		INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (2, 1, 'noapprove', 0, 0, 20, 0);
 		UPDATE project_services SET scraped_at = %[1]d, scrape_duration_secs = 5, checked_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND type = 'autoapprovaltest';
 	`,
 		scrapedAt.Unix(), scrapedAt.Add(scrapeInterval).Unix(),
@@ -495,8 +495,8 @@ func Test_AutoApproveInitialQuota(t *testing.T) {
 
 	scrapedAt = s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`
-		UPDATE project_resources SET backend_quota = 20 WHERE service_id = 1 AND name = 'approve';
-		UPDATE project_resources SET backend_quota = 30 WHERE service_id = 1 AND name = 'noapprove';
+		UPDATE project_resources SET backend_quota = 20 WHERE id = 1 AND service_id = 1 AND name = 'approve';
+		UPDATE project_resources SET backend_quota = 30 WHERE id = 2 AND service_id = 1 AND name = 'noapprove';
 		UPDATE project_services SET scraped_at = %[1]d, checked_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND type = 'autoapprovaltest';
 	`,
 		scrapedAt.Unix(), scrapedAt.Add(scrapeInterval).Unix(),

--- a/internal/datamodel/project_resource_update.go
+++ b/internal/datamodel/project_resource_update.go
@@ -22,6 +22,7 @@ package datamodel
 import (
 	"fmt"
 	"reflect"
+	"sort"
 
 	"github.com/sapcc/go-api-declarations/limes"
 	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
@@ -98,10 +99,18 @@ func (u ProjectResourceUpdate) Run(dbi db.Interface, cluster *core.Cluster, doma
 		}
 	}
 
+	//go through resources in a defined order (to ensure deterministic test behavior)
+	allResourceNames := make([]string, 0, len(allResources))
+	for resName := range allResources {
+		allResourceNames = append(allResourceNames, resName)
+	}
+	sort.Strings(allResourceNames)
+
 	//for each resource...
 	hasChanges := false
 	var result ProjectResourceUpdateResult
-	for resName, state := range allResources {
+	for _, resName := range allResourceNames {
+		state := allResources[resName]
 		//skip project_resources that we do not know about (we do not delete them
 		//here because the ResourceInfo might only be missing temporarily because
 		//of an error in resource discovery; in that case, deleting the project

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -46,12 +46,13 @@ type ClusterService struct {
 
 // ClusterResource contains a record from the `cluster_resources` table.
 type ClusterResource struct {
+	ID                int64  `db:"id"`
+	CapacitorID       string `db:"capacitor_id"`
 	ServiceID         int64  `db:"service_id"`
 	Name              string `db:"name"`
 	RawCapacity       uint64 `db:"capacity"`
 	CapacityPerAZJSON string `db:"capacity_per_az"`
 	SubcapacitiesJSON string `db:"subcapacities"`
-	CapacitorID       string `db:"capacitor_id"`
 }
 
 // Domain contains a record from the `domains` table.
@@ -70,6 +71,7 @@ type DomainService struct {
 
 // DomainResource contains a record from the `domain_resources` table.
 type DomainResource struct {
+	ID        int64  `db:"id"`
 	ServiceID int64  `db:"service_id"`
 	Name      string `db:"name"`
 	Quota     uint64 `db:"quota"`
@@ -122,6 +124,7 @@ func (s ProjectService) Ref() ProjectServiceRef {
 // ProjectResource contains a record from the `project_resources` table. Quota
 // values are NULL for resources that do not track quota.
 type ProjectResource struct {
+	ID                  int64   `db:"id"`
 	ServiceID           int64   `db:"service_id"`
 	Name                string  `db:"name"`
 	Quota               *uint64 `db:"quota"`
@@ -177,13 +180,13 @@ type ProjectCommitment struct {
 func initGorp(db *gorp.DbMap) {
 	db.AddTableWithName(ClusterCapacitor{}, "cluster_capacitors").SetKeys(false, "capacitor_id")
 	db.AddTableWithName(ClusterService{}, "cluster_services").SetKeys(true, "id")
-	db.AddTableWithName(ClusterResource{}, "cluster_resources").SetKeys(false, "service_id", "name")
+	db.AddTableWithName(ClusterResource{}, "cluster_resources").SetKeys(true, "id")
 	db.AddTableWithName(Domain{}, "domains").SetKeys(true, "id")
 	db.AddTableWithName(DomainService{}, "domain_services").SetKeys(true, "id")
-	db.AddTableWithName(DomainResource{}, "domain_resources").SetKeys(false, "service_id", "name")
+	db.AddTableWithName(DomainResource{}, "domain_resources").SetKeys(true, "id")
 	db.AddTableWithName(Project{}, "projects").SetKeys(true, "id")
 	db.AddTableWithName(ProjectService{}, "project_services").SetKeys(true, "id")
-	db.AddTableWithName(ProjectResource{}, "project_resources").SetKeys(false, "service_id", "name")
+	db.AddTableWithName(ProjectResource{}, "project_resources").SetKeys(true, "id")
 	db.AddTableWithName(ProjectRate{}, "project_rates").SetKeys(false, "service_id", "name")
 	db.AddTableWithName(ProjectCommitment{}, "project_commitments").SetKeys(true, "id")
 }

--- a/internal/test/setup.go
+++ b/internal/test/setup.go
@@ -179,7 +179,11 @@ func initDatabase(t *testing.T, fixtureFile string) *gorp.DbMap {
 	if fixtureFile != "" {
 		easypg.ExecSQLFile(t, dbm.Db, fixtureFile)
 	}
-	easypg.ResetPrimaryKeys(t, dbm.Db, "cluster_services", "domains", "domain_services", "projects", "project_commitments", "project_services")
+	easypg.ResetPrimaryKeys(t, dbm.Db,
+		"cluster_services", "cluster_resources",
+		"domains", "domain_services", "domain_resources",
+		"projects", "project_commitments", "project_services", "project_resources",
+	)
 
 	return dbm
 }


### PR DESCRIPTION
For various computations esp. relating to commitment confirmation, it will be necessary to model AZ-aware capacity, quota and usage data in the database. We currently have `project_services` below `projects` and `project_resources` below `project_services`. I want to attach a new table `project_az_resources` below `project_resources` in the same way (same for cluster level and potentially also domain level).

To avoid duplicating the current `(service_id, name)` key from the resources table into the new table, this PR adds a numeric `id` column as primary key to the resources tables, same as for most other tables.

- [x] verify that the migrations work correctly (tested on a local database using a backup of qa-de-1 as base)
- [x] API tests pass
- [x] collector tests pass