### PR TITLE
remove StrictDomainQuotaLimit feature

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -2026,67 +2026,6 @@ func requestOneQuotaChange(structureLevel string, serviceType limes.ServiceType,
 	}
 }
 
-func Test_StrictDomainQuotaLimit(t *testing.T) {
-	s := setupTest(t, "fixtures/start-data.sql")
-
-	// set up a QD config for shared/things with the default behavior
-	qdConfig := &core.QuotaDistributionConfiguration{
-		FullResourceNameRx:     "shared/things",
-		Model:                  limesresources.HierarchicalQuotaDistribution,
-		StrictDomainQuotaLimit: false,
-	}
-	s.Cluster.Config.QuotaDistributionConfigs = append([]*core.QuotaDistributionConfiguration{qdConfig}, s.Cluster.Config.QuotaDistributionConfigs...)
-
-	//NOTE: The relevant parts of start-data.sql look as follows for "shared/things":
-	// cluster_capacity      = 246
-	// domain_quota[germany] = 30
-	// domain_quota[france]  = 0 (not set)
-
-	// with StrictDomainQuotaLimit = false, we can go over the total capacity
-	assert.HTTPRequest{
-		Method: "PUT",
-		Path:   "/v1/domains/uuid-for-france",
-		// this single domain quota is below capacity, but the sum of domain quotas is not
-		Body:         requestOneQuotaChange("domain", "shared", "things", 240, limes.UnitNone),
-		ExpectStatus: 202,
-	}.Check(t, s.Handler)
-
-	// with StrictDomainQuotaLimit = true, we can always go down (even if we are not getting back into the green area)...
-	qdConfig.StrictDomainQuotaLimit = true
-	assert.HTTPRequest{
-		Method: "PUT",
-		Path:   "/v1/domains/uuid-for-france",
-		// this single domain quota is below capacity, but the sum of domain quotas is not
-		Body:         requestOneQuotaChange("domain", "shared", "things", 220, limes.UnitNone),
-		ExpectStatus: 202,
-	}.Check(t, s.Handler)
-
-	// ...and we can also just stay at the same level...
-	assert.HTTPRequest{
-		Method:       "PUT",
-		Path:         "/v1/domains/uuid-for-france",
-		Body:         requestOneQuotaChange("domain", "shared", "things", 220, limes.UnitNone),
-		ExpectStatus: 202,
-	}.Check(t, s.Handler)
-
-	// ...but we cannot go higher into the red
-	assert.HTTPRequest{
-		Method:       "PUT",
-		Path:         "/v1/domains/uuid-for-france",
-		Body:         requestOneQuotaChange("domain", "shared", "things", 240, limes.UnitNone),
-		ExpectStatus: 409,
-		ExpectBody:   assert.StringData("cannot change shared/things quota: cluster capacity may not be exceeded for this resource (maximum acceptable domain quota is 216)\n"),
-	}.Check(t, s.Handler)
-
-	// we can get exactly to the limit though (where all capacity is given out as domain quota)
-	assert.HTTPRequest{
-		Method:       "PUT",
-		Path:         "/v1/domains/uuid-for-france",
-		Body:         requestOneQuotaChange("domain", "shared", "things", 216, limes.UnitNone),
-		ExpectStatus: 202,
-	}.Check(t, s.Handler)
-}
-
 func Test_PutMaxQuotaOnProject(t *testing.T) {
 	s := setupTest(t, "fixtures/start-data.sql")
 

--- a/internal/api/quota_updater.go
+++ b/internal/api/quota_updater.go
@@ -341,7 +341,7 @@ func (u QuotaUpdater) validateQuota(srv limes.ServiceInfo, res limesresources.Re
 
 	// specific rules for domain quotas vs. project quotas
 	if u.Project == nil {
-		return u.validateDomainQuota(srv, res, clusterRes, domRes, newQuota)
+		return u.validateDomainQuota(domRes, newQuota)
 	}
 	return u.validateProjectQuota(domRes, *projRes, newQuota)
 }
@@ -399,7 +399,7 @@ func (u QuotaUpdater) validateAuthorization(srv limes.ServiceInfo, res limesreso
 	}
 }
 
-func (u QuotaUpdater) validateDomainQuota(srv limes.ServiceInfo, res limesresources.ResourceInfo, clusterRes limesresources.ClusterResourceReport, domRes limesresources.DomainResourceReport, newQuota uint64) *core.QuotaValidationError {
+func (u QuotaUpdater) validateDomainQuota(domRes limesresources.DomainResourceReport, newQuota uint64) *core.QuotaValidationError {
 	if domRes.DomainQuota == nil || domRes.ProjectsQuota == nil {
 		// defense in depth: we should have detected NoQuota resources a long time ago
 		return &core.QuotaValidationError{
@@ -419,25 +419,6 @@ func (u QuotaUpdater) validateDomainQuota(srv limes.ServiceInfo, res limesresour
 		}
 	}
 
-	// when increasing domain quota, check that cluster capacity is not exceeded (if this constraint has been enabled in the config)
-	qdConfig := u.Cluster.QuotaDistributionConfigForResource(srv.Type, res.Name)
-	if newQuota > oldQuota && qdConfig.StrictDomainQuotaLimit {
-		//NOTE: No arithmetic overflow/underflow is possible here, for the same
-		// reasons as explained below in validateProjectQuota().
-		newDomainsQuota := *clusterRes.DomainsQuota - oldQuota + newQuota
-		if newDomainsQuota > *clusterRes.Capacity {
-			maxQuota := *clusterRes.Capacity - (*clusterRes.DomainsQuota - oldQuota)
-			if *clusterRes.Capacity < *clusterRes.DomainsQuota-oldQuota {
-				maxQuota = 0
-			}
-			return &core.QuotaValidationError{
-				Status:       http.StatusConflict,
-				Message:      "cluster capacity may not be exceeded for this resource",
-				MaximumValue: &maxQuota,
-				Unit:         domRes.Unit,
-			}
-		}
-	}
 	return nil
 }
 

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -139,8 +139,6 @@ type BurstingConfiguration struct {
 type QuotaDistributionConfiguration struct {
 	FullResourceNameRx regexpext.BoundedRegexp               `yaml:"resource"`
 	Model              limesresources.QuotaDistributionModel `yaml:"model"`
-	// options for HierarchicalQuotaDistribution (TODO: remove)
-	StrictDomainQuotaLimit bool `yaml:"strict_domain_quota_limit"`
 	// options for AutogrowQuotaDistribution
 	Autogrow *AutogrowQuotaDistributionConfiguration `yaml:"autogrow"`
 }
@@ -242,9 +240,6 @@ func (cluster ClusterConfiguration) validateConfig() (errs errext.ErrorSet) {
 			errs.Addf("invalid value for distribution_model_configs[%d].model: %q", idx, qdCfg.Model)
 		}
 
-		if qdCfg.Model != limesresources.HierarchicalQuotaDistribution && qdCfg.StrictDomainQuotaLimit {
-			errs.Addf("invalid value for distribution_model_configs[%d].strict_domain_quota_limit: cannot be set for model %q", idx, qdCfg.Model)
-		}
 		if qdCfg.Model != limesresources.AutogrowQuotaDistribution && qdCfg.Autogrow != nil {
 			errs.Addf("invalid value for distribution_model_configs[%d].autogrow: cannot be set for model %q", idx, qdCfg.Model)
 		}


### PR DESCRIPTION
This only applies to the obsolete HierarchicalQuotaDistribution model.