### PR TITLE
finish conversion to AZ-aware DB records

### DIFF
--- a/internal/api/fixtures/start-data-commitments.sql
+++ b/internal/api/fixtures/start-data-commitments.sql
@@ -32,26 +32,26 @@ INSERT INTO project_services (id, project_id, type, scraped_at, checked_at) VALU
 
 -- project_resources contains only boring placeholder values
 -- berlin
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (1,  1, 'things',   10, 4, 10, 10);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (2,  1, 'capacity', 10, 4, 10, 10);
-INSERT INTO project_resources (id, service_id, name, usage) VALUES (3,  1, 'capacity_portion', 2);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (4,  2, 'things',   10, 4, 10, 10);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (5,  2, 'capacity', 10, 4, 10, 10);
-INSERT INTO project_resources (id, service_id, name, usage) VALUES (6,  2, 'capacity_portion', 2);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (1,  1, 'things',   10, 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (2,  1, 'capacity', 10, 10, 10);
+INSERT INTO project_resources (id, service_id, name) VALUES (3,  1, 'capacity_portion');
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (4,  2, 'things',   10, 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (5,  2, 'capacity', 10, 10, 10);
+INSERT INTO project_resources (id, service_id, name) VALUES (6,  2, 'capacity_portion');
 -- dresden
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (7,  3, 'things',   10, 4, 10, 10);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (8,  3, 'capacity', 10, 4, 10, 10);
-INSERT INTO project_resources (id, service_id, name, usage) VALUES (9,  3, 'capacity_portion', 2);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (10, 4, 'things',   10, 4, 10, 10);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (11, 4, 'capacity', 10, 4, 10, 10);
-INSERT INTO project_resources (id, service_id, name, usage) VALUES (12, 4, 'capacity_portion', 2);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (7,  3, 'things',   10, 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (8,  3, 'capacity', 10, 10, 10);
+INSERT INTO project_resources (id, service_id, name) VALUES (9,  3, 'capacity_portion');
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (10, 4, 'things',   10, 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (11, 4, 'capacity', 10, 10, 10);
+INSERT INTO project_resources (id, service_id, name) VALUES (12, 4, 'capacity_portion');
 -- paris
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (13, 5, 'things',   10, 4, 10, 10);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (14, 5, 'capacity', 10, 4, 10, 10);
-INSERT INTO project_resources (id, service_id, name, usage) VALUES (15, 5, 'capacity_portion', 2);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (16, 6, 'things',   10, 4, 10, 10);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (17, 6, 'capacity', 10, 4, 10, 10);
-INSERT INTO project_resources (id, service_id, name, usage) VALUES (18, 6, 'capacity_portion', 2);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (13, 5, 'things',   10, 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (14, 5, 'capacity', 10, 10, 10);
+INSERT INTO project_resources (id, service_id, name) VALUES (15, 5, 'capacity_portion');
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (16, 6, 'things',   10, 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (17, 6, 'capacity', 10, 10, 10);
+INSERT INTO project_resources (id, service_id, name) VALUES (18, 6, 'capacity_portion');
 
 -- project_az_resources has "things" as non-AZ-aware and "capacity" as AZ-aware with an even split
 INSERT INTO project_az_resources (resource_id, az, usage) VALUES (1, 'any', 4);

--- a/internal/api/fixtures/start-data-inconsistencies.sql
+++ b/internal/api/fixtures/start-data-inconsistencies.sql
@@ -31,15 +31,15 @@ INSERT INTO project_services (id, project_id, type, scraped_at, checked_at) VALU
 INSERT INTO project_services (id, project_id, type, scraped_at, checked_at) VALUES (6, 3, 'network', '2018-06-13 15:06:37', '2018-06-13 15:06:37');
 
 -- project_resources contains some pathological cases
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1, 1, 'cores',         30,  14, 10,  '', 30, NULL);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2, 1, 'ram',           100, 88, 100, '', 100, 92);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (3, 2, 'loadbalancers', 10,  5,  10,  '', 10, NULL);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (4, 3, 'cores',         14,  18, 14,  '', 14, NULL);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (5, 3, 'ram',           60,  45, 60,  '', 60, 40);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (6, 4, 'loadbalancers', 5,   2,  5,   '', 5, NULL);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (7, 5, 'cores',         30,  20,  30,  '', 30, NULL);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (8, 5, 'ram',           62,  48, 62,  '', 62, 43);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (9, 6, 'loadbalancers', 10,  4,  10,  '', 10, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (1, 1, 'cores',         30,  10,  30);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (2, 1, 'ram',           100, 100, 100);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (3, 2, 'loadbalancers', 10,  10,  10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (4, 3, 'cores',         14,  14,  14);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (5, 3, 'ram',           60,  60,  60);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (6, 4, 'loadbalancers', 5,   5,   5);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (7, 5, 'cores',         30,  30,  30);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (8, 5, 'ram',           62,  62,  62);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (9, 6, 'loadbalancers', 10,  10,  10);
 
 -- project_az_resources has everything as non-AZ-aware (the consistency checks do not really care about AZs)
 INSERT INTO project_az_resources (resource_id, az, usage, physical_usage) VALUES (1, 'any', 14, NULL);

--- a/internal/api/fixtures/start-data.sql
+++ b/internal/api/fixtures/start-data.sql
@@ -9,9 +9,9 @@ INSERT INTO cluster_services (id, type) VALUES (1, 'unshared');
 INSERT INTO cluster_services (id, type) VALUES (2, 'shared');
 
 -- all services have the resources "things" and "capacity"
-INSERT INTO cluster_resources (id, service_id, name, capacity, subcapacities, capacity_per_az, capacitor_id) VALUES (1, 1, 'things', 139, '[{"smaller_half":46},{"larger_half":93}]', '', 'scans-unshared');
-INSERT INTO cluster_resources (id, service_id, name, capacity, subcapacities, capacity_per_az, capacitor_id) VALUES (2, 2, 'things', 246, '[{"smaller_half":82},{"larger_half":164}]', '', 'scans-shared');
-INSERT INTO cluster_resources (id, service_id, name, capacity, subcapacities, capacity_per_az, capacitor_id) VALUES (3, 2, 'capacity', 185, '', '[{"name":"az-one","capacity":90,"usage":12},{"name":"az-two","capacity":95,"usage":15}]', 'scans-shared');
+INSERT INTO cluster_resources (id, service_id, name, capacitor_id) VALUES (1, 1, 'things', 'scans-unshared');
+INSERT INTO cluster_resources (id, service_id, name, capacitor_id) VALUES (2, 2, 'things', 'scans-shared');
+INSERT INTO cluster_resources (id, service_id, name, capacitor_id) VALUES (3, 2, 'capacity', 'scans-shared');
 
 -- "capacity" is modeled as AZ-aware, "things" is not
 INSERT INTO cluster_az_resources (resource_id, az, raw_capacity, usage, subcapacities) VALUES (1, 'any', 139, 45, '[{"smaller_half":46},{"larger_half":93}]');
@@ -53,26 +53,26 @@ INSERT INTO project_services (id, project_id, type, scraped_at, rates_scraped_at
 
 -- project_resources contains some pathological cases
 -- berlin (also used for test cases concerning subresources)
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (1,  1, 'things',   10, 2, 10, '[{"id":"firstthing","value":23},{"id":"secondthing","value":42}]', 10, NULL);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (2,  1, 'capacity', 10, 2, 10, '', 10, NULL);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (3,  1, 'capacity_portion', NULL, 1, NULL, '', NULL, NULL);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (4,  2, 'things',   10, 2, 10, '[{"id":"thirdthing","value":5},{"id":"fourththing","value":123}]', 10, NULL);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (5,  2, 'capacity', 10, 2, 10, '', 10, NULL);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (6,  2, 'capacity_portion', NULL, 1, NULL, '', NULL, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (1,  1, 'things',   10, 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (2,  1, 'capacity', 10, 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (3,  1, 'capacity_portion', NULL, NULL, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (4,  2, 'things',   10, 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (5,  2, 'capacity', 10, 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (6,  2, 'capacity_portion', NULL, NULL, NULL);
 -- dresden (backend quota for shared/capacity mismatches approved quota and exceeds domain quota)
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (7,  3, 'things',   10, 2, 10, '', 10, NULL);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (8,  3, 'capacity', 10, 2, 10, '', 10, NULL);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (9,  3, 'capacity_portion', NULL, 1, NULL, '', NULL, NULL);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (10, 4, 'things',   10, 2, 10, '', 10, NULL);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (11, 4, 'capacity', 10, 2, 100, '', 10, NULL);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (12, 4, 'capacity_portion', NULL, 1, NULL, '', NULL, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (7,  3, 'things',   10, 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (8,  3, 'capacity', 10, 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (9,  3, 'capacity_portion', NULL, NULL, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (10, 4, 'things',   10, 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (11, 4, 'capacity', 10, 100, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (12, 4, 'capacity_portion', NULL, NULL, NULL);
 -- paris (infinite backend quota for unshared/things; non-null physical_usage for */capacity, all other project resources should report physical_usage = usage in aggregations)
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (13, 5, 'things',   10, 2, -1, '', 10, NULL);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (14, 5, 'capacity', 10, 2, 10, '', 10, 1);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (15, 5, 'capacity_portion', NULL, 1, NULL, '', NULL, NULL);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (16, 6, 'things',   10, 2, 10, '', 10, NULL);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (17, 6, 'capacity', 10, 2, 10, '', 10, 1);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (18, 6, 'capacity_portion', NULL, 1, NULL, '', NULL, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (13, 5, 'things',   10, -1, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (14, 5, 'capacity', 10, 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (15, 5, 'capacity_portion', NULL, NULL, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (16, 6, 'things',   10, 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (17, 6, 'capacity', 10, 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (18, 6, 'capacity_portion', NULL, NULL, NULL);
 
 -- "capacity" is modeled as AZ-aware, "things" is not
 -- berlin (also used for test cases concerning subresources)
@@ -127,15 +127,19 @@ INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_big
 -- insert some bullshit data that should be filtered out by the internal/reports/ logic
 -- (cluster "north", service "weird", resource "items" and rate "frobnicate" are not configured)
 INSERT INTO cluster_services (id, type) VALUES (101, 'weird');
-INSERT INTO cluster_resources (id, service_id, name, capacity, capacitor_id) VALUES (101, 101, 'things', 1, 'scans-shared');
+INSERT INTO cluster_resources (id, service_id, name, capacitor_id) VALUES (101, 101, 'things', 'scans-shared');
+INSERT INTO cluster_az_resources (resource_id, az, raw_capacity, usage, subcapacities) VALUES (101, 'any', 2, 1, '');
 INSERT INTO domain_services (id, domain_id, type) VALUES (101, 1, 'weird');
 INSERT INTO domain_resources (id, service_id, name, quota) VALUES (101, 101, 'things', 1);
 INSERT INTO project_services (id, project_id, type) VALUES (101, 1, 'weird');
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (101, 101, 'things', 2, 1, 2, '', 2, 1);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (101, 101, 'things', 2, 2, 2);
+INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (101, 'any', NULL, 1, 1, '');
 
 INSERT INTO domain_resources (id, service_id, name, quota) VALUES (102, 1, 'items', 1);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (102, 1, 'items', 2, 1, 2, '', 2, 1);
-INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota, physical_usage) VALUES (103, 1, 'items_portion', NULL, 1, NULL, '', NULL, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (102, 1, 'items', 2, 2, 2);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (103, 1, 'items_portion', NULL, NULL, NULL);
+INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (102, 'any', NULL, 1, 1, '');
+INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (103, 'any', NULL, 1, NULL, '');
 
 INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_bigint) VALUES (1, 'service/unshared/instances:frobnicate', 5, 1000000000, '');
 INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_bigint) VALUES (2, 'service/shared/objects:frobnicate', 5, 1000000000, '');

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -409,7 +409,10 @@ func (p *v1Provider) putOrSimulateProjectAttributes(w http.ResponseWriter, r *ht
 			SELECT ps.type, pr.name
 				FROM project_services ps
 				JOIN project_resources pr ON ps.id = pr.service_id
-			 WHERE ps.project_id = $1 AND pr.usage > pr.quota`
+				JOIN project_az_resources par ON pr.id = par.resource_id
+			 WHERE ps.project_id = $1
+			 GROUP BY ps.type, pr.name, pr.quota
+			HAVING SUM(par.usage) > pr.quota`
 		err := sqlext.ForeachRow(dbi, query, []any{project.ID}, func(rows *sql.Rows) error {
 			var serviceType, resourceName string
 			err := rows.Scan(&serviceType, &resourceName)

--- a/internal/collector/capacity_scrape_test.go
+++ b/internal/collector/capacity_scrape_test.go
@@ -104,15 +104,14 @@ func Test_ScanCapacity(t *testing.T) {
 		INSERT INTO cluster_az_resources (resource_id, az, raw_capacity, usage) VALUES (2, 'any', 42, 8);
 		INSERT INTO cluster_capacitors (capacitor_id, scraped_at, scrape_duration_secs, next_scrape_at) VALUES ('unittest', 5, 5, 905);
 		INSERT INTO cluster_capacitors (capacitor_id, scraped_at, scrape_duration_secs, next_scrape_at) VALUES ('unittest2', 10, 5, 910);
-		INSERT INTO cluster_resources (id, capacitor_id, service_id, name, capacity) VALUES (1, 'unittest', 1, 'things', 42);
-		INSERT INTO cluster_resources (id, capacitor_id, service_id, name, capacity) VALUES (2, 'unittest2', 2, 'capacity', 42);
+		INSERT INTO cluster_resources (id, capacitor_id, service_id, name) VALUES (1, 'unittest', 1, 'things');
+		INSERT INTO cluster_resources (id, capacitor_id, service_id, name) VALUES (2, 'unittest2', 2, 'capacity');
 	`)
 
 	//insert some crap records
 	unknownRes := &db.ClusterResource{
 		ServiceID:   2,
 		Name:        "unknown",
-		RawCapacity: 100,
 		CapacitorID: "unittest2",
 	}
 	err := s.DB.Insert(unknownRes)
@@ -150,7 +149,7 @@ func Test_ScanCapacity(t *testing.T) {
 		UPDATE cluster_capacitors SET scraped_at = %d, next_scrape_at = %d WHERE capacitor_id = 'unittest';
 		UPDATE cluster_capacitors SET scraped_at = %d, next_scrape_at = %d WHERE capacitor_id = 'unittest2';
 		DELETE FROM cluster_resources WHERE id = 1 AND service_id = 1 AND name = 'things';
-		INSERT INTO cluster_resources (id, capacitor_id, service_id, name, capacity) VALUES (4, 'unittest', 1, 'things', 23);
+		INSERT INTO cluster_resources (id, capacitor_id, service_id, name) VALUES (4, 'unittest', 1, 'things');
 	`,
 		scrapedAt1.Unix(), scrapedAt1.Add(15*time.Minute).Unix(),
 		scrapedAt2.Unix(), scrapedAt2.Add(15*time.Minute).Unix(),
@@ -179,7 +178,7 @@ func Test_ScanCapacity(t *testing.T) {
 		UPDATE cluster_capacitors SET scraped_at = %d, next_scrape_at = %d WHERE capacitor_id = 'unittest';
 		UPDATE cluster_capacitors SET scraped_at = %d, next_scrape_at = %d WHERE capacitor_id = 'unittest2';
 		INSERT INTO cluster_capacitors (capacitor_id, scraped_at, scrape_duration_secs, serialized_metrics, next_scrape_at) VALUES ('unittest4', %d, 5, '{"smaller_half":14,"larger_half":28}', %d);
-		INSERT INTO cluster_resources (id, capacitor_id, service_id, name, capacity, subcapacities) VALUES (5, 'unittest4', 2, 'things', 42, '[{"az":"az-one","smaller_half":7},{"az":"az-one","larger_half":14},{"az":"az-two","smaller_half":7},{"az":"az-two","larger_half":14}]');
+		INSERT INTO cluster_resources (id, capacitor_id, service_id, name) VALUES (5, 'unittest4', 2, 'things');
 	`,
 		scrapedAt1.Unix(), scrapedAt1.Add(15*time.Minute).Unix(),
 		scrapedAt2.Unix(), scrapedAt2.Add(15*time.Minute).Unix(),
@@ -199,7 +198,6 @@ func Test_ScanCapacity(t *testing.T) {
 		UPDATE cluster_capacitors SET scraped_at = %d, next_scrape_at = %d WHERE capacitor_id = 'unittest';
 		UPDATE cluster_capacitors SET scraped_at = %d, next_scrape_at = %d WHERE capacitor_id = 'unittest2';
 		UPDATE cluster_capacitors SET scraped_at = %d, serialized_metrics = '{"smaller_half":3,"larger_half":7}', next_scrape_at = %d WHERE capacitor_id = 'unittest4';
-		UPDATE cluster_resources SET capacity = 10, subcapacities = '[{"az":"az-one","smaller_half":1},{"az":"az-one","larger_half":4},{"az":"az-two","smaller_half":1},{"az":"az-two","larger_half":4}]' WHERE id = 5 AND service_id = 2 AND name = 'things';
 	`,
 		scrapedAt1.Unix(), scrapedAt1.Add(15*time.Minute).Unix(),
 		scrapedAt2.Unix(), scrapedAt2.Add(15*time.Minute).Unix(),
@@ -232,7 +230,7 @@ func Test_ScanCapacity(t *testing.T) {
 		UPDATE cluster_capacitors SET scraped_at = %d, next_scrape_at = %d WHERE capacitor_id = 'unittest2';
 		UPDATE cluster_capacitors SET scraped_at = %d, next_scrape_at = %d WHERE capacitor_id = 'unittest4';
 		INSERT INTO cluster_capacitors (capacitor_id, scraped_at, scrape_duration_secs, next_scrape_at) VALUES ('unittest5', %d, 5, %d);
-		INSERT INTO cluster_resources (id, capacitor_id, service_id, name, capacity, capacity_per_az) VALUES (6, 'unittest5', 3, 'things', 42, '[{"name":"az-one","capacity":21,"usage":4},{"name":"az-two","capacity":21,"usage":4}]');
+		INSERT INTO cluster_resources (id, capacitor_id, service_id, name) VALUES (6, 'unittest5', 3, 'things');
 	`,
 		scrapedAt1.Unix(), scrapedAt1.Add(15*time.Minute).Unix(),
 		scrapedAt2.Unix(), scrapedAt2.Add(15*time.Minute).Unix(),
@@ -256,7 +254,6 @@ func Test_ScanCapacity(t *testing.T) {
 		UPDATE cluster_capacitors SET scraped_at = %d, next_scrape_at = %d WHERE capacitor_id = 'unittest2';
 		UPDATE cluster_capacitors SET scraped_at = %d, next_scrape_at = %d WHERE capacitor_id = 'unittest4';
 		UPDATE cluster_capacitors SET scraped_at = %d, next_scrape_at = %d WHERE capacitor_id = 'unittest5';
-		UPDATE cluster_resources SET capacity = 30, capacity_per_az = '[{"name":"az-one","capacity":15,"usage":3},{"name":"az-two","capacity":15,"usage":3}]' WHERE id = 6 AND service_id = 3 AND name = 'things';
 	`,
 		scrapedAt1.Unix(), scrapedAt1.Add(15*time.Minute).Unix(),
 		scrapedAt2.Unix(), scrapedAt2.Add(15*time.Minute).Unix(),

--- a/internal/collector/metrics.go
+++ b/internal/collector/metrics.go
@@ -549,7 +549,7 @@ func (c *DataMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 
 		var (
 			capacityPerAZ map[limes.AvailabilityZone]uint64
-			usagePerAZ    map[limes.AvailabilityZone]uint64
+			usagePerAZ    map[limes.AvailabilityZone]*uint64
 		)
 		err = json.Unmarshal([]byte(capacityPerAZJSON), &capacityPerAZ)
 		if err != nil {
@@ -577,10 +577,10 @@ func (c *DataMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 				)
 
 				azUsage := usagePerAZ[az]
-				if azUsage != 0 {
+				if azUsage != nil && *azUsage != 0 {
 					ch <- prometheus.MustNewConstMetric(
 						clusterUsagePerAZDesc,
-						prometheus.GaugeValue, float64(azUsage),
+						prometheus.GaugeValue, float64(*azUsage),
 						string(az), serviceType, resourceName,
 					)
 				}

--- a/internal/collector/scrape_test.go
+++ b/internal/collector/scrape_test.go
@@ -164,12 +164,12 @@ func Test_ScrapeSuccess(t *testing.T) {
 		INSERT INTO project_az_resources (resource_id, az, usage) VALUES (5, 'az-two', 0);
 		INSERT INTO project_az_resources (resource_id, az, usage, subresources) VALUES (6, 'az-one', 2, '[{"index":0},{"index":1}]');
 		INSERT INTO project_az_resources (resource_id, az, usage, subresources) VALUES (6, 'az-two', 2, '[{"index":2},{"index":3}]');
-		INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota, physical_usage) VALUES (1, 1, 'capacity', 10, 0, 100, 10, 0);
-		INSERT INTO project_resources (id, service_id, name, usage) VALUES (2, 1, 'capacity_portion', 0);
-		INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (3, 1, 'things', 0, 4, 42, '[{"index":0},{"index":1},{"index":2},{"index":3}]', 0);
-		INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota, physical_usage) VALUES (4, 2, 'capacity', 10, 0, 100, 12, 0);
-		INSERT INTO project_resources (id, service_id, name, usage) VALUES (5, 2, 'capacity_portion', 0);
-		INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, subresources, desired_backend_quota) VALUES (6, 2, 'things', 0, 4, 42, '[{"index":0},{"index":1},{"index":2},{"index":3}]', 0);
+		INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (1, 1, 'capacity', 10, 100, 10);
+		INSERT INTO project_resources (id, service_id, name) VALUES (2, 1, 'capacity_portion');
+		INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (3, 1, 'things', 0, 42, 0);
+		INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (4, 2, 'capacity', 10, 100, 12);
+		INSERT INTO project_resources (id, service_id, name) VALUES (5, 2, 'capacity_portion');
+		INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (6, 2, 'things', 0, 42, 0);
 		UPDATE project_services SET scraped_at = %[1]d, scrape_duration_secs = 5, serialized_metrics = '{"capacity_usage":0,"things_usage":4}', checked_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND type = 'unittest';
 		UPDATE project_services SET scraped_at = %[3]d, scrape_duration_secs = 5, serialized_metrics = '{"capacity_usage":0,"things_usage":4}', checked_at = %[3]d, next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND type = 'unittest';
 	`,
@@ -196,9 +196,7 @@ func Test_ScrapeSuccess(t *testing.T) {
 		UPDATE project_az_resources SET usage = 3, subresources = '[{"index":2},{"index":3},{"index":4}]' WHERE resource_id = 3 AND az = 'az-two';
 		UPDATE project_az_resources SET usage = 3, subresources = '[{"index":2},{"index":3},{"index":4}]' WHERE resource_id = 6 AND az = 'az-two';
 		UPDATE project_resources SET backend_quota = 110 WHERE id = 1 AND service_id = 1 AND name = 'capacity';
-		UPDATE project_resources SET usage = 5, subresources = '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]' WHERE id = 3 AND service_id = 1 AND name = 'things';
 		UPDATE project_resources SET backend_quota = 110 WHERE id = 4 AND service_id = 2 AND name = 'capacity';
-		UPDATE project_resources SET usage = 5, subresources = '[{"index":0},{"index":1},{"index":2},{"index":3},{"index":4}]' WHERE id = 6 AND service_id = 2 AND name = 'things';
 		UPDATE project_services SET scraped_at = %[1]d, serialized_metrics = '{"capacity_usage":0,"things_usage":5}', checked_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND type = 'unittest';
 		UPDATE project_services SET scraped_at = %[3]d, serialized_metrics = '{"capacity_usage":0,"things_usage":5}', checked_at = %[3]d, next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND type = 'unittest';
 	`,
@@ -294,10 +292,6 @@ func Test_ScrapeSuccess(t *testing.T) {
 		UPDATE project_az_resources SET usage = 5 WHERE resource_id = 2 AND az = 'az-one';
 		UPDATE project_az_resources SET usage = 20, physical_usage = 10 WHERE resource_id = 4 AND az = 'az-one';
 		UPDATE project_az_resources SET usage = 5 WHERE resource_id = 5 AND az = 'az-one';
-		UPDATE project_resources SET usage = 20, physical_usage = 10 WHERE id = 1 AND service_id = 1 AND name = 'capacity';
-		UPDATE project_resources SET usage = 5 WHERE id = 2 AND service_id = 1 AND name = 'capacity_portion';
-		UPDATE project_resources SET usage = 20, physical_usage = 10 WHERE id = 4 AND service_id = 2 AND name = 'capacity';
-		UPDATE project_resources SET usage = 5 WHERE id = 5 AND service_id = 2 AND name = 'capacity_portion';
 		UPDATE project_services SET scraped_at = %[1]d, serialized_metrics = '{"capacity_usage":20,"things_usage":5}', checked_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND type = 'unittest';
 		UPDATE project_services SET scraped_at = %[3]d, serialized_metrics = '{"capacity_usage":20,"things_usage":5}', checked_at = %[3]d, next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND type = 'unittest';
 	`,
@@ -391,12 +385,12 @@ func Test_ScrapeFailure(t *testing.T) {
 		INSERT INTO project_az_resources (resource_id, az, usage) VALUES (4, 'any', 0);
 		INSERT INTO project_az_resources (resource_id, az, usage) VALUES (5, 'any', 0);
 		INSERT INTO project_az_resources (resource_id, az, usage) VALUES (6, 'any', 0);
-		INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (1, 1, 'capacity', 10, 0, -1, 10);
-		INSERT INTO project_resources (id, service_id, name, usage) VALUES (2, 1, 'capacity_portion', 0);
-		INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (3, 1, 'things', 0, 0, -1, 0);
-		INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (4, 2, 'capacity', 10, 0, -1, 12);
-		INSERT INTO project_resources (id, service_id, name, usage) VALUES (5, 2, 'capacity_portion', 0);
-		INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (6, 2, 'things', 0, 0, -1, 0);
+		INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (1, 1, 'capacity', 10, -1, 10);
+		INSERT INTO project_resources (id, service_id, name) VALUES (2, 1, 'capacity_portion');
+		INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (3, 1, 'things', 0, -1, 0);
+		INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (4, 2, 'capacity', 10, -1, 12);
+		INSERT INTO project_resources (id, service_id, name) VALUES (5, 2, 'capacity_portion');
+		INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (6, 2, 'things', 0, -1, 0);
 		UPDATE project_services SET scraped_at = 0, checked_at = %[1]d, scrape_error_message = 'Scrape failed as requested', next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND type = 'unittest';
 		UPDATE project_services SET scraped_at = 0, checked_at = %[3]d, scrape_error_message = 'Scrape failed as requested', next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND type = 'unittest';
 	`,
@@ -446,10 +440,10 @@ func Test_ScrapeFailure(t *testing.T) {
 		DELETE FROM project_az_resources WHERE resource_id = 6 AND az = 'any';
 		INSERT INTO project_az_resources (resource_id, az, usage, subresources) VALUES (6, 'az-one', 2, '[{"index":0},{"index":1}]');
 		INSERT INTO project_az_resources (resource_id, az, usage, subresources) VALUES (6, 'az-two', 2, '[{"index":2},{"index":3}]');
-		UPDATE project_resources SET backend_quota = 100, physical_usage = 0 WHERE id = 1 AND service_id = 1 AND name = 'capacity';
-		UPDATE project_resources SET usage = 4, backend_quota = 42, subresources = '[{"index":0},{"index":1},{"index":2},{"index":3}]' WHERE id = 3 AND service_id = 1 AND name = 'things';
-		UPDATE project_resources SET backend_quota = 100, physical_usage = 0 WHERE id = 4 AND service_id = 2 AND name = 'capacity';
-		UPDATE project_resources SET usage = 4, backend_quota = 42, subresources = '[{"index":0},{"index":1},{"index":2},{"index":3}]' WHERE id = 6 AND service_id = 2 AND name = 'things';
+		UPDATE project_resources SET backend_quota = 100 WHERE id = 1 AND service_id = 1 AND name = 'capacity';
+		UPDATE project_resources SET backend_quota = 42 WHERE id = 3 AND service_id = 1 AND name = 'things';
+		UPDATE project_resources SET backend_quota = 100 WHERE id = 4 AND service_id = 2 AND name = 'capacity';
+		UPDATE project_resources SET backend_quota = 42 WHERE id = 6 AND service_id = 2 AND name = 'things';
 		UPDATE project_services SET scraped_at = %[1]d, scrape_duration_secs = 5, serialized_metrics = '{"capacity_usage":0,"things_usage":4}', checked_at = %[1]d, scrape_error_message = '', next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND type = 'unittest';
 		UPDATE project_services SET scraped_at = %[3]d, scrape_duration_secs = 5, serialized_metrics = '{"capacity_usage":0,"things_usage":4}', checked_at = %[3]d, scrape_error_message = '', next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND type = 'unittest';
 	`,
@@ -521,8 +515,8 @@ func Test_AutoApproveInitialQuota(t *testing.T) {
 	tr.DBChanges().AssertEqualf(`
 		INSERT INTO project_az_resources (resource_id, az, usage) VALUES (1, 'any', 0);
 		INSERT INTO project_az_resources (resource_id, az, usage) VALUES (2, 'any', 0);
-		INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (1, 1, 'approve', 10, 0, 10, 10);
-		INSERT INTO project_resources (id, service_id, name, quota, usage, backend_quota, desired_backend_quota) VALUES (2, 1, 'noapprove', 0, 0, 20, 0);
+		INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (1, 1, 'approve', 10, 10, 10);
+		INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (2, 1, 'noapprove', 0, 20, 0);
 		UPDATE project_services SET scraped_at = %[1]d, scrape_duration_secs = 5, checked_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND type = 'autoapprovaltest';
 	`,
 		scrapedAt.Unix(), scrapedAt.Add(scrapeInterval).Unix(),

--- a/internal/core/data.go
+++ b/internal/core/data.go
@@ -168,8 +168,8 @@ func (d UsageData) add(other UsageData) UsageData {
 // CapacityData contains capacity data for a single project resource.
 type CapacityData struct {
 	Capacity      uint64
-	Usage         uint64 //NOTE: currently only relevant on AZ level, regional level uses the aggregation of project usages
-	Subcapacities []any  //only if supported by plugin and enabled in config
+	Usage         *uint64 //NOTE: currently only relevant on AZ level, regional level uses the aggregation of project usages
+	Subcapacities []any   //only if supported by plugin and enabled in config
 }
 
 // clone implements the AZAwareData interface.
@@ -187,9 +187,16 @@ func (d CapacityData) clone() CapacityData {
 //
 //nolint:unused // looks like a linter bug
 func (d CapacityData) add(other CapacityData) CapacityData {
-	return CapacityData{
+	result := CapacityData{
 		Capacity:      d.Capacity + other.Capacity,
-		Usage:         d.Usage + other.Usage,
 		Subcapacities: append(slices.Clone(d.Subcapacities), other.Subcapacities...),
 	}
+
+	//the sum can only have a PhysicalUsage value if both sides have it
+	if d.Usage != nil && other.Usage != nil {
+		usage := *d.Usage + *other.Usage
+		result.Usage = &usage
+	}
+
+	return result
 }

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -368,4 +368,24 @@ var sqlMigrations = map[string]string{
 	"029_add_project_az_resources.down.sql": `
 		DROP TABLE project_az_resources;
 	`,
+	"030_drop_redundant_resources_columns.up.sql": `
+		ALTER TABLE cluster_resources
+			DROP COLUMN capacity,
+			DROP COLUMN subcapacities,
+			DROP COLUMN capacity_per_az;
+		ALTER TABLE project_resources
+			DROP COLUMN usage,
+			DROP COLUMN subresources,
+			DROP COLUMN physical_usage;
+	`,
+	"030_drop_redundant_resources_columns.down.sql": `
+		ALTER TABLE cluster_resources
+			ADD COLUMN capacity BIGINT NOT NULL,
+			ADD COLUMN subcapacities TEXT NOT NULL DEFAULT '',
+			ADD COLUMN capacity_per_az TEXT NOT NULL DEFAULT '';
+		ALTER TABLE project_resources
+			ADD COLUMN usage BIGINT NOT NULL,
+			ADD COLUMN subresources TEXT NOT NULL DEFAULT '',
+			ADD COLUMN physical_usage BIGINT DEFAULT NULL;
+	`,
 }

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -388,4 +388,12 @@ var sqlMigrations = map[string]string{
 			ADD COLUMN subresources TEXT NOT NULL DEFAULT '',
 			ADD COLUMN physical_usage BIGINT DEFAULT NULL;
 	`,
+	"031_fix_cluster_usage_typing.up.sql": `
+		ALTER TABLE cluster_az_resources
+			ALTER COLUMN usage DROP NOT NULL;
+	`,
+	"031_fix_cluster_usage_typing.down.sql": `
+		ALTER TABLE cluster_az_resources
+			ALTER COLUMN usage SET NOT NULL;
+	`,
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -61,13 +61,10 @@ type ClusterService struct {
 
 // ClusterResource contains a record from the `cluster_resources` table.
 type ClusterResource struct {
-	ID                int64  `db:"id"`
-	CapacitorID       string `db:"capacitor_id"`
-	ServiceID         int64  `db:"service_id"`
-	Name              string `db:"name"`
-	RawCapacity       uint64 `db:"capacity"`
-	CapacityPerAZJSON string `db:"capacity_per_az"`
-	SubcapacitiesJSON string `db:"subcapacities"`
+	ID          int64  `db:"id"`
+	CapacitorID string `db:"capacitor_id"`
+	ServiceID   int64  `db:"service_id"`
+	Name        string `db:"name"`
 }
 
 // Ref returns the ResourceRef for this resource.
@@ -157,11 +154,8 @@ type ProjectResource struct {
 	ServiceID           int64   `db:"service_id"`
 	Name                string  `db:"name"`
 	Quota               *uint64 `db:"quota"`
-	Usage               uint64  `db:"usage"`
-	PhysicalUsage       *uint64 `db:"physical_usage"`
 	BackendQuota        *int64  `db:"backend_quota"`
 	DesiredBackendQuota *uint64 `db:"desired_backend_quota"`
-	SubresourcesJSON    string  `db:"subresources"`
 }
 
 // Ref returns the ResourceRef for this resource.

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -77,7 +77,7 @@ type ClusterAZResource struct {
 	ResourceID        int64                  `db:"resource_id"`
 	AvailabilityZone  limes.AvailabilityZone `db:"az"`
 	RawCapacity       uint64                 `db:"raw_capacity"`
-	Usage             uint64                 `db:"usage"`
+	Usage             *uint64                `db:"usage"`
 	SubcapacitiesJSON string                 `db:"subcapacities"`
 }
 

--- a/internal/plugins/capacity_cinder.go
+++ b/internal/plugins/capacity_cinder.go
@@ -176,7 +176,10 @@ func (p *capacityCinderPlugin) Scrape() (result map[string]map[string]core.PerAZ
 		}
 
 		capa.Capacity += uint64(pool.Capabilities.TotalCapacityGB)
-		capa.Usage += uint64(pool.Capabilities.AllocatedCapacityGB)
+		if capa.Usage == nil {
+			capa.Usage = p2u64(0)
+		}
+		*capa.Usage += uint64(pool.Capabilities.AllocatedCapacityGB)
 
 		if p.reportSubcapacities["capacity"] {
 			capa.Subcapacities = append(capa.Subcapacities, storagePoolSubcapacity{

--- a/internal/plugins/capacity_manila.go
+++ b/internal/plugins/capacity_manila.go
@@ -260,12 +260,12 @@ func (p *capacityManilaPlugin) scrapeForShareType(shareType ManilaShareTypeSpec,
 		}
 		result.ShareGigabytes[az] = &core.CapacityData{
 			Capacity:      getShareCapacity(totalCapacityGbPerAZ[az], capBalance),
-			Usage:         getShareCapacity(allocatedCapacityGbPerAZ[az], capBalance),
+			Usage:         p2u64(getShareCapacity(allocatedCapacityGbPerAZ[az], capBalance)),
 			Subcapacities: shareSubcapacitiesPerAZ[az],
 		}
 		result.SnapshotGigabytes[az] = &core.CapacityData{
 			Capacity:      getSnapshotCapacity(totalCapacityGbPerAZ[az], capBalance),
-			Usage:         getSnapshotCapacity(allocatedCapacityGbPerAZ[az], capBalance),
+			Usage:         p2u64(getSnapshotCapacity(allocatedCapacityGbPerAZ[az], capBalance)),
 			Subcapacities: snapshotSubcapacitiesPerAZ[az],
 		}
 	}

--- a/internal/plugins/capacity_sapcc_ironic.go
+++ b/internal/plugins/capacity_sapcc_ironic.go
@@ -268,7 +268,10 @@ func (p *capacitySapccIronicPlugin) Scrape() (result map[string]map[string]core.
 
 				data.Capacity++
 				if node.StableProvisionState() == "active" {
-					data.Usage++
+					if data.Usage == nil {
+						data.Usage = p2u64(0)
+					}
+					*data.Usage++
 				}
 
 				if p.reportSubcapacities {

--- a/internal/plugins/utils.go
+++ b/internal/plugins/utils.go
@@ -1,0 +1,24 @@
+/*******************************************************************************
+*
+* Copyright 2023 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package plugins
+
+func p2u64(val uint64) *uint64 {
+	return &val
+}

--- a/internal/reports/cluster.go
+++ b/internal/reports/cluster.go
@@ -195,10 +195,10 @@ func GetClusterResources(cluster *core.Cluster, dbi db.Interface, filter Filter)
 				mergeJSONListInto(&resource.Subcapacities, *subcapacitiesInAZ)
 			}
 
-			if availabilityZone != nil && rawCapacityInAZ != nil && usageInAZ != nil {
+			if availabilityZone != nil && rawCapacityInAZ != nil {
 				azReport := limesresources.ClusterAvailabilityZoneReport{
 					Name:  *availabilityZone,
-					Usage: *usageInAZ,
+					Usage: unwrapOrDefault(usageInAZ, 0),
 				}
 				overcommitFactor := cluster.BehaviorForResource(serviceType, *resourceName, "").OvercommitFactor
 				if overcommitFactor == 0 {

--- a/internal/reports/utils.go
+++ b/internal/reports/utils.go
@@ -20,10 +20,24 @@
 package reports
 
 import (
+	"encoding/json"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/sapcc/go-api-declarations/limes"
 )
+
+func pointerTo[T any](value T) *T {
+	return &value
+}
+
+func unwrapOrDefault[T any](value *T, defaultValue T) T {
+	if value == nil {
+		return defaultValue
+	}
+	return *value
+}
 
 func mergeMinTime(lhs *limes.UnixEncodedTime, rhs *time.Time) *limes.UnixEncodedTime {
 	if rhs == nil {
@@ -45,4 +59,26 @@ func mergeMaxTime(lhs *limes.UnixEncodedTime, rhs *time.Time) *limes.UnixEncoded
 		return &val
 	}
 	return lhs
+}
+
+// Merges subcapacities and subresources across AZs.
+// Each successive `input` is a JSON list without whitespace like
+//
+//	[{"entry":1},{"entry":2}]
+//
+// and the target is a similar JSON list with all entries concatenated in order.
+// This could also be done by unmarshalling into []any, concatenating and remarshalling,
+// but this implementation is more efficient.
+func mergeJSONListInto(target *json.RawMessage, input string) {
+	if input == "" || input == "[]" {
+		return
+	}
+	if string(*target) == "" || string(*target) == "[]" {
+		*target = json.RawMessage(input)
+		return
+	}
+	*target = json.RawMessage(fmt.Sprintf("%s,%s",
+		strings.TrimSuffix(string(*target), "]"),
+		strings.TrimPrefix(input, "["),
+	))
 }

--- a/internal/test/plugins/capacity_static.go
+++ b/internal/test/plugins/capacity_static.go
@@ -36,6 +36,7 @@ type StaticCapacityPlugin struct {
 	Capacity          uint64   `yaml:"capacity"`
 	WithAZCapData     bool     `yaml:"with_capacity_per_az"`
 	WithSubcapacities bool     `yaml:"with_subcapacities"`
+	WithoutUsage      bool     `yaml:"without_usage"`
 }
 
 func init() {
@@ -64,11 +65,15 @@ func (p *StaticCapacityPlugin) Scrape() (result map[string]map[string]core.PerAZ
 				map[string]any{"az": az, "larger_half": largerHalf},
 			}
 		}
-		return &core.CapacityData{
+		result := core.CapacityData{
 			Capacity:      capacity,
-			Usage:         usage,
+			Usage:         &usage,
 			Subcapacities: subcapacities,
 		}
+		if p.WithoutUsage {
+			result.Usage = nil
+		}
+		return &result
 	}
 
 	fullCapa := core.PerAZ[core.CapacityData]{


### PR DESCRIPTION
As a followup to #370, this changeset moves all uses of AZ-aware data from the sum fields on the resources to the AZ resources tables, and then removes the sum fields that are now unused.

The one exception is the `project_resources.quota` field. Since the old quota distribution model is not AZ-aware, we continue storing quota on the resource level for now. The new quota distribution model will use the prepared `project_az_resources.quota` field once it arrives.