### PR TITLE
switch default QD model to "autogrow", forbid "hierarchical" except in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,24 +9,15 @@ Limes is an OpenStack-compatible quota/usage tracking service, originally design
 
 Pronounce the name like the [Ancient Roman border wall][wp-limes], not like the fruit. (Mnemonic: The original Limes was installed when the Romans wanted to put a quota on Germanic land use.)
 
-# The idea: Hierarchical quota delegation
+# The idea: Automatic quota distribution
 
-OpenStack groups access into three levels:
-
-1. the cluster (the sum of all the resources in an OpenStack installation, e.g. hypervisors or storage capacity)
-2. Keystone domains within that cluster
-3. Keystone projects within each domain
-
-Limes enables a similar hierarchy for resource usage and quotas: After having reviewed the cluster's capacity, a cluster
-admin can allocate quotas to domains. The domain admin can then sublease that quota to its projects. Limes will then
-write these approved project quotas into the backend services that actually manage the resources. Limes also tracks
-resource usage in all projects in all domains, so that users can make informed decisions about resource allocation at
-all levels of the hierarchy.
+Limes can discover capacity and usage for various types of OpenStack resources.
+It can then be set up to distribute quota automatically among all projects in a dynamic and automated fashion.
+Both cloud admins and project admins have several knobs to control their quota assignments in a controlled fashion.
 
 ## Unique features
 
