### PR TITLE
add LIQUID support

### DIFF
--- a/docs/operators/config.md
+++ b/docs/operators/config.md
@@ -245,6 +245,7 @@ This section lists all supported service types and the resources that are unders
 ```yaml
 services:
   - type: compute
+    service_type: compute
 ```
 
 The area for this service is `compute`.
@@ -262,6 +263,7 @@ The area for this service is `compute`.
 ```yaml
 services:
   - type: compute
+    service_type: compute
     params:
       with_subresources: true
 ```
@@ -292,6 +294,7 @@ rules supplied in the configuration like this:
 ```yaml
 services:
   - type: compute
+    service_type: compute
     params:
       hypervisor_type_rules:
         - match: extra-spec:vmware:hv_enabled # match on extra spec with name "vmware:hv_enabled"
@@ -320,6 +323,7 @@ category.
 ```yaml
 services:
   - type: compute
+    service_type: compute
     params:
       separate_instance_quotas:
         flavor_name_selection:
@@ -357,6 +361,7 @@ regular `cores`/`instances`/`ram` resources and cover instances whose flavors ha
 ```yaml
 services:
   - type: dns
+    service_type: dns
 ```
 
 The area for this service is `dns`.
@@ -373,6 +378,7 @@ When the `recordsets` quota is set, the backend quota for records is set to 20 t
 ```yaml
 services:
   - type: email-aws
+    service_type: email-aws
 ```
 
 The area for this service is `email`. This service has no resources, only rates.
@@ -389,6 +395,7 @@ The area for this service is `email`. This service has no resources, only rates.
 ```yaml
 services:
   - type: endpoint-services
+    service_type: endpoint-services
 ```
 
 The area for this service is `network`.
@@ -398,11 +405,30 @@ The area for this service is `network`.
 | `endpoints` | countable |
 | `services` | countable |
 
