### PR TITLE
add project_az_resources.historical_usage and fill during scraping 

### DIFF
--- a/internal/collector/fixtures/scrape_metrics.prom
+++ b/internal/collector/fixtures/scrape_metrics.prom
@@ -7,7 +7,7 @@ limes_cluster_capacity{resource="things",service="unittest"} 0
 # TYPE limes_domain_quota gauge
 limes_domain_quota{domain="germany",domain_id="uuid-for-germany",resource="capacity",service="unittest"} 0
 limes_domain_quota{domain="germany",domain_id="uuid-for-germany",resource="capacity_portion",service="unittest"} 0
-limes_domain_quota{domain="germany",domain_id="uuid-for-germany",resource="things",service="unittest"} 0
+limes_domain_quota{domain="germany",domain_id="uuid-for-germany",resource="things",service="unittest"} 26
 # HELP limes_newest_scraped_at Newest (i.e. largest) scraped_at timestamp for any project given a certain service in a certain OpenStack cluster.
 # TYPE limes_newest_scraped_at gauge
 limes_newest_scraped_at{service="unittest",service_name=""} 10860
@@ -23,7 +23,7 @@ limes_plugin_metrics_ok{domain="germany",domain_id="uuid-for-germany",project="d
 limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest"} 40
 limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest"} 13
 limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest"} 48
-limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest"} 15
+limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest"} 13
 # HELP limes_project_physical_usage Actual (physical) usage of a Limes resource for an OpenStack project.
 # TYPE limes_project_physical_usage gauge
 limes_project_physical_usage{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest"} 10

--- a/internal/collector/fixtures/scrape_metrics_skipzero.prom
+++ b/internal/collector/fixtures/scrape_metrics_skipzero.prom
@@ -7,7 +7,7 @@ limes_cluster_capacity{resource="things",service="unittest"} 0
 # TYPE limes_domain_quota gauge
 limes_domain_quota{domain="germany",domain_id="uuid-for-germany",resource="capacity",service="unittest"} 0
 limes_domain_quota{domain="germany",domain_id="uuid-for-germany",resource="capacity_portion",service="unittest"} 0
-limes_domain_quota{domain="germany",domain_id="uuid-for-germany",resource="things",service="unittest"} 0
+limes_domain_quota{domain="germany",domain_id="uuid-for-germany",resource="things",service="unittest"} 26
 # HELP limes_newest_scraped_at Newest (i.e. largest) scraped_at timestamp for any project given a certain service in a certain OpenStack cluster.
 # TYPE limes_newest_scraped_at gauge
 limes_newest_scraped_at{service="unittest",service_name=""} 10860
@@ -23,7 +23,7 @@ limes_plugin_metrics_ok{domain="germany",domain_id="uuid-for-germany",project="d
 limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest"} 40
 limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest"} 13
 limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest"} 48
-limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest"} 15
+limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest"} 13
 # HELP limes_project_physical_usage Actual (physical) usage of a Limes resource for an OpenStack project.
 # TYPE limes_project_physical_usage gauge
 limes_project_physical_usage{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest"} 10

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -423,4 +423,12 @@ var sqlMigrations = map[string]string{
 			DROP COLUMN creator_uuid,
 			DROP COLUMN creator_name;
 	`,
+	"033_historical_usage.up.sql": `
+		ALTER TABLE project_az_resources
+			ADD COLUMN historical_usage TEXT NOT NULL DEFAULT '';
+	`,
+	"033_historical_usage.down.sql": `
+		ALTER TABLE project_az_resources
+			DROP COLUMN historical_usage;
+	`,
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -165,12 +165,13 @@ func (r ProjectResource) Ref() ResourceRef {
 
 // ProjectAZResource contains a record from the `project_az_resources` table.
 type ProjectAZResource struct {
-	ResourceID       int64                  `db:"resource_id"`
-	AvailabilityZone limes.AvailabilityZone `db:"az"`
-	Quota            *uint64                `db:"quota"`
-	Usage            uint64                 `db:"usage"`
-	PhysicalUsage    *uint64                `db:"physical_usage"`
-	SubresourcesJSON string                 `db:"subresources"`
+	ResourceID          int64                  `db:"resource_id"`
+	AvailabilityZone    limes.AvailabilityZone `db:"az"`
+	Quota               *uint64                `db:"quota"`
+	Usage               uint64                 `db:"usage"`
+	PhysicalUsage       *uint64                `db:"physical_usage"`
+	SubresourcesJSON    string                 `db:"subresources"`
+	HistoricalUsageJSON string                 `db:"historical_usage"`
 }
 
 // ProjectRate contains a record from the `project_rates` table.

--- a/internal/util/datatypes.go
+++ b/internal/util/datatypes.go
@@ -21,6 +21,7 @@ package util
 
 import (
 	"encoding/json"
+	"time"
 
 	"gopkg.in/yaml.v2"
 )
@@ -41,6 +42,8 @@ func (f *Float64OrUnknown) UnmarshalJSON(buffer []byte) error {
 	return err
 }
 
+////////////////////////////////////////////////////////////////////////////////
+
 // YamlRawMessage is like json.RawMessage: During yaml.Unmarshal(), it will
 // just collect the provided YAML representation instead of parsing it into a
 // specific datatype. It can be used to defer parsing when the concrete target
@@ -56,4 +59,28 @@ func (m *YamlRawMessage) UnmarshalYAML(unmarshal func(any) error) error {
 	}
 	*m, err = yaml.Marshal(data)
 	return err
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+// MarshalableTimeDuration is a time.Duration that can be unmarshaled
+// from a YAML string using time.ParseDuration.
+
+type MarshalableTimeDuration time.Duration
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (d *MarshalableTimeDuration) UnmarshalYAML(unmarshal func(any) error) error {
+	var s string
+	err := unmarshal(&s)
+	if err != nil {
+		return err
+	}
+	result, err := time.ParseDuration(s)
+	*d = MarshalableTimeDuration(result)
+	return err
+}
+
+// Into is a short-hand for casting into time.Duration.
+func (d MarshalableTimeDuration) Into() time.Duration {
+	return time.Duration(d)
 }

--- a/internal/util/timeseries_test.go
+++ b/internal/util/timeseries_test.go
@@ -1,0 +1,140 @@
+/******************************************************************************
+*
+*  Copyright 2023 SAP SE
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+******************************************************************************/
+
+package util
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/sapcc/go-bits/assert"
+)
+
+func TestTimeSeries(t *testing.T) {
+	s := EmptyTimeSeries[float64]()
+	expectJSON(t, s, `{}`)
+
+	// pruning an empty time series just does nothing
+	s.PruneOldValues(time.Unix(0, 0), 25*time.Second)
+	expectJSON(t, s, `{}`)
+
+	// adding a first measurement will never fail
+	mustT(t, s.AddMeasurement(time.Unix(10, 0), 42.0))
+	expectJSON(t, s, `{"t":[10],"v":[42]}`)
+
+	// adding a second measurement works if the time is larger
+	mustT(t, s.AddMeasurement(time.Unix(15, 0), 41.0))
+	expectJSON(t, s, `{"t":[10,15],"v":[42,41]}`)
+
+	// adding the same measurement again is a no-op
+	mustT(t, s.AddMeasurement(time.Unix(15, 0), 41.0))
+	expectJSON(t, s, `{"t":[10,15],"v":[42,41]}`)
+
+	// trying to add an earlier measurement is an error
+	err := s.AddMeasurement(time.Unix(13, 0), 41.0)
+	mustFailT(t, err, "cannot add value for timestamp 13: already recorded later timestamp 15")
+
+	// trying to add contradictory measurements is an error
+	err = s.AddMeasurement(time.Unix(15, 0), 42.0)
+	mustFailT(t, err, "ambiguous value for timestamp 15: tried to record 42 now, but already recorded 41")
+
+	// add some more measurements to prepare for the pruning test
+	mustT(t, s.AddMeasurement(time.Unix(20, 0), 40.0))
+	mustT(t, s.AddMeasurement(time.Unix(25, 0), 45.0))
+	mustT(t, s.AddMeasurement(time.Unix(30, 0), 46.0))
+	mustT(t, s.AddMeasurement(time.Unix(35, 0), 47.0))
+	mustT(t, s.AddMeasurement(time.Unix(40, 0), 48.0))
+	expectJSON(t, s, `{"t":[10,15,20,25,30,35,40],"v":[42,41,40,45,46,47,48]}`)
+
+	// test pruning with cutoff aligned to a previous measurement (removes all before the cutoff)
+	s.PruneOldValues(time.Unix(40, 0), 25*time.Second)
+	expectJSON(t, s, `{"t":[15,20,25,30,35,40],"v":[41,40,45,46,47,48]}`)
+
+	// test pruning with cutoff not aligned (retains one value before the cutoff
+	// to cover the span between cutoff and next measurement)
+	s.PruneOldValues(time.Unix(40, 0), 13*time.Second)
+	expectJSON(t, s, `{"t":[25,30,35,40],"v":[45,46,47,48]}`)
+
+	// test pruning that is a no-op because nothing falls outside the boundary
+	s.PruneOldValues(time.Unix(40, 0), 100*time.Second)
+	expectJSON(t, s, `{"t":[25,30,35,40],"v":[45,46,47,48]}`)
+}
+
+func TestTimeSeriesUnmarshalErrors(t *testing.T) {
+	testcases := []struct {
+		Representation string
+		ExpectedError  string
+	}{
+		{
+			`{"t":[1,2],"v":[1,2,3]}`,
+			"cannot unmarshal TimeSeries with inconsistent length: len(t) = 2 != 3 = len(v)",
+		},
+		{
+			`{"t":[2,3,1],"v":[1,2,3]}`,
+			"cannot unmarshal TimeSeries with unsorted timestamps",
+		},
+		{
+			`{"t":[1,2,2],"v":[1,2,3]}`,
+			"cannot unmarshal TimeSeries with duplicate timestamps: 2 appears more than once",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Logf("testing unmarshal of `%s`", tc.Representation)
+		var target TimeSeries[float64]
+		mustFailT(t, json.Unmarshal([]byte(tc.Representation), &target), tc.ExpectedError)
+	}
+}
+
+func mustT(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustFailT(t *testing.T, err error, expected string) {
+	t.Helper()
+	if err == nil {
+		t.Errorf("expected to fail with %q, but got no error", expected)
+	} else if err.Error() != expected {
+		t.Errorf("expected to fail with %q, but failed with %q", expected, err.Error())
+	}
+}
+
+func expectJSON[V any](t *testing.T, value V, repr string) {
+	t.Helper()
+
+	// test that the value marshals to the given JSON representation
+	buf, err := json.Marshal(value)
+	if err != nil {
+		t.Error("while marshaling: " + err.Error())
+	} else {
+		assert.DeepEqual(t, "JSON representation", string(buf), repr)
+	}
+
+	// test that the JSON representation unmarshals into an identical value
+	var unmarshaled V
+	err = json.Unmarshal([]byte(repr), &unmarshaled)
+	if err != nil {
+		t.Error("while unmarshaling: " + err.Error())
+	} else {
+		assert.DeepEqual(t, "unmarshaled value", unmarshaled, value)
+	}
+}


### PR DESCRIPTION
We need this data to evaluate the autogrow quota distribution algorithm later on.
This is split into two commits which I recommend reviewing separately.