### PR TITLE
ensure that each project_resource has at least one project_az_resource

### DIFF
--- a/internal/collector/scrape.go
+++ b/internal/collector/scrape.go
@@ -207,6 +207,14 @@ func (c *Collector) processResourceScrapeTask(_ context.Context, task projectScr
 func (c *Collector) writeResourceScrapeResult(dbDomain db.Domain, dbProject db.Project, task projectScrapeTask, resourceData map[string]core.ResourceData, serializedMetrics []byte) error {
 	srv := task.Service
 
+	//ensure that there is at least one ProjectAZResource for each ProjectResource
+	for resName, resData := range resourceData {
+		if len(resData.UsageData) == 0 {
+			resData.UsageData = core.InAnyAZ(core.UsageData{Usage: 0})
+			resourceData[resName] = resData
+		}
+	}
+
 	tx, err := c.DB.Begin()
 	if err != nil {
 		return fmt.Errorf("while beginning transaction: %w", err)

--- a/internal/collector/scrape_test.go
+++ b/internal/collector/scrape_test.go
@@ -607,6 +607,7 @@ const (
 	`
 )
 
+//nolint:dupl
 func Test_ScrapeReturnsNoUsageData(t *testing.T) {
 	s := test.NewSetup(t,
 		test.WithConfig(testNoUsageDataConfigYAML),


### PR DESCRIPTION
This is a useful invariant to uphold to simplify reporting queries, but it could be violated by quota plugins that calculate usage by counting or summing, where no usage in any AZ would be reported if there are no items to count or sum in an empty project.