### PR TITLE
allow project admins to delete commitments up to 24h after creation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/prometheus/client_golang v1.19.0
 	github.com/prometheus/common v0.51.0
 	github.com/rs/cors v1.10.1
-	github.com/sapcc/go-api-declarations v1.10.9
+	github.com/sapcc/go-api-declarations v1.10.10
 	github.com/sapcc/go-bits v0.0.0-20240322144225-5d20162d7e9a
 	go.uber.org/automaxprocs v1.5.3
 	golang.org/x/exp v0.0.0-20240318143956-a85f2c67cd81

--- a/go.sum
+++ b/go.sum
@@ -151,8 +151,8 @@ github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjR
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/rs/cors v1.10.1 h1:L0uuZVXIKlI1SShY2nhFfo44TYvDPQ1w4oFkUJNfhyo=
 github.com/rs/cors v1.10.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
-github.com/sapcc/go-api-declarations v1.10.9 h1:k+F3W0FTyYLazII4hdFaWLJ7L+MQRcFBD9I9P/hUNBs=
-github.com/sapcc/go-api-declarations v1.10.9/go.mod h1:83R3hTANhuRXt/pXDby37IJetw8l7DG41s33Tp9NXxI=
+github.com/sapcc/go-api-declarations v1.10.10 h1:1mrawZ8jink62vhOl5lffTcI54EP7Ye1hc2ZOMLqY7M=
+github.com/sapcc/go-api-declarations v1.10.10/go.mod h1:83R3hTANhuRXt/pXDby37IJetw8l7DG41s33Tp9NXxI=
 github.com/sapcc/go-bits v0.0.0-20240322144225-5d20162d7e9a h1:IaFI3BdMZOeSirDez68wtmBceaFs8ee9EipkZGRqgsg=
 github.com/sapcc/go-bits v0.0.0-20240322144225-5d20162d7e9a/go.mod h1:9AD0qbmtyVApQezhUx7pUuExUcl2kSjB/WSMcPGo6f8=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=

--- a/vendor/github.com/sapcc/go-api-declarations/bininfo/argument.go
+++ b/vendor/github.com/sapcc/go-api-declarations/bininfo/argument.go
@@ -28,7 +28,7 @@ func HandleVersionArgument() {
 	args := os.Args[1:]
 	if len(args) > 0 {
 		if args[0] == "--version" {
-			fmt.Printf("%s version %s", binName, version)
+			fmt.Printf("%s version %s\n", binName, version)
 			os.Exit(0)
 		}
 	}

--- a/vendor/github.com/sapcc/go-api-declarations/limes/resources/commitment.go
+++ b/vendor/github.com/sapcc/go-api-declarations/limes/resources/commitment.go
@@ -45,6 +45,9 @@ type Commitment struct {
 	// and intended for informational displays only. API access should always use the UUID.
 	CreatorUUID string `json:"creator_uuid,omitempty"`
 	CreatorName string `json:"creator_name,omitempty"`
+	// CanBeDeleted will be true if the commitment can be deleted by the same user
+	// who saw this object in response to a GET query.
+	CanBeDeleted bool `json:"can_be_deleted,omitempty"`
 	// ConfirmBy is only filled if it was set in the CommitmentRequest.
 	ConfirmBy *limes.UnixEncodedTime `json:"confirm_by,omitempty"`
 	// ConfirmedAt is only filled after the commitment was confirmed.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -138,7 +138,7 @@ github.com/rabbitmq/amqp091-go
 # github.com/rs/cors v1.10.1
 ## explicit; go 1.13
 github.com/rs/cors
-# github.com/sapcc/go-api-declarations v1.10.9
+# github.com/sapcc/go-api-declarations v1.10.10
 ## explicit; go 1.21
 github.com/sapcc/go-api-declarations/bininfo
 github.com/sapcc/go-api-declarations/cadf


### PR DESCRIPTION
This was more complicated than I anticipated, so I would appreciate a second set of eyes.