### PR TITLE
plugins/nova: remove usage of GET os-quota-class-sets/flavors

### DIFF
--- a/internal/plugins/nova/flavor_translate.go
+++ b/internal/plugins/nova/flavor_translate.go
@@ -138,37 +138,12 @@ func (t FlavorTranslationTable) NovaQuotaNameForLimesResourceName(resourceName l
 // ListFlavorsWithSeparateInstanceQuota queries Nova for all separate instance
 // quotas, and returns the flavor names that Nova prefers for each.
 func (t FlavorTranslationTable) ListFlavorsWithSeparateInstanceQuota(computeV2 *gophercloud.ServiceClient) ([]string, error) {
-	// look at the magical quota class "flavors" to determine which quotas exist
-	url := computeV2.ServiceURL("os-quota-class-sets", "flavors")
-	var result gophercloud.Result
-	_, err := computeV2.Get(url, &result.Body, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	// At SAP Converged Cloud, we use separate instance quotas for baremetal
-	// (Ironic) flavors, to control precisely how many baremetal machines can be
-	// used by each domain/project. Each such quota has the resource name
-	// "instances_${FLAVOR_NAME}".
-	var body struct {
-		//NOTE: cannot use map[string]int64 here because this object contains the
-		// field "id": "default" (curse you, untyped JSON)
-		QuotaClassSet map[string]any `json:"quota_class_set"`
-	}
-	err = result.ExtractInto(&body)
-	if err != nil {
-		return nil, err
-	}
-
 	var flavorNames []string
-	for key := range body.QuotaClassSet {
-		if !strings.HasPrefix(key, "instances_") {
-			continue
+	err := FlavorSelection{}.ForeachFlavor(computeV2, func(f FullFlavor) error {
+		if f.ExtraSpecs["quota:separate"] == "true" {
+			flavorNames = append(flavorNames, f.Flavor.Name)
 		}
-		flavorName := strings.TrimPrefix(key, "instances_")
-		flavorNames = append(flavorNames, flavorName)
-		t.recordNovaPreferredName(flavorName)
-	}
-
-	return flavorNames, nil
+		return nil
+	})
+	return flavorNames, err
 }


### PR DESCRIPTION
This used to be where our Ironic team indicates to Nova which flavors use separate instance quotas. This is duplicate with the existing `quota:separate` extra spec on the flavor and caused frequent inconsistencies. The Nova implementation has now been migrated to check the `quota:separate` extra spec directly.

I tested this in QA; `test-get-quota` output did not change from before to after.