### PR TITLE
always allow creating commitments to cover existing usage

### DIFF
--- a/internal/datamodel/allocation_stats_test.go
+++ b/internal/datamodel/allocation_stats_test.go
@@ -1,0 +1,69 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package datamodel
+
+import (
+	"testing"
+
+	"github.com/sapcc/go-bits/assert"
+
+	"github.com/sapcc/limes/internal/db"
+)
+
+func TestCanAcceptCommitmentChanges(t *testing.T) {
+	// trivially acceptable because there is plenty of unassigned capacity
+	stats := clusterAZAllocationStats{
+		Capacity: 420,
+		ProjectStats: map[db.ProjectResourceID]projectAZAllocationStats{
+			1: {Committed: 5, Usage: 10},
+			2: {Committed: 5, Usage: 10},
+			3: {Committed: 5, Usage: 10},
+		},
+	}
+	additions := map[db.ProjectResourceID]uint64{2: 100}
+	result := stats.CanAcceptCommitmentChanges(additions, nil)
+	assert.DeepEqual(t, "CanAcceptCommitmentChanges", result, true)
+
+	// not acceptable because there is not enough spare capacity (30/35 is already covered by allocations)
+	stats.Capacity = 35
+	additions = map[db.ProjectResourceID]uint64{2: 20}
+	result = stats.CanAcceptCommitmentChanges(additions, nil)
+	assert.DeepEqual(t, "CanAcceptCommitmentChanges", result, false)
+
+	// acceptable because this does not move allocations (a commitment is made within a project's existing usage)
+	stats.Capacity = 35
+	additions = map[db.ProjectResourceID]uint64{2: 5}
+	result = stats.CanAcceptCommitmentChanges(additions, nil)
+	assert.DeepEqual(t, "CanAcceptCommitmentChanges", result, true)
+
+	// acceptable! reported capacity is already way overcommitted,
+	// but as a special exception, we always allow commitments that cover existing usage
+	stats.Capacity = 20
+	additions = map[db.ProjectResourceID]uint64{2: 5}
+	result = stats.CanAcceptCommitmentChanges(additions, nil)
+	assert.DeepEqual(t, "CanAcceptCommitmentChanges", result, true)
+
+	// acceptable! plain subtractions are always possible, even
+	// if the target state has the reported capacity overcommitted
+	stats.Capacity = 20
+	subtractions := map[db.ProjectResourceID]uint64{2: 3}
+	result = stats.CanAcceptCommitmentChanges(nil, subtractions)
+	assert.DeepEqual(t, "CanAcceptCommitmentChanges", result, true)
+}

--- a/internal/datamodel/confirm_project_commitments.go
+++ b/internal/datamodel/confirm_project_commitments.go
@@ -66,7 +66,7 @@ func CanConfirmNewCommitment(req limesresources.CommitmentRequest, resourceID db
 	stats := statsByAZ[req.AvailabilityZone]
 
 	additions := map[db.ProjectResourceID]uint64{resourceID: req.Amount}
-	return stats.FitsAfterCommitmentChanges(additions, nil), nil
+	return stats.CanAcceptCommitmentChanges(additions, nil), nil
 }
 
 // CanMoveExistingCommitment returns whether a commitment of the given amount
@@ -81,7 +81,7 @@ func CanMoveExistingCommitment(amount uint64, loc AZResourceLocation, sourceReso
 
 	additions := map[db.ProjectResourceID]uint64{targetResourceID: amount}
 	subtractions := map[db.ProjectResourceID]uint64{sourceResourceID: amount}
-	return stats.FitsAfterCommitmentChanges(additions, subtractions), nil
+	return stats.CanAcceptCommitmentChanges(additions, subtractions), nil
 }
 
 // ConfirmPendingCommitments goes through all unconfirmed commitments that
@@ -117,7 +117,7 @@ func ConfirmPendingCommitments(serviceType limes.ServiceType, resourceName limes
 	for _, c := range confirmableCommitments {
 		// ignore commitments that do not fit
 		additions := map[db.ProjectResourceID]uint64{c.ProjectResourceID: c.Amount}
-		if !stats.FitsAfterCommitmentChanges(additions, nil) {
+		if !stats.CanAcceptCommitmentChanges(additions, nil) {
 			continue
 		}
 


### PR DESCRIPTION
The previous situation was that, as soon as capacity was overcommitted, no new commitments could be made at all. Product management decided that this was undesirable because it locks customers out of discounted prices for committed resources through no fault of their own.

The function in question previously had test coverage indirectly through more high-level functions like ConfirmPendingCommitments. For this new exception, I added a specific testcase because this is easier than adjusting the high-level tests in the API or the ResourceScrapeJob.