### PR TITLE
Introduce TransferCommitment API

### DIFF
--- a/docs/users/api-spec-resources.md
+++ b/docs/users/api-spec-resources.md
@@ -758,7 +758,7 @@ Prepares a commitment to be transferred from a source project to a target projec
 {
   "commitment": {
     "amount": 100,
-    "transfer_status": "unlisted",
+    "transfer_status": "unlisted"
   }
 }
 ```

--- a/docs/users/api-spec-resources.md
+++ b/docs/users/api-spec-resources.md
@@ -773,9 +773,11 @@ The response is a JSON of the commitment including the following fields that ide
   }
 }
 ```
-### POST /v1/domains/:id/projects/:id/transfer-commitment/:id?token=:token
+### POST /v1/domains/:id/projects/:id/transfer-commitment/:id
 Transfers the commitment from a source project to a target project.
 Requires a project-admin token.
+Requires a transfer token in the request header:
+`Transfer-Token: [value]`.
 This endpoint receives the target project ID, but the commitment ID from the source project.
 Requires a generated token from the API: `/v1/domains/:id/projects/:id/commitments/:id/start-transfer`.
 On success the API clears the `transfer_token` and `transfer_status` from the commitment.

--- a/docs/users/api-spec-resources.md
+++ b/docs/users/api-spec-resources.md
@@ -775,6 +775,7 @@ The response is a JSON of the commitment including the following fields that ide
 ```
 ### POST /v1/domains/:id/projects/:id/transfer-commitment/:id?token=:token
 Transfers the commitment from a source project to a target project.
+Requires a project-admin token.
 This endpoint receives the target project ID, but the commitment ID from the source project.
 Requires a generated token from the API: `/v1/domains/:id/projects/:id/commitments/:id/start-transfer`.
 On success the API clears the `transfer_token` and `transfer_status` from the commitment.

--- a/docs/users/api-spec-resources.md
+++ b/docs/users/api-spec-resources.md
@@ -769,7 +769,7 @@ The response is a JSON of the commitment including the following fields that ide
 {
   "commitment": {
     "transfer_token": "token",
-    "transfer_status": "unlisted",
+    "transfer_status": "unlisted"
   }
 }
 ```

