### PR TITLE
fill PerAZ field in ClusterResourceReport

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/majewsky/schwift v1.3.0
 	github.com/prometheus/client_golang v1.17.0
 	github.com/rs/cors v1.10.1
-	github.com/sapcc/go-api-declarations v1.10.1
+	github.com/sapcc/go-api-declarations v1.10.3
 	github.com/sapcc/go-bits v0.0.0-20231025110038-7e644a44c112
 	go.uber.org/automaxprocs v1.5.3
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,8 @@ github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjR
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/rs/cors v1.10.1 h1:L0uuZVXIKlI1SShY2nhFfo44TYvDPQ1w4oFkUJNfhyo=
 github.com/rs/cors v1.10.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
-github.com/sapcc/go-api-declarations v1.10.1 h1:rCfwwdjLMxKwQ7Q6rHl1oJwES90eLWGzf/mRp1lzvQM=
-github.com/sapcc/go-api-declarations v1.10.1/go.mod h1:83R3hTANhuRXt/pXDby37IJetw8l7DG41s33Tp9NXxI=
+github.com/sapcc/go-api-declarations v1.10.3 h1:wFnq1Qx1Uv0G4F0AWT+9E4N/8n77Lm3buUpT9rFm/QY=
+github.com/sapcc/go-api-declarations v1.10.3/go.mod h1:83R3hTANhuRXt/pXDby37IJetw8l7DG41s33Tp9NXxI=
 github.com/sapcc/go-bits v0.0.0-20231025110038-7e644a44c112 h1:BdPiGuN3Ht3W3TiZ+sjMYxic90ypqsO/DB2Z7YUeloQ=
 github.com/sapcc/go-bits v0.0.0-20231025110038-7e644a44c112/go.mod h1:rfuD6L3QHx0JhZHGX8zEMPczStM25iI+GBKvCmWvLhk=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -278,6 +278,17 @@ func Test_ClusterOperations(t *testing.T) {
 		ExpectBody:   assert.JSONFixtureFile("fixtures/cluster-get-west-filtered.json"),
 	}.Check(t, s.Handler)
 
+	//check GetCluster with new API features enabled
+	assert.HTTPRequest{
+		Method: "GET",
+		Path:   "/v1/clusters/current",
+		Header: map[string]string{
+			"X-Limes-V2-API-Preview": "per-az",
+		},
+		ExpectStatus: 200,
+		ExpectBody:   assert.JSONFixtureFile("./fixtures/cluster-get-west-with-v2-api.json"),
+	}.Check(t, s.Handler)
+
 	//check GetClusterRates
 	assert.HTTPRequest{
 		Method:       "GET",
@@ -308,6 +319,15 @@ func Test_ClusterOperations(t *testing.T) {
 		Path:         "/v1/clusters/current",
 		ExpectStatus: 200,
 		ExpectBody:   assert.JSONFixtureFile("fixtures/cluster-get-west-with-overcommit.json"),
+	}.Check(t, s.Handler)
+	assert.HTTPRequest{
+		Method: "GET",
+		Path:   "/v1/clusters/current",
+		Header: map[string]string{
+			"X-Limes-V2-API-Preview": "per-az",
+		},
+		ExpectStatus: 200,
+		ExpectBody:   assert.JSONFixtureFile("fixtures/cluster-get-west-with-overcommit-and-v2-api.json"),
 	}.Check(t, s.Handler)
 }
 

