### PR TITLE
Update go api declaration dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/prometheus/client_golang v1.19.1
 	github.com/prometheus/common v0.55.0
 	github.com/rs/cors v1.11.0
-	github.com/sapcc/go-api-declarations v1.12.0
+	github.com/sapcc/go-api-declarations v1.12.1
 	github.com/sapcc/go-bits v0.0.0-20240726114140-af63b792c283
 	go.uber.org/automaxprocs v1.5.3
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56

--- a/go.sum
+++ b/go.sum
@@ -148,8 +148,8 @@ github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjR
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/rs/cors v1.11.0 h1:0B9GE/r9Bc2UxRMMtymBkHTenPkHDv0CW4Y98GBY+po=
 github.com/rs/cors v1.11.0/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
-github.com/sapcc/go-api-declarations v1.12.0 h1:lFgLbufRQ+rZOaJctF0Tw+6KWYvtRhnpVimtaNzc2So=
-github.com/sapcc/go-api-declarations v1.12.0/go.mod h1:83R3hTANhuRXt/pXDby37IJetw8l7DG41s33Tp9NXxI=
+github.com/sapcc/go-api-declarations v1.12.1 h1:1/QfRD7D4OGfZv3F1HGFwwAJtiuYUvjqE/XhE4UnpCc=
+github.com/sapcc/go-api-declarations v1.12.1/go.mod h1:83R3hTANhuRXt/pXDby37IJetw8l7DG41s33Tp9NXxI=
 github.com/sapcc/go-bits v0.0.0-20240726114140-af63b792c283 h1:6yOacq/+DZcmfL2n3cZ9xphqqHCtqoueFJ4o62c57vs=
 github.com/sapcc/go-bits v0.0.0-20240726114140-af63b792c283/go.mod h1:AWYXw+xIyaouPyJj6s1M66t/Txw0r0ft6X5Pgljg/R0=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -139,7 +139,7 @@ github.com/rabbitmq/amqp091-go
 ## explicit; go 1.13
 github.com/rs/cors
 github.com/rs/cors/internal
-# github.com/sapcc/go-api-declarations v1.12.0
+# github.com/sapcc/go-api-declarations v1.12.1
 ## explicit; go 1.21
 github.com/sapcc/go-api-declarations/bininfo
 github.com/sapcc/go-api-declarations/cadf


### PR DESCRIPTION
Update go-api-declarations to 1.12.1. Changes the `transferToken` type of a commitment to a pointer to treat it as a unique key.