### PR TITLE
remove obsolete ResourceBehavior fields

### DIFF
--- a/docs/operators/config.md
+++ b/docs/operators/config.md
@@ -121,28 +121,17 @@ Some special behaviors for resources can be configured in the `resource_behavior
 | Field | Required | Description |
 | --- | --- | --- |
 | `resource_behavior[].resource` | yes | Must contain a regex. The behavior entry applies to all resources where this regex matches against a slash-concatenated pair of service type and resource name. The anchors `^` and `$` are implied at both ends, so the regex must match the entire phrase. |
-| `resource_behavior[].scope` | yes | May contain a regex. The behavior entry applies to matching resources in all domains where this regex matches against the domain name, and in all projects where this regex matches against a slash-concatenated pair of domain and project name, i.e. `domainname/projectname`. The anchors `^` and `$` are implied at both ends, so the regex must match the entire phrase. This regex is ignored for cluster-level resources. |
 | `resource_behavior[].overcommit_factor` | no | If given, capacity for matching resources will be computed as `raw_capacity * overcommit_factor`, where `raw_capacity` is what the capacity plugin reports. |
-| `resource_behavior[].scales_with` | no | If a resource is given, matching resources scales with this resource. The other resource may be specified by its name (for resources within the same service type), or by a slash-concatenated pair of service type and resource name, e.g. `compute/cores`. |
-| `resource_behavior[].scaling_factor` | yes, if `scales_with` is given | The scaling factor that will be reported for these resources' scaling relation. |
-| `resource_behavior[].min_nonzero_project_quota` | no | A lower boundary for project quota values that are not zero. |
 | `resource_behavior[].commitment_durations` | no | If given, commitments for this resource can be created with any of the given durations. The duration format is the same as in the `commitments[].duration` attribute that appears on the resource API. If empty, this resource does not accept commitments. |
 | `resource_behavior[].commitment_is_az_aware` | no | If true, commitments for this resource must be created in a specific AZ (i.e. not in a pseudo-AZ). If false, commitments for this resource must be created in the pseudo-AZ `any`. Ignored if `commitment_durations` is empty. |
 | `resource_behavior[].commitment_min_confirm_date` | no | If given, commitments for this resource will always be created with `confirm_by` no earlier than this timestamp. This can be used to plan the introduction of commitments on a specific date. Ignored if `commitment_durations` is empty. |
-| `resource_behavior[].annotations` | no | A map of extra key-value pairs that will be inserted into matching resources as-is in responses to GET requests, e.g. at `project.services[].resources[].annotations`. |
 
 For example:
 
 ```yaml
 resource_behavior:
-  - { resource: network/healthmonitors, scales_with: network/loadbalancers, scaling_factor: 1 }
-  - { resource: network/listeners,      scales_with: network/loadbalancers, scaling_factor: 2 }
-  - { resource: network/l7policies,     scales_with: network/loadbalancers, scaling_factor: 1 }
-  - { resource: network/pools,          scales_with: network/loadbalancers, scaling_factor: 1 }
   # matches both sharev2/share_capacity and sharev2/snapshot_capacity
   - { resource: sharev2/.*_capacity, overcommit_factor: 2 }
