### PR TITLE
Add GET commitment by token endpoint

### DIFF
--- a/docs/users/api-spec-resources.md
+++ b/docs/users/api-spec-resources.md
@@ -592,6 +592,9 @@ Requires a generated token from the API: `/v1/domains/:id/projects/:id/commitmen
 On success the API clears the `transfer_token` and `transfer_status` from the commitment.
 After that, it returns the commitment as a JSON document.  
 
+### GET "/v1/domains/:id/projects/:id/commitments/:token"
+To ensure that a commitment can be checked for its `resource` type or `availability zone` before it gets transferred to a target project, this endpoint fetches the target commitment by its respective token.
+
 ### DELETE /v1/domains/:domain\_id/projects/:project\_id/commitments/:id
 
 Deletes a commitment within the given project. Requires a cloud-admin token. On success, returns 204 (No Content).

--- a/docs/users/api-spec-resources.md
+++ b/docs/users/api-spec-resources.md
@@ -592,7 +592,7 @@ Requires a generated token from the API: `/v1/domains/:id/projects/:id/commitmen
 On success the API clears the `transfer_token` and `transfer_status` from the commitment.
 After that, it returns the commitment as a JSON document.  
 
-### GET "/v1/domains/:id/projects/:id/commitments/:token"
+### GET /v1/domains/:id/projects/:id/commitments/:token
 To ensure that a commitment can be checked for its `resource` type or `availability zone` before it gets transferred to a target project, this endpoint fetches the target commitment by its respective token.
 
 ### DELETE /v1/domains/:domain\_id/projects/:project\_id/commitments/:id

