### PR TITLE
add AZ-aware resource records on the DB level

### DIFF
--- a/internal/api/fixtures/cluster-get-west-with-overcommit.json
+++ b/internal/api/fixtures/cluster-get-west-with-overcommit.json
@@ -11,6 +11,18 @@
             "unit": "B",
             "quota_distribution_model": "hierarchical",
             "capacity": 185,
+            "per_availability_zone": [
+              {
+                "name": "az-one",
+                "capacity": 90,
+                "usage": 12
+              },
+              {
+                "name": "az-two",
+                "capacity": 95,
+                "usage": 15
+              }
+            ],
             "domains_quota": 25,
             "usage": 6,
             "physical_usage": 5
@@ -56,20 +68,6 @@
             "quota_distribution_model": "hierarchical",
             "capacity": 208,
             "raw_capacity": 139,
-            "per_availability_zone": [
-              {
-                "name": "az-one",
-                "capacity": 103,
-                "raw_capacity": 69,
-                "usage": 13
-              },
-              {
-                "name": "az-two",
-                "capacity": 103,
-                "raw_capacity": 69,
-                "usage": 13
-              }
-            ],
             "domains_quota": 70,
             "usage": 6
           }

--- a/internal/api/fixtures/cluster-get-west.json
+++ b/internal/api/fixtures/cluster-get-west.json
@@ -11,6 +11,18 @@
             "unit": "B",
             "quota_distribution_model": "hierarchical",
             "capacity": 185,
+            "per_availability_zone": [
+              {
+                "name": "az-one",
+                "capacity": 90,
+                "usage": 12
+              },
+              {
+                "name": "az-two",
+                "capacity": 95,
+                "usage": 15
+              }
+            ],
             "domains_quota": 25,
             "usage": 6,
             "physical_usage": 5
@@ -54,18 +66,6 @@
             "name": "things",
             "quota_distribution_model": "hierarchical",
             "capacity": 139,
-            "per_availability_zone": [
-              {
-                "name": "az-one",
-                "capacity": 69,
-                "usage": 13
-              },
-              {
-                "name": "az-two",
-                "capacity": 69,
-                "usage": 13
-              }
-            ],
             "domains_quota": 70,
             "usage": 6
           }