-  # require each project to take at least 100 GB of object storage if they use it at all
-  - { resource: object-store/capacity, min_nonzero_project_quota: 107374182400 }
   # starting in 2024, offer commitments for Cinder storage
   - { resource: volumev2/capacity, commitment_durations: [ 1 year, 2 years, 3 years ], commitment_is_az_aware: true, commitment_min_confirm_date: 2024-01-01T00:00:00Z }
 ```
@@ -151,10 +140,8 @@ resource_behavior:
 
 Each resource uses one of several quota distribution models, with `autogrow` being the default.
 
-Resource-specific distribution models can be configured per resource in the `quota_distribution_configs[]` section. Each
-entry in this section can match multiple resources. Because the semantics of distribution models cross the boundaries of
-individual scopes, a distribution model config cannot be limited to certain scopes (like a resource behavior can). It
-always applies to the entire resource across all scopes.
+Resource-specific distribution models can be configured per resource in the `quota_distribution_configs[]` section.
+Each entry in this section can match multiple resources.
 
 | Field | Required | Description |
 | --- | --- | --- |

--- a/docs/users/api-spec-resources.md
+++ b/docs/users/api-spec-resources.md
@@ -68,17 +68,6 @@ in it. Quota always relates to "usage": For example, consider a project with for
 three NFS shares with a size of 5 GiB each and utilization of 2 GiB each. Therefore, the usage is 15 GiB and only one
 more 5 GiB share can be created, even though the physical usage is only 6 GiB.
 
-### Scaling relations
-
-Limes can advertise **scaling relations** between resources. If resource X is marked as **scaling with** resource Y, it
-means that a user agent SHOULD suggest to change the quota for X whenever the user wants to change the quota for Y.
-Scaling relations are only provided as a suggestion to user agents; they are not evaluted by Limes itself.
-
-The amount by which the quota for X is changed shall be equal to the requested change in quota for Y, multiplied with
-the advertised scaling factor. For example, if resource `network/listeners` scales with `network/loadbalancers` with a
-scaling factor of 2, when the user requests that the loadbalancers quota be increased by 5, the user agent should
-suggest to increase the listeners quota by 10.
-
 ### Contained resources
 
 Limes can advertise **containment relations** between resources. If resource X is marked as **contained in** resource Y,
@@ -314,11 +303,6 @@ The objects at `domains[].services[].resources[]` may contain the following fiel
 | `category` | string | The category of this resource (only shown when there is one). |
 | `contained_in` | string | The name of another resource (if any) within the same service that this resource is [contained in](#contained-resources). |
 | `quota_distribution_model` | string | The resource's [quota distribution model](#quota-distribution-model). The only possible value is "autogrow". |
-| `scales_with` | object | Only present when this resource is [scaling with](#scaling-relations) another resource. |
-| `scales_with.resource_name` | string | The name of the resource that this resource is scaling with. |
-| `scales_with.service_type` | string | The type name of the service containing the resource that this resource is scaling with. |
-| `scales_with.factor` | unsigned float | The factor with which this resource is scaling with the other resource. |
-| `annotations` | object | An object with string keys and string values containing arbitrary metadata that was configured for this resource in this domain by Limes's operator. |
 | `quota` | unsigned integer | The domain quota for this resource. |
 | `projects_quota` | unsigned integer | The sum of all project quotas for this resource across all projects in this domain. |
 | `usage` | unsigned integer | The sum of all usage values for this resource across all projects in this domain. |
@@ -439,11 +423,6 @@ The objects at `projects[].services[].resources[]` may contain the following fie
 | `category` | string | The category of this resource (only shown when there is one). |
 | `contained_in` | string | The name of another resource (if any) within the same service that this resource is [contained in](#contained-resources). |
 | `quota_distribution_model` | string | The resource's [quota distribution model](#quota-distribution-model). The only possible value is "autogrow". |
-| `scales_with` | object | Only present when this resource is [scaling with](#scaling-relations) another resource. |
-| `scales_with.resource_name` | string | The name of the resource that this resource is scaling with. |
-| `scales_with.service_type` | string | The type name of the service containing the resource that this resource is scaling with. |
-| `scales_with.factor` | unsigned float | The factor with which this resource is scaling with the other resource. |
-| `annotations` | object | An object with string keys and string values containing arbitrary metadata that was configured for this resource in this project by Limes's operator. |
 | `quota` | unsigned integer | The granted quota for this resource in this project. |
 | `usable_quota` | unsigned integer | **Deprecated.** Always equal to `quota`. |
 | `usage` | unsigned integer | The usage of this resource in this project. |

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -97,23 +97,6 @@ const (
 							window: 1s
 
 		resource_behavior:
-			# check minimum non-zero project quota constraint
-			- { resource: unshared/things, min_nonzero_project_quota: 10 }
-
-			# check how scaling relations are reported
-			- { resource: unshared/things, scales_with: shared/things, scaling_factor: 2 }
-
-			# check how annotations are reported
-			- resource: 'shared/.*things'
-				scope:    'germany(?:/dresden)?'
-				annotations:
-					annotated: true
-					text:      'this annotation appears on shared things of domain germany and project dresden'
-			- resource: shared/things
-				scope:    germany/dresden
-				annotations:
-					text: 'this annotation appears on shared/things of project dresden only'
-
 			# check how commitment config is reported
 			- resource: 'shared/(capacity|things)$'
 				commitment_durations: ["1 hour", "2 hours"]

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -214,7 +214,7 @@ func (p *v1Provider) parseAndValidateCommitmentRequest(w http.ResponseWriter, r 
 		http.Error(w, "no such resource", http.StatusUnprocessableEntity)
 		return nil, nil
 	}
-	behavior := p.Cluster.BehaviorForResource(req.ServiceType, req.ResourceName, "")
+	behavior := p.Cluster.BehaviorForResource(req.ServiceType, req.ResourceName)
 	if len(behavior.CommitmentDurations) == 0 {
 		http.Error(w, "commitments are not enabled for this resource", http.StatusUnprocessableEntity)
 		return nil, nil

--- a/internal/api/fixtures/domain-get-france.json
+++ b/internal/api/fixtures/domain-get-france.json
@@ -73,12 +73,7 @@
             "projects_quota": 10,
             "usage": 2,
             "backend_quota": 0,
-            "infinite_backend_quota": true,
-            "scales_with": {
-              "resource_name": "things",
-              "service_type": "shared",
-              "factor": 2
-            }
+            "infinite_backend_quota": true
           }
         ],
         "max_scraped_at": 55,

--- a/internal/api/fixtures/domain-get-germany.json
+++ b/internal/api/fixtures/domain-get-germany.json
@@ -41,11 +41,7 @@
             },
             "quota": 30,
             "projects_quota": 20,
-            "usage": 4,
-            "annotations": {
-              "annotated": true,
-              "text": "this annotation appears on shared things of domain germany and project dresden"
-            }
+            "usage": 4
           }
         ],
         "max_scraped_at": 44,
@@ -74,12 +70,7 @@
             "quota_distribution_model": "hierarchical",
             "quota": 50,
             "projects_quota": 20,
-            "usage": 4,
-            "scales_with": {
-              "resource_name": "things",
-              "service_type": "shared",
-              "factor": 2
-            }
+            "usage": 4
           }
         ],
         "max_scraped_at": 33,

--- a/internal/api/fixtures/domain-list-filtered.json
+++ b/internal/api/fixtures/domain-list-filtered.json
@@ -48,11 +48,7 @@
               },
               "quota": 30,
               "projects_quota": 20,
-              "usage": 4,
-              "annotations": {
-                "annotated": true,
-                "text": "this annotation appears on shared things of domain germany and project dresden"
-              }
+              "usage": 4
             }
           ],
           "max_scraped_at": 44,

--- a/internal/api/fixtures/domain-list-with-v2-api.json
+++ b/internal/api/fixtures/domain-list-with-v2-api.json
@@ -116,12 +116,7 @@
               "projects_quota": 10,
               "usage": 2,
               "backend_quota": 0,
-              "infinite_backend_quota": true,
-              "scales_with": {
-                "resource_name": "things",
-                "service_type": "shared",
-                "factor": 2
-              }
+              "infinite_backend_quota": true
             }
           ],
           "max_scraped_at": 55,
@@ -202,11 +197,7 @@
               },
               "quota": 30,
               "projects_quota": 20,
-              "usage": 4,
-              "annotations": {
-                "annotated": true,
-                "text": "this annotation appears on shared things of domain germany and project dresden"
-              }
+              "usage": 4
             }
           ],
           "max_scraped_at": 44,
@@ -278,12 +269,7 @@
               },
               "quota": 50,
               "projects_quota": 20,
-              "usage": 4,
-              "scales_with": {
-                "resource_name": "things",
-                "service_type": "shared",
-                "factor": 2
-              }
+              "usage": 4
             }
           ],
           "max_scraped_at": 33,

--- a/internal/api/fixtures/domain-list.json
+++ b/internal/api/fixtures/domain-list.json
@@ -74,12 +74,7 @@
               "projects_quota": 10,
               "usage": 2,
               "backend_quota": 0,
-              "infinite_backend_quota": true,
-              "scales_with": {
-                "resource_name": "things",
-                "service_type": "shared",
-                "factor": 2
-              }
+              "infinite_backend_quota": true
             }
           ],
           "max_scraped_at": 55,
@@ -129,11 +124,7 @@
               },
               "quota": 30,
               "projects_quota": 20,
-              "usage": 4,
-              "annotations": {
-                "annotated": true,
-                "text": "this annotation appears on shared things of domain germany and project dresden"
-              }
+              "usage": 4
             }
           ],
           "max_scraped_at": 44,
@@ -162,12 +153,7 @@
               "quota_distribution_model": "hierarchical",
               "quota": 50,
               "projects_quota": 20,
-              "usage": 4,
-              "scales_with": {
-                "resource_name": "things",
-                "service_type": "shared",
-                "factor": 2
-              }
+              "usage": 4
             }
           ],
           "max_scraped_at": 33,

--- a/internal/api/fixtures/project-get-berlin.json
+++ b/internal/api/fixtures/project-get-berlin.json
@@ -69,12 +69,7 @@
             "quota_distribution_model": "hierarchical",
             "quota": 10,
             "usable_quota": 10,
-            "usage": 2,
-            "scales_with": {
-              "resource_name": "things",
-              "service_type": "shared",
-              "factor": 2
-            }
+            "usage": 2
           }
         ],
         "scraped_at": 11

--- a/internal/api/fixtures/project-get-details-berlin.json
+++ b/internal/api/fixtures/project-get-details-berlin.json
@@ -89,12 +89,7 @@
                 "id": "secondthing",
                 "value": 42
               }
-            ],
-            "scales_with": {
-              "resource_name": "things",
-              "service_type": "shared",
-              "factor": 2
-            }
+            ]
           }
         ],
         "scraped_at": 11

--- a/internal/api/fixtures/project-get-dresden.json
+++ b/internal/api/fixtures/project-get-dresden.json
@@ -42,11 +42,7 @@
             },
             "quota": 10,
             "usable_quota": 10,
-            "usage": 2,
-            "annotations": {
-              "annotated": true,
-              "text": "this annotation appears on shared/things of project dresden only"
-            }
+            "usage": 2
           }
         ],
         "scraped_at": 44
@@ -74,12 +70,7 @@
             "quota_distribution_model": "hierarchical",
             "quota": 10,
             "usable_quota": 10,
-            "usage": 2,
-            "scales_with": {
-              "resource_name": "things",
-              "service_type": "shared",
-              "factor": 2
-            }
+            "usage": 2
           }
         ],
         "scraped_at": 33

--- a/internal/api/fixtures/project-get-paris.json
+++ b/internal/api/fixtures/project-get-paris.json
@@ -73,12 +73,7 @@
             "quota": 10,
             "usable_quota": 10,
             "usage": 2,
-            "backend_quota": -1,
-            "scales_with": {
-              "resource_name": "things",
-              "service_type": "shared",
-              "factor": 2
-            }
+            "backend_quota": -1
           }
         ],
         "scraped_at": 55

--- a/internal/api/fixtures/project-list-filtered.json
+++ b/internal/api/fixtures/project-list-filtered.json
@@ -49,11 +49,7 @@
               },
               "quota": 10,
               "usable_quota": 10,
-              "usage": 2,
-              "annotations": {
-                "annotated": true,
-                "text": "this annotation appears on shared/things of project dresden only"
-              }
+              "usage": 2
             }
           ],
           "scraped_at": 44

--- a/internal/api/fixtures/project-list-with-v2-api.json
+++ b/internal/api/fixtures/project-list-with-v2-api.json
@@ -118,12 +118,7 @@
               },
               "quota": 10,
               "usable_quota": 10,
-              "usage": 2,
-              "scales_with": {
-                "resource_name": "things",
-                "service_type": "shared",
-                "factor": 2
-              }
+              "usage": 2
             }
           ],
           "scraped_at": 11
@@ -204,11 +199,7 @@
               },
               "quota": 10,
               "usable_quota": 10,
-              "usage": 2,
-              "annotations": {
-                "annotated": true,
-                "text": "this annotation appears on shared/things of project dresden only"
-              }
+              "usage": 2
             }
           ],
           "scraped_at": 44
@@ -277,12 +268,7 @@
               },
               "quota": 10,
               "usable_quota": 10,
-              "usage": 2,
-              "scales_with": {
-                "resource_name": "things",
-                "service_type": "shared",
-                "factor": 2
-              }
+              "usage": 2
             }
           ],
           "scraped_at": 33

--- a/internal/api/fixtures/project-list.json
+++ b/internal/api/fixtures/project-list.json
@@ -70,12 +70,7 @@
               "quota_distribution_model": "hierarchical",
               "quota": 10,
               "usable_quota": 10,
-              "usage": 2,
-              "scales_with": {
-                "resource_name": "things",
-                "service_type": "shared",
-                "factor": 2
-              }
+              "usage": 2
             }
           ],
           "scraped_at": 11
@@ -125,11 +120,7 @@
               },
               "quota": 10,
               "usable_quota": 10,
-              "usage": 2,
-              "annotations": {
-                "annotated": true,
-                "text": "this annotation appears on shared/things of project dresden only"
-              }
+              "usage": 2
             }
           ],
           "scraped_at": 44
@@ -157,12 +148,7 @@
               "quota_distribution_model": "hierarchical",
               "quota": 10,
               "usable_quota": 10,
-              "usage": 2,
-              "scales_with": {
-                "resource_name": "things",
-                "service_type": "shared",
-                "factor": 2
-              }
+              "usage": 2
             }
           ],
           "scraped_at": 33

--- a/internal/collector/capacity_scrape.go
+++ b/internal/collector/capacity_scrape.go
@@ -385,7 +385,7 @@ func (c *Collector) processCapacityScrapeTask(_ context.Context, task capacitySc
 }
 
 func (c *Collector) confirmPendingCommitmentsIfNecessary(serviceType limes.ServiceType, resourceName limesresources.ResourceName) error {
-	behavior := c.Cluster.BehaviorForResource(serviceType, resourceName, "")
+	behavior := c.Cluster.BehaviorForResource(serviceType, resourceName)
 	now := c.MeasureTime()
 
 	// do not run ConfirmPendingCommitments if commitments are not enabled (or not live yet) for this resource

--- a/internal/collector/metrics.go
+++ b/internal/collector/metrics.go
@@ -622,7 +622,7 @@ func (c *DataMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 			}
 		}
 
-		overcommitFactor := c.Cluster.BehaviorForResource(serviceType, resourceName, "").OvercommitFactor
+		overcommitFactor := c.Cluster.BehaviorForResource(serviceType, resourceName).OvercommitFactor
 		if reportAZBreakdown {
 			for az, azCapacity := range capacityPerAZ {
 				ch <- prometheus.MustNewConstMetric(

--- a/internal/datamodel/allocation_stats.go
+++ b/internal/datamodel/allocation_stats.go
@@ -105,7 +105,7 @@ func collectAZAllocationStats(serviceType limes.ServiceType, resourceName limesr
 
 	// get capacity
 	queryArgs := []any{serviceType, resourceName, azFilter}
-	overcommitFactor := cluster.BehaviorForResource(serviceType, resourceName, "").OvercommitFactor
+	overcommitFactor := cluster.BehaviorForResource(serviceType, resourceName).OvercommitFactor
 	err := sqlext.ForeachRow(dbi, getRawCapacityInResourceQuery, queryArgs, func(rows *sql.Rows) error {
 		var (
 			az          limes.AvailabilityZone

--- a/internal/datamodel/resource_demand.go
+++ b/internal/datamodel/resource_demand.go
@@ -60,7 +60,7 @@ var (
 
 // GetOvercommitFactor implements the CapacityPluginBackchannel interface.
 func (i capacityPluginBackchannelImpl) GetOvercommitFactor(serviceType limes.ServiceType, resourceName limesresources.ResourceName) (core.OvercommitFactor, error) {
-	return i.Cluster.BehaviorForResource(serviceType, resourceName, "").OvercommitFactor, nil
+	return i.Cluster.BehaviorForResource(serviceType, resourceName).OvercommitFactor, nil
 }
 
 // GetGlobalResourceDemand implements the CapacityPluginBackchannel interface.

--- a/internal/reports/cluster.go
+++ b/internal/reports/cluster.go
@@ -229,7 +229,7 @@ func GetClusterResources(cluster *core.Cluster, now time.Time, dbi db.Interface,
 					Name:  *availabilityZone,
 					Usage: unwrapOrDefault(usageInAZ, 0),
 				}
-				overcommitFactor := cluster.BehaviorForResource(serviceType, *resourceName, "").OvercommitFactor
+				overcommitFactor := cluster.BehaviorForResource(serviceType, *resourceName).OvercommitFactor
 				azReport.Capacity = overcommitFactor.ApplyTo(*rawCapacityInAZ)
 				if azReport.Capacity != *rawCapacityInAZ {
 					azReport.RawCapacity = *rawCapacityInAZ
@@ -322,7 +322,7 @@ func GetClusterResources(cluster *core.Cluster, now time.Time, dbi db.Interface,
 	//epilogue: perform some calculations that require the full sum over all AZs to be done
 	for serviceType, service := range report.Services {
 		for resourceName, resource := range service.Resources {
-			overcommitFactor := cluster.BehaviorForResource(serviceType, resourceName, "").OvercommitFactor
+			overcommitFactor := cluster.BehaviorForResource(serviceType, resourceName).OvercommitFactor
 			if overcommitFactor == 0 {
 				resource.Capacity = resource.RawCapacity
 				resource.RawCapacity = nil
@@ -435,7 +435,7 @@ func findInClusterReport(cluster *core.Cluster, report *limesresources.ClusterRe
 		if !cluster.HasResource(serviceType, *resourceName) {
 			return service, nil
 		}
-		globalBehavior := cluster.BehaviorForResource(serviceType, *resourceName, "")
+		globalBehavior := cluster.BehaviorForResource(serviceType, *resourceName)
 		resource = &limesresources.ClusterResourceReport{
 			ResourceInfo:     cluster.InfoForResource(serviceType, *resourceName),
 			CommitmentConfig: globalBehavior.ToCommitmentConfig(now),

--- a/internal/reports/domain.go
+++ b/internal/reports/domain.go
@@ -371,13 +371,10 @@ func (d domains) Find(cluster *core.Cluster, domainUUID, domainName string, serv
 		if !cluster.HasResource(*serviceType, *resourceName) {
 			return domain, service, resource
 		}
-		localBehavior := cluster.BehaviorForResource(*serviceType, *resourceName, domainName)
-		globalBehavior := cluster.BehaviorForResource(*serviceType, *resourceName, "")
+		behavior := cluster.BehaviorForResource(*serviceType, *resourceName)
 		resource = &limesresources.DomainResourceReport{
 			ResourceInfo:     cluster.InfoForResource(*serviceType, *resourceName),
-			Scaling:          globalBehavior.ToScalingBehavior(),
-			Annotations:      localBehavior.Annotations,
-			CommitmentConfig: globalBehavior.ToCommitmentConfig(now),
+			CommitmentConfig: behavior.ToCommitmentConfig(now),
 		}
 		if !resource.NoQuota {
 			qdConfig := cluster.QuotaDistributionConfigForResource(*serviceType, *resourceName)

--- a/internal/reports/project.go
+++ b/internal/reports/project.go
@@ -185,16 +185,13 @@ func GetProjectResources(cluster *core.Cluster, domain db.Domain, project *db.Pr
 		}
 
 		// start new resource report when necessary
-		localBehavior := cluster.BehaviorForResource(*serviceType, *resourceName, domain.Name+"/"+projectName)
-		globalBehavior := cluster.BehaviorForResource(*serviceType, *resourceName, "")
+		behavior := cluster.BehaviorForResource(*serviceType, *resourceName)
 		resReport := srvReport.Resources[*resourceName]
 		if resReport == nil {
 			resReport = &limesresources.ProjectResourceReport{
 				ResourceInfo:     cluster.InfoForResource(*serviceType, *resourceName),
 				Usage:            0,
-				Scaling:          globalBehavior.ToScalingBehavior(),
-				Annotations:      localBehavior.Annotations,
-				CommitmentConfig: globalBehavior.ToCommitmentConfig(now),
+				CommitmentConfig: behavior.ToCommitmentConfig(now),
 				// all other fields are set below
 			}
 

--- a/main.go
+++ b/main.go
@@ -431,7 +431,7 @@ type mockCapacityPluginBackchannel struct {
 
 // GetOvercommitFactor implements the CapacityPluginBackchannel interface.
 func (b mockCapacityPluginBackchannel) GetOvercommitFactor(serviceType limes.ServiceType, resourceName limesresources.ResourceName) (core.OvercommitFactor, error) {
-	return b.Cluster.BehaviorForResource(serviceType, resourceName, "").OvercommitFactor, nil
+	return b.Cluster.BehaviorForResource(serviceType, resourceName).OvercommitFactor, nil
 }
 
 // GetGlobalResourceDemand implements the core.CapacityPluginBackchannel interface.


### PR DESCRIPTION
- Scaling behaviors were used as a UI hint for quota editing.
- MinNonZeroProjectQuota is a constraint that ApplyComputedProjectQuota ignores.
- Annotations was used to mark resources as "can_autoscale" for Castellum.

Also, scoping support for behaviors is removed, since all remaining ResourceBehavior attributes do not support scoping anyway.