### PR TITLE
rework the commitments data model and API

### DIFF
--- a/docs/example-policy.yaml
+++ b/docs/example-policy.yaml
@@ -17,6 +17,7 @@ project:lower: rule:project_editor
 domain:lower_lowpriv: rule:project_editor
 project:set_rate_limit: rule:domain_editor
 project:discover: rule:domain_editor
+project:uncommit: rule:cluster_admin
 
 domain:list: rule:cluster_admin
 domain:show: rule:domain_viewer

--- a/docs/operators/config.md
+++ b/docs/operators/config.md
@@ -135,7 +135,7 @@ Some special behaviors for resources can be configured in the `resource_behavior
 | `resource_behavior[].scaling_factor` | yes, if `scales_with` is given | The scaling factor that will be reported for these resources' scaling relation. |
 | `resource_behavior[].min_nonzero_project_quota` | no | A lower boundary for project quota values that are not zero. |
 | `resource_behavior[].commitment_durations` | no | If given, commitments for this resource can be created with any of the given durations. The duration format is the same as in the `commitments[].duration` attribute that appears on the resource API. |
-| `resource_behavior[].commitment_min_confirm_date` | no | If given, commitments for this resource will always be created with `confirm_after` no earlier than this timestamp. This can be used to plan the introduction of commitments on a specific date. |
+| `resource_behavior[].commitment_min_confirm_date` | no | If given, commitments for this resource will always be created with `confirm_by` no earlier than this timestamp. This can be used to plan the introduction of commitments on a specific date. |
 | `resource_behavior[].annotations` | no | A map of extra key-value pairs that will be inserted into matching resources as-is in responses to GET requests, e.g. at `project.services[].resources[].annotations`. |
 
 For example:

--- a/docs/users/api-spec-resources.md
+++ b/docs/users/api-spec-resources.md
@@ -687,7 +687,7 @@ The following fields can appear in the response body:
 | `commitments[].amount` | integer | The amount of usage that was committed to. |
 | `commitments[].unit` | string | For measured resources, the unit for this resource. The value from the `amount` field is measured in this unit. |
 | `commitments[].duration` | string | The requested duration of this commitment, expressed as a comma-separated sequence of positive integer multiples of time units like "1 year, 3 months". Acceptable time units include "second", "minute", "hour", "day", "month" and "year". |
-| `commitments[].requested_at` | integer | UNIX timestamp when this commitment was requested. |
+| `commitments[].created_at` | integer | UNIX timestamp when this commitment was created. |
 | `commitments[].confirmed_at` | integer | UNIX timestamp when this commitment was confirmed. Only shown after confirmation. |
 | `commitments[].expires_at` | integer | UNIX timestamp when this commitment is set to expire. Only shown after confirmation. |
 | `commitments[].transferable` | boolean | Whether the commitment is marked for transfer to a different project. Transferable commitments do not count towards quota calculation in their project, but still block capacity and still count towards billing. Not shown if false. |

--- a/docs/users/api-spec-resources.md
+++ b/docs/users/api-spec-resources.md
@@ -115,9 +115,13 @@ Commitments are always tied to an availability zone to aid in demand planning on
 
 Commitments follow a simple state machine:
 
-* `-> requested`: Commitments are created by a project administrator. They are not active until confirmed.
-* `requested -> confirmed`: Once the underlying capacity has been reserved for the project, the commitment is confirmed.
+* `-> unconfirmed`: Commitments are created by a project administrator.
   Price discounts and capacity guarantees apply only once the commitment is confirmed.
+  Creating an unconfirmed commitment is only possible if the commitment is created with a `confirm_by` timestamp.
+  Such commitments are intended for demand management and forecasting.
+* `unconfirmed -> confirmed`: Once the underlying capacity has been reserved for the project, the commitment is confirmed.
+* `-> confirmed`: Commiments can also be created by a project administrator in an immediately-confirmed state,
+  if the respective capacity can be reserved for the project immediately.
 * `confirmed -> expired`: Once the commitment's duration elapses, the price discount and capacity guarantee elapse.
   The duration until expiry counts starting from the state transition into `confirmed`.
 
@@ -735,6 +739,15 @@ Returns 201 (Created) on success. Result is a JSON document like:
 ```
 
 The `commitment` object has the same structure as the `commitments[]` objects in `GET /v1/domains/:domain_id/projects/:project_id/commitments`.
+
+### POST /v1/domains/:domain\_id/projects/:project\_id/commitments/can-confirm
+
+Checks if a new commitment within the given project could be confirmed immediately.
+Requires a project-admin token, and a request body that is a JSON document with the same contents as for `POST /v1/domains/:domain\_id/projects/:project\_id/commitments/new`, except that the `commitment.confirm_by` attribute must not be set.
+
+Returns 200 (OK) on success, and a JSON document like `{"result":true}` or `{"result":false}`.
+
+The `result` field indicates whether this commitment can be created without a `confirm_by` attribute, that is, confirmed immediately upon creation.
 
 ### DELETE /v1/domains/:domain\_id/projects/:project\_id/commitments/:id
 

--- a/docs/users/api-spec-resources.md
+++ b/docs/users/api-spec-resources.md
@@ -692,8 +692,9 @@ The following fields can appear in the response body:
 | `commitments[].unit` | string | For measured resources, the unit for this resource. The value from the `amount` field is measured in this unit. |
 | `commitments[].duration` | string | The requested duration of this commitment, expressed as a comma-separated sequence of positive integer multiples of time units like "1 year, 3 months". Acceptable time units include "second", "minute", "hour", "day", "month" and "year". |
 | `commitments[].created_at` | integer | UNIX timestamp when this commitment was created. |
+| `commitments[].confirm_by` | integer | UNIX timestamp when this commitment should be confirmed. Only shown if this was given when creating the commitment, to delay confirmation into the future. |
 | `commitments[].confirmed_at` | integer | UNIX timestamp when this commitment was confirmed. Only shown after confirmation. |
-| `commitments[].expires_at` | integer | UNIX timestamp when this commitment is set to expire. Only shown after confirmation. |
+| `commitments[].expires_at` | integer | UNIX timestamp when this commitment is set to expire. Note that the duration counts from `confirm_by` (or from `created_at` for immediately-confirmed commitments) and is calculated at creation time, so this is also shown on unconfirmed commitments. |
 | `commitments[].transferable` | boolean | Whether the commitment is marked for transfer to a different project. Transferable commitments do not count towards quota calculation in their project, but still block capacity and still count towards billing. Not shown if false. |
 
 ### POST /v1/domains/:domain\_id/projects/:project\_id/commitments/new