--- a/docs/users/api-spec-resources.md
+++ b/docs/users/api-spec-resources.md
@@ -764,7 +764,7 @@ Prepares a commitment to be transferred from a source project to a target projec
 ```
 If the amount to transfer is equal to the commitment, the whole commitment will be marked as transferrable. If the amount is less than the commitment, the commitment will be split in two and the requested amount will be marked as transferrable.
 The transfer status indicates if the commitment stays `unlisted` (private) or `public`.
-The response is a JSON of the commitment including the following fields that identify a commitment in it's transferrable state:
+The response is a JSON of the commitment including the following fields that identify a commitment in its transferrable state:
 ```json
 {
   "commitment": {

--- a/docs/users/api-spec-resources.md
+++ b/docs/users/api-spec-resources.md
@@ -762,7 +762,9 @@ Prepares a commitment to be transferred from a source project to a target projec
   }
 }
 ```
-If the amount to transfer is equal to the commitment, the whole commitment will be marked as transferrable. If the amount is less than the commitment, the commitment will be split in two and the requested amount will be marked as transferrable.The transfer status indicates if the commitment stays `unlisted` (private) or `public`. The response is a JSON of the commitment including the following fields that identify a commitment in it's transferrable state:
+If the amount to transfer is equal to the commitment, the whole commitment will be marked as transferrable. If the amount is less than the commitment, the commitment will be split in two and the requested amount will be marked as transferrable.
+The transfer status indicates if the commitment stays `unlisted` (private) or `public`.
+The response is a JSON of the commitment including the following fields that identify a commitment in it's transferrable state:
 ```json
 {
   "commitment": {

--- a/docs/users/api-spec-resources.md
+++ b/docs/users/api-spec-resources.md
@@ -752,6 +752,28 @@ Returns 200 (OK) on success, and a JSON document like `{"result":true}` or `{"re
 
 The `result` field indicates whether this commitment can be created without a `confirm_by` attribute, that is, confirmed immediately upon creation.
 
+### POST /v1/domains/:id/projects/:id/commitments/:id/start-transfer
+Prepares a commitment to be transferred from a source project to a target project. Requires a project-admin token, and a request body that is a JSON document like:
+```json
+{
+  "commitment": {
+    "amount": 100,
+    "transfer_status": "unlisted",
+  }
+}
+```
+If the amount to transfer is equal to the commitment, the whole commitment will be marked as transferrable. If the amount is less than the commitment, the commitment will be split in two and the requested amount will be marked as transferrable.The transfer status indicates if the commitment stays `unlisted` (private) or `public`. The response is a JSON of the commitment including the following fields that identify a commitment in it's transferrable state:
+```json
+{
+  "commitment": {
+    "transfer_token": "token",
+    "transfer_status": "unlisted",
+  }
+}
+```
+### POST /v1/domains/:id/projects/:id/transfer-commitment/:id?token=:token
+Transfers the commitment from a source project to a target project. This endpoint receives the target project ID, but the commitment ID from the source project. Requires a generated token from the API: `/v1/domains/:id/projects/:id/commitments/:id/start-transfer`. On success the API clears the `transfer_token` and `transfer_status` from the commitment. After that, it returns the commitment as a JSON document.  
+
 ### DELETE /v1/domains/:domain\_id/projects/:project\_id/commitments/:id
 
 Deletes a commitment within the given project. Requires a cloud-admin token. On success, returns 204 (No Content).

--- a/docs/users/api-spec-resources.md
+++ b/docs/users/api-spec-resources.md
@@ -774,7 +774,11 @@ The response is a JSON of the commitment including the following fields that ide
 }
 ```
 ### POST /v1/domains/:id/projects/:id/transfer-commitment/:id?token=:token
-Transfers the commitment from a source project to a target project. This endpoint receives the target project ID, but the commitment ID from the source project. Requires a generated token from the API: `/v1/domains/:id/projects/:id/commitments/:id/start-transfer`. On success the API clears the `transfer_token` and `transfer_status` from the commitment. After that, it returns the commitment as a JSON document.  
+Transfers the commitment from a source project to a target project.
+This endpoint receives the target project ID, but the commitment ID from the source project.
+Requires a generated token from the API: `/v1/domains/:id/projects/:id/commitments/:id/start-transfer`.
+On success the API clears the `transfer_token` and `transfer_status` from the commitment.
+After that, it returns the commitment as a JSON document.  
 
 ### DELETE /v1/domains/:domain\_id/projects/:project\_id/commitments/:id
 

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -83,10 +83,10 @@ var (
 		  JOIN project_services ps ON pr.service_id = ps.id
 		 WHERE par.id = $1
 	`)
-	getCommitmentWithMatchingTransferToken = sqlext.SimplifyWhitespace(`
+	getCommitmentWithMatchingTransferTokenQuery = sqlext.SimplifyWhitespace(`
 		SELECT * FROM project_commitments WHERE transfer_token = $1
 	`)
-	findTargetAZResourceIDBySourceID = sqlext.SimplifyWhitespace(`
+	findTargetAZResourceIDBySourceIDQuery = sqlext.SimplifyWhitespace(`
 	  SELECT par.id 
 	    FROM project_az_resources as par
 		JOIN project_resources pr ON par.resource_id = pr.id

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -501,6 +501,12 @@ func (p *v1Provider) StartCommitmentTransfer(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	// reject commitments that are not confirmed yet.
+	if dbCommitment.ConfirmedAt == nil {
+		http.Error(w, "project needs to be confirmed in order to transfer it.", http.StatusUnprocessableEntity)
+		return
+	}
+
 	// Mark whole commitment or a newly created, splitted one as transferrable.
 	tx, err := p.DB.Begin()
 	if respondwith.ErrorText(w, err) {

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -463,7 +463,6 @@ func (p *v1Provider) StartCommitmentTransfer(w http.ResponseWriter, r *http.Requ
 	httpapi.IdentifyEndpoint(r, "/v1/domains/:id/projects/:id/commitments/:id/start-transfer")
 	token := p.CheckToken(r)
 	if !token.Require(w, "project:edit") {
-		http.Error(w, "insufficient access rights.", http.StatusForbidden)
 		return
 	}
 	dbDomain := p.FindDomainFromRequest(w, r)

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -110,9 +110,6 @@ var (
 	updateCommitmentSuperseded = sqlext.SimplifyWhitespace(`
 		UPDATE project_commitments SET superseded_at = $1 WHERE id = $2
 	`)
-	updateCommitmentAZResourceID = sqlext.SimplifyWhitespace(`
-		UPDATE project_commitments SET az_resource_id = $1 WHERE id = $2
-	`)
 )
 
 // GetProjectCommitments handles GET /v1/domains/:domain_id/projects/:project_id/commitments.

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -503,7 +503,7 @@ func (p *v1Provider) StartCommitmentTransfer(w http.ResponseWriter, r *http.Requ
 
 	// reject commitments that are not confirmed yet.
 	if dbCommitment.ConfirmedAt == nil {
-		http.Error(w, "project needs to be confirmed in order to transfer it.", http.StatusUnprocessableEntity)
+		http.Error(w, "commitment needs to be confirmed in order to transfer it.", http.StatusUnprocessableEntity)
 		return
 	}
 

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -471,6 +471,7 @@ func (p *v1Provider) StartCommitmentTransfer(w http.ResponseWriter, r *http.Requ
 	}
 	dbProject := p.FindProjectFromRequest(w, r, dbDomain)
 	if dbProject == nil {
+		http.Error(w, "project not found.", http.StatusNotFound)
 		return
 	}
 	var parseTarget struct {

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -475,8 +475,12 @@ func (p *v1Provider) StartCommitmentTransfer(w http.ResponseWriter, r *http.Requ
 		http.Error(w, "project not found.", http.StatusNotFound)
 		return
 	}
+	// TODO: eventually migrate this struct into go-api-declarations
 	var parseTarget struct {
-		Request limesresources.Commitment `json:"commitment"`
+		Request struct {
+			Amount         uint64                                  `json:"amount"`
+			TransferStatus limesresources.CommitmentTransferStatus `json:"transfer_status,omitempty"`
+		} `json:"commitment"`
 	}
 	if !RequireJSON(w, r, &parseTarget) {
 		http.Error(w, "json not parsable.", http.StatusBadRequest)

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -598,13 +598,13 @@ func (p *v1Provider) buildSplitCommitment(dbCommitment db.ProjectCommitment, amo
 
 // TransferCommitment handles POST /v1/domains/{domain_id}/projects/{project_id}/transfer-commitment/{id}?token={token}
 func (p *v1Provider) TransferCommitment(w http.ResponseWriter, r *http.Request) {
-	httpapi.IdentifyEndpoint(r, "/v1/domains/:id/projects/:id/transfer-commitment/:id?token=:token")
+	httpapi.IdentifyEndpoint(r, "/v1/domains/:id/projects/:id/transfer-commitment/:id")
 	token := p.CheckToken(r)
 	if !token.Require(w, "project:edit") {
 		http.Error(w, "insufficient access rights.", http.StatusForbidden)
 		return
 	}
-	transferToken := r.URL.Query().Get("token")
+	transferToken := r.Header.Get("Transfer-Token")
 	if transferToken == "" {
 		http.Error(w, "no transfer token provided", http.StatusBadRequest)
 		return

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -435,4 +435,10 @@ func (p *v1Provider) DeleteProjectCommitment(w http.ResponseWriter, r *http.Requ
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (p *v1Provider) TransferCommitment(w http.ResponseWriter, r *http.Request) {}
+func (p *v1Provider) TransferCommitment(w http.ResponseWriter, r *http.Request) {
+	httpapi.IdentifyEndpoint(r, "/v1/domains/:id/projects/:id/commitments/:id/start-transfer")
+	token := p.CheckToken(r)
+	if !token.Require(w, "project:edit") {
+		return
+	}
+}

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -434,3 +434,5 @@ func (p *v1Provider) DeleteProjectCommitment(w http.ResponseWriter, r *http.Requ
 	})
 	w.WriteHeader(http.StatusNoContent)
 }
+
+func (p *v1Provider) TransferCommitment(w http.ResponseWriter, r *http.Request) {}

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -466,7 +466,7 @@ func (p *v1Provider) TransferCommitment(w http.ResponseWriter, r *http.Request) 
 	// TODO: token generations has to be checked in test.
 
 	// execute update
-	row, err := p.DB.Exec(updateCommitmentTransferState, req.TransferStatus, "hallo", req.ID)
+	_, err := p.DB.Exec(updateCommitmentTransferState, req.TransferStatus, "hallo", req.ID)
 	if respondwith.ErrorText(w, err) {
 		return
 	}
@@ -492,7 +492,13 @@ func (p *v1Provider) TransferCommitment(w http.ResponseWriter, r *http.Request) 
 	}
 
 	c := p.convertCommitmentToDisplayForm(dbCommitment, loc)
-	fmt.Println(row)
+	logAndPublishEvent(p.timeNow(), r, token, http.StatusAccepted, commitmentEventTarget{
+		DomainID:    dbDomain.UUID,
+		DomainName:  dbDomain.Name,
+		ProjectID:   dbProject.UUID,
+		ProjectName: dbProject.Name,
+		Commitment:  c,
+	})
 	respondwith.JSON(w, http.StatusAccepted, map[string]any{"commitment": c})
 }
 

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -526,8 +526,8 @@ func (p *v1Provider) StartCommitmentTransfer(w http.ResponseWriter, r *http.Requ
 		now := p.timeNow()
 		transferAmount := req.Amount
 		remainingAmount := dbCommitment.Amount - req.Amount
-		transferCommitment := p.splitCommitment(dbCommitment, transferAmount)
-		remainingCommitment := p.splitCommitment(dbCommitment, remainingAmount)
+		transferCommitment := p.buildSplitCommitment(dbCommitment, transferAmount)
+		remainingCommitment := p.buildSplitCommitment(dbCommitment, remainingAmount)
 		err = tx.Insert(&transferCommitment)
 		if respondwith.ErrorText(w, err) {
 			return
@@ -612,7 +612,7 @@ func (p *v1Provider) TransferCommitment(w http.ResponseWriter, r *http.Request) 
 
 	// find commitment by transfer_token
 	var dbCommitment db.ProjectCommitment
-	err := p.DB.SelectOne(&dbCommitment, getCommitmentWithMatchingTransferToken, transferToken)
+	err := p.DB.SelectOne(&dbCommitment, getCommitmentWithMatchingTransferTokenQuery, transferToken)
 	if errors.Is(err, sql.ErrNoRows) {
 		http.Error(w, "no matching commitment found", http.StatusNotFound)
 		return
@@ -622,7 +622,7 @@ func (p *v1Provider) TransferCommitment(w http.ResponseWriter, r *http.Request) 
 
 	// get target AZ_RESOURCE_ID
 	var targetResourceID db.ProjectAZResourceID
-	err = p.DB.QueryRow(findTargetAZResourceIDBySourceID, targetProject.ID, dbCommitment.AZResourceID).Scan(&targetResourceID)
+	err = p.DB.QueryRow(findTargetAZResourceIDBySourceIDQuery, targetProject.ID, dbCommitment.AZResourceID).Scan(&targetResourceID)
 	if respondwith.ErrorText(w, err) {
 		return
 	}

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -641,8 +641,8 @@ func (p *v1Provider) TransferCommitment(w http.ResponseWriter, r *http.Request) 
 
 	dbCommitment.TransferStatus = ""
 	dbCommitment.TransferToken = ""
-        dbCommitment.AZResourceID = targetResourceID
-	err := p.DB.Update(&dbCommitment)
+	dbCommitment.AZResourceID = targetResourceID
+	_, err = p.DB.Update(&dbCommitment)
 	if respondwith.ErrorText(w, err) {
 		return
 	}

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -463,10 +463,12 @@ func (p *v1Provider) StartCommitmentTransfer(w http.ResponseWriter, r *http.Requ
 	httpapi.IdentifyEndpoint(r, "/v1/domains/:id/projects/:id/commitments/:id/start-transfer")
 	token := p.CheckToken(r)
 	if !token.Require(w, "project:edit") {
+		http.Error(w, "insufficient access rights.", http.StatusForbidden)
 		return
 	}
 	dbDomain := p.FindDomainFromRequest(w, r)
 	if dbDomain == nil {
+		http.Error(w, "domain not found.", http.StatusNotFound)
 		return
 	}
 	dbProject := p.FindProjectFromRequest(w, r, dbDomain)
@@ -478,6 +480,7 @@ func (p *v1Provider) StartCommitmentTransfer(w http.ResponseWriter, r *http.Requ
 		Request limesresources.Commitment `json:"commitment"`
 	}
 	if !RequireJSON(w, r, &parseTarget) {
+		http.Error(w, "json not parsable.", http.StatusBadRequest)
 		return
 	}
 	req := parseTarget.Request
@@ -590,6 +593,7 @@ func (p *v1Provider) TransferCommitment(w http.ResponseWriter, r *http.Request) 
 	httpapi.IdentifyEndpoint(r, "/v1/domains/:id/projects/:id/transfer-commitment/:id?token=:token")
 	token := p.CheckToken(r)
 	if !token.Require(w, "project:edit") {
+		http.Error(w, "insufficient access rights.", http.StatusForbidden)
 		return
 	}
 	transferToken := r.URL.Query().Get("token")
@@ -598,10 +602,12 @@ func (p *v1Provider) TransferCommitment(w http.ResponseWriter, r *http.Request) 
 	}
 	dbDomain := p.FindDomainFromRequest(w, r)
 	if dbDomain == nil {
+		http.Error(w, "domain not found.", http.StatusNotFound)
 		return
 	}
 	targetProject := p.FindProjectFromRequest(w, r, dbDomain)
 	if targetProject == nil {
+		http.Error(w, "project not found.", http.StatusNotFound)
 		return
 	}
 

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -489,12 +489,12 @@ func (p *v1Provider) StartCommitmentTransfer(w http.ResponseWriter, r *http.Requ
 	req := parseTarget.Request
 
 	if req.TransferStatus != limesresources.CommitmentTransferStatusUnlisted && req.TransferStatus != limesresources.CommitmentTransferStatusPublic {
-		respondwith.JSON(w, http.StatusBadRequest, fmt.Sprintf("Invalid transfer_status code. Must be %s or %s.", limesresources.CommitmentTransferStatusUnlisted, limesresources.CommitmentTransferStatusPublic))
+		http.Error(w, fmt.Sprintf("Invalid transfer_status code. Must be %s or %s.", limesresources.CommitmentTransferStatusUnlisted, limesresources.CommitmentTransferStatusPublic), http.StatusBadRequest)
 		return
 	}
 
 	if req.Amount <= 0 {
-		respondwith.JSON(w, http.StatusBadRequest, "Delivered amount needs to be a positive value.")
+		http.Error(w, "Delivered amount needs to be a positive value.", http.StatusBadRequest)
 		return
 	}
 
@@ -601,7 +601,8 @@ func (p *v1Provider) TransferCommitment(w http.ResponseWriter, r *http.Request) 
 	}
 	transferToken := r.URL.Query().Get("token")
 	if transferToken == "" {
-		respondwith.ErrorText(w, errors.New("no transfer token provided"))
+		http.Error(w, "no transfer token provided", http.StatusBadRequest)
+		return
 	}
 	dbDomain := p.FindDomainFromRequest(w, r)
 	if dbDomain == nil {

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -571,7 +571,7 @@ func (p *v1Provider) StartCommitmentTransfer(w http.ResponseWriter, r *http.Requ
 	respondwith.JSON(w, http.StatusAccepted, map[string]any{"commitment": c})
 }
 
-func (p *v1Provider) splitCommitment(dbCommitment db.ProjectCommitment, amount uint64) db.ProjectCommitment {
+func (p *v1Provider) buildSplitCommitment(dbCommitment db.ProjectCommitment, amount uint64) db.ProjectCommitment {
 	now := p.timeNow()
 	return db.ProjectCommitment{
 		AZResourceID:  dbCommitment.AZResourceID,

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -19,7 +19,6 @@
 package api
 
 import (
-	"crypto/rand"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -463,10 +462,10 @@ func (p *v1Provider) TransferCommitment(w http.ResponseWriter, r *http.Request) 
 	req := parseTarget.Request
 
 	// create a transfer token
-	// TODO: token generations has to be checked in test.
+	transferToken := p.generateTransferToken()
 
 	// execute update
-	_, err := p.DB.Exec(updateCommitmentTransferState, req.TransferStatus, "hallo", req.ID)
+	_, err := p.DB.Exec(updateCommitmentTransferState, req.TransferStatus, transferToken, req.ID)
 	if respondwith.ErrorText(w, err) {
 		return
 	}
@@ -500,13 +499,4 @@ func (p *v1Provider) TransferCommitment(w http.ResponseWriter, r *http.Request) 
 		Commitment:  c,
 	})
 	respondwith.JSON(w, http.StatusAccepted, map[string]any{"commitment": c})
-}
-
-func (p *v1Provider) createToken() (string, error) {
-	tokenBytes := make([]byte, 12)
-	_, err := rand.Read(tokenBytes)
-	if err != nil {
-		return "", fmt.Errorf("could not generate token: %s", err.Error())
-	}
-	return string(tokenBytes), nil
 }

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -441,7 +441,7 @@ func (p *v1Provider) DeleteProjectCommitment(w http.ResponseWriter, r *http.Requ
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// TransferCommitment handles POST /v1/domains/:id/projects/:id/commitments/:id/start-transfer
+// StartCommitmentTransfer handles POST /v1/domains/:id/projects/:id/commitments/:id/start-transfer
 func (p *v1Provider) StartCommitmentTransfer(w http.ResponseWriter, r *http.Request) {
 	httpapi.IdentifyEndpoint(r, "/v1/domains/:id/projects/:id/commitments/:id/start-transfer")
 	token := p.CheckToken(r)
@@ -559,4 +559,19 @@ func (p *v1Provider) splitCommitment(dbCommitment db.ProjectCommitment, amount u
 		ExpiresAt:     dbCommitment.ExpiresAt,
 		PredecessorID: &dbCommitment.ID,
 	}
+}
+
+// TransferCommitment handles POST /v1/domains/{domain_id}/projects/{project_id}/transfer-commitment/{id}?token={token}
+func (p *v1Provider) TransferCommitment(w http.ResponseWriter, r *http.Request) {
+	httpapi.IdentifyEndpoint(r, "/v1/domains/{domain_id}/projects/{project_id}/transfer-commitment/{id}")
+	token := p.CheckToken(r)
+	if !token.Require(w, "project:edit") {
+		return
+	}
+	transferToken := r.URL.Query().Get("token")
+	if transferToken == "" {
+		respondwith.ErrorText(w, errors.New("No transfer token provided"))
+	}
+
+	respondwith.JSON(w, http.StatusAccepted, "")
 }

--- a/internal/api/commitment_test.go
+++ b/internal/api/commitment_test.go
@@ -677,6 +677,7 @@ func Test_StartCommitmentTransfer(t *testing.T) {
 		Method:       "POST",
 		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/1/start-transfer",
 		ExpectStatus: http.StatusBadRequest,
+		ExpectBody:   assert.StringData("Delivered amount needs to be a positive value.\n"),
 		Body:         assert.JSONObject{"commitment": assert.JSONObject{"amount": 0, "transfer_status": "public"}},
 	}.Check(t, s.Handler)
 }
@@ -759,12 +760,14 @@ func Test_TransferCommitment(t *testing.T) {
 		Method:       http.MethodPost,
 		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-dresden/transfer-commitment/1?token=wrongToken",
 		ExpectStatus: http.StatusNotFound,
+		ExpectBody:   assert.StringData("no matching commitment found\n"),
 	}.Check(t, s.Handler)
 
 	// No token provided
 	assert.HTTPRequest{
 		Method:       "POST",
 		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/transfer-commitment/1",
-		ExpectStatus: http.StatusInternalServerError,
+		ExpectStatus: http.StatusBadRequest,
+		ExpectBody:   assert.StringData("no transfer token provided\n"),
 	}.Check(t, s.Handler)
 }

--- a/internal/api/commitment_test.go
+++ b/internal/api/commitment_test.go
@@ -672,13 +672,22 @@ func Test_StartCommitmentTransfer(t *testing.T) {
 		Body:         assert.JSONObject{"commitment": assert.JSONObject{"amount": 10, "transfer_status": "unlisted"}},
 	}.Check(t, s.Handler)
 
-	// Negative Test, Amount = 0.
+	// Negative Test, amount = 0.
 	assert.HTTPRequest{
 		Method:       "POST",
 		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/1/start-transfer",
 		ExpectStatus: http.StatusBadRequest,
-		ExpectBody:   assert.StringData("Delivered amount needs to be a positive value.\n"),
+		ExpectBody:   assert.StringData("delivered amount needs to be a positive value.\n"),
 		Body:         assert.JSONObject{"commitment": assert.JSONObject{"amount": 0, "transfer_status": "public"}},
+	}.Check(t, s.Handler)
+
+	// Negative Test, delivered amount > commitment amount
+	assert.HTTPRequest{
+		Method:       "POST",
+		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/1/start-transfer",
+		ExpectStatus: http.StatusBadRequest,
+		ExpectBody:   assert.StringData("delivered amount exceeds the commitment amount.\n"),
+		Body:         assert.JSONObject{"commitment": assert.JSONObject{"amount": 11, "transfer_status": "public"}},
 	}.Check(t, s.Handler)
 }
 

--- a/internal/api/commitment_test.go
+++ b/internal/api/commitment_test.go
@@ -614,6 +614,8 @@ func Test_TransferCommitment(t *testing.T) {
 		"creator_name":      "alice@Default",
 		"confirm_by":        confirmBy,
 		"expires_at":        s.Clock.Now().Add(time.Duration(confirmBy)*time.Second + 1*time.Hour).Unix(),
+		"transfer_status":   "unlisted",
+		"transfer_token":    transferToken,
 	}
 
 	assert.HTTPRequest{

--- a/internal/api/commitment_test.go
+++ b/internal/api/commitment_test.go
@@ -614,7 +614,7 @@ func Test_TransferCommitment(t *testing.T) {
 		"creator_name":      "alice@Default",
 		"confirm_by":        confirmBy,
 		"expires_at":        s.Clock.Now().Add(time.Duration(confirmBy)*time.Second + 1*time.Hour).Unix(),
-		"transfer_status":   "unlisted",
+		"transfer_status":   "public",
 		"transfer_token":    transferToken,
 	}
 
@@ -623,6 +623,14 @@ func Test_TransferCommitment(t *testing.T) {
 		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/1/start-transfer",
 		ExpectStatus: http.StatusAccepted,
 		ExpectBody:   assert.JSONObject{"commitment": resp2},
-		Body:         assert.JSONObject{"commitment": assert.JSONObject{"amount": 9, "transfer_status": "unlisted"}},
+		Body:         assert.JSONObject{"commitment": assert.JSONObject{"amount": 9, "transfer_status": "public"}},
+	}.Check(t, s.Handler)
+
+	// 3. Negative Test
+	assert.HTTPRequest{
+		Method:       "POST",
+		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/1/start-transfer",
+		ExpectStatus: http.StatusBadRequest,
+		Body:         assert.JSONObject{"commitment": assert.JSONObject{"amount": 0, "transfer_status": "public"}},
 	}.Check(t, s.Handler)
 }

--- a/internal/api/commitment_test.go
+++ b/internal/api/commitment_test.go
@@ -792,7 +792,8 @@ func Test_TransferCommitment(t *testing.T) {
 
 	assert.HTTPRequest{
 		Method:       http.MethodPost,
-		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-dresden/transfer-commitment/1?token=" + transferToken,
+		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-dresden/transfer-commitment/1",
+		Header:       map[string]string{"Transfer-Token": transferToken},
 		ExpectBody:   assert.JSONObject{"commitment": resp2},
 		ExpectStatus: http.StatusAccepted,
 	}.Check(t, s.Handler)
@@ -808,7 +809,8 @@ func Test_TransferCommitment(t *testing.T) {
 
 	assert.HTTPRequest{
 		Method:       http.MethodPost,
-		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/transfer-commitment/2?token=" + transferToken,
+		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/transfer-commitment/2",
+		Header:       map[string]string{"Transfer-Token": transferToken},
 		ExpectBody:   assert.JSONObject{"commitment": resp4},
 		ExpectStatus: http.StatusAccepted,
 	}.Check(t, s.Handler)
@@ -816,7 +818,8 @@ func Test_TransferCommitment(t *testing.T) {
 	// wrong token
 	assert.HTTPRequest{
 		Method:       http.MethodPost,
-		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-dresden/transfer-commitment/1?token=wrongToken",
+		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-dresden/transfer-commitment/1",
+		Header:       map[string]string{"Transfer-Token": "wrongToken"},
 		ExpectStatus: http.StatusNotFound,
 		ExpectBody:   assert.StringData("no matching commitment found\n"),
 	}.Check(t, s.Handler)

--- a/internal/api/commitment_test.go
+++ b/internal/api/commitment_test.go
@@ -808,7 +808,7 @@ func Test_TransferCommitment(t *testing.T) {
 
 	assert.HTTPRequest{
 		Method:       http.MethodPost,
-		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/transfer-commitment/1?token=" + transferToken,
+		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/transfer-commitment/2?token=" + transferToken,
 		ExpectBody:   assert.JSONObject{"commitment": resp4},
 		ExpectStatus: http.StatusAccepted,
 	}.Check(t, s.Handler)

--- a/internal/api/commitment_test.go
+++ b/internal/api/commitment_test.go
@@ -62,11 +62,11 @@ const testCommitmentsYAMLWithoutMinConfirmDate = `
      		type: --test-generic
      resource_behavior:
      	# the resources in "first" have commitments, the ones in "second" do not
-     	- resource: first/.*
+     	- resource: second/.*
      		commitment_durations: ["1 hour", "2 hours"]
-     	- resource: first/things
+     	- resource: second/things
      		commitment_is_az_aware: false
-     	- resource: first/capacity
+     	- resource: second/capacity
      		commitment_is_az_aware: true
 `
 
@@ -575,7 +575,7 @@ func Test_StartCommitmentTransfer(t *testing.T) {
 	req1 := func(transferStatus string) assert.JSONObject {
 		return assert.JSONObject{
 			"id":                1,
-			"service_type":      "first",
+			"service_type":      "second",
 			"resource_name":     "capacity",
 			"availability_zone": "az-two",
 			"amount":            10,
@@ -587,7 +587,7 @@ func Test_StartCommitmentTransfer(t *testing.T) {
 
 	resp1 := assert.JSONObject{
 		"id":                1,
-		"service_type":      "first",
+		"service_type":      "second",
 		"resource_name":     "capacity",
 		"availability_zone": "az-two",
 		"amount":            10,
@@ -620,7 +620,7 @@ func Test_StartCommitmentTransfer(t *testing.T) {
 	// TransferAmount < CommitmentAmount
 	resp2 := assert.JSONObject{
 		"id":                2,
-		"service_type":      "first",
+		"service_type":      "second",
 		"resource_name":     "capacity",
 		"availability_zone": "az-two",
 		"amount":            9,
@@ -648,7 +648,7 @@ func Test_StartCommitmentTransfer(t *testing.T) {
 	var confirmBy = s.Clock.Now().Unix()
 	req2 := assert.JSONObject{
 		"id":                4,
-		"service_type":      "first",
+		"service_type":      "second",
 		"resource_name":     "capacity",
 		"availability_zone": "az-two",
 		"amount":            10,
@@ -701,7 +701,7 @@ func Test_TransferCommitment(t *testing.T) {
 	var transferToken = test.GenerateDummyToken()
 	req1 := assert.JSONObject{
 		"id":                1,
-		"service_type":      "first",
+		"service_type":      "second",
 		"resource_name":     "capacity",
 		"availability_zone": "az-two",
 		"amount":            10,
@@ -711,7 +711,7 @@ func Test_TransferCommitment(t *testing.T) {
 
 	resp1 := assert.JSONObject{
 		"id":                1,
-		"service_type":      "first",
+		"service_type":      "second",
 		"resource_name":     "capacity",
 		"availability_zone": "az-two",
 		"amount":            10,
@@ -728,7 +728,7 @@ func Test_TransferCommitment(t *testing.T) {
 
 	resp2 := assert.JSONObject{
 		"id":                1,
-		"service_type":      "first",
+		"service_type":      "second",
 		"resource_name":     "capacity",
 		"availability_zone": "az-two",
 		"amount":            10,
@@ -744,7 +744,7 @@ func Test_TransferCommitment(t *testing.T) {
 	// Split commitment
 	resp3 := assert.JSONObject{
 		"id":                2,
-		"service_type":      "first",
+		"service_type":      "second",
 		"resource_name":     "capacity",
 		"availability_zone": "az-two",
 		"amount":            9,
@@ -760,7 +760,7 @@ func Test_TransferCommitment(t *testing.T) {
 	}
 	resp4 := assert.JSONObject{
 		"id":                2,
-		"service_type":      "first",
+		"service_type":      "second",
 		"resource_name":     "capacity",
 		"availability_zone": "az-two",
 		"amount":            9,

--- a/internal/api/commitment_test.go
+++ b/internal/api/commitment_test.go
@@ -572,7 +572,7 @@ func Test_StartCommitmentTransfer(t *testing.T) {
 
 	// Test on confirmed commitment should succeed.
 	// TransferAmount >= CommitmentAmount
-	req1 := func(transfer_status string) assert.JSONObject {
+	req1 := func(transferStatus string) assert.JSONObject {
 		return assert.JSONObject{
 			"id":                1,
 			"service_type":      "first",

--- a/internal/api/commitment_test.go
+++ b/internal/api/commitment_test.go
@@ -645,7 +645,7 @@ func Test_StartCommitmentTransfer(t *testing.T) {
 
 	// Test on unconfirmed commitment should fail.
 	// ID is 4, because 2 additional commitments were created previously.
-	var confirmBy = time.Now().Unix()
+	var confirmBy = s.Clock.Now().Unix()
 	req2 := assert.JSONObject{
 		"id":                4,
 		"service_type":      "first",

--- a/internal/api/commitment_test.go
+++ b/internal/api/commitment_test.go
@@ -580,7 +580,7 @@ func Test_StartCommitmentTransfer(t *testing.T) {
 			"availability_zone": "az-two",
 			"amount":            10,
 			"duration":          "1 hour",
-			"transfer_status":   transfer_status,
+			"transfer_status":   transferStatus,
 			"transfer_token":    "",
 		}
 	}

--- a/internal/api/commitment_test.go
+++ b/internal/api/commitment_test.go
@@ -550,6 +550,8 @@ func Test_TransferCommitment(t *testing.T) {
 		test.WithAPIHandler(NewV1API),
 	)
 
+	var transferToken = test.GenerateDummyToken()
+
 	var confirmBy = time.Now().Unix()
 	// create the transfer data
 	req1 := func(transfer_status string) assert.JSONObject {
@@ -580,7 +582,7 @@ func Test_TransferCommitment(t *testing.T) {
 		"confirm_by":        confirmBy,
 		"expires_at":        s.Clock.Now().Add(time.Duration(confirmBy)*time.Second + 1*time.Hour).Unix(),
 		"transfer_status":   "unlisted",
-		"transfer_token":    "hallo",
+		"transfer_token":    transferToken,
 	}
 
 	assert.HTTPRequest{

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -70,12 +70,14 @@ type v1Provider struct {
 	listProjectsMutex sync.Mutex
 	//slots for test doubles
 	timeNow func() time.Time
+	//identifies commitments that will be transferred to other projects.
+	generateTransferToken func() string
 }
 
 // NewV1API creates an httpapi.API that serves the Limes v1 API.
 // It also returns the VersionData for this API version which is needed for the
 // version advertisement on "GET /".
-func NewV1API(cluster *core.Cluster, dbm *gorp.DbMap, tokenValidator gopherpolicy.Validator, timeNow func() time.Time) httpapi.API {
+func NewV1API(cluster *core.Cluster, dbm *gorp.DbMap, tokenValidator gopherpolicy.Validator, timeNow func() time.Time, generateToken func() string) httpapi.API {
 	p := &v1Provider{Cluster: cluster, DB: dbm, tokenValidator: tokenValidator, timeNow: timeNow}
 	p.VersionData = VersionData{
 		Status: "CURRENT",
@@ -92,6 +94,7 @@ func NewV1API(cluster *core.Cluster, dbm *gorp.DbMap, tokenValidator gopherpolic
 			},
 		},
 	}
+	p.generateTransferToken = generateToken
 
 	return p
 }
@@ -108,6 +111,11 @@ func NewTokenValidator(provider *gophercloud.ProviderClient, eo gophercloud.Endp
 	}
 	err = tv.LoadPolicyFile(osext.GetenvOrDefault("LIMES_API_POLICY_PATH", "/etc/limes/policy.yaml"))
 	return &tv, err
+}
+
+func (p *v1Provider) OverrideGenerateToken(generateTransferToken func() string) *v1Provider {
+	p.generateTransferToken = generateTransferToken
+	return p
 }
 
 // AddTo implements the httpapi.API interface.

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -162,6 +162,7 @@ func (p *v1Provider) AddTo(r *mux.Router) {
 	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments/can-confirm").HandlerFunc(p.CanConfirmNewProjectCommitment)
 	r.Methods("DELETE").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments/{id}").HandlerFunc(p.DeleteProjectCommitment)
 	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments/{id}/start-transfer").HandlerFunc(p.StartCommitmentTransfer)
+	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/transfer-commitment/{id}").HandlerFunc(p.TransferCommitment)
 }
 
 // RequireJSON will parse the request body into the given data structure, or

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -161,7 +161,7 @@ func (p *v1Provider) AddTo(r *mux.Router) {
 	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments/new").HandlerFunc(p.CreateProjectCommitment)
 	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments/can-confirm").HandlerFunc(p.CanConfirmNewProjectCommitment)
 	r.Methods("DELETE").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments/{id}").HandlerFunc(p.DeleteProjectCommitment)
-	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments/{id}/start-transfer").HandlerFunc(p.TransferCommitment)
+	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments/{id}/start-transfer").HandlerFunc(p.StartCommitmentTransfer)
 }
 
 // RequireJSON will parse the request body into the given data structure, or

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -153,6 +153,7 @@ func (p *v1Provider) AddTo(r *mux.Router) {
 	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments/new").HandlerFunc(p.CreateProjectCommitment)
 	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments/can-confirm").HandlerFunc(p.CanConfirmNewProjectCommitment)
 	r.Methods("DELETE").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments/{id}").HandlerFunc(p.DeleteProjectCommitment)
+	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments/{id}/start-transfer").HandlerFunc(p.TransferCommitment)
 }
 
 // RequireJSON will parse the request body into the given data structure, or

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -77,7 +77,7 @@ type v1Provider struct {
 // NewV1API creates an httpapi.API that serves the Limes v1 API.
 // It also returns the VersionData for this API version which is needed for the
 // version advertisement on "GET /".
-func NewV1API(cluster *core.Cluster, dbm *gorp.DbMap, tokenValidator gopherpolicy.Validator, timeNow func() time.Time, generateToken func() string) httpapi.API {
+func NewV1API(cluster *core.Cluster, dbm *gorp.DbMap, tokenValidator gopherpolicy.Validator, timeNow func() time.Time, generateTransferToken func() string) httpapi.API {
 	p := &v1Provider{Cluster: cluster, DB: dbm, tokenValidator: tokenValidator, timeNow: timeNow}
 	p.VersionData = VersionData{
 		Status: "CURRENT",
@@ -94,7 +94,7 @@ func NewV1API(cluster *core.Cluster, dbm *gorp.DbMap, tokenValidator gopherpolic
 			},
 		},
 	}
-	p.generateTransferToken = generateToken
+	p.generateTransferToken = generateTransferToken
 
 	return p
 }
@@ -113,7 +113,7 @@ func NewTokenValidator(provider *gophercloud.ProviderClient, eo gophercloud.Endp
 	return &tv, err
 }
 
-func (p *v1Provider) OverrideGenerateToken(generateTransferToken func() string) *v1Provider {
+func (p *v1Provider) OverrideGenerateTransferToken(generateTransferToken func() string) *v1Provider {
 	p.generateTransferToken = generateTransferToken
 	return p
 }

--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -48,7 +48,7 @@ func unwrapOrDefault[T any](value *T, defaultValue T) T {
 }
 
 func GenerateToken() string {
-	tokenBytes := make([]byte, 12)
+	tokenBytes := make([]byte, 24)
 	_, err := rand.Read(tokenBytes)
 	if err != nil {
 		panic(err.Error())

--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -47,7 +47,11 @@ func unwrapOrDefault[T any](value *T, defaultValue T) T {
 	return *value
 }
 
-func GenerateToken() string {
+/*
+Generates a token that is used to transfer a commitment from a source to a target project.
+The token will be attached to the commitment that will be transferred and stored in the database until the transfer is concluded.
+*/
+func GenerateTransferToken() string {
 	tokenBytes := make([]byte, 24)
 	_, err := rand.Read(tokenBytes)
 	if err != nil {

--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -47,10 +47,8 @@ func unwrapOrDefault[T any](value *T, defaultValue T) T {
 	return *value
 }
 
-/*
-Generates a token that is used to transfer a commitment from a source to a target project.
-The token will be attached to the commitment that will be transferred and stored in the database until the transfer is concluded.
-*/
+// Generates a token that is used to transfer a commitment from a source to a target project.
+// The token will be attached to the commitment that will be transferred and stored in the database until the transfer is concluded.
 func GenerateTransferToken() string {
 	tokenBytes := make([]byte, 24)
 	_, err := rand.Read(tokenBytes)

--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -19,6 +19,8 @@
 package api
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"time"
 
 	"github.com/sapcc/go-api-declarations/limes"
@@ -43,4 +45,13 @@ func unwrapOrDefault[T any](value *T, defaultValue T) T {
 		return defaultValue
 	}
 	return *value
+}
+
+func GenerateToken() string {
+	tokenBytes := make([]byte, 12)
+	_, err := rand.Read(tokenBytes)
+	if err != nil {
+		panic(err.Error())
+	}
+	return hex.EncodeToString(tokenBytes)
 }

--- a/main.go
+++ b/main.go
@@ -214,7 +214,7 @@ func taskServe(cluster *core.Cluster, args []string, provider *gophercloud.Provi
 	})
 	mux := http.NewServeMux()
 	mux.Handle("/", httpapi.Compose(
-		api.NewV1API(cluster, dbm, tokenValidator, time.Now),
+		api.NewV1API(cluster, dbm, tokenValidator, time.Now, api.GenerateToken),
 		pprofapi.API{IsAuthorized: pprofapi.IsRequestFromLocalhost},
 		httpapi.WithGlobalMiddleware(api.ForbidClusterIDHeader),
 		httpapi.WithGlobalMiddleware(corsMiddleware.Handler),

--- a/main.go
+++ b/main.go
@@ -214,7 +214,7 @@ func taskServe(cluster *core.Cluster, args []string, provider *gophercloud.Provi
 	})
 	mux := http.NewServeMux()
 	mux.Handle("/", httpapi.Compose(
-		api.NewV1API(cluster, dbm, tokenValidator, time.Now, api.GenerateToken),
+		api.NewV1API(cluster, dbm, tokenValidator, time.Now, api.GenerateTransferToken),
 		pprofapi.API{IsAuthorized: pprofapi.IsRequestFromLocalhost},
 		httpapi.WithGlobalMiddleware(api.ForbidClusterIDHeader),
 		httpapi.WithGlobalMiddleware(corsMiddleware.Handler),


### PR DESCRIPTION
productionChecklist:
- [x] I updated the documentation to describe the semantical or interface changes I introduced.

This PR introduces commitment transfers from a source to a target project.
Two API's will be implemented:
- [x] start-transfer: Either marks a commitment as transferrable or splits the commitment into two parts where the provided amount will be the indicator for the transferrable commitment
- [x] transfer-commitment: Where the actual commitment transfer from a source to a target AZ_RESOURCE_ID will be executed.