### PR TITLE
do not clear ProjectAZResource.Quota during scrape

### DIFF
--- a/internal/collector/scrape.go
+++ b/internal/collector/scrape.go
@@ -321,7 +321,6 @@ func (c *Collector) writeResourceScrapeResult(dbDomain db.Domain, dbProject db.P
 			Update: func(azRes *db.ProjectAZResource) (err error) {
 				az := azRes.AvailabilityZone
 				data := usageData[az]
-				azRes.Quota = nil // TODO: add the new quota distribution model that assigns quota per AZ
 				azRes.Usage = data.Usage
 				azRes.PhysicalUsage = data.PhysicalUsage
 


### PR DESCRIPTION
When I added this TODO months ago, I anticipated that we would put ACPQ here instead of in CapacityScrapeJob.
