### PR TITLE
add new PerAZ field to ProjectResourceReport

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/majewsky/schwift v1.3.0
 	github.com/prometheus/client_golang v1.17.0
 	github.com/rs/cors v1.10.1
-	github.com/sapcc/go-api-declarations v1.10.0
+	github.com/sapcc/go-api-declarations v1.10.1
 	github.com/sapcc/go-bits v0.0.0-20231025110038-7e644a44c112
 	go.uber.org/automaxprocs v1.5.3
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,8 @@ github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjR
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/rs/cors v1.10.1 h1:L0uuZVXIKlI1SShY2nhFfo44TYvDPQ1w4oFkUJNfhyo=
 github.com/rs/cors v1.10.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
-github.com/sapcc/go-api-declarations v1.10.0 h1:1RydcuO+8Cc48QZs92FhzV8Md8ljH29Z8zaodvZXIoM=
-github.com/sapcc/go-api-declarations v1.10.0/go.mod h1:83R3hTANhuRXt/pXDby37IJetw8l7DG41s33Tp9NXxI=
+github.com/sapcc/go-api-declarations v1.10.1 h1:rCfwwdjLMxKwQ7Q6rHl1oJwES90eLWGzf/mRp1lzvQM=
+github.com/sapcc/go-api-declarations v1.10.1/go.mod h1:83R3hTANhuRXt/pXDby37IJetw8l7DG41s33Tp9NXxI=
 github.com/sapcc/go-bits v0.0.0-20231025110038-7e644a44c112 h1:BdPiGuN3Ht3W3TiZ+sjMYxic90ypqsO/DB2Z7YUeloQ=
 github.com/sapcc/go-bits v0.0.0-20231025110038-7e644a44c112/go.mod h1:rfuD6L3QHx0JhZHGX8zEMPczStM25iI+GBKvCmWvLhk=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -260,11 +260,9 @@ func GetDomainReport(cluster *core.Cluster, dbDomain db.Domain, dbi db.Interface
 }
 
 // GetProjectResourceReport is a convenience wrapper around reports.GetProjectResources() for getting a single project resource report.
