### PR TITLE
remove project_resources.desired_backend_quota field

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -815,11 +815,10 @@ func Test_LargeProjectList(t *testing.T) {
 			}
 			for _, resourceName := range []limesresources.ResourceName{"things", "capacity"} {
 				resource := db.ProjectResource{
-					ServiceID:           service.ID,
-					Name:                resourceName,
-					Quota:               p2u64(0),
-					BackendQuota:        p2i64(0),
-					DesiredBackendQuota: p2u64(0),
+					ServiceID:    service.ID,
+					Name:         resourceName,
+					Quota:        p2u64(0),
+					BackendQuota: p2i64(0),
 				}
 				azResource := db.ProjectAZResource{
 					// ResourceID is filled in below once we have it
@@ -830,7 +829,6 @@ func Test_LargeProjectList(t *testing.T) {
 					resource.Quota = p2u64(uint64(idx))
 					azResource.Usage = uint64(idx / 2)
 					resource.BackendQuota = p2i64(int64(idx))
-					resource.DesiredBackendQuota = p2u64(uint64(idx))
 				}
 				err = s.DB.Insert(&resource)
 				if err != nil {

--- a/internal/api/fixtures/start-data-commitments.sql
+++ b/internal/api/fixtures/start-data-commitments.sql
@@ -33,25 +33,25 @@ INSERT INTO project_services (id, project_id, type, scraped_at, checked_at) VALU
 
 -- project_resources contains only boring placeholder values
 -- berlin
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (1,  1, 'things',   10, 10, 10);
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (2,  1, 'capacity', 10, 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (1,  1, 'things',   10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (2,  1, 'capacity', 10, 10);
 INSERT INTO project_resources (id, service_id, name) VALUES (3,  1, 'capacity_portion');
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (4,  2, 'things',   10, 10, 10);
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (5,  2, 'capacity', 10, 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (4,  2, 'things',   10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (5,  2, 'capacity', 10, 10);
 INSERT INTO project_resources (id, service_id, name) VALUES (6,  2, 'capacity_portion');
 -- dresden
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (7,  3, 'things',   10, 10, 10);
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (8,  3, 'capacity', 10, 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (7,  3, 'things',   10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (8,  3, 'capacity', 10, 10);
 INSERT INTO project_resources (id, service_id, name) VALUES (9,  3, 'capacity_portion');
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (10, 4, 'things',   10, 10, 10);
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (11, 4, 'capacity', 10, 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (10, 4, 'things',   10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (11, 4, 'capacity', 10, 10);
 INSERT INTO project_resources (id, service_id, name) VALUES (12, 4, 'capacity_portion');
 -- paris
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (13, 5, 'things',   10, 10, 10);
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (14, 5, 'capacity', 10, 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (13, 5, 'things',   10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (14, 5, 'capacity', 10, 10);
 INSERT INTO project_resources (id, service_id, name) VALUES (15, 5, 'capacity_portion');
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (16, 6, 'things',   10, 10, 10);
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (17, 6, 'capacity', 10, 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (16, 6, 'things',   10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (17, 6, 'capacity', 10, 10);
 INSERT INTO project_resources (id, service_id, name) VALUES (18, 6, 'capacity_portion');
 
 -- project_az_resources has "things" as non-AZ-aware and "capacity" as AZ-aware with an even split

--- a/internal/api/fixtures/start-data-inconsistencies.sql
+++ b/internal/api/fixtures/start-data-inconsistencies.sql
@@ -18,15 +18,15 @@ INSERT INTO project_services (id, project_id, type, scraped_at, checked_at) VALU
 INSERT INTO project_services (id, project_id, type, scraped_at, checked_at) VALUES (6, 3, 'network', '2018-06-13 15:06:37', '2018-06-13 15:06:37');
 
 -- project_resources contains some pathological cases
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (1, 1, 'cores',         30,  10,  30);
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (2, 1, 'ram',           100, 100, 100);
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (3, 2, 'loadbalancers', 10,  10,  10);
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (4, 3, 'cores',         14,  14,  14);
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (5, 3, 'ram',           60,  60,  60);
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (6, 4, 'loadbalancers', 5,   5,   5);
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (7, 5, 'cores',         30,  30,  30);
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (8, 5, 'ram',           62,  62,  62);
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (9, 6, 'loadbalancers', 10,  10,  10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (1, 1, 'cores',         30,  10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (2, 1, 'ram',           100, 100);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (3, 2, 'loadbalancers', 10,  10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (4, 3, 'cores',         14,  14);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (5, 3, 'ram',           60,  60);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (6, 4, 'loadbalancers', 5,   5);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (7, 5, 'cores',         30,  30);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (8, 5, 'ram',           62,  62);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (9, 6, 'loadbalancers', 10,  10);
 
 -- project_az_resources has everything as non-AZ-aware (the consistency checks do not really care about AZs)
 INSERT INTO project_az_resources (id, resource_id, az, usage, physical_usage) VALUES (1, 1, 'any', 14, NULL);

--- a/internal/api/fixtures/start-data.sql
+++ b/internal/api/fixtures/start-data.sql
@@ -39,26 +39,26 @@ INSERT INTO project_services (id, project_id, type, scraped_at, rates_scraped_at
 
 -- project_resources contains some pathological cases
 -- berlin (also used for test cases concerning subresources)
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (1,  1, 'things',   10, 10, 10);
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (2,  1, 'capacity', 10, 10, 10);
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (3,  1, 'capacity_portion', NULL, NULL, NULL);
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (4,  2, 'things',   10, 10, 10);
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (5,  2, 'capacity', 10, 10, 10);
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (6,  2, 'capacity_portion', NULL, NULL, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (1,  1, 'things',   10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (2,  1, 'capacity', 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (3,  1, 'capacity_portion', NULL, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (4,  2, 'things',   10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (5,  2, 'capacity', 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (6,  2, 'capacity_portion', NULL, NULL);
 -- dresden (backend quota for shared/capacity mismatches approved quota and exceeds domain quota)
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (7,  3, 'things',   10, 10, 10);
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (8,  3, 'capacity', 10, 10, 10);
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (9,  3, 'capacity_portion', NULL, NULL, NULL);
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (10, 4, 'things',   10, 10, 10);
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (11, 4, 'capacity', 10, 100, 10);
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (12, 4, 'capacity_portion', NULL, NULL, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (7,  3, 'things',   10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (8,  3, 'capacity', 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (9,  3, 'capacity_portion', NULL, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (10, 4, 'things',   10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (11, 4, 'capacity', 10, 100);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (12, 4, 'capacity_portion', NULL, NULL);
 -- paris (infinite backend quota for unshared/things; non-null physical_usage for */capacity, all other project resources should report physical_usage = usage in aggregations)
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (13, 5, 'things',   10, -1, 10);
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (14, 5, 'capacity', 10, 10, 10);
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (15, 5, 'capacity_portion', NULL, NULL, NULL);
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (16, 6, 'things',   10, 10, 10);
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota, max_quota_from_admin) VALUES (17, 6, 'capacity', 10, 10, 10, 200);
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (18, 6, 'capacity_portion', NULL, NULL, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (13, 5, 'things',   10, -1);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (14, 5, 'capacity', 10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (15, 5, 'capacity_portion', NULL, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (16, 6, 'things',   10, 10);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota, max_quota_from_admin) VALUES (17, 6, 'capacity', 10, 10, 200);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (18, 6, 'capacity_portion', NULL, NULL);
 
 -- "capacity" is modeled as AZ-aware, "things" is not
 -- NOTE: AZ-aware resources also have an entry for AZ "any" with 0 usage
@@ -148,11 +148,11 @@ INSERT INTO cluster_services (id, type) VALUES (101, 'weird');
 INSERT INTO cluster_resources (id, service_id, name, capacitor_id) VALUES (101, 101, 'things', 'scans-shared');
 INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, subcapacities) VALUES (101, 101, 'any', 2, 1, '');
 INSERT INTO project_services (id, project_id, type) VALUES (101, 1, 'weird');
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (101, 101, 'things', 2, 2, 2);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (101, 101, 'things', 2, 2);
 INSERT INTO project_az_resources (id, resource_id, az, quota, usage, physical_usage, subresources) VALUES (101, 101, 'any', NULL, 1, 1, '');
 
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (102, 1, 'items', 2, 2, 2);
-INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (103, 1, 'items_portion', NULL, NULL, NULL);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (102, 1, 'items', 2, 2);
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (103, 1, 'items_portion', NULL, NULL);
 INSERT INTO project_az_resources (id, resource_id, az, quota, usage, physical_usage, subresources) VALUES (102, 102, 'any', NULL, 1, 1, '');
 INSERT INTO project_az_resources (id, resource_id, az, quota, usage, physical_usage, subresources) VALUES (103, 103, 'any', NULL, 1, NULL, '');
 

--- a/internal/collector/capacity_scrape_test.go
+++ b/internal/collector/capacity_scrape_test.go
@@ -458,10 +458,10 @@ func Test_ScanCapacityWithCommitments(t *testing.T) {
 		UPDATE project_az_resources SET quota = 8 WHERE id = 26 AND resource_id = 11 AND az = 'any';
 		UPDATE project_az_resources SET quota = 1 WHERE id = 27 AND resource_id = 11 AND az = 'az-one';
 		UPDATE project_az_resources SET quota = 1 WHERE id = 28 AND resource_id = 11 AND az = 'az-two';
-		UPDATE project_resources SET quota = 10, desired_backend_quota = 10 WHERE id = 11 AND service_id = 4 AND name = 'capacity';
-		UPDATE project_resources SET quota = 251, desired_backend_quota = 251 WHERE id = 2 AND service_id = 1 AND name = 'capacity';
-		UPDATE project_resources SET quota = 10, desired_backend_quota = 10 WHERE id = 5 AND service_id = 2 AND name = 'capacity';
-		UPDATE project_resources SET quota = 10, desired_backend_quota = 10 WHERE id = 8 AND service_id = 3 AND name = 'capacity';
+		UPDATE project_resources SET quota = 10 WHERE id = 11 AND service_id = 4 AND name = 'capacity';
+		UPDATE project_resources SET quota = 251 WHERE id = 2 AND service_id = 1 AND name = 'capacity';
+		UPDATE project_resources SET quota = 10 WHERE id = 5 AND service_id = 2 AND name = 'capacity';
+		UPDATE project_resources SET quota = 10 WHERE id = 8 AND service_id = 3 AND name = 'capacity';
 	`, timestampUpdates())
 
 	// day 1: test that confirmation works at all
@@ -474,7 +474,7 @@ func Test_ScanCapacityWithCommitments(t *testing.T) {
 	tr.DBChanges().AssertEqualf(`%s
 		UPDATE project_az_resources SET quota = 10 WHERE id = 18 AND resource_id = 2 AND az = 'az-one';
 		UPDATE project_commitments SET confirmed_at = %d, state = 'active' WHERE id = 1;
-		UPDATE project_resources SET quota = 260, desired_backend_quota = 260 WHERE id = 2 AND service_id = 1 AND name = 'capacity';
+		UPDATE project_resources SET quota = 260 WHERE id = 2 AND service_id = 1 AND name = 'capacity';
 	`, timestampUpdates(), scrapedAt1.Unix())
 
 	// day 2: test that confirmation considers the resource's capacity overcommit factor
@@ -489,7 +489,7 @@ func Test_ScanCapacityWithCommitments(t *testing.T) {
 		UPDATE project_az_resources SET quota = 110 WHERE id = 18 AND resource_id = 2 AND az = 'az-one';
 		UPDATE project_commitments SET confirmed_at = %d, state = 'active' WHERE id = 2;
 		UPDATE project_commitments SET state = 'pending' WHERE id = 3;
-		UPDATE project_resources SET quota = 360, desired_backend_quota = 360 WHERE id = 2 AND service_id = 1 AND name = 'capacity';
+		UPDATE project_resources SET quota = 360 WHERE id = 2 AND service_id = 1 AND name = 'capacity';
 	`, timestampUpdates(), scrapedAt1.Unix())
 
 	// day 3: test confirmation order with several commitments, on second/capacity in az-one
@@ -508,7 +508,7 @@ func Test_ScanCapacityWithCommitments(t *testing.T) {
 		UPDATE project_commitments SET confirmed_at = %d, state = 'active' WHERE id = 4;
 		UPDATE project_commitments SET confirmed_at = %d, state = 'active' WHERE id = 5;
 		UPDATE project_commitments SET state = 'pending' WHERE id = 6;
-		UPDATE project_resources SET quota = 21, desired_backend_quota = 21 WHERE id = 11 AND service_id = 4 AND name = 'capacity';
+		UPDATE project_resources SET quota = 21 WHERE id = 11 AND service_id = 4 AND name = 'capacity';
 	`, timestampUpdates(), scrapedAt2.Unix(), scrapedAt2.Unix())
 
 	// day 4: test how confirmation interacts with existing usage, on first/capacity in az-two
@@ -523,7 +523,7 @@ func Test_ScanCapacityWithCommitments(t *testing.T) {
 		UPDATE project_az_resources SET quota = 300 WHERE id = 19 AND resource_id = 2 AND az = 'az-two';
 		UPDATE project_commitments SET state = 'pending' WHERE id = 7;
 		UPDATE project_commitments SET confirmed_at = %d, state = 'active' WHERE id = 8;
-		UPDATE project_resources SET quota = 410, desired_backend_quota = 410 WHERE id = 2 AND service_id = 1 AND name = 'capacity';
+		UPDATE project_resources SET quota = 410 WHERE id = 2 AND service_id = 1 AND name = 'capacity';
 	`, timestampUpdates(), scrapedAt1.Unix())
 
 	// day 5: test commitments that cannot be confirmed until the previous commitment expires, on second/capacity in az-one
@@ -540,7 +540,7 @@ func Test_ScanCapacityWithCommitments(t *testing.T) {
 		UPDATE project_az_resources SET quota = 22 WHERE id = 22 AND resource_id = 5 AND az = 'az-two';
 		UPDATE project_commitments SET state = 'pending' WHERE id = 10;
 		UPDATE project_commitments SET confirmed_at = %d, state = 'active' WHERE id = 9;
-		UPDATE project_resources SET quota = 23, desired_backend_quota = 23 WHERE id = 5 AND service_id = 2 AND name = 'capacity';
+		UPDATE project_resources SET quota = 23 WHERE id = 5 AND service_id = 2 AND name = 'capacity';
 	`, timestampUpdates(), scrapedAt2.Unix())
 
 	// ...Once ID=9 expires an hour later, ID=10 can be confirmed.
@@ -554,8 +554,8 @@ func Test_ScanCapacityWithCommitments(t *testing.T) {
 		UPDATE project_az_resources SET quota = 2 WHERE id = 28 AND resource_id = 11 AND az = 'az-two';
 		UPDATE project_commitments SET confirmed_at = %d, state = 'active' WHERE id = 10;
 		UPDATE project_commitments SET state = 'expired' WHERE id = 9;
-		UPDATE project_resources SET quota = 22, desired_backend_quota = 22 WHERE id = 11 AND service_id = 4 AND name = 'capacity';
-		UPDATE project_resources SET quota = 10, desired_backend_quota = 10 WHERE id = 5 AND service_id = 2 AND name = 'capacity';
+		UPDATE project_resources SET quota = 22 WHERE id = 11 AND service_id = 4 AND name = 'capacity';
+		UPDATE project_resources SET quota = 10 WHERE id = 5 AND service_id = 2 AND name = 'capacity';
 	`, timestampUpdates(), scrapedAt2.Unix())
 
 	// test GetGlobalResourceDemand (this is not used by any of our test plugins,

--- a/internal/collector/scrape_test.go
+++ b/internal/collector/scrape_test.go
@@ -144,12 +144,12 @@ func Test_ScrapeSuccess(t *testing.T) {
 		INSERT INTO project_az_resources (id, resource_id, az, usage, historical_usage) VALUES (7, 3, 'any', 0, '{"t":[%[1]d],"v":[0]}');
 		INSERT INTO project_az_resources (id, resource_id, az, usage, subresources, historical_usage) VALUES (8, 3, 'az-one', 2, '[{"index":0},{"index":1}]', '{"t":[%[1]d],"v":[2]}');
 		INSERT INTO project_az_resources (id, resource_id, az, usage, subresources, historical_usage) VALUES (9, 3, 'az-two', 2, '[{"index":2},{"index":3}]', '{"t":[%[1]d],"v":[2]}');
-		INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (1, 1, 'capacity', 0, 100, 0);
+		INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (1, 1, 'capacity', 0, 100);
 		INSERT INTO project_resources (id, service_id, name) VALUES (2, 1, 'capacity_portion');
-		INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (3, 1, 'things', 0, 42, 0);
-		INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (4, 2, 'capacity', 0, 100, 0);
+		INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (3, 1, 'things', 0, 42);
+		INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (4, 2, 'capacity', 0, 100);
 		INSERT INTO project_resources (id, service_id, name) VALUES (5, 2, 'capacity_portion');
-		INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (6, 2, 'things', 0, 42, 0);
+		INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (6, 2, 'things', 0, 42);
 		UPDATE project_services SET scraped_at = %[1]d, scrape_duration_secs = 5, serialized_metrics = '{"capacity_usage":0,"things_usage":4}', checked_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND type = 'unittest';
 		UPDATE project_services SET scraped_at = %[3]d, scrape_duration_secs = 5, serialized_metrics = '{"capacity_usage":0,"things_usage":4}', checked_at = %[3]d, next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND type = 'unittest';
 	`,
@@ -256,10 +256,10 @@ func Test_ScrapeSuccess(t *testing.T) {
 	scrapedAt1 = s.Clock.Now().Add(-5 * time.Second)
 	scrapedAt2 = s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`
-		UPDATE project_resources SET quota = 20, backend_quota = 20, desired_backend_quota = 20 WHERE id = 1 AND service_id = 1 AND name = 'capacity';
-		UPDATE project_resources SET quota = 13, backend_quota = 13, desired_backend_quota = 13 WHERE id = 3 AND service_id = 1 AND name = 'things';
-		UPDATE project_resources SET quota = 20, backend_quota = 20, desired_backend_quota = 20 WHERE id = 4 AND service_id = 2 AND name = 'capacity';
-		UPDATE project_resources SET quota = 13, backend_quota = 13, desired_backend_quota = 13 WHERE id = 6 AND service_id = 2 AND name = 'things';
+		UPDATE project_resources SET quota = 20, backend_quota = 20 WHERE id = 1 AND service_id = 1 AND name = 'capacity';
+		UPDATE project_resources SET quota = 13, backend_quota = 13 WHERE id = 3 AND service_id = 1 AND name = 'things';
+		UPDATE project_resources SET quota = 20, backend_quota = 20 WHERE id = 4 AND service_id = 2 AND name = 'capacity';
+		UPDATE project_resources SET quota = 13, backend_quota = 13 WHERE id = 6 AND service_id = 2 AND name = 'things';
 		UPDATE project_services SET scraped_at = %[1]d, checked_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND type = 'unittest';
 		UPDATE project_services SET scraped_at = %[3]d, checked_at = %[3]d, next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND type = 'unittest';
 	`,
@@ -413,12 +413,12 @@ func Test_ScrapeFailure(t *testing.T) {
 		INSERT INTO project_az_resources (id, resource_id, az, usage) VALUES (4, 4, 'any', 0);
 		INSERT INTO project_az_resources (id, resource_id, az, usage) VALUES (5, 5, 'any', 0);
 		INSERT INTO project_az_resources (id, resource_id, az, usage) VALUES (6, 6, 'any', 0);
-		INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (1, 1, 'capacity', 0, -1, 0);
+		INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (1, 1, 'capacity', 0, -1);
 		INSERT INTO project_resources (id, service_id, name) VALUES (2, 1, 'capacity_portion');
-		INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (3, 1, 'things', 0, -1, 0);
-		INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (4, 2, 'capacity', 0, -1, 0);
+		INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (3, 1, 'things', 0, -1);
+		INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (4, 2, 'capacity', 0, -1);
 		INSERT INTO project_resources (id, service_id, name) VALUES (5, 2, 'capacity_portion');
-		INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (6, 2, 'things', 0, -1, 0);
+		INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (6, 2, 'things', 0, -1);
 		UPDATE project_services SET scraped_at = 0, checked_at = %[1]d, scrape_error_message = 'Scrape failed as requested', next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND type = 'unittest';
 		UPDATE project_services SET scraped_at = 0, checked_at = %[3]d, scrape_error_message = 'Scrape failed as requested', next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND type = 'unittest';
 	`,
@@ -585,7 +585,7 @@ func Test_ScrapeReturnsNoUsageData(t *testing.T) {
 	tr0.AssertEqualf(`
 		INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
 		INSERT INTO project_az_resources (id, resource_id, az, usage) VALUES (1, 1, 'any', 0);
-		INSERT INTO project_resources (id, service_id, name, quota, backend_quota, desired_backend_quota) VALUES (1, 1, 'things', 0, 0, 0);
+		INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (1, 1, 'things', 0, 0);
 		INSERT INTO project_services (id, project_id, type, scraped_at, scrape_duration_secs, checked_at, next_scrape_at, rates_next_scrape_at) VALUES (1, 1, 'noop', %[1]d, 5, %[1]d, %[2]d, 0);
 		INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany');
 	`,

--- a/internal/datamodel/apply_backend_quota.go
+++ b/internal/datamodel/apply_backend_quota.go
@@ -32,13 +32,13 @@ import (
 
 var (
 	backendQuotaSelectQuery = sqlext.SimplifyWhitespace(`
-		SELECT name, backend_quota, desired_backend_quota
+		SELECT name, backend_quota, quota
 		  FROM project_resources
-		 WHERE service_id = $1 AND desired_backend_quota IS NOT NULL
+		 WHERE service_id = $1 AND quota IS NOT NULL
 	`)
 	backendQuotaMarkAsAppliedQuery = sqlext.SimplifyWhitespace(`
 		UPDATE project_resources
-		   SET backend_quota = desired_backend_quota
+		   SET backend_quota = quota
 		 WHERE service_id = $1
 	`)
 )

--- a/internal/datamodel/apply_computed_project_quota.go
+++ b/internal/datamodel/apply_computed_project_quota.go
@@ -55,7 +55,7 @@ var (
 		UPDATE project_az_resources SET quota = $1 WHERE quota IS DISTINCT FROM $1 AND az = $2 AND resource_id = $3
 	`)
 	acpqUpdateProjectQuotaQuery = sqlext.SimplifyWhitespace(`
-		UPDATE project_resources SET quota = $1, desired_backend_quota = $1 WHERE (quota IS DISTINCT FROM $1 OR desired_backend_quota IS DISTINCT FROM $1) AND id = $2
+		UPDATE project_resources SET quota = $1 WHERE quota IS DISTINCT FROM $1 AND id = $2
 	`)
 )
 
@@ -187,7 +187,7 @@ func ApplyComputedProjectQuota(serviceType limes.ServiceType, resourceName limes
 	return tx.Commit()
 
 	//NOTE: Quotas are not applied to the backend here because OpenStack is way too inefficient in practice.
-	// We wait for the next scrape cycle to come around and notice that `backend_quota != desired_backend_quota`.
+	// We wait for the next scrape cycle to come around and notice that `backend_quota != quota`.
 }
 
 // Calculation space for a single project AZ resource.

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -235,4 +235,13 @@ var sqlMigrations = map[string]string{
 		DROP TABLE domain_resources;
 		DROP TABLE domain_services;
 	`,
+	"041_remove_project_resources_desired_backend_quota.down.sql": `
+		ALTER TABLE project_resources
+			ADD COLUMN desired_backend_quota BIGINT DEFAULT NULL;
+		UPDATE project_resources SET desired_backend_quota = quota;
+	`,
+	"041_remove_project_resources_desired_backend_quota.up.sql": `
+		ALTER TABLE project_resources
+			DROP COLUMN desired_backend_quota;
+	`,
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -117,7 +117,6 @@ type ProjectResource struct {
 	Name                    limesresources.ResourceName `db:"name"`
 	Quota                   *uint64                     `db:"quota"`
 	BackendQuota            *int64                      `db:"backend_quota"`
-	DesiredBackendQuota     *uint64                     `db:"desired_backend_quota"`
 	MinQuotaFromBackend     *uint64                     `db:"min_quota_from_backend"`
 	MaxQuotaFromBackend     *uint64                     `db:"max_quota_from_backend"`
 	MaxQuotaFromAdmin       *uint64                     `db:"max_quota_from_admin"`

--- a/internal/reports/inconsistency.go
+++ b/internal/reports/inconsistency.go
@@ -62,24 +62,24 @@ type MismatchProjectQuota struct {
 }
 
 var ospqReportQuery = sqlext.SimplifyWhitespace(`
-	SELECT d.uuid, d.name, p.uuid, p.name, ps.type, pr.name, pr.desired_backend_quota, SUM(par.usage)
+	SELECT d.uuid, d.name, p.uuid, p.name, ps.type, pr.name, pr.quota, SUM(par.usage)
 	  FROM projects p
 	  JOIN domains d ON d.id = p.domain_id
 	  JOIN project_services ps ON ps.project_id = p.id {{AND ps.type = $service_type}}
 	  JOIN project_resources pr ON pr.service_id = ps.id {{AND pr.name = $resource_name}}
 	  JOIN project_az_resources par ON pr.id = par.resource_id
-	 GROUP BY d.uuid, d.name, p.uuid, p.name, ps.type, pr.name, pr.desired_backend_quota
-	HAVING SUM(par.usage) > pr.desired_backend_quota
+	 GROUP BY d.uuid, d.name, p.uuid, p.name, ps.type, pr.name, pr.quota
+	HAVING SUM(par.usage) > pr.quota
 	 ORDER BY d.name, p.name, ps.type, pr.name
 `)
 
 var mmpqReportQuery = sqlext.SimplifyWhitespace(`
-	SELECT d.uuid, d.name, p.uuid, p.name, ps.type, pr.name, pr.desired_backend_quota, pr.backend_quota
+	SELECT d.uuid, d.name, p.uuid, p.name, ps.type, pr.name, pr.quota, pr.backend_quota
 	  FROM projects p
 	  JOIN domains d ON d.id = p.domain_id
 	  JOIN project_services ps ON ps.project_id = p.id {{AND ps.type = $service_type}}
 	  JOIN project_resources pr ON pr.service_id = ps.id {{AND pr.name = $resource_name}}
-	WHERE pr.backend_quota != pr.desired_backend_quota
+	WHERE pr.backend_quota != pr.quota
 	ORDER BY d.name, p.name, ps.type, pr.name
 `)
 


### PR DESCRIPTION
This field is redundant now: With the removal of quota bursting, there are never situations where `quota != desired_backend_quota`.