--- a/internal/api/fixtures/cluster-get-west-with-overcommit-and-v2-api.json
+++ b/internal/api/fixtures/cluster-get-west-with-overcommit-and-v2-api.json
@@ -1,0 +1,142 @@
+{
+  "cluster": {
+    "id": "current",
+    "services": [
+      {
+        "type": "shared",
+        "area": "shared",
+        "resources": [
+          {
+            "name": "capacity",
+            "unit": "B",
+            "quota_distribution_model": "hierarchical",
+            "capacity": 185,
+            "per_az": {
+              "az-one": {
+                "capacity": 90,
+                "usage": 12,
+                "projects_usage": 3,
+                "physical_usage": 2
+              },
+              "az-two": {
+                "capacity": 95,
+                "usage": 15,
+                "projects_usage": 3,
+                "physical_usage": 3
+              }
+            },
+            "per_availability_zone": [
+              {
+                "name": "az-one",
+                "capacity": 90,
+                "usage": 12
+              },
+              {
+                "name": "az-two",
+                "capacity": 95,
+                "usage": 15
+              }
+            ],
+            "domains_quota": 25,
+            "usage": 6,
+            "physical_usage": 5
+          },
+          {
+            "name": "capacity_portion",
+            "unit": "B",
+            "contained_in": "capacity",
+            "per_az": {
+              "az-one": {
+                "capacity": 0,
+                "projects_usage": 3
+              },
+              "az-two": {
+                "capacity": 0
+              }
+            },
+            "usage": 3
+          },
+          {
+            "name": "things",
+            "quota_distribution_model": "hierarchical",
+            "capacity": 615,
+            "raw_capacity": 246,
+            "per_az": {
+              "any": {
+                "capacity": 615,
+                "raw_capacity": 246,
+                "usage": 158,
+                "projects_usage": 6
+              }
+            },
+            "domains_quota": 30,
+            "usage": 6
+          }
+        ],
+        "max_scraped_at": 66,
+        "min_scraped_at": 22
+      },
+      {
+        "type": "unshared",
+        "area": "unshared",
+        "resources": [
+          {
+            "name": "capacity",
+            "unit": "B",
+            "quota_distribution_model": "hierarchical",
+            "per_az": {
+              "az-one": {
+                "capacity": 0,
+                "projects_usage": 3,
+                "physical_usage": 2
+              },
+              "az-two": {
+                "capacity": 0,
+                "projects_usage": 3,
+                "physical_usage": 3
+              }
+            },
+            "domains_quota": 100,
+            "usage": 6,
+            "physical_usage": 5
+          },
+          {
+            "name": "capacity_portion",
+            "unit": "B",
+            "contained_in": "capacity",
+            "per_az": {
+              "az-one": {
+                "capacity": 0,
+                "projects_usage": 3
+              },
+              "az-two": {
+                "capacity": 0
+              }
+            },
+            "usage": 3
+          },
+          {
+            "name": "things",
+            "quota_distribution_model": "hierarchical",
+            "capacity": 208,
+            "raw_capacity": 139,
+            "per_az": {
+              "any": {
+                "capacity": 208,
+                "raw_capacity": 139,
+                "usage": 45,
+                "projects_usage": 6
+              }
+            },
+            "domains_quota": 70,
+            "usage": 6
+          }
+        ],
+        "max_scraped_at": 55,
+        "min_scraped_at": 11
+      }
+    ],
+    "max_scraped_at": 1100,
+    "min_scraped_at": 1000
+  }
+}

