### PR TITLE
do not try to compute quota for resources with NoQuota flag

### DIFF
--- a/internal/datamodel/apply_computed_project_quota.go
+++ b/internal/datamodel/apply_computed_project_quota.go
@@ -93,7 +93,11 @@ func (c *projectLocalQuotaConstraints) AddMaxQuota(value *uint64) {
 // ApplyComputedProjectQuota reevaluates auto-computed project quotas for the
 // given resource, if supported by its quota distribution model.
 func ApplyComputedProjectQuota(serviceType limes.ServiceType, resourceName limesresources.ResourceName, dbm *gorp.DbMap, cluster *core.Cluster, now time.Time) error {
-	// only run for resources with autogrow QD model
+	// only run for resources with quota and autogrow QD model
+	resInfo := cluster.InfoForResource(serviceType, resourceName)
+	if resInfo.NoQuota {
+		return nil
+	}
 	qdCfg := cluster.QuotaDistributionConfigForResource(serviceType, resourceName)
 	if qdCfg.Autogrow == nil {
 		return nil


### PR DESCRIPTION
This was not a problem until yesterday, when I added capacity to our only NoQuota resource (`sharev2/snapmirror_capacity`), thus giving ApplyComputedProjectQuota the prerequisite needed to actually commit this error.