@@ -721,6 +722,7 @@ The following fields can appear in the request body:
 | `commitment.availability_zone` | string | The availability zone in which usage is committed. |
 | `commitment.amount` | integer | The amount of usage that was committed to. For measured resources, this is measured in the resource's unit as reported on the project resource. |
 | `commitment.duration` | string | The requested duration of this commitment. This must be one of the options reported on the project resource. |
+| `commitment.confirm_by` | integer | UNIX timestamp of the time by which this commitment should be confirmed. If not given, Limes will immediately try to confirm this commitment, and return an error if there is not enough committable capacity. If given, Limes will confirm this commitment after `confirm_by` has passed, as soon as enough committable capacity is available. |
 
 Returns 201 (Created) on success. Result is a JSON document like:
 
@@ -739,6 +741,7 @@ Returns 201 (Created) on success. Result is a JSON document like:
 ```
 
 The `commitment` object has the same structure as the `commitments[]` objects in `GET /v1/domains/:domain_id/projects/:project_id/commitments`.
+If `confirm_by` was given, a successful response will include the `confirmed_at` timestamp.
 
 ### POST /v1/domains/:domain\_id/projects/:project\_id/commitments/can-confirm
 

--- a/docs/users/api-spec-resources.md
+++ b/docs/users/api-spec-resources.md
@@ -738,7 +738,7 @@ The `commitment` object has the same structure as the `commitments[]` objects in
 
 ### DELETE /v1/domains/:domain\_id/projects/:project\_id/commitments/:id
 
-Deletes a commitment within the given project. Requires a project-admin token. On success, returns 204 (No Content).
+Deletes a commitment within the given project. Requires a cloud-admin token. On success, returns 204 (No Content).
 
 Only unconfirmed commitments may be deleted. If the commitment has already been confirmed, returns 403 (Forbidden).
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/prometheus/client_golang v1.17.0
 	github.com/prometheus/common v0.45.0
 	github.com/rs/cors v1.10.1
-	github.com/sapcc/go-api-declarations v1.10.3
+	github.com/sapcc/go-api-declarations v1.10.4
 	github.com/sapcc/go-bits v0.0.0-20231130134726-6ee9377708fc
 	go.uber.org/automaxprocs v1.5.3
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,8 @@ github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjR
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/rs/cors v1.10.1 h1:L0uuZVXIKlI1SShY2nhFfo44TYvDPQ1w4oFkUJNfhyo=
 github.com/rs/cors v1.10.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
-github.com/sapcc/go-api-declarations v1.10.3 h1:wFnq1Qx1Uv0G4F0AWT+9E4N/8n77Lm3buUpT9rFm/QY=
-github.com/sapcc/go-api-declarations v1.10.3/go.mod h1:83R3hTANhuRXt/pXDby37IJetw8l7DG41s33Tp9NXxI=
+github.com/sapcc/go-api-declarations v1.10.4 h1:ZUq/2GjOMaKTVuWQrhY09Hu20Smk3SbDqItCJT0H9mg=
+github.com/sapcc/go-api-declarations v1.10.4/go.mod h1:83R3hTANhuRXt/pXDby37IJetw8l7DG41s33Tp9NXxI=
 github.com/sapcc/go-bits v0.0.0-20231130134726-6ee9377708fc h1:8iSTUru2Z4TQE05zx6pNsUCZ0bqJYi0fjBgR2TvyhBE=
 github.com/sapcc/go-bits v0.0.0-20231130134726-6ee9377708fc/go.mod h1:FIWKXosF0bYCpTBPLsyWtFgYmiYcYJnXJus4BgyUwLA=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -112,6 +112,11 @@ const (
 				scope:    germany/dresden
 				annotations:
 					text: 'this annotation appears on shared/things of project dresden only'
+
+			# check how commitment config is reported
+			- resource: shared/capacity
+				commitment_durations: ["1 hour", "2 hours"]
+				commitment_min_confirm_date: '1970-01-08T00:00:00Z' # one week after start of mock.Clock
 	`
 )
 

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -261,7 +261,7 @@ func (p *v1Provider) CreateProjectCommitment(w http.ResponseWriter, r *http.Requ
 func (p *v1Provider) DeleteProjectCommitment(w http.ResponseWriter, r *http.Request) {
 	httpapi.IdentifyEndpoint(r, "/v1/domains/:id/projects/:id/commitments/:id")
 	token := p.CheckToken(r)
-	if !token.Require(w, "project:edit") {
+	if !token.Require(w, "project:uncommit") {
 		return
 	}
 	dbDomain := p.FindDomainFromRequest(w, r)
@@ -286,14 +286,6 @@ func (p *v1Provider) DeleteProjectCommitment(w http.ResponseWriter, r *http.Requ
 	err = p.DB.SelectOne(&dbService, `SELECT * FROM project_services WHERE id = $1`, dbCommitment.ServiceID)
 	if respondwith.ErrorText(w, err) {
 		return
-	}
-
-	//commitments cannot be deleted once they have been confirmed
-	if dbCommitment.ConfirmedAt != nil {
-		if !token.Check("cluster:edit") {
-			http.Error(w, "cannot delete a confirmed commitment", http.StatusForbidden)
-			return
-		}
 	}
 
 	//perform deletion

--- a/internal/api/commitment_test.go
+++ b/internal/api/commitment_test.go
@@ -77,7 +77,9 @@ func TestCommitmentLifecycle(t *testing.T) {
 		"amount":            10,
 		"unit":              "B",
 		"duration":          "1 hour",
-		"requested_at":      s.Clock.Now().Unix(),
+		"created_at":        s.Clock.Now().Unix(),
+		"creator_uuid":      "uuid-for-alice",
+		"creator_name":      "alice@Default",
 	}
 	assert.HTTPRequest{
 		Method:       http.MethodPost,
@@ -104,7 +106,9 @@ func TestCommitmentLifecycle(t *testing.T) {
 		"amount":            20,
 		"unit":              "B",
 		"duration":          "2 hours",
-		"requested_at":      s.Clock.Now().Unix(),
+		"created_at":        s.Clock.Now().Unix(),
+		"creator_uuid":      "uuid-for-alice",
+		"creator_name":      "alice@Default",
 	}
 	assert.HTTPRequest{
 		Method:       http.MethodPost,

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -151,6 +151,7 @@ func (p *v1Provider) AddTo(r *mux.Router) {
 
 	r.Methods("GET").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments").HandlerFunc(p.GetProjectCommitments)
 	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments/new").HandlerFunc(p.CreateProjectCommitment)
+	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments/can-confirm").HandlerFunc(p.CanConfirmNewProjectCommitment)
 	r.Methods("DELETE").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments/{id}").HandlerFunc(p.DeleteProjectCommitment)
 }
 

--- a/internal/api/fixtures/project-get-berlin-bursting-disabled.json
+++ b/internal/api/fixtures/project-get-berlin-bursting-disabled.json
@@ -16,6 +16,13 @@
             "name": "capacity",
             "unit": "B",
             "quota_distribution_model": "hierarchical",
+            "commitment_config": {
+              "durations": [
+                "1 hour",
+                "2 hours"
+              ],
+              "min_confirm_by": 604800
+            },
             "quota": 10,
             "usable_quota": 10,
             "usage": 2

--- a/internal/api/fixtures/project-get-berlin-bursting-enabled.json
+++ b/internal/api/fixtures/project-get-berlin-bursting-enabled.json
@@ -16,6 +16,13 @@
             "name": "capacity",
             "unit": "B",
             "quota_distribution_model": "hierarchical",
+            "commitment_config": {
+              "durations": [
+                "1 hour",
+                "2 hours"
+              ],
+              "min_confirm_by": 604800
+            },
             "quota": 10,
             "usable_quota": 11,
             "usage": 2

--- a/internal/api/fixtures/project-get-berlin-bursting-in-progress.json
+++ b/internal/api/fixtures/project-get-berlin-bursting-in-progress.json
@@ -16,6 +16,13 @@
             "name": "capacity",
             "unit": "B",
             "quota_distribution_model": "hierarchical",
+            "commitment_config": {
+              "durations": [
+                "1 hour",
+                "2 hours"
+              ],
+              "min_confirm_by": 604800
+            },
             "quota": 10,
             "usable_quota": 11,
             "usage": 2

--- a/internal/api/fixtures/project-get-berlin.json
+++ b/internal/api/fixtures/project-get-berlin.json
@@ -12,6 +12,13 @@
             "name": "capacity",
             "unit": "B",
             "quota_distribution_model": "hierarchical",
+            "commitment_config": {
+              "durations": [
+                "1 hour",
+                "2 hours"
+              ],
+              "min_confirm_by": 604800
+            },
             "quota": 10,
             "usable_quota": 10,
             "usage": 2

--- a/internal/api/fixtures/project-get-details-berlin.json
+++ b/internal/api/fixtures/project-get-details-berlin.json
@@ -12,6 +12,13 @@
             "name": "capacity",
             "unit": "B",
             "quota_distribution_model": "hierarchical",
+            "commitment_config": {
+              "durations": [
+                "1 hour",
+                "2 hours"
+              ],
+              "min_confirm_by": 604800
+            },
             "quota": 10,
             "usable_quota": 10,
             "usage": 2

--- a/internal/api/fixtures/project-get-dresden.json
+++ b/internal/api/fixtures/project-get-dresden.json
@@ -12,6 +12,13 @@
             "name": "capacity",
             "unit": "B",
             "quota_distribution_model": "hierarchical",
+            "commitment_config": {
+              "durations": [
+                "1 hour",
+                "2 hours"
+              ],
+              "min_confirm_by": 604800
+            },
             "quota": 10,
             "usable_quota": 10,
             "usage": 2,

--- a/internal/api/fixtures/project-get-paris.json
+++ b/internal/api/fixtures/project-get-paris.json
@@ -12,6 +12,13 @@
             "name": "capacity",
             "unit": "B",
             "quota_distribution_model": "hierarchical",
+            "commitment_config": {
+              "durations": [
+                "1 hour",
+                "2 hours"
+              ],
+              "min_confirm_by": 604800
+            },
             "quota": 10,
             "usable_quota": 10,
             "usage": 2,

--- a/internal/api/fixtures/project-list-with-v2-api.json
+++ b/internal/api/fixtures/project-list-with-v2-api.json
@@ -13,6 +13,13 @@
               "name": "capacity",
               "unit": "B",
               "quota_distribution_model": "hierarchical",
+              "commitment_config": {
+                "durations": [
+                  "1 hour",
+                  "2 hours"
+                ],
+                "min_confirm_by": 604800
+              },
               "per_az": {
                 "az-one": {
                   "usage": 1
@@ -123,6 +130,13 @@
               "name": "capacity",
               "unit": "B",
               "quota_distribution_model": "hierarchical",
+              "commitment_config": {
+                "durations": [
+                  "1 hour",
+                  "2 hours"
+                ],
+                "min_confirm_by": 604800
+              },
               "per_az": {
                 "az-one": {
                   "usage": 1

--- a/internal/api/fixtures/project-list.json
+++ b/internal/api/fixtures/project-list.json
@@ -13,6 +13,13 @@
               "name": "capacity",
               "unit": "B",
               "quota_distribution_model": "hierarchical",
+              "commitment_config": {
+                "durations": [
+                  "1 hour",
+                  "2 hours"
+                ],
+                "min_confirm_by": 604800
+              },
               "quota": 10,
               "usable_quota": 10,
               "usage": 2
@@ -81,6 +88,13 @@
               "name": "capacity",
               "unit": "B",
               "quota_distribution_model": "hierarchical",
+              "commitment_config": {
+                "durations": [
+                  "1 hour",
+                  "2 hours"
+                ],
+                "min_confirm_by": 604800
+              },
               "quota": 10,
               "usable_quota": 10,
               "usage": 2,

--- a/internal/api/fixtures/start-data-commitments.sql
+++ b/internal/api/fixtures/start-data-commitments.sql
@@ -1,9 +1,18 @@
 CREATE OR REPLACE FUNCTION unix(i integer) RETURNS timestamp AS $$ SELECT TO_TIMESTAMP(i) AT TIME ZONE 'Etc/UTC' $$ LANGUAGE SQL;
 
+INSERT INTO cluster_capacitors (capacitor_id, scraped_at, next_scrape_at) VALUES ('unittest', UNIX(1000), UNIX(2000));
+
 INSERT INTO cluster_services (id, type) VALUES (1, 'first');
 INSERT INTO cluster_services (id, type) VALUES (2, 'second');
 
--- cluster_resources is empty: the commitment tests do not care about capacity for now
+-- cluster_resources and cluster_az_resources have entries for the resources where commitments are enabled in the config
+INSERT INTO cluster_resources (id, service_id, name, capacitor_id) VALUES (1, 1, 'capacity', 'unittest');
+INSERT INTO cluster_resources (id, service_id, name, capacitor_id) VALUES (2, 2, 'capacity', 'unittest');
+
+INSERT INTO cluster_az_resources (resource_id, az, raw_capacity, usage, subcapacities) VALUES (1, 'az-one', 10, 6, '');
+INSERT INTO cluster_az_resources (resource_id, az, raw_capacity, usage, subcapacities) VALUES (1, 'az-two', 20, 6, '');
+INSERT INTO cluster_az_resources (resource_id, az, raw_capacity, usage, subcapacities) VALUES (2, 'az-one', 30, 6, '');
+INSERT INTO cluster_az_resources (resource_id, az, raw_capacity, usage, subcapacities) VALUES (2, 'az-two', 40, 6, '');
 
 -- two domains (default setup for StaticDiscoveryPlugin)
 INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');

--- a/internal/api/fixtures/start-data.sql
+++ b/internal/api/fixtures/start-data.sql
@@ -111,16 +111,16 @@ INSERT INTO project_az_resources (resource_id, az, quota, usage, physical_usage,
 
 -- project_commitments has several entries for project dresden
 -- on "unshared/capacity": regular active commitments with different durations
-INSERT INTO project_commitments (id, service_id, resource_name, availability_zone, amount, duration, requested_at, confirm_after, confirmed_at, expires_at) VALUES (1, 3, 'capacity', 'az-one', 1,   '2 years',    UNIX(1), UNIX(1), UNIX(1), UNIX(100000001));
-INSERT INTO project_commitments (id, service_id, resource_name, availability_zone, amount, duration, requested_at, confirm_after, confirmed_at, expires_at) VALUES (2, 3, 'capacity', 'az-one', 1,   '1 year',     UNIX(2), UNIX(2), UNIX(2), UNIX(100000002));
-INSERT INTO project_commitments (id, service_id, resource_name, availability_zone, amount, duration, requested_at, confirm_after, confirmed_at, expires_at) VALUES (3, 3, 'capacity', 'az-one', 1,   '1 year',     UNIX(3), UNIX(3), UNIX(3), UNIX(100000003));
-INSERT INTO project_commitments (id, service_id, resource_name, availability_zone, amount, duration, requested_at, confirm_after, confirmed_at, expires_at) VALUES (4, 3, 'capacity', 'az-two', 2,   '1 year',     UNIX(4), UNIX(4), UNIX(4), UNIX(100000004));
+INSERT INTO project_commitments (id, service_id, resource_name, availability_zone, amount, duration, created_at, creator_uuid, creator_name, confirm_by, confirmed_at, expires_at) VALUES (1, 3, 'capacity', 'az-one', 1,   '2 years',    UNIX(1), 'uuid-for-alice', 'alice@Default', UNIX(1), UNIX(1), UNIX(100000001));
+INSERT INTO project_commitments (id, service_id, resource_name, availability_zone, amount, duration, created_at, creator_uuid, creator_name, confirm_by, confirmed_at, expires_at) VALUES (2, 3, 'capacity', 'az-one', 1,   '1 year',     UNIX(2), 'uuid-for-alice', 'alice@Default', UNIX(2), UNIX(2), UNIX(100000002));
+INSERT INTO project_commitments (id, service_id, resource_name, availability_zone, amount, duration, created_at, creator_uuid, creator_name, confirm_by, confirmed_at, expires_at) VALUES (3, 3, 'capacity', 'az-one', 1,   '1 year',     UNIX(3), 'uuid-for-alice', 'alice@Default', UNIX(3), UNIX(3), UNIX(100000003));
+INSERT INTO project_commitments (id, service_id, resource_name, availability_zone, amount, duration, created_at, creator_uuid, creator_name, confirm_by, confirmed_at, expires_at) VALUES (4, 3, 'capacity', 'az-two', 2,   '1 year',     UNIX(4), 'uuid-for-alice', 'alice@Default', UNIX(4), UNIX(4), UNIX(100000004));
 -- on "unshared/capacity": unconfirmed commitments should not be reported
-INSERT INTO project_commitments (id, service_id, resource_name, availability_zone, amount, duration, requested_at, confirm_after, confirmed_at, expires_at) VALUES (5, 3, 'capacity', 'az-two', 100, '2 years',    UNIX(5), UNIX(5), NULL,    NULL);
+INSERT INTO project_commitments (id, service_id, resource_name, availability_zone, amount, duration, created_at, creator_uuid, creator_name, confirm_by, confirmed_at, expires_at) VALUES (5, 3, 'capacity', 'az-two', 100, '2 years',    UNIX(5), 'uuid-for-alice', 'alice@Default', UNIX(5), NULL,    NULL);
 -- on "unshared/capacity": expired commitments should not be reported (NOTE: the test's clock stands at UNIX timestamp 3600)
-INSERT INTO project_commitments (id, service_id, resource_name, availability_zone, amount, duration, requested_at, confirm_after, confirmed_at, expires_at) VALUES (6, 3, 'capacity', 'az-one', 5,   '10 minutes', UNIX(6), UNIX(6), UNIX(6), UNIX(606));
+INSERT INTO project_commitments (id, service_id, resource_name, availability_zone, amount, duration, created_at, creator_uuid, creator_name, confirm_by, confirmed_at, expires_at) VALUES (6, 3, 'capacity', 'az-one', 5,   '10 minutes', UNIX(6), 'uuid-for-alice', 'alice@Default', UNIX(6), UNIX(6), UNIX(606));
 -- on "shared/capacity": only an unconfirmed commitment that should not be reported, this tests that the entire "committed" structure is absent in the JSON
-INSERT INTO project_commitments (id, service_id, resource_name, availability_zone, amount, duration, requested_at, confirm_after, confirmed_at, expires_at) VALUES (7, 4, 'capacity', 'az-one', 100, '2 years',    UNIX(7), UNIX(7), NULL,    NULL);
+INSERT INTO project_commitments (id, service_id, resource_name, availability_zone, amount, duration, created_at, creator_uuid, creator_name, confirm_by, confirmed_at, expires_at) VALUES (7, 4, 'capacity', 'az-one', 100, '2 years',    UNIX(7), 'uuid-for-alice', 'alice@Default', UNIX(7), NULL,    NULL);
 
 -- project_rates also has multiple different setups to test different cases
 -- berlin has custom rate limits

--- a/internal/api/fixtures/start-data.sql
+++ b/internal/api/fixtures/start-data.sql
@@ -116,11 +116,11 @@ INSERT INTO project_commitments (id, service_id, resource_name, availability_zon
 INSERT INTO project_commitments (id, service_id, resource_name, availability_zone, amount, duration, created_at, creator_uuid, creator_name, confirm_by, confirmed_at, expires_at) VALUES (3, 3, 'capacity', 'az-one', 1,   '1 year',     UNIX(3), 'uuid-for-alice', 'alice@Default', UNIX(3), UNIX(3), UNIX(100000003));
 INSERT INTO project_commitments (id, service_id, resource_name, availability_zone, amount, duration, created_at, creator_uuid, creator_name, confirm_by, confirmed_at, expires_at) VALUES (4, 3, 'capacity', 'az-two', 2,   '1 year',     UNIX(4), 'uuid-for-alice', 'alice@Default', UNIX(4), UNIX(4), UNIX(100000004));
 -- on "unshared/capacity": unconfirmed commitments should not be reported
-INSERT INTO project_commitments (id, service_id, resource_name, availability_zone, amount, duration, created_at, creator_uuid, creator_name, confirm_by, confirmed_at, expires_at) VALUES (5, 3, 'capacity', 'az-two', 100, '2 years',    UNIX(5), 'uuid-for-alice', 'alice@Default', UNIX(5), NULL,    NULL);
+INSERT INTO project_commitments (id, service_id, resource_name, availability_zone, amount, duration, created_at, creator_uuid, creator_name, confirm_by, confirmed_at, expires_at) VALUES (5, 3, 'capacity', 'az-two', 100, '2 years',    UNIX(5), 'uuid-for-alice', 'alice@Default', UNIX(5), NULL,    UNIX(100000005));
 -- on "unshared/capacity": expired commitments should not be reported (NOTE: the test's clock stands at UNIX timestamp 3600)
 INSERT INTO project_commitments (id, service_id, resource_name, availability_zone, amount, duration, created_at, creator_uuid, creator_name, confirm_by, confirmed_at, expires_at) VALUES (6, 3, 'capacity', 'az-one', 5,   '10 minutes', UNIX(6), 'uuid-for-alice', 'alice@Default', UNIX(6), UNIX(6), UNIX(606));
--- on "shared/capacity": only an unconfirmed commitment that should not be reported, this tests that the entire "committed" structure is absent in the JSON
-INSERT INTO project_commitments (id, service_id, resource_name, availability_zone, amount, duration, created_at, creator_uuid, creator_name, confirm_by, confirmed_at, expires_at) VALUES (7, 4, 'capacity', 'az-one', 100, '2 years',    UNIX(7), 'uuid-for-alice', 'alice@Default', UNIX(7), NULL,    NULL);
+-- on "shared/capacity": only an unconfirmed commitment that should not be reported, this tests that the entire "committed" structure is absent in the JSON for that resource
+INSERT INTO project_commitments (id, service_id, resource_name, availability_zone, amount, duration, created_at, creator_uuid, creator_name, confirm_by, confirmed_at, expires_at) VALUES (7, 4, 'capacity', 'az-one', 100, '2 years',    UNIX(7), 'uuid-for-alice', 'alice@Default', UNIX(7), NULL,    UNIX(100000007));
 
 -- project_rates also has multiple different setups to test different cases
 -- berlin has custom rate limits

--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -1,0 +1,46 @@
+/******************************************************************************
+*
+*  Copyright 2023 SAP SE
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+******************************************************************************/
+
+package api
+
+import (
+	"time"
+
+	"github.com/sapcc/go-api-declarations/limes"
+)
+
+func maybeUnixEncodedTime(t *time.Time) *limes.UnixEncodedTime {
+	if t == nil {
+		return nil
+	}
+	return &limes.UnixEncodedTime{Time: *t}
+}
+
+func maybeUnpackUnixEncodedTime(t *limes.UnixEncodedTime) *time.Time {
+	if t == nil {
+		return nil
+	}
+	return &t.Time
+}
+
+func unwrapOrDefault[T any](value *T, defaultValue T) T {
+	if value == nil {
+		return defaultValue
+	}
+	return *value
+}

--- a/internal/core/resource_behavior.go
+++ b/internal/core/resource_behavior.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sapcc/go-api-declarations/limes"
 	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
 	"github.com/sapcc/go-bits/errext"
 	"github.com/sapcc/go-bits/regexpext"
@@ -92,13 +93,17 @@ func (b ResourceBehavior) ToScalingBehavior() *limesresources.ScalingBehavior {
 
 // ToCommitmentConfig returns the CommitmentConfiguration for this resource,
 // or nil if commitments are not allowed on this resource.
-func (b ResourceBehavior) ToCommitmentConfig() *limesresources.CommitmentConfiguration {
+func (b ResourceBehavior) ToCommitmentConfig(now time.Time) *limesresources.CommitmentConfiguration {
 	if len(b.CommitmentDurations) == 0 {
 		return nil
 	}
-	return &limesresources.CommitmentConfiguration{
+	result := limesresources.CommitmentConfiguration{
 		Durations: b.CommitmentDurations,
 	}
+	if b.CommitmentMinConfirmDate != nil && b.CommitmentMinConfirmDate.After(now) {
+		result.MinConfirmBy = &limes.UnixEncodedTime{Time: *b.CommitmentMinConfirmDate}
+	}
+	return &result
 }
 
 // Merge computes the union of both given resource behaviors.

--- a/internal/datamodel/confirm_project_commitments.go
+++ b/internal/datamodel/confirm_project_commitments.go
@@ -18,10 +18,100 @@
 
 package datamodel
 
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
+	"github.com/sapcc/go-bits/sqlext"
+
+	"github.com/sapcc/limes/internal/core"
+	"github.com/sapcc/limes/internal/db"
+)
+
 // ConfirmProjectCommitments will try to confirm as many additional commitments
 // as can be covered at the current capacity and usage values.
 func ConfirmProjectCommitments(serviceType, resourceName string) error {
 	//TODO implement (this stub allows UI development on the commitment API to proceed)
 	//TODO note to self: generate audit events upon confirmation
 	return nil
+}
+
+var (
+	// We need to ensure that `sum_over_projects(max(committed, usage)) <= capacity`.
+	// For the target project, `committed` includes both existing confirmed commitments
+	// as well as the given commitment.
+	getRawCapacityQuery = sqlext.SimplifyWhitespace(`
+		SELECT car.raw_capacity
+			FROM cluster_services cs
+			JOIN cluster_resources cr ON cr.service_id = cs.id
+			JOIN cluster_az_resources car ON car.resource_id = cr.id
+		 WHERE cs.type = $1 AND cr.name = $2 AND car.az = $3
+	`)
+	getCommitabilityStatsQuery = sqlext.SimplifyWhitespace(`
+		WITH committed AS (
+			SELECT ps.project_id AS project_id, SUM(pc.amount) AS amount
+			  FROM project_services ps
+			  JOIN project_commitments pc ON pc.service_id = ps.id
+			 WHERE ps.type = $1 AND pc.resource_name = $2 AND pc.availability_zone = $3
+			   AND pc.confirmed_at IS NOT NULL AND pc.superseded_at IS NULL AND pc.expires_at > $4
+			 GROUP BY ps.project_id
+		), used AS (
+			SELECT ps.project_id AS project_id, par.usage AS amount
+			  FROM project_services ps
+			  JOIN project_resources pr ON pr.service_id = ps.id
+			  JOIN project_az_resources par ON par.resource_id = pr.id
+			 WHERE ps.type = $1 AND pr.name = $2 AND par.az = $3
+		)
+		SELECT COALESCE(c.project_id, u.project_id), COALESCE(c.amount, 0), COALESCE(u.amount, 0)
+		  FROM committed c FULL OUTER JOIN used u ON u.project_id = c.project_id
+	`)
+)
+
+// CanConfirmNewCommitment returns whether the given commitment request can be
+// confirmed immediately upon creation in the given project.
+func CanConfirmNewCommitment(req limesresources.CommitmentRequest, project db.Project, cluster *core.Cluster, dbi db.Interface, now time.Time) (bool, error) {
+	clusterBehavior := cluster.BehaviorForResource(req.ServiceType, req.ResourceName, "")
+
+	//query DB for capacity
+	var rawCapacity uint64
+	queryArgs := []any{req.ServiceType, req.ResourceName, req.AvailabilityZone}
+	err := dbi.QueryRow(getRawCapacityQuery, queryArgs...).Scan(&rawCapacity)
+	if err != nil {
+		return false, fmt.Errorf("while getting raw capacity for %s/%s: %w", req.ServiceType, req.ResourceName, err)
+	}
+	capacity := rawCapacity
+	if clusterBehavior.OvercommitFactor != 0 {
+		capacity = clusterBehavior.OvercommitFactor.ApplyTo(rawCapacity)
+	}
+
+	//query DB for commitment-relevant utilization
+	queryArgs = []any{req.ServiceType, req.ResourceName, req.AvailabilityZone, now}
+	usedCapacity := uint64(0)
+	err = sqlext.ForeachRow(dbi, getCommitabilityStatsQuery, queryArgs, func(rows *sql.Rows) error {
+		var (
+			projectID int64
+			committed uint64
+			usage     uint64
+		)
+		err := rows.Scan(&projectID, &committed, &usage)
+		if err != nil {
+			return err
+		}
+
+		// calculate `sum_over_projects(max(committed, usage))` including the requested commitment
+		if projectID == project.ID {
+			usedCapacity += max(committed+req.Amount, usage)
+		} else {
+			usedCapacity += max(committed, usage)
+		}
+		return nil
+	})
+	if err != nil {
+		return false, fmt.Errorf("while getting allocation stats for %s/%s: %w", req.ServiceType, req.ResourceName, err)
+	}
+
+	//commitment can be confirmed if it and all other commitments and usage fit in the total capacity
+	return usedCapacity <= capacity, nil
 }

--- a/internal/datamodel/confirm_project_commitments.go
+++ b/internal/datamodel/confirm_project_commitments.go
@@ -30,14 +30,6 @@ import (
 	"github.com/sapcc/limes/internal/db"
 )
 
-// ConfirmProjectCommitments will try to confirm as many additional commitments
-// as can be covered at the current capacity and usage values.
-func ConfirmProjectCommitments(serviceType, resourceName string) error {
-	//TODO implement (this stub allows UI development on the commitment API to proceed)
-	//TODO note to self: generate audit events upon confirmation
-	return nil
-}
-
 var (
 	// We need to ensure that `sum_over_projects(max(committed, usage)) <= capacity`.
 	// For the target project, `committed` includes both existing confirmed commitments

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -400,7 +400,8 @@ var sqlMigrations = map[string]string{
 		ALTER TABLE project_commitments
 			RENAME COLUMN confirm_after TO confirm_by;
 		ALTER TABLE project_commitments
-			ALTER COLUMN confirm_by DROP NOT NULL;
+			ALTER COLUMN confirm_by DROP NOT NULL,
+			ALTER COLUMN expires_at SET NOT NULL;
 		ALTER TABLE project_commitments
 			RENAME COLUMN requested_at TO created_at;
 		ALTER TABLE project_commitments
@@ -414,7 +415,8 @@ var sqlMigrations = map[string]string{
 		ALTER TABLE project_commitments
 			RENAME COLUMN confirm_by TO confirm_after;
 		ALTER TABLE project_commitments
-			ALTER COLUMN confirm_after SET NOT NULL;
+			ALTER COLUMN confirm_after SET NOT NULL,
+			ALTER COLUMN expires_at DROP NOT NULL;
 		ALTER TABLE project_commitments
 			RENAME COLUMN created_at TO requested_at;
 		ALTER TABLE project_commitments

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -396,4 +396,29 @@ var sqlMigrations = map[string]string{
 		ALTER TABLE cluster_az_resources
 			ALTER COLUMN usage SET NOT NULL;
 	`,
+	"032_commitment_rework.up.sql": `
+		ALTER TABLE project_commitments
+			RENAME COLUMN confirm_after TO confirm_by;
+		ALTER TABLE project_commitments
+			ALTER COLUMN confirm_by DROP NOT NULL;
+		ALTER TABLE project_commitments
+			RENAME COLUMN requested_at TO created_at;
+		ALTER TABLE project_commitments
+			ADD COLUMN creator_uuid TEXT NOT NULL DEFAULT '',
+			ADD COLUMN creator_name TEXT NOT NULL DEFAULT '';
+		ALTER TABLE project_commitments
+			ALTER COLUMN creator_uuid DROP DEFAULT,
+			ALTER COLUMN creator_name DROP DEFAULT;
+	`,
+	"032_commitment_rework.down.sql": `
+		ALTER TABLE project_commitments
+			RENAME COLUMN confirm_by TO confirm_after;
+		ALTER TABLE project_commitments
+			ALTER COLUMN confirm_after SET NOT NULL;
+		ALTER TABLE project_commitments
+			RENAME COLUMN created_at TO requested_at;
+		ALTER TABLE project_commitments
+			DROP COLUMN creator_uuid,
+			DROP COLUMN creator_name;
+	`,
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -198,7 +198,7 @@ type ProjectCommitment struct {
 	CreatorName      string                            `db:"creator_name"`
 	ConfirmBy        *time.Time                        `db:"confirm_by"`
 	ConfirmedAt      *time.Time                        `db:"confirmed_at"`
-	ExpiresAt        *time.Time                        `db:"expires_at"`
+	ExpiresAt        time.Time                         `db:"expires_at"`
 
 	//A commitment can be superseded e.g. by splitting it into smaller parts.
 	//When that happens, the new commitments will point to the one that they

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -193,8 +193,10 @@ type ProjectCommitment struct {
 	AvailabilityZone limes.AvailabilityZone            `db:"availability_zone"`
 	Amount           uint64                            `db:"amount"`
 	Duration         limesresources.CommitmentDuration `db:"duration"`
-	RequestedAt      time.Time                         `db:"requested_at"`
-	ConfirmAfter     time.Time                         `db:"confirm_after"`
+	CreatedAt        time.Time                         `db:"created_at"`
+	CreatorUUID      string                            `db:"creator_uuid"` // format: "username@userdomainname"
+	CreatorName      string                            `db:"creator_name"`
+	ConfirmBy        *time.Time                        `db:"confirm_by"`
 	ConfirmedAt      *time.Time                        `db:"confirmed_at"`
 	ExpiresAt        *time.Time                        `db:"expires_at"`
 

--- a/internal/reports/project.go
+++ b/internal/reports/project.go
@@ -206,7 +206,7 @@ func GetProjectResources(cluster *core.Cluster, domain db.Domain, project *db.Pr
 			if !resReport.NoQuota {
 				qdConfig := cluster.QuotaDistributionConfigForResource(*serviceType, *resourceName)
 				resReport.QuotaDistributionModel = qdConfig.Model
-				resReport.CommitmentConfig = behavior.ToCommitmentConfig()
+				resReport.CommitmentConfig = behavior.ToCommitmentConfig(now)
 				if quota != nil {
 					resReport.Quota = quota
 					resReport.UsableQuota = quota

--- a/internal/test/mock_validator.go
+++ b/internal/test/mock_validator.go
@@ -32,12 +32,13 @@ type PolicyEnforcer struct {
 	AllowDomain  bool
 	AllowProject bool
 	//flags by action
-	AllowView    bool
-	AllowEdit    bool
-	AllowRaise   bool
-	AllowRaiseLP bool
-	AllowLower   bool
-	AllowLowerLP bool
+	AllowView     bool
+	AllowEdit     bool
+	AllowRaise    bool
+	AllowRaiseLP  bool
+	AllowLower    bool
+	AllowLowerLP  bool
+	AllowUncommit bool
 	//match by request attribute
 	RejectServiceType string
 }
@@ -81,6 +82,8 @@ func (e *PolicyEnforcer) allowAction(action string) bool {
 		return e.AllowLower
 	case "lower_lowpriv":
 		return e.AllowLowerLP
+	case "uncommit":
+		return e.AllowUncommit
 	default:
 		return true
 	}

--- a/internal/test/setup.go
+++ b/internal/test/setup.go
@@ -118,15 +118,16 @@ func NewSetup(t *testing.T, opts ...SetupOption) Setup {
 
 	//load mock policy (where everything is allowed)
 	enforcer := &PolicyEnforcer{
-		AllowCluster: true,
-		AllowDomain:  true,
-		AllowProject: true,
-		AllowView:    true,
-		AllowEdit:    true,
-		AllowRaise:   true,
-		AllowRaiseLP: true,
-		AllowLower:   true,
-		AllowLowerLP: true,
+		AllowCluster:  true,
+		AllowDomain:   true,
+		AllowProject:  true,
+		AllowView:     true,
+		AllowEdit:     true,
+		AllowRaise:    true,
+		AllowRaiseLP:  true,
+		AllowLower:    true,
+		AllowLowerLP:  true,
+		AllowUncommit: true,
 	}
 	mockUserIdentity := map[string]string{
 		"user_id":             "uuid-for-alice",

--- a/internal/test/setup.go
+++ b/internal/test/setup.go
@@ -128,7 +128,17 @@ func NewSetup(t *testing.T, opts ...SetupOption) Setup {
 		AllowLower:   true,
 		AllowLowerLP: true,
 	}
-	s.TokenValidator = mock.NewValidator(enforcer, nil)
+	mockUserIdentity := map[string]string{
+		"user_id":             "uuid-for-alice",
+		"user_name":           "alice",
+		"user_domain_name":    "Default",
+		"user_domain_id":      "uuid-for-default",
+		"project_id":          "uuid-for-admin",
+		"project_name":        "admin",
+		"project_domain_name": "Default",
+		"project_domain_id":   "uuid-for-default",
+	}
+	s.TokenValidator = mock.NewValidator(enforcer, mockUserIdentity)
 
 	if params.APIBuilder != nil {
 		s.Handler = httpapi.Compose(

--- a/vendor/github.com/sapcc/go-api-declarations/cadf/event.go
+++ b/vendor/github.com/sapcc/go-api-declarations/cadf/event.go
@@ -88,13 +88,14 @@ type Resource struct {
 	// project_id and domain_id are OpenStack extensions (introduced by Keystone and keystone(audit)middleware)
 	ProjectID string `json:"project_id,omitempty"`
 	DomainID  string `json:"domain_id,omitempty"`
-	// project_name, project_domain_name, domain_name, application_credential_id are Hermes extensions for
-	// initiator resources only (they all refer to the token scope; the initiating user's original domain
-	// is described by "domain")
+	// project_name, project_domain_name, domain_name, application_credential_id, request_id and global_request_id
+	// are Hermes extensions for initiator resources only (not for target or observer)
 	ProjectName       string `json:"project_name,omitempty"`
 	ProjectDomainName string `json:"project_domain_name,omitempty"`
 	DomainName        string `json:"domain_name,omitempty"`
 	AppCredentialID   string `json:"application_credential_id,omitempty"`
+	RequestID         string `json:"request_id,omitempty"`
+	GlobalRequestID   string `json:"global_request_id,omitempty"`
 }
 
 // Reason contains HTTP Code and Type, and is optional in the CADF spec

--- a/vendor/github.com/sapcc/go-api-declarations/limes/resources/commitment.go
+++ b/vendor/github.com/sapcc/go-api-declarations/limes/resources/commitment.go
@@ -39,7 +39,12 @@ type Commitment struct {
 	Amount           uint64                 `json:"amount"`
 	Unit             limes.Unit             `json:"unit"`
 	Duration         CommitmentDuration     `json:"duration"`
-	RequestedAt      limes.UnixEncodedTime  `json:"requested_at"`
+	CreatedAt        limes.UnixEncodedTime  `json:"created_at"`
+	// CreatorUUID and CreatorName identify the user who created this commitment.
+	// CreatorName is in the format `fmt.Sprintf("%s@%s", userName, userDomainName)`
+	// and intended for informational displays only. API access should always use the UUID.
+	CreatorUUID string `json:"creator_uuid,omitempty"`
+	CreatorName string `json:"creator_name,omitempty"`
 	// ConfirmedAt and ExpiresAt are only filled after the commitment was confirmed.
 	ConfirmedAt *limes.UnixEncodedTime `json:"confirmed_at,omitempty"`
 	ExpiresAt   *limes.UnixEncodedTime `json:"expires_at,omitempty"`

--- a/vendor/github.com/sapcc/go-api-declarations/limes/resources/commitment.go
+++ b/vendor/github.com/sapcc/go-api-declarations/limes/resources/commitment.go
@@ -47,7 +47,7 @@ type Commitment struct {
 	CreatorName string `json:"creator_name,omitempty"`
 	// ConfirmBy is only filled if it was set in the CommitmentRequest.
 	ConfirmBy *limes.UnixEncodedTime `json:"confirm_by,omitempty"`
-	// ConfirmedAt and ExpiresAt are only filled after the commitment was confirmed.
+	// ConfirmedAt is only filled after the commitment was confirmed.
 	ConfirmedAt *limes.UnixEncodedTime `json:"confirmed_at,omitempty"`
 	ExpiresAt   limes.UnixEncodedTime  `json:"expires_at,omitempty"`
 	// TransferStatus and TransferToken are only filled while the commitment is marked for transfer.

--- a/vendor/github.com/sapcc/go-api-declarations/limes/resources/commitment.go
+++ b/vendor/github.com/sapcc/go-api-declarations/limes/resources/commitment.go
@@ -45,9 +45,11 @@ type Commitment struct {
 	// and intended for informational displays only. API access should always use the UUID.
 	CreatorUUID string `json:"creator_uuid,omitempty"`
 	CreatorName string `json:"creator_name,omitempty"`
+	// ConfirmBy is only filled if it was set in the CommitmentRequest.
+	ConfirmBy *limes.UnixEncodedTime `json:"confirm_by,omitempty"`
 	// ConfirmedAt and ExpiresAt are only filled after the commitment was confirmed.
 	ConfirmedAt *limes.UnixEncodedTime `json:"confirmed_at,omitempty"`
-	ExpiresAt   *limes.UnixEncodedTime `json:"expires_at,omitempty"`
+	ExpiresAt   limes.UnixEncodedTime  `json:"expires_at,omitempty"`
 	// TransferStatus and TransferToken are only filled while the commitment is marked for transfer.
 	TransferStatus CommitmentTransferStatus `json:"transfer_status,omitempty"`
 	TransferToken  string                   `json:"transfer_token,omitempty"`

--- a/vendor/github.com/sapcc/go-api-declarations/limes/resources/commitment.go
+++ b/vendor/github.com/sapcc/go-api-declarations/limes/resources/commitment.go
@@ -60,6 +60,7 @@ type CommitmentRequest struct {
 	AvailabilityZone limes.AvailabilityZone `json:"availability_zone"`
 	Amount           uint64                 `json:"amount"`
 	Duration         CommitmentDuration     `json:"duration"`
+	ConfirmBy        *limes.UnixEncodedTime `json:"confirm_by,omitempty"`
 }
 
 // CommitmentTransferStatus is an enum.

--- a/vendor/github.com/sapcc/go-api-declarations/limes/resources/metadata.go
+++ b/vendor/github.com/sapcc/go-api-declarations/limes/resources/metadata.go
@@ -97,4 +97,6 @@ const (
 type CommitmentConfiguration struct {
 	// Allowed durations for commitments on this resource.
 	Durations []CommitmentDuration `json:"durations"`
+	// If shown, commitments must be created with `confirm_by` at or after this timestamp.
+	MinConfirmBy *limes.UnixEncodedTime `json:"min_confirm_by,omitempty"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -140,7 +140,7 @@ github.com/rabbitmq/amqp091-go
 # github.com/rs/cors v1.10.1
 ## explicit; go 1.13
 github.com/rs/cors
-# github.com/sapcc/go-api-declarations v1.10.3
+# github.com/sapcc/go-api-declarations v1.10.4
 ## explicit; go 1.21
 github.com/sapcc/go-api-declarations/bininfo
 github.com/sapcc/go-api-declarations/cadf


### PR DESCRIPTION
Based on feedback from the Demand Management folks, and my own thoughts based on that feedback. Roughly ordered by complexity:

- [x] rename `requested_at` field to `created_at` (in the future, there will be several workflows to create commitment objects that are not really requests)
- [x] add fields to identify the creating user (cheap to do now; if we need it later, we can save ourselves a tedious and expensive lookup in the audit log)
- [x] commitments shall never be deleteable by regular users, only by cloud admins
- [x] report `min_confirm_date` in commitment config
- [x] add a dry-run API endpoint, to test if a commitment of X size in a given AZ could be confirmed immediately
- [x] change semantics of `confirm_after` while renaming it to `confirm_by`
  - [x] `confirm_by` can be chosen by the user
  - [x] commitments without `confirm_by` can only be created if they can be confirmed immediately (hence why we need the aforementioned dry run ability for a clean UI workflow)
  - [x] commitments with `confirm_by` will have `expires_at = confirm_by + duration` instead of `expires_at = confirmed_at + duration` (i.e. if we take longer to provide the requested capacity, the customer shall not be bound to pay for it longer than they anticipated when requesting)
  - [x] commitments with `confirm_by` need to have `confirm_by >= min_confirm_date` (hence why this config attribute needs to be surfaced in the API)

~This includes changes to the vendored go-api-declarations copy that does not exist in this form in that module's upstream repo. All the changes to go-api-declarations to this feature branch will be bundled into a single commit in go-api-declarations in the end to avoid a bunch of useless intermediate releases on that upstream repo.~ Done.