### PR TITLE
plugins/swift: do not try to assign base quota to deleted Swift accounts

### DIFF
--- a/internal/plugins/swift.go
+++ b/internal/plugins/swift.go
@@ -133,6 +133,7 @@ func (p *swiftPlugin) Scrape(project core.KeystoneProject, allAZs []limes.Availa
 		return map[limesresources.ResourceName]core.ResourceData{
 			"capacity": {
 				Quota:     0,
+				MaxQuota:  p2u64(0), // do not try to assign quota to this project in ApplyComputedProjectQuota(), it will not work
 				UsageData: core.InAnyAZ(core.UsageData{Usage: 0}),
 			},
 		}, nil, nil


### PR DESCRIPTION
As part of the project deletion process, customers are expected to delete their Swift accounts. Between the account deletion and the actual project deletion, we now get a lot of errors from limes-collect like:

```
2024/06/17 13:07:46 ERROR: could not sync object-store quotas for project monsoon3/cc-demo2: could not PUT "<account>" in Swift: expected 201/202 response, got 403 instead: Recently deleted
```

because Limes is still trying to assign base quota to these projects even though there is no Swift account to write the quota into.