--- a/docs/users/api-spec-resources.md
+++ b/docs/users/api-spec-resources.md
@@ -592,7 +592,7 @@ Requires a generated token from the API: `/v1/domains/:id/projects/:id/commitmen
 On success the API clears the `transfer_token` and `transfer_status` from the commitment.
 After that, it returns the commitment as a JSON document.  
 
-### GET /v1/domains/:id/projects/:id/commitments/:token
+### GET /v1/commitments/:token
 To ensure that a commitment can be checked for its `resource` type or `availability zone` before it gets transferred to a target project, this endpoint fetches the target commitment by its respective token.
 
 ### DELETE /v1/domains/:domain\_id/projects/:project\_id/commitments/:id

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -627,9 +627,9 @@ func (p *v1Provider) buildSplitCommitment(dbCommitment db.ProjectCommitment, amo
 	}
 }
 
-// GetCommitmentByTransferToken handles GET /v1/domains/{domain_id}/projects/{project_id}/commitments/{token}
+// GetCommitmentByTransferToken handles GET /v1/commitments/{token}
 func (p *v1Provider) GetCommitmentByTransferToken(w http.ResponseWriter, r *http.Request) {
-	httpapi.IdentifyEndpoint(r, "/v1/domains/:id/projects/:id/commitments/:token")
+	httpapi.IdentifyEndpoint(r, "/v1/commitments/:token")
 	token := p.CheckToken(r)
 	if !token.Require(w, "project:show") {
 		http.Error(w, "insufficient access rights.", http.StatusForbidden)
@@ -638,16 +638,6 @@ func (p *v1Provider) GetCommitmentByTransferToken(w http.ResponseWriter, r *http
 	transferToken := mux.Vars(r)["token"]
 	if transferToken == "" {
 		http.Error(w, "no transfer token provided", http.StatusBadRequest)
-		return
-	}
-	dbDomain := p.FindDomainFromRequest(w, r)
-	if dbDomain == nil {
-		http.Error(w, "domain not found.", http.StatusNotFound)
-		return
-	}
-	dbProject := p.FindProjectFromRequest(w, r, dbDomain)
-	if dbProject == nil {
-		http.Error(w, "project not found.", http.StatusNotFound)
 		return
 	}
 
@@ -694,13 +684,6 @@ func (p *v1Provider) GetCommitmentByTransferToken(w http.ResponseWriter, r *http
 	}
 
 	c := p.convertCommitmentToDisplayForm(dbCommitment, loc, token)
-	logAndPublishEvent(p.timeNow(), r, token, http.StatusAccepted, commitmentEventTarget{
-		DomainID:    dbDomain.UUID,
-		DomainName:  dbDomain.Name,
-		ProjectID:   dbProject.UUID,
-		ProjectName: dbProject.Name,
-		Commitment:  c,
-	})
 	respondwith.JSON(w, http.StatusAccepted, map[string]any{"commitment": c})
 }
 

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -666,7 +666,7 @@ func (p *v1Provider) GetCommitmentByTransferToken(w http.ResponseWriter, r *http
 	var dbCommitment db.ProjectCommitment
 	err = p.DB.SelectOne(&dbCommitment, findCommitmentByTransferToken, transferToken)
 	if errors.Is(err, sql.ErrNoRows) {
-		http.Error(w, "commitment unexpectingly not found.", http.StatusNotFound)
+		http.Error(w, "commitment unexpectedly not found.", http.StatusNotFound)
 		return
 	} else if respondwith.ErrorText(w, err) {
 		return

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -632,14 +632,9 @@ func (p *v1Provider) GetCommitmentByTransferToken(w http.ResponseWriter, r *http
 	httpapi.IdentifyEndpoint(r, "/v1/commitments/:token")
 	token := p.CheckToken(r)
 	if !token.Require(w, "project:show") {
-		http.Error(w, "insufficient access rights.", http.StatusForbidden)
 		return
 	}
 	transferToken := mux.Vars(r)["token"]
-	if transferToken == "" {
-		http.Error(w, "no transfer token provided", http.StatusBadRequest)
-		return
-	}
 
 	// The token column is a unique key, so we expect only one result.
 	var dbCommitment db.ProjectCommitment
@@ -671,7 +666,6 @@ func (p *v1Provider) TransferCommitment(w http.ResponseWriter, r *http.Request) 
 	httpapi.IdentifyEndpoint(r, "/v1/domains/:id/projects/:id/transfer-commitment/:id")
 	token := p.CheckToken(r)
 	if !token.Require(w, "project:edit") {
-		http.Error(w, "insufficient access rights.", http.StatusForbidden)
 		return
 	}
 	transferToken := r.Header.Get("Transfer-Token")

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -702,7 +702,6 @@ func (p *v1Provider) GetCommitmentByTransferToken(w http.ResponseWriter, r *http
 		Commitment:  c,
 	})
 	respondwith.JSON(w, http.StatusAccepted, map[string]any{"commitment": c})
-
 }
 
 // TransferCommitment handles POST /v1/domains/{domain_id}/projects/{project_id}/transfer-commitment/{id}?token={token}

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -88,7 +88,7 @@ var (
 		SELECT * FROM project_commitments WHERE id = $1 AND transfer_token = $2
 	`)
 	findCommitmentByTransferToken = sqlext.SimplifyWhitespace(`
-		SELECT * from project_commitments where transfer_token = $1
+		SELECT * FROM project_commitments WHERE transfer_token = $1
    `)
 	findTargetAZResourceIDBySourceIDQuery = sqlext.SimplifyWhitespace(`
 		WITH source as (

--- a/internal/api/commitment_test.go
+++ b/internal/api/commitment_test.go
@@ -802,7 +802,7 @@ func Test_GetCommitmentByToken(t *testing.T) {
 	// Get commitment by token.
 	assert.HTTPRequest{
 		Method:       http.MethodGet,
-		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-dresden/commitments/" + transferToken,
+		Path:         "/v1/commitments/" + transferToken,
 		ExpectBody:   assert.JSONObject{"commitment": resp1},
 		ExpectStatus: http.StatusAccepted,
 	}.Check(t, s.Handler)
@@ -810,7 +810,7 @@ func Test_GetCommitmentByToken(t *testing.T) {
 	// Now check a token that does not exist.
 	assert.HTTPRequest{
 		Method:       http.MethodGet,
-		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-dresden/commitments/" + "notExistingToken",
+		Path:         "/v1/commitments/" + "notExistingToken",
 		ExpectStatus: http.StatusNotFound,
 		ExpectBody:   assert.StringData("no matching commitment found.\n"),
 	}.Check(t, s.Handler)
@@ -831,7 +831,7 @@ func Test_GetCommitmentByToken(t *testing.T) {
 	}.Check(t, s.Handler)
 	assert.HTTPRequest{
 		Method:       http.MethodGet,
-		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-dresden/commitments/" + transferToken,
+		Path:         "/v1/commitments/" + transferToken,
 		ExpectStatus: http.StatusConflict,
 		ExpectBody:   assert.StringData("detected multiple commitments with the same token.\n"),
 	}.Check(t, s.Handler)

--- a/internal/api/commitment_test.go
+++ b/internal/api/commitment_test.go
@@ -741,38 +741,12 @@ func Test_GetCommitmentByToken(t *testing.T) {
 		"amount":            10,
 		"duration":          "1 hour",
 	}
-	req2 := assert.JSONObject{
-		"id":                2,
-		"service_type":      "second",
-		"resource_name":     "capacity",
-		"availability_zone": "az-two",
-		"amount":            20,
-		"duration":          "1 hour",
-	}
-
 	resp1 := assert.JSONObject{
 		"id":                1,
 		"service_type":      "second",
 		"resource_name":     "capacity",
 		"availability_zone": "az-two",
 		"amount":            10,
-		"unit":              "B",
-		"duration":          "1 hour",
-		"created_at":        s.Clock.Now().Unix(),
-		"creator_uuid":      "uuid-for-alice",
-		"creator_name":      "alice@Default",
-		"can_be_deleted":    true,
-		"confirmed_at":      0,
-		"expires_at":        3600,
-		"transfer_status":   "unlisted",
-		"transfer_token":    transferToken,
-	}
-	resp2 := assert.JSONObject{
-		"id":                2,
-		"service_type":      "second",
-		"resource_name":     "capacity",
-		"availability_zone": "az-two",
-		"amount":            20,
 		"unit":              "B",
 		"duration":          "1 hour",
 		"created_at":        s.Clock.Now().Unix(),
@@ -813,27 +787,6 @@ func Test_GetCommitmentByToken(t *testing.T) {
 		Path:         "/v1/commitments/" + "notExistingToken",
 		ExpectStatus: http.StatusNotFound,
 		ExpectBody:   assert.StringData("no matching commitment found.\n"),
-	}.Check(t, s.Handler)
-
-	// Token exists twice in the database.
-	assert.HTTPRequest{
-		Method:       http.MethodPost,
-		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-dresden/commitments/new",
-		Body:         assert.JSONObject{"commitment": req2},
-		ExpectStatus: http.StatusCreated,
-	}.Check(t, s.Handler)
-	assert.HTTPRequest{
-		Method:       "POST",
-		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-dresden/commitments/2/start-transfer",
-		ExpectStatus: http.StatusAccepted,
-		ExpectBody:   assert.JSONObject{"commitment": resp2},
-		Body:         assert.JSONObject{"commitment": assert.JSONObject{"amount": 20, "transfer_status": "unlisted"}},
-	}.Check(t, s.Handler)
-	assert.HTTPRequest{
-		Method:       http.MethodGet,
-		Path:         "/v1/commitments/" + transferToken,
-		ExpectStatus: http.StatusConflict,
-		ExpectBody:   assert.StringData("detected multiple commitments with the same token.\n"),
 	}.Check(t, s.Handler)
 }
 

--- a/internal/api/commitment_test.go
+++ b/internal/api/commitment_test.go
@@ -678,9 +678,15 @@ func Test_StartCommitmentTransfer(t *testing.T) {
 		Body:         assert.JSONObject{"commitment": assert.JSONObject{"amount": 10, "transfer_status": "unlisted"}},
 	}.Check(t, s.Handler)
 
+	assert.HTTPRequest{
+		Method:       http.MethodDelete,
+		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/1",
+		ExpectStatus: http.StatusNoContent,
+	}.Check(t, s.Handler)
+
 	// TransferAmount < CommitmentAmount
 	resp2 := assert.JSONObject{
-		"id":                2,
+		"id":                3,
 		"service_type":      "second",
 		"resource_name":     "capacity",
 		"availability_zone": "az-two",
@@ -698,8 +704,15 @@ func Test_StartCommitmentTransfer(t *testing.T) {
 	}
 
 	assert.HTTPRequest{
+		Method:       http.MethodPost,
+		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/new",
+		Body:         assert.JSONObject{"commitment": req1},
+		ExpectStatus: http.StatusCreated,
+	}.Check(t, s.Handler)
+
+	assert.HTTPRequest{
 		Method:       "POST",
-		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/1/start-transfer",
+		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/2/start-transfer",
 		ExpectStatus: http.StatusAccepted,
 		ExpectBody:   assert.JSONObject{"commitment": resp2},
 		Body:         assert.JSONObject{"commitment": assert.JSONObject{"amount": 9, "transfer_status": "public"}},
@@ -717,7 +730,7 @@ func Test_StartCommitmentTransfer(t *testing.T) {
 	// Negative Test, delivered amount > commitment amount
 	assert.HTTPRequest{
 		Method:       "POST",
-		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/1/start-transfer",
+		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/2/start-transfer",
 		ExpectStatus: http.StatusBadRequest,
 		ExpectBody:   assert.StringData("delivered amount exceeds the commitment amount.\n"),
 		Body:         assert.JSONObject{"commitment": assert.JSONObject{"amount": 11, "transfer_status": "public"}},

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -163,7 +163,7 @@ func (p *v1Provider) AddTo(r *mux.Router) {
 	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments/can-confirm").HandlerFunc(p.CanConfirmNewProjectCommitment)
 	r.Methods("DELETE").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments/{id}").HandlerFunc(p.DeleteProjectCommitment)
 	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments/{id}/start-transfer").HandlerFunc(p.StartCommitmentTransfer)
-	r.Methods("GET").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments/{token}").HandlerFunc(p.GetCommitmentByTransferToken)
+	r.Methods("GET").Path("/v1/commitments/{token}").HandlerFunc(p.GetCommitmentByTransferToken)
 	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/transfer-commitment/{id}").HandlerFunc(p.TransferCommitment)
 }
 

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -163,6 +163,7 @@ func (p *v1Provider) AddTo(r *mux.Router) {
 	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments/can-confirm").HandlerFunc(p.CanConfirmNewProjectCommitment)
 	r.Methods("DELETE").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments/{id}").HandlerFunc(p.DeleteProjectCommitment)
 	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments/{id}/start-transfer").HandlerFunc(p.StartCommitmentTransfer)
+	r.Methods("GET").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments/{token}").HandlerFunc(p.GetCommitmentByTransferToken)
 	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/transfer-commitment/{id}").HandlerFunc(p.TransferCommitment)
 }
 

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -260,10 +260,6 @@ var sqlMigrations = map[string]string{
 		ALTER TABLE project_services
 			ADD COLUMN quota_sync_duration_secs REAL NOT NULL DEFAULT 0;
 	`,
-	"044_add_unique_key_to_transfer_token.down.sql": `
-		ALTER TABLE project_commitments
-			DROP CONSTRAINT project_commitments_transfer_token_key;
-	`,
 	"044_add_unique_key_to_transfer_token.up.sql": `
 		CREATE UNIQUE INDEX on project_commitments (transfer_token)
             WHERE transfer_token <> '';

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -260,4 +260,8 @@ var sqlMigrations = map[string]string{
 		ALTER TABLE project_services
 			ADD COLUMN quota_sync_duration_secs REAL NOT NULL DEFAULT 0;
 	`,
+	"044_add_unique_key_to_transfer_token.up.sql": `
+		ALTER TABLE project_commitments 
+			ADD CONSTRAINT unique_token UNIQUE (transfer_token);
+	`,
 }

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -260,9 +260,11 @@ var sqlMigrations = map[string]string{
 		ALTER TABLE project_services
 			ADD COLUMN quota_sync_duration_secs REAL NOT NULL DEFAULT 0;
 	`,
-	"044_add_unique_key_to_transfer_token.down.sql": ``,
+	"044_add_unique_key_to_transfer_token.down.sql": `
+		DROP INDEX transfer_token_idx;
+	`,
 	"044_add_unique_key_to_transfer_token.up.sql": `
-		CREATE UNIQUE INDEX on project_commitments (transfer_token)
+		CREATE UNIQUE INDEX transfer_token_idx ON project_commitments (transfer_token)
             WHERE transfer_token <> '';
 	`,
 }

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -260,6 +260,7 @@ var sqlMigrations = map[string]string{
 		ALTER TABLE project_services
 			ADD COLUMN quota_sync_duration_secs REAL NOT NULL DEFAULT 0;
 	`,
+	"044_add_unique_key_to_transfer_token.down.sql": ``,
 	"044_add_unique_key_to_transfer_token.up.sql": `
 		CREATE UNIQUE INDEX on project_commitments (transfer_token)
             WHERE transfer_token <> '';

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -260,8 +260,12 @@ var sqlMigrations = map[string]string{
 		ALTER TABLE project_services
 			ADD COLUMN quota_sync_duration_secs REAL NOT NULL DEFAULT 0;
 	`,
+	"044_add_unique_key_to_transfer_token.down.sql": `
+		ALTER TABLE project_commitments
+			DROP CONSTRAINT project_commitments_transfer_token_key;
+	`,
 	"044_add_unique_key_to_transfer_token.up.sql": `
-		ALTER TABLE project_commitments 
-			ADD CONSTRAINT unique_token UNIQUE (transfer_token);
+		ALTER TABLE project_commitments
+			ADD CONSTRAINT UNIQUE (transfer_token);
 	`,
 }

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -266,6 +266,6 @@ var sqlMigrations = map[string]string{
 	`,
 	"044_add_unique_key_to_transfer_token.up.sql": `
 		CREATE UNIQUE INDEX on project_commitments (transfer_token)
-            where transfer_token <> '';
+            WHERE transfer_token <> '';
 	`,
 }

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -265,7 +265,7 @@ var sqlMigrations = map[string]string{
 			DROP CONSTRAINT project_commitments_transfer_token_key;
 	`,
 	"044_add_unique_key_to_transfer_token.up.sql": `
-		ALTER TABLE project_commitments
-			ADD CONSTRAINT UNIQUE (transfer_token);
+		CREATE UNIQUE INDEX on project_commitments (transfer_token)
+            where transfer_token <> '';
 	`,
 }


### PR DESCRIPTION
The transfer commitment endpoint is fine in scenarios when it get called after the start-transfer endpoint, because it returns the commitment first.
Because new requirments arise that require to transfer a commitment between projects, the start-transfer endpoint and the transfer endpoint are now decoupled from each other. To mitigate this, I would like to introduce an endpoint that gets a commitment by its token.

This approach also ensures that a commitment can be checked for its details (resource, AZ) before it actually gets transferred to the target project. This is an important detail for the UI.