### PR TITLE
fix quota overcommit being forced off by an entirely empty AZ

### DIFF
--- a/internal/datamodel/allocation_stats.go
+++ b/internal/datamodel/allocation_stats.go
@@ -55,6 +55,11 @@ func (c clusterAZAllocationStats) AllowsQuotaOvercommit(cfg core.AutogrowQuotaDi
 	for _, stats := range c.ProjectStats {
 		usedCapacity += max(stats.Committed, stats.Usage)
 	}
+	if c.Capacity == 0 {
+		// explicit special case to avoid divide-by-zero below
+		return usedCapacity == 0
+	}
+
 	usedPercent := 100 * float64(usedCapacity) / float64(c.Capacity)
 	return usedPercent < cfg.AllowQuotaOvercommitUntilAllocatedPercent
 }


### PR DESCRIPTION
We allow quota overcommit for the "any" AZ if all real AZs allow it. But because of a divide-by-zero error, this condition was evaluated incorrectly for AZs with zero capacity and zero usage. Now we correctly ignore such AZs.