-* Limes can take over the handling of initial project quotas: All quotas for a new project (or domain) will be set to zero initially, until a sufficiently privileged user approves quota explicitly.
-* Limes records quota changes in an Open Standards [CADF Format](https://www.dmtf.org/sites/default/files/standards/documents/DSP0262_1.0.0.pdf), and is compatible with other cloud based audit APIs (e.g. [Hermes](https://github.com/sapcc/hermes)).
+* Limes records quota changes in the Open Standards [CADF Format](https://www.dmtf.org/sites/default/files/standards/documents/DSP0262_1.0.0.pdf), and is compatible with other cloud based audit APIs (e.g. [Hermes](https://github.com/sapcc/hermes)).
 * Quota and usage data can be exposed as [Prometheus metrics](https://prometheus.io) for monitoring and alerting.
 
 # Documentation

--- a/docs/users/api-spec-resources.md
+++ b/docs/users/api-spec-resources.md
@@ -242,7 +242,7 @@ The objects at `cluster.services[].resources[]` may contain the following fields
 | `unit` | string | The unit of this resource (only shown for measured resources). |
 | `category` | string | The category of this resource (only shown when there is one). |
 | `contained_in` | string | The name of another resource (if any) within the same service that this resource is [contained in](#contained-resources). |
-| `quota_distribution_model` | string | The resource's [quota distribution model](#quota-distribution-model). The only possible value is "hierarchical". |
+| `quota_distribution_model` | string | The resource's [quota distribution model](#quota-distribution-model). The only possible value is "autogrow". |
 | `capacity` | unsigned integer | The available capacity for this resource. |
 | `raw_capacity` | unsigned integer | The available raw capacity for this resource (only shown for [overcommitted resources](#overcommit)). |
 | `per_availability_zone` | list of objects | A breakdown of this resource's capacity by availability zone (only shown for resources supporting a breakdown by AZ). |
@@ -333,7 +333,7 @@ The objects at `domains[].services[].resources[]` may contain the following fiel
 | `unit` | string | The unit of this resource (only shown for measured resources). |
 | `category` | string | The category of this resource (only shown when there is one). |
 | `contained_in` | string | The name of another resource (if any) within the same service that this resource is [contained in](#contained-resources). |
-| `quota_distribution_model` | string | The resource's [quota distribution model](#quota-distribution-model). The only possible value is "hierarchical". |
+| `quota_distribution_model` | string | The resource's [quota distribution model](#quota-distribution-model). The only possible value is "autogrow". |
 | `scales_with` | object | Only present when this resource is [scaling with](#scaling-relations) another resource. |
 | `scales_with.resource_name` | string | The name of the resource that this resource is scaling with. |
 | `scales_with.service_type` | string | The type name of the service containing the resource that this resource is scaling with. |
@@ -554,7 +554,7 @@ The objects at `projects[].services[].resources[]` may contain the following fie
 | `unit` | string | The unit of this resource (only shown for measured resources). |
 | `category` | string | The category of this resource (only shown when there is one). |
 | `contained_in` | string | The name of another resource (if any) within the same service that this resource is [contained in](#contained-resources). |
-| `quota_distribution_model` | string | The resource's [quota distribution model](#quota-distribution-model). The only possible value is "hierarchical". |
+| `quota_distribution_model` | string | The resource's [quota distribution model](#quota-distribution-model). The only possible value is "autogrow". |
 | `scales_with` | object | Only present when this resource is [scaling with](#scaling-relations) another resource. |
 | `scales_with.resource_name` | string | The name of the resource that this resource is scaling with. |
 | `scales_with.service_type` | string | The type name of the service containing the resource that this resource is scaling with. |

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -122,6 +122,10 @@ const (
 				commitment_is_az_aware: true
 			- resource: shared/things
 				commitment_is_az_aware: false
+
+		quota_distribution_configs:
+			# TODO: remove and use the new default
+			- { resource: '.*', model: hierarchical }
 	`
 )
 
@@ -2031,7 +2035,7 @@ func Test_StrictDomainQuotaLimit(t *testing.T) {
 		Model:                  limesresources.HierarchicalQuotaDistribution,
 		StrictDomainQuotaLimit: false,
 	}
-	s.Cluster.Config.QuotaDistributionConfigs = append(s.Cluster.Config.QuotaDistributionConfigs, qdConfig)
+	s.Cluster.Config.QuotaDistributionConfigs = append([]*core.QuotaDistributionConfiguration{qdConfig}, s.Cluster.Config.QuotaDistributionConfigs...)
 
 	//NOTE: The relevant parts of start-data.sql look as follows for "shared/things":
 	// cluster_capacity      = 246

--- a/internal/collector/capacity_scrape_test.go
+++ b/internal/collector/capacity_scrape_test.go
@@ -75,6 +75,9 @@ const (
 		resource_behavior:
 			# overcommit should be reflected in capacity metrics
 			- { resource: unshared2/capacity, overcommit_factor: 2.5 }
+		quota_distribution_configs:
+			# TODO: remove and use the new default
+			- { resource: '.*', model: hierarchical }
 	`
 
 	testScanCapacityNoopConfigYAML = `

--- a/internal/collector/keystone_test.go
+++ b/internal/collector/keystone_test.go
@@ -42,6 +42,9 @@ const (
 				type: --test-generic
 			- service_type: unshared
 				type: --test-generic
+		quota_distribution_configs:
+			# TODO: remove and use the new default
+			- { resource: '.*', model: hierarchical }
 	`
 )
 

--- a/internal/collector/ratescrape_test.go
+++ b/internal/collector/ratescrape_test.go
@@ -60,6 +60,9 @@ const (
 		bursting:
 			# this should have no effect on rates
 			max_multiplier: 0.1
+		quota_distribution_configs:
+			# TODO: remove and use the new default
+			- { resource: '.*', model: hierarchical }
 	`
 )
 

--- a/internal/collector/scrape_test.go
+++ b/internal/collector/scrape_test.go
@@ -107,6 +107,8 @@ const (
 		quota_distribution_configs:
 			# this is only used to check that historical_usage is tracked
 			- { resource: unittest/things, model: autogrow, autogrow: { growth_multiplier: 1.0, usage_data_retention_period: 48h } }
+			# TODO: remove and use the new default
+			- { resource: '.*', model: hierarchical }
 	`
 )
 
@@ -592,6 +594,9 @@ const (
 				type: --test-auto-approval
 				params:
 					static_backend_quota: 10
+		quota_distribution_configs:
+			# TODO: remove and use the new default
+			- { resource: '.*', model: hierarchical }
 	`
 )
 
@@ -657,6 +662,9 @@ const (
 		services:
 			- service_type: noop
 				type: --test-noop
+		quota_distribution_configs:
+			# TODO: remove and use the new default
+			- { resource: '.*', model: hierarchical }
 	`
 )
 
@@ -706,6 +714,9 @@ const (
 				type: --test-noop
 				params:
 					with_empty_resource: true
+		quota_distribution_configs:
+			# TODO: remove and use the new default
+			- { resource: '.*', model: hierarchical }
 	`
 )
 

--- a/internal/core/cluster.go
+++ b/internal/core/cluster.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"slices"
+	"time"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/sapcc/go-api-declarations/limes"
@@ -310,8 +311,17 @@ func (c *Cluster) QuotaDistributionConfigForResource(serviceType limes.ServiceTy
 		}
 	}
 
-	// default behavior
-	return QuotaDistributionConfiguration{Model: limesresources.HierarchicalQuotaDistribution}
+	// default behavior: do not give out any quota except for existing usage or with explicit quota override
+	return QuotaDistributionConfiguration{
+		Model: limesresources.AutogrowQuotaDistribution,
+		Autogrow: &AutogrowQuotaDistributionConfiguration{
+			AllowQuotaOvercommit:     false,
+			ProjectBaseQuota:         0,
+			GrowthMultiplier:         1.0,
+			GrowthMinimum:            0,
+			UsageDataRetentionPeriod: util.MarshalableTimeDuration(1 * time.Second),
+		},
+	}
 }
 
 // HasUsageForRate checks whether the given service is enabled in this cluster and

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -139,11 +139,15 @@ type BurstingConfiguration struct {
 type QuotaDistributionConfiguration struct {
 	FullResourceNameRx regexpext.BoundedRegexp               `yaml:"resource"`
 	Model              limesresources.QuotaDistributionModel `yaml:"model"`
-	// options for HierarchicalQuotaDistribution
+	// options for HierarchicalQuotaDistribution (TODO: remove)
 	StrictDomainQuotaLimit bool `yaml:"strict_domain_quota_limit"`
 	// options for AutogrowQuotaDistribution
 	Autogrow *AutogrowQuotaDistributionConfiguration `yaml:"autogrow"`
 }
+
+// AllowHierarchicalQuotaDistribution is only set in unit tests, while we
+// rewrite them towards AutogrowQuotaDistribution. Outside of unit tests, HQD is forbidden.
+var AllowHierarchicalQuotaDistribution = false
 
 // AutogrowQuotaDistributionConfiguration appears in type QuotaDistributionConfiguration.
 type AutogrowQuotaDistributionConfiguration struct {
@@ -221,7 +225,9 @@ func (cluster ClusterConfiguration) validateConfig() (errs errext.ErrorSet) {
 
 		switch qdCfg.Model {
 		case limesresources.HierarchicalQuotaDistribution:
-			// ok
+			if !AllowHierarchicalQuotaDistribution {
+				errs.Addf("invalid value for distribution_model_configs[%d].model: support for %q has been removed", idx, qdCfg.Model)
+			}
 		case limesresources.AutogrowQuotaDistribution:
 			if qdCfg.Autogrow == nil {
 				missing(fmt.Sprintf(`distribution_model_configs[%d].autogrow`, idx))

--- a/internal/core/constraints_test.go
+++ b/internal/core/constraints_test.go
@@ -118,6 +118,12 @@ func clusterForQuotaConstraintTest() *Cluster {
 			"service-one": quotaConstraintTestPlugin{},
 			"service-two": quotaConstraintTestPlugin{},
 		},
+		Config: ClusterConfiguration{
+			QuotaDistributionConfigs: []*QuotaDistributionConfiguration{{
+				FullResourceNameRx: ".*",
+				Model:              limesresources.HierarchicalQuotaDistribution,
+			}},
+		},
 	}
 }
 

--- a/internal/test/setup.go
+++ b/internal/test/setup.go
@@ -108,6 +108,7 @@ func GenerateDummyToken() string {
 // NewSetup prepares most or all pieces of Keppel for a test.
 func NewSetup(t *testing.T, opts ...SetupOption) Setup {
 	logg.ShowDebug = osext.GetenvBool("LIMES_DEBUG")
+	core.AllowHierarchicalQuotaDistribution = true // TODO: remove once all tests have been rewritten
 	var params setupParams
 	for _, option := range opts {
 		option(&params)


### PR DESCRIPTION
Tests can still use "hierarchical" because it would be too big of a change to rewrite all of these at once.

Also, start removing references to hierarchical quota distribution from the docs.