### PR TITLE
add PUT /v1/domains/:id/projects/:id/max-quota

### DIFF
--- a/internal/api/audit.go
+++ b/internal/api/audit.go
@@ -153,6 +153,44 @@ func (t quotaEventTarget) Render() cadf.Resource {
 	}
 }
 
+// maxQuotaEventTarget renders a cadf.Event.Target for a max_quota change event.
+type maxQuotaEventTarget struct {
+	DomainID        string
+	DomainName      string
+	ProjectID       string
+	ProjectName     string
+	ServiceType     limes.ServiceType
+	ResourceName    limesresources.ResourceName
+	RequestedChange maxQuotaChange
+}
+
+type maxQuotaChange struct {
+	OldValue *uint64
+	NewValue *uint64
+}
+
+// Render implements the audittools.TargetRenderer interface type.
+func (t maxQuotaEventTarget) Render() cadf.Resource {
+	payloadBytes, _ := json.Marshal(map[string]any{ //nolint:errcheck // cannot fail because all types are safe to marshal
+		"oldMaxQuota": t.RequestedChange.OldValue,
+		"newMaxQuota": t.RequestedChange.NewValue,
+	})
+
+	return cadf.Resource{
+		TypeURI:     fmt.Sprintf("service/%s/%s/max-quota", t.ServiceType, t.ResourceName),
+		ID:          t.ProjectID,
+		DomainID:    t.DomainID,
+		DomainName:  t.DomainName,
+		ProjectID:   t.ProjectID,
+		ProjectName: t.ProjectName,
+		Attachments: []cadf.Attachment{{
+			Name:    "payload",
+			TypeURI: "mime:application/json",
+			Content: string(payloadBytes),
+		}},
+	}
+}
+
 // burstEventTarget contains the structure for rendering a cadf.Event.Target for
 // changes regarding quota bursting for some project.
 type burstEventTarget struct {

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -151,6 +151,7 @@ func (p *v1Provider) AddTo(r *mux.Router) {
 	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/sync").HandlerFunc(p.SyncProject)
 	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/simulate-put").HandlerFunc(p.SimulatePutProject)
 	r.Methods("PUT").Path("/v1/domains/{domain_id}/projects/{project_id}").HandlerFunc(p.PutProject)
+	r.Methods("PUT").Path("/v1/domains/{domain_id}/projects/{project_id}/max-quota").HandlerFunc(p.PutProjectMaxQuota)
 	r.Methods("GET").Path("/rates/v1/domains/{domain_id}/projects").HandlerFunc(p.ListProjectRates)
 	r.Methods("GET").Path("/rates/v1/domains/{domain_id}/projects/{project_id}").HandlerFunc(p.GetProjectRates)
 	r.Methods("POST").Path("/rates/v1/domains/{domain_id}/projects/{project_id}/sync").HandlerFunc(p.SyncProjectRates)


### PR DESCRIPTION
This is a very temporary API to fill the new `project_resources.max_quota_from_admin` field. I did not add this to the API spec because it's only a hidden feature for now. It will become properly documented in the v2 API that we will for sure do this year, no way that's gonna get delayed, I promise.