### PR TITLE
capacity-nova: add shadowing support for pooled resources

### DIFF
--- a/docs/operators/config.md
+++ b/docs/operators/config.md
@@ -780,7 +780,10 @@ The `params.hypervisor_selection` can also contains lists of strings in the `req
   hypervisor will be considered shadowed. Its capacity will not be counted, just as for hypervisors that are excluded
   entirely by `required_traits`, but if the hypervisor contains running instances of split flavors (see below), this
   existing usage will be counted towards the total capacity. Shadowing is used to represent usage by legacy instances
-  while migrating to a different resource provider trait setup.
+  while migrating to a different resource provider trait setup. It can also be employed to report capacity
+  conservatively during a decommissioning operation: When moving payload from an old hypervisor to a newer model, both
+  hypervisors should be shadowed during this operation to avoid higher capacity being reported while both generations of
+  hypervisor are enabled concurrently.
 
 The `params.flavor_selection` parameter can be used to control how flavors are enumerated. Only those flavors will be
 considered which have all the extra specs noted in `required_extra_specs`, and none of those noted in

--- a/internal/plugins/nova/capacity.go
+++ b/internal/plugins/nova/capacity.go
@@ -55,6 +55,17 @@ func (c *PartialCapacity) Add(other PartialCapacity) {
 	}
 }
 
+func (c PartialCapacity) CappedToUsage() PartialCapacity {
+	return PartialCapacity{
+		VCPUs:              c.VCPUs.CappedToUsage(),
+		MemoryMB:           c.MemoryMB.CappedToUsage(),
+		LocalGB:            c.LocalGB.CappedToUsage(),
+		RunningVMs:         c.RunningVMs,
+		MatchingAggregates: c.MatchingAggregates,
+		Subcapacities:      c.Subcapacities,
+	}
+}
+
 func (c PartialCapacity) IntoCapacityData(resourceName string, maxRootDiskSize float64, subcapacities []any) core.CapacityData {
 	switch resourceName {
 	case "cores":
@@ -91,4 +102,11 @@ func (c PartialCapacity) IntoCapacityData(resourceName string, maxRootDiskSize f
 type PartialCapacityMetric struct {
 	Capacity uint64
 	Usage    uint64
+}
+
+func (m PartialCapacityMetric) CappedToUsage() PartialCapacityMetric {
+	return PartialCapacityMetric{
+		Capacity: min(m.Capacity, m.Usage),
+		Usage:    m.Usage,
+	}
 }

--- a/internal/plugins/nova/hypervisor_subcapacity.go
+++ b/internal/plugins/nova/hypervisor_subcapacity.go
@@ -1,0 +1,107 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package nova
+
+import (
+	"github.com/sapcc/go-api-declarations/limes"
+)
+
+// Subcapacity is the structure for subcapacities reported by the "nova" capacity plugin.
+// Each subcapacity refers to a single Nova hypervisor.
+//
+// This structure can appear on both pooled resources (using the Capacity and Usage fields to report only one dimension at a time),
+// or on split flavors (using the CapacityVector and UsageVector fields to report all dimensions at once).
+type Subcapacity struct {
+	ServiceHost      string                 `json:"service_host"`
+	AvailabilityZone limes.AvailabilityZone `json:"az"`
+	AggregateName    string                 `json:"aggregate"`
+	Capacity         *uint64                `json:"capacity,omitempty"`
+	Usage            *uint64                `json:"usage,omitempty"`
+	CapacityVector   *BinpackVector[uint64] `json:"capacity_vector,omitempty"`
+	UsageVector      *BinpackVector[uint64] `json:"usage_vector,omitempty"`
+	Traits           []string               `json:"traits"`
+}
+
+// PooledSubcapacityBuilder is used to build subcapacity lists for pooled resources.
+type PooledSubcapacityBuilder struct {
+	// These are actually []Subcapacity, but we store them as []any because
+	// that's what goes into type core.CapacityData in the end.
+	CoresSubcapacities     []any
+	InstancesSubcapacities []any
+	RAMSubcapacities       []any
+}
+
+func (b *PooledSubcapacityBuilder) AddHypervisor(h MatchingHypervisor, maxRootDiskSize float64) {
+	pc := h.PartialCapacity()
+
+	hvCoresCapa := pc.IntoCapacityData("cores", maxRootDiskSize, nil)
+	b.CoresSubcapacities = append(b.CoresSubcapacities, Subcapacity{
+		ServiceHost:      h.Hypervisor.Service.Host,
+		AggregateName:    h.AggregateName,
+		AvailabilityZone: h.AvailabilityZone,
+		Capacity:         &hvCoresCapa.Capacity,
+		Usage:            hvCoresCapa.Usage,
+		Traits:           h.Traits,
+	})
+	hvInstancesCapa := pc.IntoCapacityData("instances", maxRootDiskSize, nil)
+	b.InstancesSubcapacities = append(b.InstancesSubcapacities, Subcapacity{
+		ServiceHost:      h.Hypervisor.Service.Host,
+		AggregateName:    h.AggregateName,
+		AvailabilityZone: h.AvailabilityZone,
+		Capacity:         &hvInstancesCapa.Capacity,
+		Usage:            hvInstancesCapa.Usage,
+		Traits:           h.Traits,
+	})
+	hvRAMCapa := pc.IntoCapacityData("ram", maxRootDiskSize, nil)
+	b.RAMSubcapacities = append(b.RAMSubcapacities, Subcapacity{
+		ServiceHost:      h.Hypervisor.Service.Host,
+		AggregateName:    h.AggregateName,
+		AvailabilityZone: h.AvailabilityZone,
+		Capacity:         &hvRAMCapa.Capacity,
+		Usage:            hvRAMCapa.Usage,
+		Traits:           h.Traits,
+	})
+}
+
+// PooledSubcapacityBuilder is used to build subcapacity lists for split flavors.
+// These subcapacities are reported on the first flavor in alphabetic order.
+type SplitFlavorSubcapacityBuilder struct {
+	Subcapacities []any
+}
+
+func (b *SplitFlavorSubcapacityBuilder) AddHypervisor(h MatchingHypervisor) {
+	pc := h.PartialCapacity()
+	b.Subcapacities = append(b.Subcapacities, Subcapacity{
+		ServiceHost:      h.Hypervisor.Service.Host,
+		AggregateName:    h.AggregateName,
+		AvailabilityZone: h.AvailabilityZone,
+		CapacityVector: &BinpackVector[uint64]{
+			VCPUs:    pc.VCPUs.Capacity,
+			MemoryMB: pc.MemoryMB.Capacity,
+			LocalGB:  pc.LocalGB.Capacity,
+		},
+		UsageVector: &BinpackVector[uint64]{
+			VCPUs:    pc.VCPUs.Usage,
+			MemoryMB: pc.MemoryMB.Usage,
+			LocalGB:  pc.LocalGB.Usage,
+		},
+		Traits: h.Traits,
+	})
+}


### PR DESCRIPTION
The documentation change alludes to what this is about: We are currently scanning Nova capacity with

```
params:
  required_traits: [ !CUSTOM_DECOMMISIONING, ... ]
  ...
```

This leads to hypervisors that are about to be decommissioned getting ignored entirely, i.e. they do not count towards capacity at all. This was fine when we gave out quota manually, and the capacity operations team was manually keeping track of decom activities.

But now, ConfirmPendingCommitments and ApplyComputedProjectQuota need a more accurate depiction of available capacity. If there are hypervisors with the CUSTOM_DECOMMISIONING trait that still have existing usage on them, it will hurt us to underestimate real capacity this much. Therefore, it has been decided to count capacity for these hypervisors **only so far as to cover existing payload on them**.

This is the same logic that we have already implemented for split flavors under the name "shadowing", so this commit extends the `shadowing_traits` attribute to work with pooled resources, too. Then we can change the capacitor config to

```
params:
  shadowing_traits: [ CUSTOM_DECOMMISIONING, ... ]
  ...
```

@SuperSandro2000 For your reviewing pleasure, I've split this up into two commits: The first, bigger one is a refactoring that you might have an easier time judging because it does not change actual semantics. The second, smaller commit is the behavioral change as described above.