+### `liquid`: Any service with LIQUID support
+
+```yaml
+services:
+  - type: liquid
+    service_type: someservice
+    params:
+      area: storage
+      liquid_service_type: liquid-myservice
+```
+
+This is a generic integration method for any service that supports [LIQUID](https://pkg.go.dev/github.com/sapcc/go-api-declarations/liquid);
+see documentation over there. The LIQUID endpoint will by located in the Keystone service catalog at service type `liquid-$SERVICE_TYPE`,
+unless this default is overridden by `params.liquid_service_type`. The area for this service is as configured in `params.area`.
+
+Currently, any increase in the ServiceInfo version of the liquid will prompt a fatal error in Limes, thus usually forcing it to restart.
+This is something that we plan on changing into a graceful reload in the future.
+
 ### `keppel`: Keppel v1
 
-```
+```yaml
 services:
   - type: keppel
+    service_type: keppel
 ```
 
 The area for this service is `storage`.
@@ -416,6 +442,7 @@ The area for this service is `storage`.
 ```yaml
 services:
   - type: network
+    service_type: network
 ```
 
 The area for this service is `network`. Resources are categorized into `networking` for SDN resources and `loadbalancing` for LBaaS resources.
@@ -449,6 +476,7 @@ automatically created in a new project.
 ```yaml
 services:
   - type: object-store
+    service_type: object-store
 ```
 
 The area for this service is `storage`.
@@ -462,6 +490,7 @@ The area for this service is `storage`.
 ```yaml
 services:
   - type: sharev2
+    service_type: sharev2
     params:
       share_types:
         - name: default
@@ -561,6 +590,7 @@ The service type name refers to the v2 API for backwards compatibility reasons.
 ```yaml
 services:
   - type: volumev2
+    service_type: volumev2
     params:
       volume_types: [ vmware, vmware_hdd ]
       with_volume_subresources: true
@@ -653,6 +683,24 @@ subcapacity corresponds to one Cinder pool, and bears the following attributes:
 | `az` | string | The pool's availability zone. The AZ is determined by matching the pool's hostname against the list of services configured in Cinder. |
 | `capacity_gib` | integer | Total capacity of this pool in GiB. This corresponds to the pool's `total_capacity_gb` attribute in Cinder. |
 | `usage_gib` | integer | Usage level of this pool in GiB. This corresponds to the pool's `allocated_capacity_gb` attribute in Cinder. |
+
+### `liquid`
+
+```yaml
+capacitors:
+  - id: liquid-nova
+    type: liquid
+    params:
+      service_type: compute
+      liquid_service_type: liquid-nova
+```
+
+This is a generic integration method for any service that supports [LIQUID](https://pkg.go.dev/github.com/sapcc/go-api-declarations/liquid);
+see documentation over there. The LIQUID endpoint will by located in the Keystone service catalog at service type `liquid-$SERVICE_TYPE`,
+using the value from `params.service_type`, unless this default logic is overridden by `params.liquid_service_type`.
+
+Currently, any increase in the ServiceInfo version of the liquid will prompt a fatal error in Limes, thus usually forcing it to restart.
+This is something that we plan on changing into a graceful reload in the future.
 
 ### `manila`
 

--- a/internal/plugins/capacity_liquid.go
+++ b/internal/plugins/capacity_liquid.go
@@ -1,0 +1,136 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package plugins
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sapcc/go-api-declarations/limes"
+	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
+	"github.com/sapcc/go-api-declarations/liquid"
+	"github.com/sapcc/go-bits/logg"
+
+	"github.com/sapcc/limes/internal/core"
+)
+
+type liquidCapacityPlugin struct {
+	// configuration
+	ServiceType       limes.ServiceType `yaml:"service_type"`
+	LiquidServiceType string            `yaml:"liquid_service_type"`
+	EndpointOverride  string            `yaml:"endpoint_override"` // see comment on liquidQuotaPlugin for details
+
+	// state
+	LiquidServiceInfo liquid.ServiceInfo `yaml:"-"`
+	LiquidClient      *LiquidV1Client    `yaml:"-"`
+}
+
+func init() {
+	core.CapacityPluginRegistry.Add(func() core.CapacityPlugin { return &liquidCapacityPlugin{} })
+}
+
+// PluginTypeID implements the core.QuotaPlugin interface.
+func (p *liquidCapacityPlugin) PluginTypeID() string {
+	return "liquid"
+}
+
+// Init implements the core.QuotaPlugin interface.
+func (p *liquidCapacityPlugin) Init(ctx context.Context, client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (err error) {
+	if p.ServiceType == "" {
+		return errors.New("missing required value: params.service_type")
+	}
+	if p.LiquidServiceType == "" {
+		p.LiquidServiceType = "liquid-" + string(p.ServiceType)
+	}
+
+	p.LiquidClient, err = NewLiquidV1(client, eo, p.LiquidServiceType, p.EndpointOverride)
+	if err != nil {
+		return fmt.Errorf("cannot initialize ServiceClient for %s: %w", p.LiquidServiceType, err)
+	}
+	p.LiquidServiceInfo, err = p.LiquidClient.GetInfo(ctx)
+	return err
+}
+
+// Scrape implements the core.QuotaPlugin interface.
+func (p *liquidCapacityPlugin) Scrape(ctx context.Context, backchannel core.CapacityPluginBackchannel, allAZs []limes.AvailabilityZone) (result map[limes.ServiceType]map[limesresources.ResourceName]core.PerAZ[core.CapacityData], serializedMetrics []byte, err error) {
+	req := liquid.ServiceCapacityRequest{
+		AllAZs:           allAZs,
+		DemandByResource: make(map[liquid.ResourceName]liquid.ResourceDemand, len(p.LiquidServiceInfo.Resources)),
+	}
+
+	for resName, resInfo := range p.LiquidServiceInfo.Resources {
+		if !resInfo.HasCapacity {
+			continue
+		}
+		if !resInfo.NeedsResourceDemand {
+			continue
+		}
+		req.DemandByResource[resName], err = backchannel.GetResourceDemand(p.ServiceType, resName)
+		if err != nil {
+			return nil, nil, fmt.Errorf("while getting resource demand for %s/%s: %w", p.ServiceType, resName, err)
+		}
+	}
+
+	resp, err := p.LiquidClient.GetCapacityReport(ctx, req)
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp.InfoVersion != p.LiquidServiceInfo.Version {
+		logg.Fatal("ServiceInfo version for %s changed from %d to %d; restarting now to reload ServiceInfo...",
+			p.LiquidServiceType, p.LiquidServiceInfo.Version, resp.InfoVersion)
+	}
+
+	resultInService := make(map[limesresources.ResourceName]core.PerAZ[core.CapacityData], len(p.LiquidServiceInfo.Resources))
+	for resName := range p.LiquidServiceInfo.Resources {
+		resReport := resp.Resources[resName]
+
+		resData := make(core.PerAZ[core.CapacityData], len(resReport.PerAZ))
+		for az, azReport := range resReport.PerAZ {
+			resData[az] = &core.CapacityData{
+				Capacity:      azReport.Capacity,
+				Usage:         azReport.Usage,
+				Subcapacities: castSliceToAny(azReport.Subcapacities),
+			}
+		}
+		resultInService[resName] = resData
+	}
+	result = map[limes.ServiceType]map[limesresources.ResourceName]core.PerAZ[core.CapacityData]{
+		p.ServiceType: resultInService,
+	}
+
+	serializedMetrics, err = liquidSerializeMetrics(p.LiquidServiceInfo.CapacityMetricFamilies, resp.Metrics)
+	if err != nil {
+		return nil, nil, fmt.Errorf("while serializing metrics: %w", err)
+	}
+	return result, serializedMetrics, nil
+}
+
+// DescribeMetrics implements the core.QuotaPlugin interface.
+func (p *liquidCapacityPlugin) DescribeMetrics(ch chan<- *prometheus.Desc) {
+	liquidDescribeMetrics(ch, p.LiquidServiceInfo.CapacityMetricFamilies, nil)
+}
+
+// CollectMetrics implements the core.QuotaPlugin interface.
+func (p *liquidCapacityPlugin) CollectMetrics(ch chan<- prometheus.Metric, serializedMetrics []byte, capacitorID string) error {
+	return liquidCollectMetrics(ch, serializedMetrics, p.LiquidServiceInfo.CapacityMetricFamilies, nil, nil)
+}

--- a/internal/plugins/client_liquid.go
+++ b/internal/plugins/client_liquid.go
@@ -1,0 +1,199 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package plugins
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"slices"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sapcc/go-api-declarations/liquid"
+)
+
+type LiquidV1Client struct {
+	gophercloud.ServiceClient
+}
+
+// NewLiquidV1 creates a ServiceClient for interacting with a liquid.
+// Ref: <https://pkg.go.dev/github.com/sapcc/go-api-declarations/liquid>
+func NewLiquidV1(client *gophercloud.ProviderClient, endpointOpts gophercloud.EndpointOpts, liquidServiceType, endpointOverride string) (*LiquidV1Client, error) {
+	var (
+		endpoint string
+		err      error
+	)
+	if endpointOverride == "" {
+		endpointOpts.ApplyDefaults(liquidServiceType)
+		endpoint, err = client.EndpointLocator(endpointOpts)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		endpoint = endpointOverride
+	}
+
+	return &LiquidV1Client{
+		ServiceClient: gophercloud.ServiceClient{
+			ProviderClient: client,
+			Endpoint:       endpoint,
+			Type:           liquidServiceType,
+		},
+	}, nil
+}
+
+// GetInfo executes GET /v1/info.
+func (c *LiquidV1Client) GetInfo(ctx context.Context) (result liquid.ServiceInfo, err error) {
+	url := c.ServiceURL("v1", "info")
+	opts := gophercloud.RequestOpts{KeepResponseBody: true}
+	resp, err := c.Get(ctx, url, nil, &opts)
+	if err == nil {
+		err = parseLiquidResponse(resp, &result)
+	}
+	return
+}
+
+// GetCapacityReport executes POST /v1/report-capacity.
+func (c *LiquidV1Client) GetCapacityReport(ctx context.Context, req liquid.ServiceCapacityRequest) (result liquid.ServiceCapacityReport, err error) {
+	url := c.ServiceURL("v1", "report-capacity")
+	opts := gophercloud.RequestOpts{KeepResponseBody: true, OkCodes: []int{http.StatusOK}}
+	resp, err := c.Post(ctx, url, req, nil, &opts)
+	if err == nil {
+		err = parseLiquidResponse(resp, &result)
+	}
+	return
+}
+
+// GetUsageReport executes POST /v1/projects/:uuid/report-usage.
+func (c *LiquidV1Client) GetUsageReport(ctx context.Context, projectUUID string, req liquid.ServiceUsageRequest) (result liquid.ServiceUsageReport, err error) {
+	url := c.ServiceURL("v1", "projects", projectUUID, "report-usage")
+	opts := gophercloud.RequestOpts{KeepResponseBody: true, OkCodes: []int{http.StatusOK}}
+	resp, err := c.Post(ctx, url, req, nil, &opts)
+	if err == nil {
+		err = parseLiquidResponse(resp, &result)
+	}
+	return
+}
+
+// PutQuota executes PUT /v1/projects/:uuid/quota.
+func (c *LiquidV1Client) PutQuota(ctx context.Context, projectUUID string, req liquid.ServiceQuotaRequest) (err error) {
+	url := c.ServiceURL("v1", "projects", projectUUID, "quota")
+	opts := gophercloud.RequestOpts{KeepResponseBody: true, OkCodes: []int{http.StatusNoContent}}
+	_, err = c.Post(ctx, url, req, nil, &opts) //nolint:bodyclose // either the response is 204 and does not have a body, or it's an error and Gophercloud does a ReadAll() internally
+	return
+}
+
+// We do not use the standard response body parsing from Gophercloud
+// because we want to be strict and DisallowUnknownFields().
+func parseLiquidResponse(resp *http.Response, result any) error {
+	defer resp.Body.Close()
+	dec := json.NewDecoder(resp.Body)
+	dec.DisallowUnknownFields()
+	err := dec.Decode(&result)
+	if err != nil {
+		return fmt.Errorf("could not parse response body from %s %s: %w",
+			resp.Request.Method, resp.Request.URL.String(), err)
+	}
+	return nil
+}
+
+// Plugin-internal serialization format for metrics (see Scrape() and CollectMetrics()).
+//
+// When storing metrics from LIQUID in the Limes DB, we must also store parts of the
+// MetricFamilyInfo alongside it, since the ServiceInfo might be updated between the serialization
+// in Scrape() and the respective deserialization in CollectMetrics().
+//
+// This logic lives here because it is shared between liquidCapacityPlugin and liquidQuotaPlugin.
+type liquidSerializedMetricFamily struct {
+	LabelKeys []string        `json:"lk"`
+	Metrics   []liquid.Metric `json:"m"`
+}
+
+func liquidSerializeMetrics(families map[liquid.MetricName]liquid.MetricFamilyInfo, metrics map[liquid.MetricName][]liquid.Metric) ([]byte, error) {
+	serializableMetrics := make(map[liquid.MetricName]liquidSerializedMetricFamily, len(families))
+	for metricName, metricFamilyInfo := range families {
+		for _, metric := range metrics[metricName] {
+			if len(metric.LabelValues) != len(metricFamilyInfo.LabelKeys) {
+				return nil, fmt.Errorf("found unexpected number of label values on a %s metric: got %d values for %d keys",
+					metricName, len(metric.LabelValues), len(metricFamilyInfo.LabelKeys))
+			}
+		}
+
+		serializableMetrics[metricName] = liquidSerializedMetricFamily{
+			LabelKeys: metricFamilyInfo.LabelKeys,
+			Metrics:   metrics[metricName],
+		}
+	}
+	return json.Marshal(serializableMetrics)
+}
+
+func liquidDescribeMetrics(ch chan<- *prometheus.Desc, families map[liquid.MetricName]liquid.MetricFamilyInfo, extraLabelKeys []string) {
+	for metricName, info := range families {
+		ch <- prometheus.NewDesc(string(metricName), info.Help, append(extraLabelKeys, info.LabelKeys...), nil)
+	}
+}
+
+func liquidCollectMetrics(ch chan<- prometheus.Metric, serializedMetrics []byte, families map[liquid.MetricName]liquid.MetricFamilyInfo, extraLabelKeys, extraLabelValues []string) error {
+	var metricFamilies map[liquid.MetricName]liquidSerializedMetricFamily
+	err := json.Unmarshal(serializedMetrics, &metricFamilies)
+	if err != nil {
+		return err
+	}
+
+	for metricName, info := range families {
+		metricFamily := metricFamilies[metricName]
+
+		desc := prometheus.NewDesc(string(metricName), info.Help, append(slices.Clone(extraLabelKeys), info.LabelKeys...), nil)
+		valueType := prometheus.GaugeValue
+		if info.Type == liquid.MetricTypeCounter {
+			valueType = prometheus.CounterValue
+		}
+
+		// build a mapping from the label placements in the serialization to the currently valid one
+		labelMapping := make([]int, len(info.LabelKeys))
+		for idx, key := range info.LabelKeys {
+			labelMapping[idx] = slices.Index(metricFamily.LabelKeys, key)
+		}
+
+		// some labels are reused for all metrics
+		reorderedLabels := make([]string, len(extraLabelValues)+len(info.LabelKeys))
+		copy(reorderedLabels[0:len(extraLabelValues)], extraLabelValues)
+		for _, metric := range metricFamily.Metrics {
+			// fill the remaining slots with the metrics' specific label values
+			offset := len(extraLabelValues)
+			for targetIdx, sourceIdx := range labelMapping {
+				if sourceIdx == -1 {
+					reorderedLabels[offset+targetIdx] = ""
+				} else {
+					reorderedLabels[offset+targetIdx] = metric.LabelValues[sourceIdx]
+				}
+			}
+			m, err := prometheus.NewConstMetric(desc, valueType, metric.Value, reorderedLabels...)
+			if err != nil {
+				return err
+			}
+			ch <- m
+		}
+	}
+
+	return nil
+}

--- a/internal/plugins/liquid.go
+++ b/internal/plugins/liquid.go
@@ -1,0 +1,201 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package plugins
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"slices"
+	"strings"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sapcc/go-api-declarations/limes"
+	limesrates "github.com/sapcc/go-api-declarations/limes/rates"
+	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
+	"github.com/sapcc/go-api-declarations/liquid"
+	"github.com/sapcc/go-bits/logg"
+
+	"github.com/sapcc/limes/internal/core"
+)
+
+type liquidQuotaPlugin struct {
+	// configuration
+	Area              string            `yaml:"area"`
+	LiquidServiceType string            `yaml:"liquid_service_type"`
+	ServiceType       limes.ServiceType `yaml:"-"`
+
+	// TODO: remove EndpointOverride once obsolete
+	//
+	// My ultimate goal is to move the test harness for quota/capacity plugins into limesctl, once the
+	// plugins are rewritten into liquids. Until then, this override can be set to something like
+	// "http://localhost:8000" to target a development copy of a liquid.
+	EndpointOverride string `yaml:"endpoint_override"`
+
+	// state
+	LiquidServiceInfo liquid.ServiceInfo `yaml:"-"`
+	LiquidClient      *LiquidV1Client    `yaml:"-"`
+}
+
+func init() {
+	core.QuotaPluginRegistry.Add(func() core.QuotaPlugin { return &liquidQuotaPlugin{} })
+}
+
+// PluginTypeID implements the core.QuotaPlugin interface.
+func (p *liquidQuotaPlugin) PluginTypeID() string {
+	return "liquid"
+}
+
+// Init implements the core.QuotaPlugin interface.
+func (p *liquidQuotaPlugin) Init(ctx context.Context, client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, serviceType limes.ServiceType) (err error) {
+	if p.Area == "" {
+		return errors.New("missing required value: params.area")
+	}
+	p.ServiceType = serviceType
+	if p.LiquidServiceType == "" {
+		p.LiquidServiceType = "liquid-" + string(p.ServiceType)
+	}
+
+	p.LiquidClient, err = NewLiquidV1(client, eo, p.LiquidServiceType, p.EndpointOverride)
+	if err != nil {
+		return fmt.Errorf("cannot initialize ServiceClient for liquid-%s: %w", serviceType, err)
+	}
+	p.LiquidServiceInfo, err = p.LiquidClient.GetInfo(ctx)
+	return err
+}
+
+// ServiceInfo implements the core.QuotaPlugin interface.
+func (p *liquidQuotaPlugin) ServiceInfo(serviceType limes.ServiceType) limes.ServiceInfo {
+	return limes.ServiceInfo{
+		Type:        serviceType,
+		ProductName: strings.TrimPrefix(p.LiquidServiceType, "liquid-"),
+		Area:        p.Area,
+	}
+}
+
+// Resources implements the core.QuotaPlugin interface.
+func (p *liquidQuotaPlugin) Resources() []limesresources.ResourceInfo {
+	result := make([]limesresources.ResourceInfo, 0, len(p.LiquidServiceInfo.Resources))
+	for resName, resInfo := range p.LiquidServiceInfo.Resources {
+		result = append(result, limesresources.ResourceInfo{
+			Name:     resName,
+			Unit:     resInfo.Unit,
+			Category: "", // TODO: once required, add plugin configuration for the category mapping
+			NoQuota:  !resInfo.HasQuota,
+		})
+	}
+	slices.SortFunc(result, func(lhs, rhs limesresources.ResourceInfo) int {
+		return strings.Compare(string(lhs.Name), string(rhs.Name))
+	})
+	return result
+}
+
+// Scrape implements the core.QuotaPlugin interface.
+func (p *liquidQuotaPlugin) Scrape(ctx context.Context, project core.KeystoneProject, allAZs []limes.AvailabilityZone) (result map[limesresources.ResourceName]core.ResourceData, serializedMetrics []byte, err error) {
+	req := liquid.ServiceUsageRequest{AllAZs: allAZs}
+	resp, err := p.LiquidClient.GetUsageReport(ctx, project.UUID, req)
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp.InfoVersion != p.LiquidServiceInfo.Version {
+		logg.Fatal("ServiceInfo version for %s changed from %d to %d; restarting now to reload ServiceInfo...",
+			p.LiquidServiceType, p.LiquidServiceInfo.Version, resp.InfoVersion)
+	}
+
+	result = make(map[limesresources.ResourceName]core.ResourceData, len(p.LiquidServiceInfo.Resources))
+	for resName := range p.LiquidServiceInfo.Resources {
+		resReport := resp.Resources[resName]
+
+		var resData core.ResourceData
+		if resReport.Quota != nil {
+			resData.Quota = *resReport.Quota
+		}
+		if resReport.Forbidden {
+			resData.MaxQuota = p2u64(0) // this is a temporary approximation; TODO: make Forbidden a first-class citizen in Limes core
+		}
+
+		resData.UsageData = make(core.PerAZ[core.UsageData], len(resReport.PerAZ))
+		for az, azReport := range resReport.PerAZ {
+			resData.UsageData[az] = &core.UsageData{
+				Usage:         azReport.Usage,
+				PhysicalUsage: azReport.PhysicalUsage,
+				Subresources:  castSliceToAny(azReport.Subresources),
+			}
+		}
+
+		result[resName] = resData
+	}
+
+	serializedMetrics, err = liquidSerializeMetrics(p.LiquidServiceInfo.UsageMetricFamilies, resp.Metrics)
+	if err != nil {
+		return nil, nil, fmt.Errorf("while serializing metrics: %w", err)
+	}
+	return result, serializedMetrics, nil
+}
+
+func castSliceToAny[T any](input []T) (output []any) {
+	if input == nil {
+		return nil
+	}
+	output = make([]any, len(input))
+	for idx, val := range input {
+		output[idx] = val
+	}
+	return output
+}
+
+// SetQuota implements the core.QuotaPlugin interface.
+func (p *liquidQuotaPlugin) SetQuota(ctx context.Context, project core.KeystoneProject, quotas map[limesresources.ResourceName]uint64) error {
+	req := liquid.ServiceQuotaRequest{
+		Resources: make(map[liquid.ResourceName]liquid.ResourceQuotaRequest, len(quotas)),
+	}
+	for resName, quota := range quotas {
+		req.Resources[resName] = liquid.ResourceQuotaRequest{Quota: quota}
+	}
+
+	return p.LiquidClient.PutQuota(ctx, project.UUID, req)
+}
+
+// Rates implements the core.QuotaPlugin interface.
+func (p *liquidQuotaPlugin) Rates() []limesrates.RateInfo {
+	return nil
+}
+
+// ScrapeRates implements the core.QuotaPlugin interface.
+func (p *liquidQuotaPlugin) ScrapeRates(ctx context.Context, project core.KeystoneProject, prevSerializedState string) (result map[limesrates.RateName]*big.Int, serializedState string, err error) {
+	return nil, "", nil
+}
+
+// DescribeMetrics implements the core.QuotaPlugin interface.
+func (p *liquidQuotaPlugin) DescribeMetrics(ch chan<- *prometheus.Desc) {
+	liquidDescribeMetrics(ch, p.LiquidServiceInfo.UsageMetricFamilies,
+		[]string{"domain_id", "project_id"},
+	)
+}
+
+// CollectMetrics implements the core.QuotaPlugin interface.
+func (p *liquidQuotaPlugin) CollectMetrics(ch chan<- prometheus.Metric, project core.KeystoneProject, serializedMetrics []byte) error {
+	return liquidCollectMetrics(ch, serializedMetrics, p.LiquidServiceInfo.UsageMetricFamilies,
+		[]string{"domain_id", "project_id"},
+		[]string{project.Domain.UUID, project.UUID},
+	)
+}


### PR DESCRIPTION
I believe these plugins to be feature-complete, but since the only existing LIQUID implementation is in Keppel, I cannot test most of it. `test-get-quota` against liquid-keppel works fine:

```
$ tail -n 6 config-eu-de-1.yaml
- service_type: keppel
  type: liquid
  params:
    area: storage
    endpoint_override: https://keppel.eu-de-1.cloud.sap/liquid/

$ make && env LIMES_DEBUG=true ./build/limes test-get-quota config-eu-de-1.yaml $EXAMPLE_PROJECT_ID keppel
...
{
  "images": {
    "Quota": 25000,
    "MinQuota": null,
    "MaxQuota": null,
    "UsageData": {
      "any": {
        "Usage": 12115,
        "PhysicalUsage": null,
        "Subresources": null
      }
    }
  }
}
```

(This is using the EndpointOverride config option because the service catalog entry for liquid-keppel is currently stuck in seeding hell.)

But liquid-keppel reports neither capacity nor metrics, so there is not really any way to test these parts right now. I would still like to get this merged now; test coverage will come as I convert more plugins into liquids. First up would be the Swift plugin because it's reasonably small and tests metrics support, and then after that one of the smaller ones that reports capacity (e.g. Cinder).