--- a/internal/api/fixtures/cluster-get-west-with-v2-api.json
+++ b/internal/api/fixtures/cluster-get-west-with-v2-api.json
@@ -1,0 +1,138 @@
+{
+  "cluster": {
+    "id": "current",
+    "services": [
+      {
+        "type": "shared",
+        "area": "shared",
+        "resources": [
+          {
+            "name": "capacity",
+            "unit": "B",
+            "quota_distribution_model": "hierarchical",
+            "capacity": 185,
+            "per_az": {
+              "az-one": {
+                "capacity": 90,
+                "usage": 12,
+                "projects_usage": 3,
+                "physical_usage": 2
+              },
+              "az-two": {
+                "capacity": 95,
+                "usage": 15,
+                "projects_usage": 3,
+                "physical_usage": 3
+              }
+            },
+            "per_availability_zone": [
+              {
+                "name": "az-one",
+                "capacity": 90,
+                "usage": 12
+              },
+              {
+                "name": "az-two",
+                "capacity": 95,
+                "usage": 15
+              }
+            ],
+            "domains_quota": 25,
+            "usage": 6,
+            "physical_usage": 5
+          },
+          {
+            "name": "capacity_portion",
+            "unit": "B",
+            "contained_in": "capacity",
+            "per_az": {
+              "az-one": {
+                "capacity": 0,
+                "projects_usage": 3
+              },
+              "az-two": {
+                "capacity": 0
+              }
+            },
+            "usage": 3
+          },
+          {
+            "name": "things",
+            "quota_distribution_model": "hierarchical",
+            "capacity": 246,
+            "per_az": {
+              "any": {
+                "capacity": 246,
+                "usage": 158,
+                "projects_usage": 6
+              }
+            },
+            "domains_quota": 30,
+            "usage": 6
+          }
+        ],
+        "max_scraped_at": 66,
+        "min_scraped_at": 22
+      },
+      {
+        "type": "unshared",
+        "area": "unshared",
+        "resources": [
+          {
+            "name": "capacity",
+            "unit": "B",
+            "quota_distribution_model": "hierarchical",
+            "per_az": {
+              "az-one": {
+                "capacity": 0,
+                "projects_usage": 3,
+                "physical_usage": 2
+              },
+              "az-two": {
+                "capacity": 0,
+                "projects_usage": 3,
+                "physical_usage": 3
+              }
+            },
+            "domains_quota": 100,
+            "usage": 6,
+            "physical_usage": 5
+          },
+          {
+            "name": "capacity_portion",
+            "unit": "B",
+            "contained_in": "capacity",
+            "per_az": {
+              "az-one": {
+                "capacity": 0,
+                "projects_usage": 3
+              },
+              "az-two": {
+                "capacity": 0
+              }
+            },
+            "usage": 3
+          },
+          {
+            "name": "things",
+            "quota_distribution_model": "hierarchical",
+            "capacity": 139,
+            "per_az": {
+              "any": {
+                "capacity": 139,
+                "usage": 45,
+                "projects_usage": 6
+              }
+            },
+            "domains_quota": 70,
+            "usage": 6
+          }
+        ],
+        "max_scraped_at": 55,
+        "min_scraped_at": 11
+      }
+    ],
+    "max_scraped_at": 1100,
+    "min_scraped_at": 1000
+  }
+}

--- a/vendor/github.com/sapcc/go-api-declarations/limes/resources/report_cluster.go
+++ b/vendor/github.com/sapcc/go-api-declarations/limes/resources/report_cluster.go
@@ -76,9 +76,15 @@ type ClusterAvailabilityZoneReport struct {
 //
 // This type is part of the v2 API feature preview.
 type ClusterAZResourceReport struct {
-	Capacity    uint64  `json:"capacity"`
-	RawCapacity uint64  `json:"raw_capacity,omitempty"`
-	Usage       *uint64 `json:"usage,omitempty"`
+	Capacity    uint64 `json:"capacity"`
+	RawCapacity uint64 `json:"raw_capacity,omitempty"`
+	//Usage is what the backend reports. This is only shown if the backend does indeed report a summarized cluster-wide usage level.
+	Usage *uint64 `json:"usage,omitempty"`
+	//ProjectsUsage is the aggregate of the usage across all projects, as reported by the backend on the project level.
+	ProjectsUsage uint64 `json:"projects_usage,omitempty"`
+	//PhysicalUsage is collected per project and then aggregated, same as ProjectsUsage.
+	PhysicalUsage *uint64         `json:"physical_usage,omitempty"`
+	Subcapacities json.RawMessage `json:"subcapacities,omitempty"`
 }
 
 // ClusterServiceReports provides fast lookup of services by service type, but

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -142,7 +142,7 @@ github.com/rabbitmq/amqp091-go
 # github.com/rs/cors v1.10.1
 ## explicit; go 1.13
 github.com/rs/cors
-# github.com/sapcc/go-api-declarations v1.10.1
+# github.com/sapcc/go-api-declarations v1.10.3
 ## explicit; go 1.21
 github.com/sapcc/go-api-declarations/bininfo
 github.com/sapcc/go-api-declarations/cadf


### PR DESCRIPTION
Same behavior as for ProjectResourceReport: It's gated behind the "v2 preview" feature flag. Also, this bumps go-api-declarations twice because I realized how many fields were missing from ClusterAZResourceReport halfway through.