--- a/internal/api/fixtures/start-data-commitments.sql
+++ b/internal/api/fixtures/start-data-commitments.sql
@@ -32,25 +32,57 @@ INSERT INTO project_services (id, project_id, type, scraped_at, checked_at) VALU
 
 -- project_resources contains only boring placeholder values
 -- berlin
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (1,  1, 'things',   10, 2, 10, 10);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (2,  1, 'capacity', 10, 2, 10, 10);
-INSERT INTO project_resources (id, service_id, name, usage) VALUES (3,  1, 'capacity_portion', 1);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (4,  2, 'things',   10, 2, 10, 10);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (5,  2, 'capacity', 10, 2, 10, 10);
-INSERT INTO project_resources (id, service_id, name, usage) VALUES (6,  2, 'capacity_portion', 1);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (1,  1, 'things',   10, 4, 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (2,  1, 'capacity', 10, 4, 10, 10);
+INSERT INTO project_resources (id, service_id, name, usage) VALUES (3,  1, 'capacity_portion', 2);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (4,  2, 'things',   10, 4, 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (5,  2, 'capacity', 10, 4, 10, 10);
+INSERT INTO project_resources (id, service_id, name, usage) VALUES (6,  2, 'capacity_portion', 2);
 -- dresden
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (7,  3, 'things',   10, 2, 10, 10);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (8,  3, 'capacity', 10, 2, 10, 10);
-INSERT INTO project_resources (id, service_id, name, usage) VALUES (9,  3, 'capacity_portion', 1);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (10, 4, 'things',   10, 2, 10, 10);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (11, 4, 'capacity', 10, 2, 10, 10);
-INSERT INTO project_resources (id, service_id, name, usage) VALUES (12, 4, 'capacity_portion', 1);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (7,  3, 'things',   10, 4, 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (8,  3, 'capacity', 10, 4, 10, 10);
+INSERT INTO project_resources (id, service_id, name, usage) VALUES (9,  3, 'capacity_portion', 2);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (10, 4, 'things',   10, 4, 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (11, 4, 'capacity', 10, 4, 10, 10);
+INSERT INTO project_resources (id, service_id, name, usage) VALUES (12, 4, 'capacity_portion', 2);
 -- paris
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (13, 5, 'things',   10, 2, 10, 10);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (14, 5, 'capacity', 10, 2, 10, 10);
-INSERT INTO project_resources (id, service_id, name, usage) VALUES (15, 5, 'capacity_portion', 1);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (16, 6, 'things',   10, 2, 10, 10);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (17, 6, 'capacity', 10, 2, 10, 10);
-INSERT INTO project_resources (id, service_id, name, usage) VALUES (18, 6, 'capacity_portion', 1);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (13, 5, 'things',   10, 4, 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (14, 5, 'capacity', 10, 4, 10, 10);
+INSERT INTO project_resources (id, service_id, name, usage) VALUES (15, 5, 'capacity_portion', 2);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (16, 6, 'things',   10, 4, 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (17, 6, 'capacity', 10, 4, 10, 10);
+INSERT INTO project_resources (id, service_id, name, usage) VALUES (18, 6, 'capacity_portion', 2);
+
+-- project_az_resources has "things" as non-AZ-aware and "capacity" as AZ-aware with an even split
+INSERT INTO project_az_resources (resource_id, az, usage) VALUES (1, 'any', 4);
+INSERT INTO project_az_resources (resource_id, az, usage) VALUES (2, 'az-one', 2);
+INSERT INTO project_az_resources (resource_id, az, usage) VALUES (2, 'az-two', 2);
+INSERT INTO project_az_resources (resource_id, az, usage) VALUES (3, 'az-one', 1);
+INSERT INTO project_az_resources (resource_id, az, usage) VALUES (3, 'az-two', 1);
+INSERT INTO project_az_resources (resource_id, az, usage) VALUES (4, 'any', 4);
+INSERT INTO project_az_resources (resource_id, az, usage) VALUES (5, 'az-one', 2);
+INSERT INTO project_az_resources (resource_id, az, usage) VALUES (5, 'az-two', 2);
+INSERT INTO project_az_resources (resource_id, az, usage) VALUES (6, 'az-one', 1);
+INSERT INTO project_az_resources (resource_id, az, usage) VALUES (6, 'az-two', 1);
+INSERT INTO project_az_resources (resource_id, az, usage) VALUES (7, 'any', 4);
+INSERT INTO project_az_resources (resource_id, az, usage) VALUES (8, 'az-one', 2);
+INSERT INTO project_az_resources (resource_id, az, usage) VALUES (8, 'az-two', 2);
+INSERT INTO project_az_resources (resource_id, az, usage) VALUES (9, 'az-one', 1);
+INSERT INTO project_az_resources (resource_id, az, usage) VALUES (9, 'az-two', 1);
+INSERT INTO project_az_resources (resource_id, az, usage) VALUES (10, 'any', 4);
+INSERT INTO project_az_resources (resource_id, az, usage) VALUES (11, 'az-one', 2);
+INSERT INTO project_az_resources (resource_id, az, usage) VALUES (11, 'az-two', 2);
+INSERT INTO project_az_resources (resource_id, az, usage) VALUES (12, 'az-one', 1);
+INSERT INTO project_az_resources (resource_id, az, usage) VALUES (12, 'az-two', 1);
+INSERT INTO project_az_resources (resource_id, az, usage) VALUES (13, 'any', 4);
+INSERT INTO project_az_resources (resource_id, az, usage) VALUES (14, 'az-one', 2);
+INSERT INTO project_az_resources (resource_id, az, usage) VALUES (14, 'az-two', 2);
+INSERT INTO project_az_resources (resource_id, az, usage) VALUES (15, 'az-one', 1);
+INSERT INTO project_az_resources (resource_id, az, usage) VALUES (15, 'az-two', 1);
+INSERT INTO project_az_resources (resource_id, az, usage) VALUES (16, 'any', 4);
+INSERT INTO project_az_resources (resource_id, az, usage) VALUES (17, 'az-one', 2);
+INSERT INTO project_az_resources (resource_id, az, usage) VALUES (17, 'az-two', 2);
+INSERT INTO project_az_resources (resource_id, az, usage) VALUES (18, 'az-one', 1);
+INSERT INTO project_az_resources (resource_id, az, usage) VALUES (18, 'az-two', 1);
 
 -- project_rates is empty: no rates configured

--- a/internal/api/fixtures/start-data-inconsistencies.sql
+++ b/internal/api/fixtures/start-data-inconsistencies.sql
@@ -40,3 +40,14 @@ INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota
 INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (7, 5, 'cores',         30,  20,  30,  '', 30, NULL);
 INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (8, 5, 'ram',           62,  48, 62,  '', 62, 43);
 INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (9, 6, 'loadbalancers', 10,  4,  10,  '', 10, NULL);
+
+-- project_az_resources has everything as non-AZ-aware (the consistency checks do not really care about AZs)
+INSERT INTO project_az_resources (resource_id, az, usage, physical_usage) VALUES (1, 'any', 14, NULL);
+INSERT INTO project_az_resources (resource_id, az, usage, physical_usage) VALUES (2, 'any', 88, 92);
+INSERT INTO project_az_resources (resource_id, az, usage, physical_usage) VALUES (3, 'any', 5,  NULL);
+INSERT INTO project_az_resources (resource_id, az, usage, physical_usage) VALUES (4, 'any', 18, NULL);
+INSERT INTO project_az_resources (resource_id, az, usage, physical_usage) VALUES (5, 'any', 45, 40);
+INSERT INTO project_az_resources (resource_id, az, usage, physical_usage) VALUES (6, 'any', 2,  NULL);
+INSERT INTO project_az_resources (resource_id, az, usage, physical_usage) VALUES (7, 'any', 20, NULL);
+INSERT INTO project_az_resources (resource_id, az, usage, physical_usage) VALUES (8, 'any', 48, 43);
+INSERT INTO project_az_resources (resource_id, az, usage, physical_usage) VALUES (9, 'any', 4,  NULL);

--- a/internal/api/fixtures/start-data.sql
+++ b/internal/api/fixtures/start-data.sql
@@ -9,9 +9,15 @@ INSERT INTO cluster_services (id, type) VALUES (1, 'unshared');
 INSERT INTO cluster_services (id, type) VALUES (2, 'shared');
 
 -- all services have the resources "things" and "capacity"
-INSERT INTO cluster_resources (id, service_id, name, capacity, subcapacities, capacity_per_az, capacitor_id) VALUES (1, 1, 'things', 139, '[{"smaller_half":46},{"larger_half":93}]', '[{"name":"az-one","capacity":69,"usage":13},{"name":"az-two","capacity":69,"usage":13}]', 'scans-unshared');
+INSERT INTO cluster_resources (id, service_id, name, capacity, subcapacities, capacity_per_az, capacitor_id) VALUES (1, 1, 'things', 139, '[{"smaller_half":46},{"larger_half":93}]', '', 'scans-unshared');
 INSERT INTO cluster_resources (id, service_id, name, capacity, subcapacities, capacity_per_az, capacitor_id) VALUES (2, 2, 'things', 246, '[{"smaller_half":82},{"larger_half":164}]', '', 'scans-shared');
-INSERT INTO cluster_resources (id, service_id, name, capacity, subcapacities, capacity_per_az, capacitor_id) VALUES (3, 2, 'capacity', 185, '', '', 'scans-shared');
+INSERT INTO cluster_resources (id, service_id, name, capacity, subcapacities, capacity_per_az, capacitor_id) VALUES (3, 2, 'capacity', 185, '', '[{"name":"az-one","capacity":90,"usage":12},{"name":"az-two","capacity":95,"usage":15}]', 'scans-shared');
+
+-- "capacity" is modeled as AZ-aware, "things" is not
+INSERT INTO cluster_az_resources (resource_id, az, raw_capacity, usage, subcapacities) VALUES (1, 'any', 139, 45, '[{"smaller_half":46},{"larger_half":93}]');
+INSERT INTO cluster_az_resources (resource_id, az, raw_capacity, usage, subcapacities) VALUES (2, 'any', 246, 158, '[{"smaller_half":82},{"larger_half":164}]');
+INSERT INTO cluster_az_resources (resource_id, az, raw_capacity, usage, subcapacities) VALUES (3, 'az-one', 90, 12, '');
+INSERT INTO cluster_az_resources (resource_id, az, raw_capacity, usage, subcapacities) VALUES (3, 'az-two', 95, 15, '');
 
 -- two domains
 INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
@@ -67,6 +73,41 @@ INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota
 INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (16, 6, 'things',   10, 2, 10, '', 10, NULL);
 INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (17, 6, 'capacity', 10, 2, 10, '', 10, 1);
 INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (18, 6, 'capacity_portion', NULL, 1, NULL, '', NULL, NULL);
+
+-- "capacity" is modeled as AZ-aware, "things" is not
+-- berlin (also used for test cases concerning subresources)
+INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (1,  'any',    NULL, 2, NULL, '[{"id":"firstthing","value":23},{"id":"secondthing","value":42}]');
+INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (2,  'az-one', NULL, 1, NULL, '');
+INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (2,  'az-two', NULL, 1, NULL, '');
+INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (3,  'az-one', NULL, 1, NULL, '');
+INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (3,  'az-two', NULL, 0, NULL, '');
+INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (4,  'any',    NULL, 2, NULL, '[{"id":"thirdthing","value":5},{"id":"fourththing","value":123}]');
+INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (5,  'az-one', NULL, 1, NULL, '');
+INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (5,  'az-two', NULL, 1, NULL, '');
+INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (6,  'az-one', NULL, 1, NULL, '');
+INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (6,  'az-two', NULL, 0, NULL, '');
+-- dresden
+INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (7,  'any',    NULL, 2, NULL, '');
+INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (8,  'az-one', NULL, 1, NULL, '');
+INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (8,  'az-two', NULL, 1, NULL, '');
+INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (9,  'az-one', NULL, 1, NULL, '');
+INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (9,  'az-two', NULL, 0, NULL, '');
+INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (10, 'any',    NULL, 2, NULL, '');
+INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (11, 'az-one', NULL, 1, NULL, '');
+INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (11, 'az-two', NULL, 1, NULL, '');
+INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (12, 'az-one', NULL, 1, NULL, '');
+INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (12, 'az-two', NULL, 0, NULL, '');
+-- paris (non-null physical_usage for */capacity, all other project resources should report physical_usage = usage in aggregations)
+INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (13, 'any',    NULL, 2, NULL, '');
+INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (14, 'az-one', NULL, 1, 0, '');
+INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (14, 'az-two', NULL, 1, 1, '');
+INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (15, 'az-one', NULL, 1, NULL, '');
+INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (15, 'az-two', NULL, 0, NULL, '');
+INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (16, 'any',    NULL, 2, NULL, '');
+INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (17, 'az-one', NULL, 1, 0, '');
+INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (17, 'az-two', NULL, 1, 1, '');
+INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (18, 'az-one', NULL, 1, NULL, '');
+INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (18, 'az-two', NULL, 0, NULL, '');
 
 -- project_rates also has multiple different setups to test different cases
 -- berlin has custom rate limits

--- a/internal/collector/capacity_scrape.go
+++ b/internal/collector/capacity_scrape.go
@@ -24,6 +24,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -162,21 +163,6 @@ func (c *Collector) processCapacityScrapeTask(_ context.Context, task capacitySc
 		return fmt.Errorf("cannot collect cluster service mapping: %w", err)
 	}
 
-	//collect ownership information for existing cluster_resources
-	var dbResources []db.ClusterResource
-	_, err = c.DB.Select(&dbResources, `SELECT * FROM cluster_resources`)
-	if err != nil {
-		return fmt.Errorf("cannot inspect existing cluster resources: %w", err)
-	}
-	dbResourceLookup := make(map[string]map[string]db.ClusterResource)
-	for _, res := range dbResources {
-		serviceType := serviceTypeForID[res.ServiceID]
-		if dbResourceLookup[serviceType] == nil {
-			dbResourceLookup[serviceType] = make(map[string]db.ClusterResource)
-		}
-		dbResourceLookup[serviceType][res.Name] = res
-	}
-
 	//scrape capacity data
 	capacityData, serializedMetrics, err := plugin.Scrape()
 	task.Timing.FinishedAt = c.MeasureTimeAtEnd()
@@ -207,32 +193,63 @@ func (c *Collector) processCapacityScrapeTask(_ context.Context, task capacitySc
 	}
 	defer sqlext.RollbackUnlessCommitted(tx)
 
-	//create or update cluster_resources for this capacitor
+	//collect existing cluster_resources
+	var dbResources []db.ClusterResource
+	_, err = tx.Select(&dbResources, `SELECT * FROM cluster_resources`)
+	if err != nil {
+		return fmt.Errorf("cannot inspect existing cluster resources: %w", err)
+	}
+
+	//define the scope of the update
+	var dbOwnedResources []db.ClusterResource
+	for _, res := range dbResources {
+		if res.CapacitorID == capacitor.CapacitorID {
+			dbOwnedResources = append(dbOwnedResources, res)
+		}
+	}
+
+	var wantedResources []db.ResourceRef
 	for serviceType, serviceData := range capacityData {
 		if !c.Cluster.HasService(serviceType) {
 			logg.Info("discarding capacities reported by %s for unknown service type: %s", capacitor.CapacitorID, serviceType)
 			continue
 		}
+		serviceID, ok := serviceIDForType[serviceType]
+		if !ok {
+			return fmt.Errorf("no cluster_services entry for service type %s (check if CheckConsistencyJob runs correctly)", serviceType)
+		}
 
-		for resourceName, resourceDataPerAZ := range serviceData {
+		for resourceName := range serviceData {
 			if !c.Cluster.HasResource(serviceType, resourceName) {
 				logg.Info("discarding capacity reported by %s for unknown resource name: %s/%s", capacitor.CapacitorID, serviceType, resourceName)
 				continue
 			}
-			serviceID, ok := serviceIDForType[serviceType]
-			if !ok {
-				return fmt.Errorf("no cluster_services entry for service type %s (check if CheckConsistencyJob runs correctly)", serviceType)
-			}
+			wantedResources = append(wantedResources, db.ResourceRef{
+				ServiceID: serviceID,
+				Name:      resourceName,
+			})
+		}
+	}
+	slices.SortFunc(wantedResources, db.CompareResourceRefs) //for deterministic test behavior
+
+	//create, update and delete cluster_resources for this capacitor as needed
+	setUpdate := db.SetUpdate[db.ClusterResource, db.ResourceRef]{
+		ExistingRecords: dbOwnedResources,
+		WantedKeys:      wantedResources,
+		KeyForRecord:    db.ClusterResource.Ref,
+		Create: func(ref db.ResourceRef) (db.ClusterResource, error) {
+			return db.ClusterResource{
+				ServiceID:   ref.ServiceID,
+				Name:        ref.Name,
+				CapacitorID: capacitor.CapacitorID,
+			}, nil
+		},
+		Update: func(res *db.ClusterResource) error {
+			serviceType := serviceTypeForID[res.ServiceID]
+			resourceDataPerAZ := capacityData[serviceType][res.Name]
 
 			summedResourceData := resourceDataPerAZ.Sum()
-			res := db.ClusterResource{
-				ServiceID:         serviceID,
-				Name:              resourceName,
-				RawCapacity:       summedResourceData.Capacity,
-				CapacityPerAZJSON: "", //see below
-				SubcapacitiesJSON: "", //see below
-				CapacitorID:       capacitor.CapacitorID,
-			}
+			res.RawCapacity = summedResourceData.Capacity
 
 			if shouldStoreAZReport(resourceDataPerAZ) {
 				buf, err := json.Marshal(convertAZReport(resourceDataPerAZ))
@@ -240,6 +257,8 @@ func (c *Collector) processCapacityScrapeTask(_ context.Context, task capacitySc
 					return fmt.Errorf("could not convert capacities per AZ to JSON: %w", err)
 				}
 				res.CapacityPerAZJSON = string(buf)
+			} else {
+				res.CapacityPerAZJSON = ""
 			}
 
 			if len(summedResourceData.Subcapacities) > 0 {
@@ -248,41 +267,15 @@ func (c *Collector) processCapacityScrapeTask(_ context.Context, task capacitySc
 					return fmt.Errorf("could not convert subcapacities to JSON: %w", err)
 				}
 				res.SubcapacitiesJSON = string(buf)
-			}
-
-			if _, exists := dbResourceLookup[serviceType][resourceName]; exists {
-				res.ID = dbResourceLookup[serviceType][resourceName].ID
-				_, err = tx.Update(&res)
 			} else {
-				err = tx.Insert(&res)
+				res.SubcapacitiesJSON = ""
 			}
-			if err != nil {
-				return fmt.Errorf("could not write cluster resource %s/%s: %w", serviceType, resourceName, err)
-			}
-		}
+			return nil
+		},
 	}
-
-	//delete cluster_resources owned by this capacitor for which we do not have capacityData anymore
-	for serviceType, serviceMapping := range dbResourceLookup {
-		for resourceName, res := range serviceMapping {
-			//do not delete if owned by a different capacitor
-			if res.CapacitorID != capacitor.CapacitorID {
-				continue
-			}
-
-			//do not delete if we still have capacity data
-			_, ok := capacityData[serviceType][resourceName]
-			if ok {
-				continue
-			}
-
-			_, err = tx.Exec(`DELETE FROM cluster_resources WHERE service_id = $1 AND name = $2`,
-				serviceIDForType[serviceType], resourceName,
-			)
-			if err != nil {
-				return fmt.Errorf("could not cleanup cluster resource %s/%s: %w", serviceType, resourceName, err)
-			}
-		}
+	_, err = setUpdate.Execute(tx)
+	if err != nil {
+		return err
 	}
 
 	_, err = tx.Update(&capacitor)

--- a/internal/collector/scrape_test.go
+++ b/internal/collector/scrape_test.go
@@ -155,12 +155,12 @@ func Test_ScrapeSuccess(t *testing.T) {
 	tr.DBChanges().AssertEqualf(`
 		INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota, physical_usage) VALUES (1, 1, 'capacity', 10, 0, 100, 10, 0);
 		INSERT INTO project_resources (id, service_id, name, usage) VALUES (2, 1, 'capacity_portion', 0);
-		INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (3, 1, 'things', 0, 2, 42, '[{"index":0},{"index":1}]', 0);
+		INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (3, 1, 'things', 0, 4, 42, '[{"index":0},{"index":1},{"index":2},{"index":3}]', 0);
 		INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota, physical_usage) VALUES (4, 2, 'capacity', 10, 0, 100, 12, 0);
 		INSERT INTO project_resources (id, service_id, name, usage) VALUES (5, 2, 'capacity_portion', 0);
-		INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (6, 2, 'things', 0, 2, 42, '[{"index":0},{"index":1}]', 0);
-		UPDATE project_services SET scraped_at = %[1]d, scrape_duration_secs = 5, serialized_metrics = '{"capacity_usage":0,"things_usage":2}', checked_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND type = 'unittest';
-		UPDATE project_services SET scraped_at = %[3]d, scrape_duration_secs = 5, serialized_metrics = '{"capacity_usage":0,"things_usage":2}', checked_at = %[3]d, next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND type = 'unittest';
+		INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (6, 2, 'things', 0, 4, 42, '[{"index":0},{"index":1},{"index":2},{"index":3}]', 0);
+		UPDATE project_services SET scraped_at = %[1]d, scrape_duration_secs = 5, serialized_metrics = '{"capacity_usage":0,"things_usage":4}', checked_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND type = 'unittest';
+		UPDATE project_services SET scraped_at = %[3]d, scrape_duration_secs = 5, serialized_metrics = '{"capacity_usage":0,"things_usage":4}', checked_at = %[3]d, next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND type = 'unittest';
 	`,
 		scrapedAt1.Unix(), scrapedAt1.Add(scrapeInterval).Unix(),
 		scrapedAt2.Unix(), scrapedAt2.Add(scrapeInterval).Unix(),
@@ -406,11 +406,11 @@ func Test_ScrapeFailure(t *testing.T) {
 	scrapedAt2 := s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`
 		UPDATE project_resources SET backend_quota = 100, physical_usage = 0 WHERE id = 1 AND service_id = 1 AND name = 'capacity';
-		UPDATE project_resources SET usage = 2, backend_quota = 42, subresources = '[{"index":0},{"index":1}]' WHERE id = 3 AND service_id = 1 AND name = 'things';
+		UPDATE project_resources SET usage = 4, backend_quota = 42, subresources = '[{"index":0},{"index":1},{"index":2},{"index":3}]' WHERE id = 3 AND service_id = 1 AND name = 'things';
 		UPDATE project_resources SET backend_quota = 100, physical_usage = 0 WHERE id = 4 AND service_id = 2 AND name = 'capacity';
-		UPDATE project_resources SET usage = 2, backend_quota = 42, subresources = '[{"index":0},{"index":1}]' WHERE id = 6 AND service_id = 2 AND name = 'things';
-		UPDATE project_services SET scraped_at = %[1]d, scrape_duration_secs = 5, serialized_metrics = '{"capacity_usage":0,"things_usage":2}', checked_at = %[1]d, scrape_error_message = '', next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND type = 'unittest';
-		UPDATE project_services SET scraped_at = %[3]d, scrape_duration_secs = 5, serialized_metrics = '{"capacity_usage":0,"things_usage":2}', checked_at = %[3]d, scrape_error_message = '', next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND type = 'unittest';
+		UPDATE project_resources SET usage = 4, backend_quota = 42, subresources = '[{"index":0},{"index":1},{"index":2},{"index":3}]' WHERE id = 6 AND service_id = 2 AND name = 'things';
+		UPDATE project_services SET scraped_at = %[1]d, scrape_duration_secs = 5, serialized_metrics = '{"capacity_usage":0,"things_usage":4}', checked_at = %[1]d, scrape_error_message = '', next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND type = 'unittest';
+		UPDATE project_services SET scraped_at = %[3]d, scrape_duration_secs = 5, serialized_metrics = '{"capacity_usage":0,"things_usage":4}', checked_at = %[3]d, scrape_error_message = '', next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND type = 'unittest';
 	`,
 		scrapedAt1.Unix(), scrapedAt1.Add(scrapeInterval).Unix(),
 		scrapedAt2.Unix(), scrapedAt2.Add(scrapeInterval).Unix(),

--- a/internal/core/data.go
+++ b/internal/core/data.go
@@ -40,6 +40,26 @@ func InUnknownAZ[D AZAwareData[D]](data D) PerAZ[D] {
 	return PerAZ[D]{limes.AvailabilityZoneUnknown: &data}
 }
 
+// Clone returns a deep copy of this map.
+func (p PerAZ[D]) Clone() PerAZ[D] {
+	result := make(PerAZ[D], len(p))
+	for az, data := range p {
+		cloned := (*data).clone()
+		result[az] = &cloned
+	}
+	return result
+}
+
+// Keys returns all availability zones that have entries in this map.
+func (p PerAZ[D]) Keys() []limes.AvailabilityZone {
+	result := make([]limes.AvailabilityZone, 0, len(p))
+	for az := range p {
+		result = append(result, az)
+	}
+	slices.Sort(result)
+	return result
+}
+
 // Sum returns a sum of all data in this container.
 // This can be used if data can only be stored as a whole, not broken down by AZ.
 func (p PerAZ[D]) Sum() D {

--- a/internal/core/data.go
+++ b/internal/core/data.go
@@ -65,6 +65,24 @@ func (p PerAZ[D]) Sum() D {
 	return result
 }
 
+// Normalize sums all data for unknown AZs into the pseudo-AZ "unknown".
+func (p PerAZ[D]) Normalize(knownAZs []limes.AvailabilityZone) PerAZ[D] {
+	unknowns := make(PerAZ[D])
+	result := make(PerAZ[D])
+	for az, data := range p {
+		if az == limes.AvailabilityZoneAny || slices.Contains(knownAZs, az) {
+			result[az] = data
+		} else {
+			unknowns[az] = data
+		}
+	}
+	if len(unknowns) > 0 {
+		unknownsSum := unknowns.Sum()
+		result[limes.AvailabilityZoneUnknown] = &unknownsSum
+	}
+	return result
+}
+
 // AZAwareData is an interface for types that can be put into the PerAZ container.
 type AZAwareData[Self any] interface {
 	// List of permitted types. This is required for type inference, as explained here:

--- a/internal/datamodel/project_resource_update.go
+++ b/internal/datamodel/project_resource_update.go
@@ -47,6 +47,8 @@ type ProjectResourceUpdateResult struct {
 	//DesiredBackendQuota. The caller should call ApplyBackendQuota() for these
 	//services once the DB transaction has been committed.
 	HasBackendQuotaDrift bool
+	//The set of resources that exists in the DB after the update.
+	DBResources []db.ProjectResource
 }
 
 // Run executes the given ProjectResourceUpdate operation:
@@ -170,6 +172,7 @@ func (u ProjectResourceUpdate) Run(dbi db.Interface, cluster *core.Cluster, doma
 			}
 			hasChanges = true
 		}
+		result.DBResources = append(result.DBResources, res)
 
 		//check if we need to tell the caller to call ApplyBackendQuota after the tx
 		if !resInfo.NoQuota {

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -340,4 +340,18 @@ var sqlMigrations = map[string]string{
 		ALTER TABLE project_resources
 			RENAME CONSTRAINT project_resources_service_id_fkey1 TO project_resources_service_id_fkey;
 	`,
+
+	"028_add_cluster_az_resources.up.sql": `
+		CREATE TABLE cluster_az_resources (
+			resource_id    BIGINT  NOT NULL REFERENCES cluster_resources ON DELETE CASCADE,
+			az             TEXT    NOT NULL,
+			raw_capacity   BIGINT  NOT NULL,
+			usage          BIGINT  NOT NULL,
+			subcapacities  TEXT    NOT NULL DEFAULT '',
+			UNIQUE (resource_id, az)
+		);
+	`,
+	"028_add_cluster_az_resources.down.sql": `
+		DROP TABLE cluster_az_resources;
+	`,
 }

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -354,4 +354,18 @@ var sqlMigrations = map[string]string{
 	"028_add_cluster_az_resources.down.sql": `
 		DROP TABLE cluster_az_resources;
 	`,
+	"029_add_project_az_resources.up.sql": `
+		CREATE TABLE project_az_resources (
+			resource_id     BIGINT  NOT NULL REFERENCES project_resources ON DELETE CASCADE,
+			az              TEXT    NOT NULL,
+			quota           BIGINT  DEFAULT NULL, -- null if resInfo.NoQuota == true
+			usage           BIGINT  NOT NULL,
+			physical_usage  BIGINT  DEFAULT NULL,
+			subresources    TEXT    NOT NULL DEFAULT '',
+			UNIQUE (resource_id, az)
+		);
+	`,
+	"029_add_project_az_resources.down.sql": `
+		DROP TABLE project_az_resources;
+	`,
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -164,6 +164,21 @@ type ProjectResource struct {
 	SubresourcesJSON    string  `db:"subresources"`
 }
 
+// Ref returns the ResourceRef for this resource.
+func (r ProjectResource) Ref() ResourceRef {
+	return ResourceRef{r.ServiceID, r.Name}
+}
+
+// ProjectAZResource contains a record from the `project_az_resources` table.
+type ProjectAZResource struct {
+	ResourceID       int64                  `db:"resource_id"`
+	AvailabilityZone limes.AvailabilityZone `db:"az"`
+	Quota            *uint64                `db:"quota"`
+	Usage            uint64                 `db:"usage"`
+	PhysicalUsage    *uint64                `db:"physical_usage"`
+	SubresourcesJSON string                 `db:"subresources"`
+}
+
 // ProjectRate contains a record from the `project_rates` table.
 type ProjectRate struct {
 	ServiceID     int64              `db:"service_id"`
@@ -217,6 +232,7 @@ func initGorp(db *gorp.DbMap) {
 	db.AddTableWithName(Project{}, "projects").SetKeys(true, "id")
 	db.AddTableWithName(ProjectService{}, "project_services").SetKeys(true, "id")
 	db.AddTableWithName(ProjectResource{}, "project_resources").SetKeys(true, "id")
+	db.AddTableWithName(ProjectAZResource{}, "project_az_resources").SetKeys(false, "resource_id", "az")
 	db.AddTableWithName(ProjectRate{}, "project_rates").SetKeys(false, "service_id", "name")
 	db.AddTableWithName(ProjectCommitment{}, "project_commitments").SetKeys(true, "id")
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -75,6 +75,15 @@ func (r ClusterResource) Ref() ResourceRef {
 	return ResourceRef{r.ServiceID, r.Name}
 }
 
+// ClusterAZResource contains a record from the `cluster_az_resources` table.
+type ClusterAZResource struct {
+	ResourceID        int64                  `db:"resource_id"`
+	AvailabilityZone  limes.AvailabilityZone `db:"az"`
+	RawCapacity       uint64                 `db:"raw_capacity"`
+	Usage             uint64                 `db:"usage"`
+	SubcapacitiesJSON string                 `db:"subcapacities"`
+}
+
 // Domain contains a record from the `domains` table.
 type Domain struct {
 	ID   int64  `db:"id"`
@@ -201,6 +210,7 @@ func initGorp(db *gorp.DbMap) {
 	db.AddTableWithName(ClusterCapacitor{}, "cluster_capacitors").SetKeys(false, "capacitor_id")
 	db.AddTableWithName(ClusterService{}, "cluster_services").SetKeys(true, "id")
 	db.AddTableWithName(ClusterResource{}, "cluster_resources").SetKeys(true, "id")
+	db.AddTableWithName(ClusterAZResource{}, "cluster_az_resources").SetKeys(false, "resource_id", "az")
 	db.AddTableWithName(Domain{}, "domains").SetKeys(true, "id")
 	db.AddTableWithName(DomainService{}, "domain_services").SetKeys(true, "id")
 	db.AddTableWithName(DomainResource{}, "domain_resources").SetKeys(true, "id")

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -20,6 +20,7 @@
 package db
 
 import (
+	"strings"
 	"time"
 
 	"github.com/go-gorp/gorp/v3"
@@ -27,6 +28,20 @@ import (
 	limesrates "github.com/sapcc/go-api-declarations/limes/rates"
 	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
 )
+
+// ResourceRef identifies an individual ProjectResource, DomainResource or ClusterResource.
+type ResourceRef struct {
+	ServiceID int64  `db:"service_id"`
+	Name      string `db:"name"`
+}
+
+// CompareResourceRefs is a compare function for ResourceRef (for use with slices.SortFunc etc.)
+func CompareResourceRefs(lhs, rhs ResourceRef) int {
+	if lhs.ServiceID != rhs.ServiceID {
+		return int(rhs.ServiceID - lhs.ServiceID)
+	}
+	return strings.Compare(lhs.Name, rhs.Name)
+}
 
 // ClusterCapacitor contains a record from the `cluster_capacitors` table.
 type ClusterCapacitor struct {
@@ -53,6 +68,11 @@ type ClusterResource struct {
 	RawCapacity       uint64 `db:"capacity"`
 	CapacityPerAZJSON string `db:"capacity_per_az"`
 	SubcapacitiesJSON string `db:"subcapacities"`
+}
+
+// Ref returns the ResourceRef for this resource.
+func (r ClusterResource) Ref() ResourceRef {
+	return ResourceRef{r.ServiceID, r.Name}
 }
 
 // Domain contains a record from the `domains` table.

--- a/internal/db/setupdate.go
+++ b/internal/db/setupdate.go
@@ -1,0 +1,106 @@
+/******************************************************************************
+*
+*  Copyright 2023 SAP SE
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+******************************************************************************/
+
+package db
+
+import (
+	"fmt"
+	"reflect"
+	"slices"
+
+	gorp "github.com/go-gorp/gorp/v3"
+)
+
+// SetUpdate describes an operation where we have an existing set of records (type R),
+// and a set of records that we want to have, as identified by some key (type K).
+// Records that we want to keep are updated, missing records are created,
+// and existing records that we do not want to have are deleted.
+type SetUpdate[R any, K comparable] struct {
+	// All relevant records that currently exist in the DB.
+	ExistingRecords []R
+	// All keys for which we want to have a record in the DB.
+	WantedKeys []K
+
+	// KeyForRecord reads the key out of an existing record.
+	// This does not need to be the primary key.
+	// Whatever unique identifier the caller has available is fine.
+	KeyForRecord func(R) K
+
+	// Callback for creating a new record for a missing key.
+	//
+	// After this, the Update callback will also be called on the new record.
+	// This avoids code duplication between the create and update callbacks.
+	Create func(K) (R, error)
+	// Callback for updating an existing record.
+	Update func(*R) error
+}
+
+// Execute executes this SetUpdate.
+// Returns the set of records that exist in the DB after this update.
+func (u SetUpdate[R, K]) Execute(tx *gorp.Transaction) ([]R, error) {
+	// create or update wanted records
+	var result []R
+	for _, k := range u.WantedKeys {
+		idx := slices.IndexFunc(u.ExistingRecords, func(r R) bool { return u.KeyForRecord(r) == k })
+		if idx == -1 {
+			// we do not have this record -> create it
+			r, err := u.Create(k)
+			if err == nil {
+				err = u.Update(&r)
+			}
+			if err != nil {
+				return nil, fmt.Errorf("could not build new %T record with key %v: %w", r, k, err)
+			}
+
+			err = tx.Insert(&r)
+			if err != nil {
+				return nil, fmt.Errorf("could not insert %T record with key %v: %w", r, k, err)
+			}
+			result = append(result, r)
+		} else {
+			// we have this record -> update it
+			r := u.ExistingRecords[idx]
+			err := u.Update(&r)
+			if err != nil {
+				return nil, fmt.Errorf("could not build updated %T record with key %v: %w", r, k, err)
+			}
+
+			// only update in the DB if necessary
+			if !reflect.DeepEqual(r, u.ExistingRecords[idx]) {
+				_, err = tx.Update(&r)
+				if err != nil {
+					return nil, fmt.Errorf("could not update %T record with key %v: %w", r, k, err)
+				}
+			}
+			result = append(result, r)
+		}
+	}
+
+	// delete unwanted records
+	for _, r := range u.ExistingRecords {
+		k := u.KeyForRecord(r)
+		if !slices.Contains(u.WantedKeys, k) {
+			_, err := tx.Delete(&r) //nolint:gosec // this pointer is not held beyond the call
+			if err != nil {
+				return nil, fmt.Errorf("could not delete %T record with key %v: %w", r, k, err)
+			}
+		}
+	}
+
+	return result, nil
+}

--- a/internal/db/setupdate.go
+++ b/internal/db/setupdate.go
@@ -30,6 +30,8 @@ import (
 // and a set of records that we want to have, as identified by some key (type K).
 // Records that we want to keep are updated, missing records are created,
 // and existing records that we do not want to have are deleted.
+//
+// TODO This is not yet used in most of the places that could benefit from it.
 type SetUpdate[R any, K comparable] struct {
 	// All relevant records that currently exist in the DB.
 	ExistingRecords []R

--- a/internal/test/plugins/quota_generic.go
+++ b/internal/test/plugins/quota_generic.go
@@ -75,15 +75,17 @@ func (p *GenericQuotaPlugin) Init(provider *gophercloud.ProviderClient, eo gophe
 	p.StaticResourceData = map[string]*core.ResourceData{
 		"things": {
 			Quota: 42,
-			UsageData: core.InAnyAZ(core.UsageData{
-				Usage: 4,
-			}),
+			UsageData: core.PerAZ[core.UsageData]{
+				"az-one": {Usage: 2},
+				"az-two": {Usage: 2},
+			},
 		},
 		"capacity": {
 			Quota: 100,
-			UsageData: core.InAnyAZ(core.UsageData{
-				Usage: 0,
-			}),
+			UsageData: core.PerAZ[core.UsageData]{
+				"az-one": {Usage: 0},
+				"az-two": {Usage: 0},
+			},
 		},
 	}
 	p.OverrideQuota = make(map[string]map[string]uint64)
@@ -151,24 +153,25 @@ func (p *GenericQuotaPlugin) Scrape(project core.KeystoneProject) (result map[st
 
 	result = make(map[string]core.ResourceData)
 	for key, val := range p.StaticResourceData {
-		usageData := val.UsageData[limes.AvailabilityZoneAny]
 		copyOfVal := core.ResourceData{
-			Quota: val.Quota,
-			UsageData: core.InAnyAZ(core.UsageData{
-				Usage: usageData.Usage,
-			}),
+			Quota:     val.Quota,
+			UsageData: val.UsageData.Clone(),
 		}
 
 		//test coverage for PhysicalUsage != Usage
 		if key == "capacity" {
-			physUsage := usageData.Usage / 2
-			copyOfVal.UsageData[limes.AvailabilityZoneAny].PhysicalUsage = &physUsage
+			for _, data := range copyOfVal.UsageData {
+				physUsage := data.Usage / 2
+				data.PhysicalUsage = &physUsage
+			}
 
 			//derive a resource that does not track quota
+			portionUsage := make(core.PerAZ[core.UsageData])
+			for az, data := range copyOfVal.UsageData {
+				portionUsage[az] = &core.UsageData{Usage: data.Usage / 4}
+			}
 			result["capacity_portion"] = core.ResourceData{
-				UsageData: core.InAnyAZ(core.UsageData{
-					Usage: usageData.Usage / 4,
-				}),
+				UsageData: portionUsage,
 			}
 		}
 
@@ -186,21 +189,23 @@ func (p *GenericQuotaPlugin) Scrape(project core.KeystoneProject) (result map[st
 	}
 
 	//make up some subresources for "things"
-	thingsUsage := int(result["things"].UsageData[limes.AvailabilityZoneAny].Usage)
-	subres := make([]any, thingsUsage)
-	for idx := 0; idx < thingsUsage; idx++ {
-		subres[idx] = map[string]any{
-			"index": idx,
+	counter := 0
+	for _, az := range result["things"].UsageData.Keys() {
+		thingsUsage := result["things"].UsageData[az].Usage
+		subresources := make([]any, thingsUsage)
+		for idx := uint64(0); idx < thingsUsage; idx++ {
+			subresources[idx] = map[string]any{"index": counter}
+			counter++
 		}
+		result["things"].UsageData[az].Subresources = subresources
 	}
-	result["things"].UsageData[limes.AvailabilityZoneAny].Subresources = subres
 
 	//make up some serialized metrics (reporting usage as a metric is usually
 	//nonsensical since limes-collect already reports all usages as metrics, but
 	//this is only a testcase anyway)
 	serializedMetrics = fmt.Sprintf(`{"capacity_usage":%d,"things_usage":%d}`,
-		result["capacity"].UsageData[limes.AvailabilityZoneAny].Usage,
-		result["things"].UsageData[limes.AvailabilityZoneAny].Usage)
+		result["capacity"].UsageData.Sum().Usage,
+		result["things"].UsageData.Sum().Usage)
 
 	return result, serializedMetrics, nil
 }

--- a/internal/test/plugins/quota_generic.go
+++ b/internal/test/plugins/quota_generic.go
@@ -76,7 +76,7 @@ func (p *GenericQuotaPlugin) Init(provider *gophercloud.ProviderClient, eo gophe
 		"things": {
 			Quota: 42,
 			UsageData: core.InAnyAZ(core.UsageData{
-				Usage: 2,
+				Usage: 4,
 			}),
 		},
 		"capacity": {


### PR DESCRIPTION
The new tables are only filled and maintained right now, but not used. Once this change is rolled out, I will do the next wave where this data gets used in reports, and then the old fields in `cluster_resources` and `project_resources` will be deleted once they are not used anymore.