### PR TITLE
plugins/nova: add support for hardware-versioned quota

### DIFF
--- a/docs/operators/config.md
+++ b/docs/operators/config.md
@@ -343,6 +343,14 @@ same flavor, and Limes prefers the name `bm_newflavor2`. The preferred name will
 for the respective separate instance quota. In the previous example, the resource will be called
 `instances_bm_newflavor2` since `bm_newflavor2` is the flavor alias that Limes prefers.
 
+#### Hardware-versioned quota
+
+On SAP Converged Cloud (or any other OpenStack cluster where Nova carries the relevant patches), there will be
+additional resources following the name pattern `hw_version_(.+)_(cores|instances|ram)`. Any of these resources that
+exist will also be reported by Limes. (Not all resources may exist for a given hardware version). They behave like the
+regular `cores`/`instances`/`ram` resources and cover instances whose flavors have the respective value in the
+`quota:hw_version` extra spec.
+
 ### `dns`: Designate v2
 
 ```yaml

--- a/internal/plugins/nova_subresources.go
+++ b/internal/plugins/nova_subresources.go
@@ -51,6 +51,7 @@ type novaInstanceSubresource struct {
 	MemoryMiB      limes.ValueWithUnit  `json:"ram"`
 	DiskGiB        limes.ValueWithUnit  `json:"disk"`
 	VideoMemoryMiB *limes.ValueWithUnit `json:"video_ram,omitempty"`
+	HWVersion      string               `json:"-"` // this is only used for sorting the subresource into the right resource
 	// information from image
 	OSType string `json:"os_type"`
 }
@@ -97,6 +98,7 @@ func (p *novaPlugin) buildInstanceSubresource(instance nova.Instance) (res novaI
 			}
 		}
 	}
+	res.HWVersion = flavorInfo.ExtraSpecs["quota:hw_version"]
 
 	// calculate classifications based on flavor data
 	if len(p.HypervisorTypeRules) > 0 {


### PR DESCRIPTION
Ref: <https://github.com/sapcc/nova/pull/469>

I tested in prod that `limes test-get-quota` returns the same output before and after the change (since no hardware-versioned quotas exist there yet).