-//
-//nolint:dupl
-func GetProjectResourceReport(cluster *core.Cluster, dbDomain db.Domain, dbProject db.Project, dbi db.Interface, filter reports.Filter) (*limesresources.ProjectReport, error) {
+func GetProjectResourceReport(cluster *core.Cluster, dbDomain db.Domain, dbProject db.Project, now time.Time, dbi db.Interface, filter reports.Filter) (*limesresources.ProjectReport, error) {
 	var result *limesresources.ProjectReport
-	err := reports.GetProjectResources(cluster, dbDomain, &dbProject, dbi, filter, func(r *limesresources.ProjectReport) error {
+	err := reports.GetProjectResources(cluster, dbDomain, &dbProject, now, dbi, filter, func(r *limesresources.ProjectReport) error {
 		result = r
 		return nil
 	})
@@ -278,8 +276,6 @@ func GetProjectResourceReport(cluster *core.Cluster, dbDomain db.Domain, dbProje
 }
 
 // GetProjectRateReport is a convenience wrapper around reports.GetProjectRates() for getting a single project rate report.
-//
-//nolint:dupl
 func GetProjectRateReport(cluster *core.Cluster, dbDomain db.Domain, dbProject db.Project, dbi db.Interface, filter reports.Filter) (*limesrates.ProjectReport, error) {
 	var result *limesrates.ProjectReport
 	err := reports.GetProjectRates(cluster, dbDomain, &dbProject, dbi, filter, func(r *limesrates.ProjectReport) error {

--- a/internal/api/domains.go
+++ b/internal/api/domains.go
@@ -118,6 +118,7 @@ func (p *v1Provider) putOrSimulatePutDomain(w http.ResponseWriter, r *http.Reque
 
 	updater := QuotaUpdater{
 		Cluster:    p.Cluster,
+		Now:        p.timeNow(),
 		CanRaise:   checkToken("domain:raise"),
 		CanRaiseLP: checkToken("domain:raise_lowpriv"),
 		CanLower:   checkToken("domain:lower"),

--- a/internal/api/fixtures/project-list-with-v2-api.json
+++ b/internal/api/fixtures/project-list-with-v2-api.json
@@ -1,0 +1,236 @@
+{
+  "projects": [
+    {
+      "id": "uuid-for-berlin",
+      "name": "berlin",
+      "parent_id": "uuid-for-germany",
+      "services": [
+        {
+          "type": "shared",
+          "area": "shared",
+          "resources": [
+            {
+              "name": "capacity",
+              "unit": "B",
+              "quota_distribution_model": "hierarchical",
+              "per_az": {
+                "az-one": {
+                  "usage": 1
+                },
+                "az-two": {
+                  "usage": 1
+                }
+              },
+              "quota": 10,
+              "usable_quota": 10,
+              "usage": 2
+            },
+            {
+              "name": "capacity_portion",
+              "unit": "B",
+              "contained_in": "capacity",
+              "per_az": {
+                "az-one": {
+                  "usage": 1
+                },
+                "az-two": {
+                  "usage": 0
+                }
+              },
+              "usage": 1
+            },
+            {
+              "name": "things",
+              "quota_distribution_model": "hierarchical",
+              "per_az": {
+                "any": {
+                  "usage": 2
+                }
+              },
+              "quota": 10,
+              "usable_quota": 10,
+              "usage": 2
+            }
+          ],
+          "scraped_at": 22
+        },
+        {
+          "type": "unshared",
+          "area": "unshared",
+          "resources": [
+            {
+              "name": "capacity",
+              "unit": "B",
+              "quota_distribution_model": "hierarchical",
+              "per_az": {
+                "az-one": {
+                  "usage": 1
+                },
+                "az-two": {
+                  "usage": 1
+                }
+              },
+              "quota": 10,
+              "usable_quota": 10,
+              "usage": 2
+            },
+            {
+              "name": "capacity_portion",
+              "unit": "B",
+              "contained_in": "capacity",
+              "per_az": {
+                "az-one": {
+                  "usage": 1
+                },
+                "az-two": {
+                  "usage": 0
+                }
+              },
+              "usage": 1
+            },
+            {
+              "name": "things",
+              "quota_distribution_model": "hierarchical",
+              "per_az": {
+                "any": {
+                  "usage": 2
+                }
+              },
+              "quota": 10,
+              "usable_quota": 10,
+              "usage": 2,
+              "scales_with": {
+                "resource_name": "things",
+                "service_type": "shared",
+                "factor": 2
+              }
+            }
+          ],
+          "scraped_at": 11
+        }
+      ]
+    },
+    {
+      "id": "uuid-for-dresden",
+      "name": "dresden",
+      "parent_id": "uuid-for-berlin",
+      "services": [
+        {
+          "type": "shared",
+          "area": "shared",
+          "resources": [
+            {
+              "name": "capacity",
+              "unit": "B",
+              "quota_distribution_model": "hierarchical",
+              "per_az": {
+                "az-one": {
+                  "usage": 1
+                },
+                "az-two": {
+                  "usage": 1
+                }
+              },
+              "quota": 10,
+              "usable_quota": 10,
+              "usage": 2,
+              "backend_quota": 100
+            },
+            {
+              "name": "capacity_portion",
+              "unit": "B",
+              "contained_in": "capacity",
+              "per_az": {
+                "az-one": {
+                  "usage": 1
+                },
+                "az-two": {
+                  "usage": 0
+                }
+              },
+              "usage": 1
+            },
+            {
+              "name": "things",
+              "quota_distribution_model": "hierarchical",
+              "per_az": {
+                "any": {
+                  "usage": 2
+                }
+              },
+              "quota": 10,
+              "usable_quota": 10,
+              "usage": 2,
+              "annotations": {
+                "annotated": true,
+                "text": "this annotation appears on shared/things of project dresden only"
+              }
+            }
+          ],
+          "scraped_at": 44
+        },
+        {
+          "type": "unshared",
+          "area": "unshared",
+          "resources": [
+            {
+              "name": "capacity",
+              "unit": "B",
+              "quota_distribution_model": "hierarchical",
+              "per_az": {
+                "az-one": {
+                  "committed": {
+                    "1 year": 2,
+                    "2 years": 1
+                  },
+                  "usage": 1
+                },
+                "az-two": {
+                  "committed": {
+                    "1 year": 2
+                  },
+                  "usage": 1
+                }
+              },
+              "quota": 10,
+              "usable_quota": 10,
+              "usage": 2
+            },
+            {
+              "name": "capacity_portion",
+              "unit": "B",
+              "contained_in": "capacity",
+              "per_az": {
+                "az-one": {
+                  "usage": 1
+                },
+                "az-two": {
+                  "usage": 0
+                }
+              },
+              "usage": 1
+            },
+            {
+              "name": "things",
+              "quota_distribution_model": "hierarchical",
+              "per_az": {
+                "any": {
+                  "usage": 2
+                }
+              },
+              "quota": 10,
+              "usable_quota": 10,
+              "usage": 2,
+              "scales_with": {
+                "resource_name": "things",
+                "service_type": "shared",
+                "factor": 2
+              }
+            }
+          ],
+          "scraped_at": 33
+        }
+      ]
+    }
+  ]
+}

--- a/internal/api/fixtures/start-data.sql
+++ b/internal/api/fixtures/start-data.sql
@@ -109,6 +109,19 @@ INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage,
 INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (18, 'az-one', NULL, 1, NULL, '');
 INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage, subresources) VALUES (18, 'az-two', NULL, 0, NULL, '');
 
+-- project_commitments has several entries for project dresden
+-- on "unshared/capacity": regular active commitments with different durations
+INSERT INTO project_commitments (id, service_id, resource_name, availability_zone, amount, duration, requested_at, confirm_after, confirmed_at, expires_at) VALUES (1, 3, 'capacity', 'az-one', 1,   '2 years',    UNIX(1), UNIX(1), UNIX(1), UNIX(100000001));
+INSERT INTO project_commitments (id, service_id, resource_name, availability_zone, amount, duration, requested_at, confirm_after, confirmed_at, expires_at) VALUES (2, 3, 'capacity', 'az-one', 1,   '1 year',     UNIX(2), UNIX(2), UNIX(2), UNIX(100000002));
+INSERT INTO project_commitments (id, service_id, resource_name, availability_zone, amount, duration, requested_at, confirm_after, confirmed_at, expires_at) VALUES (3, 3, 'capacity', 'az-one', 1,   '1 year',     UNIX(3), UNIX(3), UNIX(3), UNIX(100000003));
+INSERT INTO project_commitments (id, service_id, resource_name, availability_zone, amount, duration, requested_at, confirm_after, confirmed_at, expires_at) VALUES (4, 3, 'capacity', 'az-two', 2,   '1 year',     UNIX(4), UNIX(4), UNIX(4), UNIX(100000004));
+-- on "unshared/capacity": unconfirmed commitments should not be reported
+INSERT INTO project_commitments (id, service_id, resource_name, availability_zone, amount, duration, requested_at, confirm_after, confirmed_at, expires_at) VALUES (5, 3, 'capacity', 'az-two', 100, '2 years',    UNIX(5), UNIX(5), NULL,    NULL);
+-- on "unshared/capacity": expired commitments should not be reported (NOTE: the test's clock stands at UNIX timestamp 3600)
+INSERT INTO project_commitments (id, service_id, resource_name, availability_zone, amount, duration, requested_at, confirm_after, confirmed_at, expires_at) VALUES (6, 3, 'capacity', 'az-one', 5,   '10 minutes', UNIX(6), UNIX(6), UNIX(6), UNIX(606));
+-- on "shared/capacity": only an unconfirmed commitment that should not be reported, this tests that the entire "committed" structure is absent in the JSON
+INSERT INTO project_commitments (id, service_id, resource_name, availability_zone, amount, duration, requested_at, confirm_after, confirmed_at, expires_at) VALUES (7, 4, 'capacity', 'az-one', 100, '2 years',    UNIX(7), UNIX(7), NULL,    NULL);
+
 -- project_rates also has multiple different setups to test different cases
 -- berlin has custom rate limits
 INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_bigint) VALUES (1, 'service/unshared/instances:create', 5, 60000000000, '');

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -63,7 +63,7 @@ func (p *v1Provider) ListProjects(w http.ResponseWriter, r *http.Request) {
 
 	filter := reports.ReadFilter(r, p.Cluster.GetServiceTypesForArea)
 	stream := NewJSONListStream[*limesresources.ProjectReport](w, r, "projects")
-	stream.FinalizeDocument(reports.GetProjectResources(p.Cluster, *dbDomain, nil, p.DB, filter, stream.WriteItem))
+	stream.FinalizeDocument(reports.GetProjectResources(p.Cluster, *dbDomain, nil, p.timeNow(), p.DB, filter, stream.WriteItem))
 }
 
 // GetProject handles GET /v1/domains/:domain_id/projects/:project_id.
@@ -82,7 +82,7 @@ func (p *v1Provider) GetProject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	project, err := GetProjectResourceReport(p.Cluster, *dbDomain, *dbProject, p.DB, reports.ReadFilter(r, p.Cluster.GetServiceTypesForArea))
+	project, err := GetProjectResourceReport(p.Cluster, *dbDomain, *dbProject, p.timeNow(), p.DB, reports.ReadFilter(r, p.Cluster.GetServiceTypesForArea))
 	if respondwith.ErrorText(w, err) {
 		return
 	}
@@ -225,6 +225,7 @@ func (p *v1Provider) putOrSimulatePutProjectQuotas(w http.ResponseWriter, r *htt
 
 	updater := QuotaUpdater{
 		Cluster:    p.Cluster,
+		Now:        p.timeNow(),
 		CanRaise:   checkToken("project:raise"),
 		CanRaiseLP: checkToken("project:raise_lowpriv"),
 		CanLower:   checkToken("project:lower"),

--- a/internal/api/quota_updater.go
+++ b/internal/api/quota_updater.go
@@ -45,6 +45,9 @@ type QuotaUpdater struct {
 	Domain  *db.Domain  //always set (for project quota updates, contains the project's domain)
 	Project *db.Project //nil for domain quota updates
 
+	//context
+	Now time.Time
+
 	//AuthZ info
 	CanRaise   func(serviceType, resourceName string) bool
 	CanRaiseLP func(serviceType, resourceName string) bool //low-privilege raise
@@ -124,7 +127,7 @@ func (u *QuotaUpdater) ValidateInput(input limesresources.QuotaRequest, dbi db.I
 	//for project scope, we also need a project report for validation
 	var projectReport *limesresources.ProjectReport
 	if u.Project != nil {
-		projectReport, err = GetProjectResourceReport(u.Cluster, *u.Domain, *u.Project, dbi, reports.Filter{})
+		projectReport, err = GetProjectResourceReport(u.Cluster, *u.Domain, *u.Project, u.Now, dbi, reports.Filter{})
 		if err != nil {
 			return err
 		}

--- a/internal/reports/filter.go
+++ b/internal/reports/filter.go
@@ -22,6 +22,7 @@ package reports
 import (
 	"net/http"
 	"regexp"
+	"strings"
 
 	"github.com/sapcc/limes/internal/db"
 )
@@ -34,6 +35,7 @@ type Filter struct {
 
 	WithSubresources  bool
 	WithSubcapacities bool
+	WithAZBreakdown   bool
 
 	IsSubcapacityAllowed func(serviceType, resourceName string) bool
 }
@@ -55,6 +57,7 @@ func ReadFilter(r *http.Request, getServiceTypesForArea func(string) []string) F
 		f.WithSubresources = ok
 		f.WithSubcapacities = ok
 	}
+	f.WithAZBreakdown = strings.Contains(r.Header.Get("X-Limes-V2-API-Preview"), "per-az")
 
 	if areas, ok := queryValues["area"]; ok {
 		var areaServices []string

--- a/internal/reports/project.go
+++ b/internal/reports/project.go
@@ -71,7 +71,7 @@ var (
 // reports with the highest detail levels can be several MB large, we don't just
 // return them all in a big list. Instead, the `submit` callback gets called
 // once for each project report once that report is complete.
-func GetProjectResources(cluster *core.Cluster, domain db.Domain, project *db.Project, dbi db.Interface, filter Filter, submit func(*limesresources.ProjectReport) error) error {
+func GetProjectResources(cluster *core.Cluster, domain db.Domain, project *db.Project, now time.Time, dbi db.Interface, filter Filter, submit func(*limesresources.ProjectReport) error) error {
 	clusterCanBurst := cluster.Config.Bursting.MaxMultiplier > 0
 
 	fields := map[string]any{"p.domain_id": domain.ID}

--- a/internal/reports/project.go
+++ b/internal/reports/project.go
@@ -21,6 +21,7 @@ package reports
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -51,9 +52,9 @@ var (
 	 WHERE %s
 	 ORDER BY p.uuid
 `)
-	// NOTE: The subquery emulates the behavior of the old `usage` and `physical_usage` columns on `project_resources`.
+
 	projectReportQuery = sqlext.SimplifyWhitespace(`
-	SELECT p.uuid, p.name, COALESCE(p.parent_uuid, ''), p.has_bursting, ps.type, ps.scraped_at, pr.name, pr.quota, par.usage, par.physical_usage, pr.backend_quota, par.subresources
+	SELECT p.id, p.uuid, p.name, COALESCE(p.parent_uuid, ''), p.has_bursting, ps.type, ps.scraped_at, pr.name, pr.quota, par.az, par.usage, par.physical_usage, pr.backend_quota, par.subresources
 	  FROM projects p
 	  LEFT OUTER JOIN project_services ps ON ps.project_id = p.id {{AND ps.type = $service_type}}
 	  LEFT OUTER JOIN project_resources pr ON pr.service_id = ps.id {{AND pr.name = $resource_name}}
@@ -61,6 +62,14 @@ var (
 	 WHERE %s
 	 ORDER BY p.uuid, par.az
 `)
+
+	projectReportCommitmentsQuery = sqlext.SimplifyWhitespace(`
+	SELECT ps.type, pc.resource_name, pc.availability_zone, pc.duration, SUM(pc.amount)
+	  FROM project_services ps
+	  JOIN project_commitments pc ON pc.service_id = ps.id
+	 WHERE ps.project_id = $1 AND pc.confirmed_at IS NOT NULL AND pc.superseded_at IS NULL AND pc.expires_at > $2
+	 GROUP BY ps.type, pc.resource_name, pc.availability_zone, pc.duration
+	`)
 )
 
 // GetProjectResources returns limes.ProjectReport reports for all projects in
@@ -87,9 +96,13 @@ func GetProjectResources(cluster *core.Cluster, domain db.Domain, project *db.Pr
 	queryStr, joinArgs := filter.PrepareQuery(queryStr)
 	whereStr, whereArgs := db.BuildSimpleWhereClause(fields, len(joinArgs))
 
-	var projectReport *limesresources.ProjectReport
+	var (
+		currentProjectID int64
+		projectReport    *limesresources.ProjectReport
+	)
 	err := sqlext.ForeachRow(dbi, fmt.Sprintf(queryStr, whereStr), append(joinArgs, whereArgs...), func(rows *sql.Rows) error {
 		var (
+			projectID          int64
 			projectUUID        string
 			projectName        string
 			projectParentUUID  string
@@ -98,15 +111,16 @@ func GetProjectResources(cluster *core.Cluster, domain db.Domain, project *db.Pr
 			scrapedAt          *time.Time
 			resourceName       *string
 			quota              *uint64
+			az                 *limes.AvailabilityZone
 			azUsage            *uint64
 			azPhysicalUsage    *uint64
 			backendQuota       *int64
 			azSubresources     *string
 		)
 		err := rows.Scan(
-			&projectUUID, &projectName, &projectParentUUID, &projectHasBursting,
+			&projectID, &projectUUID, &projectName, &projectParentUUID, &projectHasBursting,
 			&serviceType, &scrapedAt, &resourceName,
-			&quota, &azUsage, &azPhysicalUsage, &backendQuota, &azSubresources,
+			&quota, &az, &azUsage, &azPhysicalUsage, &backendQuota, &azSubresources,
 		)
 		if err != nil {
 			return err
@@ -115,16 +129,21 @@ func GetProjectResources(cluster *core.Cluster, domain db.Domain, project *db.Pr
 		//if we're moving to a different project, publish the finished report
 		//first (and then allow for it to be GCd)
 		if projectReport != nil && projectReport.UUID != projectUUID {
-			finalizeProjectReport(projectReport)
-			err := submit(projectReport)
+			err := finalizeProjectResourceReport(projectReport, currentProjectID, now, dbi, filter)
+			if err != nil {
+				return err
+			}
+			err = submit(projectReport)
 			if err != nil {
 				return err
 			}
 			projectReport = nil
+			currentProjectID = 0
 		}
 
 		//start new project report when necessary
 		if projectReport == nil {
+			currentProjectID = projectID
 			projectReport = &limesresources.ProjectReport{
 				ProjectInfo: limes.ProjectInfo{
 					Name:       projectName,
@@ -180,6 +199,10 @@ func GetProjectResources(cluster *core.Cluster, domain db.Domain, project *db.Pr
 				//all other fields are set below
 			}
 
+			if filter.WithAZBreakdown {
+				resReport.PerAZ = make(limesresources.ProjectAZResourceReports)
+			}
+
 			if !resReport.NoQuota {
 				qdConfig := cluster.QuotaDistributionConfigForResource(*serviceType, *resourceName)
 				resReport.QuotaDistributionModel = qdConfig.Model
@@ -202,7 +225,7 @@ func GetProjectResources(cluster *core.Cluster, domain db.Domain, project *db.Pr
 		}
 
 		//fill data from project_az_resources into resource report
-		if azUsage == nil {
+		if az == nil {
 			return nil //no project_az_resources available
 		}
 		resReport.Usage += *azUsage
@@ -216,6 +239,16 @@ func GetProjectResources(cluster *core.Cluster, domain db.Domain, project *db.Pr
 			mergeJSONListInto(&resReport.Subresources, *azSubresources)
 		}
 
+		if filter.WithAZBreakdown {
+			resReport.PerAZ[*az] = &limesresources.ProjectAZResourceReport{
+				Quota:         nil, //TODO: report this once we have a distribution model that fills quota per AZ
+				Committed:     nil, //will be filled by finalizeProjectResourceReport()
+				Usage:         *azUsage,
+				PhysicalUsage: azPhysicalUsage,
+				Subresources:  json.RawMessage(*azSubresources),
+			}
+		}
+
 		return nil
 	})
 	if err != nil {
@@ -224,13 +257,16 @@ func GetProjectResources(cluster *core.Cluster, domain db.Domain, project *db.Pr
 
 	//submit final project report
 	if projectReport != nil {
-		finalizeProjectReport(projectReport)
+		err := finalizeProjectResourceReport(projectReport, currentProjectID, now, dbi, filter)
+		if err != nil {
+			return err
+		}
 		return submit(projectReport)
 	}
 	return nil
 }
 
-func finalizeProjectReport(projectReport *limesresources.ProjectReport) {
+func finalizeProjectResourceReport(projectReport *limesresources.ProjectReport, projectID int64, now time.Time, dbi db.Interface, filter Filter) error {
 	if projectReport.Bursting != nil && projectReport.Bursting.Enabled {
 		for _, srvReport := range projectReport.Services {
 			for _, resReport := range srvReport.Resources {
@@ -240,6 +276,48 @@ func finalizeProjectReport(projectReport *limesresources.ProjectReport) {
 			}
 		}
 	}
+
+	if filter.WithAZBreakdown {
+		// if `per_az` is shown, we need to compute the sum of all active commitments using a different query
+		err := sqlext.ForeachRow(dbi, projectReportCommitmentsQuery, []any{projectID, now}, func(rows *sql.Rows) error {
+			var (
+				serviceType  string
+				resourceName string
+				az           limes.AvailabilityZone
+				duration     limesresources.CommitmentDuration
+				amount       uint64
+			)
+			err := rows.Scan(&serviceType, &resourceName, &az, &duration, &amount)
+			if err != nil {
+				return err
+			}
+
+			srvReport := projectReport.Services[serviceType]
+			if srvReport == nil {
+				return nil
+			}
+			resReport := srvReport.Resources[resourceName]
+			if resReport == nil {
+				return nil
+			}
+			azReport := resReport.PerAZ[az]
+			if azReport == nil {
+				return nil
+			}
+
+			if azReport.Committed == nil {
+				azReport.Committed = make(map[string]uint64)
+			}
+			azReport.Committed[duration.String()] = amount
+
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // GetProjectRates works just like GetProjects, except that rate data is returned instead of resource data.

--- a/vendor/github.com/sapcc/go-api-declarations/limes/resources/report_cluster.go
+++ b/vendor/github.com/sapcc/go-api-declarations/limes/resources/report_cluster.go
@@ -95,4 +95,4 @@ type ClusterAvailabilityZoneReports map[limes.AvailabilityZone]*ClusterAvailabil
 
 // ClusterAZResourceReport is a substructure of ClusterResourceReport that breaks
 // down capacity and usage data for a single resource by availability zone.
-type ClusterAZResourceReports map[limes.AvailabilityZone]ClusterAZResourceReport
+type ClusterAZResourceReports map[limes.AvailabilityZone]*ClusterAZResourceReport

--- a/vendor/github.com/sapcc/go-api-declarations/limes/resources/report_project.go
+++ b/vendor/github.com/sapcc/go-api-declarations/limes/resources/report_project.go
@@ -96,4 +96,4 @@ type ProjectResourceReports map[string]*ProjectResourceReport
 
 // ProjectAZResourceReport is a substructure of ProjectResourceReport that breaks
 // down quota and usage data for a single resource by availability zone.
-type ProjectAZResourceReports map[limes.AvailabilityZone]ProjectAZResourceReport
+type ProjectAZResourceReports map[limes.AvailabilityZone]*ProjectAZResourceReport

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -142,7 +142,7 @@ github.com/rabbitmq/amqp091-go
 # github.com/rs/cors v1.10.1
 ## explicit; go 1.13
 github.com/rs/cors
-# github.com/sapcc/go-api-declarations v1.10.0
+# github.com/sapcc/go-api-declarations v1.10.1
 ## explicit; go 1.21
 github.com/sapcc/go-api-declarations/bininfo
 github.com/sapcc/go-api-declarations/cadf


### PR DESCRIPTION
Since this increases the report size substantially, this is gated behind the HTTP header `X-Limes-V2-API-Preview: per-az` for now, which will only be used by clients that actually need the AZ breakdown.

The API spec does not reflect this, since this is currently a "hidden API". It will become fully official when we bump the API to v2. At that point, I will also update the API spec to reflect these new capabilities.