### PR TITLE
optimize SQL query in collectAZAllocationStats()

### DIFF
--- a/internal/datamodel/allocation_stats.go
+++ b/internal/datamodel/allocation_stats.go
@@ -119,13 +119,13 @@ var (
 	`)
 
 	getUsageInResourceQuery = sqlext.SimplifyWhitespace(`
-		SELECT pr.id, par.az, par.usage, par.historical_usage,
-		       (SELECT COALESCE(SUM(pc.amount), 0) FROM project_commitments pc
-		         WHERE pc.az_resource_id = par.id AND pc.state = 'active')
+		SELECT pr.id, par.az, par.usage, par.historical_usage, COALESCE(SUM(pc.amount), 0)
 		  FROM project_services ps
 		  JOIN project_resources pr ON pr.service_id = ps.id
 		  JOIN project_az_resources par ON par.resource_id = pr.id
+		  LEFT OUTER JOIN project_commitments pc ON pc.az_resource_id = par.id AND pc.state = 'active'
 		 WHERE ps.type = $1 AND pr.name = $2 AND ($3::text IS NULL OR par.az = $3)
+		 GROUP BY pr.id, par.az, par.usage, par.historical_usage
 	`)
 )
 


### PR DESCRIPTION
Rewriting from a sub-SELECT into a LEFT OUTER JOIN is something that I expected the query optimizer to be able to do, but evidently not. This change increases performance by a factor of about 70 (i.e. 7000%) in my tests on eu-de-1. EXPLAINs below before for reference (first before, then after).

```
postgres@127.0.0.1:limes> EXPLAIN (ANALYZE,BUFFERS) SELECT pr.id, par.az, par.usage, par.historical_usage, (SELECT COALESCE(SUM(pc.amount), 0) FROM project_commitments pc WHERE pc.az_resource_id = par.id AND pc.state = 'active') FROM project_services ps JOIN project_resources pr ON pr.service_id = ps.id JOIN project_az_resources par ON par.resource_id = pr.id WHERE ps.type = 'compute' AND pr.name = 'cores';
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| QUERY PLAN                                                                                                                                                                 |
|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| Nested Loop  (cost=0.84..305593.43 rows=908 width=82) (actual time=13.005..16142.820 rows=10257 loops=1)                                                                   |
|   Buffers: shared hit=2587213 read=3293                                                                                                                                    |
|   ->  Nested Loop  (cost=0.42..6126.16 rows=289 width=8) (actual time=12.060..131.534 rows=2563 loops=1)                                                                   |
|         Buffers: shared hit=9731 read=1439                                                                                                                                 |
|         ->  Seq Scan on project_services ps  (cost=0.00..1202.34 rows=2563 width=8) (actual time=12.032..19.725 rows=2563 loops=1)                                         |
|               Filter: (type = 'compute'::text)                                                                                                                             |
|               Rows Removed by Filter: 20504                                                                                                                                |
|               Buffers: shared hit=914                                                                                                                                      |
|         ->  Index Scan using project_resources_service_id_name_key on project_resources pr  (cost=0.42..1.92 rows=1 width=16) (actual time=0.042..0.042 rows=1 loops=2563) |
|               Index Cond: ((service_id = ps.id) AND (name = 'cores'::text))                                                                                                |
|               Buffers: shared hit=8815 read=1439                                                                                                                           |
|   ->  Index Scan using project_az_resources_resource_id_az_key on project_az_resources par  (cost=0.42..4.33 rows=4 width=58) (actual time=0.030..0.037 rows=4 loops=2563) |
|         Index Cond: (resource_id = pr.id)                                                                                                                                  |
|         Buffers: shared hit=13232 read=1854                                                                                                                                |
|   SubPlan 1                                                                                                                                                                |
|     ->  Aggregate  (cost=328.41..328.42 rows=1 width=32) (actual time=1.550..1.550 rows=1 loops=10257)                                                                     |
|           Buffers: shared hit=2564250                                                                                                                                      |
|           ->  Seq Scan on project_commitments pc  (cost=0.00..328.40 rows=1 width=8) (actual time=1.469..1.547 rows=0 loops=10257)                                         |
|                 Filter: ((az_resource_id = par.id) AND (state = 'active'::text))                                                                                           |
|                 Rows Removed by Filter: 5235                                                                                                                               |
|                 Buffers: shared hit=2564250                                                                                                                                |
| Planning:                                                                                                                                                                  |
|   Buffers: shared hit=39                                                                                                                                                   |
| Planning Time: 0.422 ms                                                                                                                                                    |
| JIT:                                                                                                                                                                       |
|   Functions: 22                                                                                                                                                            |
|   Options: Inlining false, Optimization false, Expressions true, Deforming true                                                                                            |
|   Timing: Generation 1.004 ms, Inlining 0.000 ms, Optimization 0.489 ms, Emission 11.552 ms, Total 13.045 ms                                                               |
| Execution Time: 16145.878 ms                                                                                                                                               |
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
EXPLAIN 29
Time: 16.167s (16 seconds), executed in: 16.160s (16 seconds)

postgres@127.0.0.1:limes> EXPLAIN (ANALYZE,BUFFERS)
 SELECT pr.id, par.az, par.usage, par.historical_usage, COALESCE(SUM(pc.amount), 0)
 FROM project_services ps
 JOIN project_resources pr ON pr.service_id = ps.id
 JOIN project_az_resources par ON par.resource_id = pr.id
 LEFT OUTER JOIN project_commitments pc ON pc.az_resource_id = par.id AND pc.state = 'active'
 WHERE ps.type = 'compute' AND pr.name = 'cores'
 GROUP BY pr.id, par.az, par.usage, par.historical_usage;
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| QUERY PLAN                                                                                                                                                                                               |
|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| Finalize GroupAggregate  (cost=7284.11..7404.46 rows=908 width=82) (actual time=200.759..218.498 rows=10257 loops=1)                                                                                     |
|   Group Key: pr.id, par.az, par.usage, par.historical_usage                                                                                                                                              |
|   Buffers: shared hit=24352 read=2552                                                                                                                                                                    |
|   ->  Gather Merge  (cost=7284.11..7381.77 rows=756 width=82) (actual time=200.747..211.402 rows=10257 loops=1)                                                                                          |
|         Workers Planned: 2                                                                                                                                                                               |
|         Workers Launched: 2                                                                                                                                                                              |
|         Buffers: shared hit=24352 read=2552                                                                                                                                                              |
|         ->  Partial GroupAggregate  (cost=6284.09..6294.48 rows=378 width=82) (actual time=131.118..133.783 rows=3419 loops=3)                                                                           |
|               Group Key: pr.id, par.az, par.usage, par.historical_usage                                                                                                                                  |
|               Buffers: shared hit=24352 read=2552                                                                                                                                                        |
|               ->  Sort  (cost=6284.09..6285.03 rows=378 width=58) (actual time=131.108..131.330 rows=3519 loops=3)                                                                                       |
|                     Sort Key: pr.id, par.az, par.usage, par.historical_usage                                                                                                                             |
|                     Sort Method: quicksort  Memory: 882kB                                                                                                                                                |
|                     Buffers: shared hit=24352 read=2552                                                                                                                                                  |
|                     Worker 0:  Sort Method: quicksort  Memory: 169kB                                                                                                                                     |
|                     Worker 1:  Sort Method: quicksort  Memory: 189kB                                                                                                                                     |
|                     ->  Hash Left Join  (cost=372.74..6267.90 rows=378 width=58) (actual time=3.077..128.395 rows=3519 loops=3)                                                                          |
|                           Hash Cond: (par.id = pc.az_resource_id)                                                                                                                                        |
|                           Buffers: shared hit=24321 read=2551                                                                                                                                            |
|                           ->  Nested Loop  (cost=0.71..5871.29 rows=378 width=58) (actual time=0.059..124.272 rows=3419 loops=3)                                                                         |
|                                 Buffers: shared hit=23547 read=2551                                                                                                                                      |
|                                 ->  Nested Loop  (cost=0.29..5347.31 rows=120 width=8) (actual time=0.032..61.640 rows=854 loops=3)                                                                      |
|                                       Buffers: shared hit=10920 read=90                                                                                                                                  |
|                                       ->  Parallel Seq Scan on project_resources pr  (cost=0.00..4532.81 rows=1084 width=16) (actual time=0.014..58.220 rows=854 loops=3)                                |
|                                             Filter: (name = 'cores'::text)                                                                                                                               |
|                                             Rows Removed by Filter: 76890                                                                                                                                |
|                                             Buffers: shared hit=3318 read=1                                                                                                                              |
|                                       ->  Index Scan using project_services_pkey on project_services ps  (cost=0.29..0.75 rows=1 width=8) (actual time=0.004..0.004 rows=1 loops=2563)                   |
|                                             Index Cond: (id = pr.service_id)                                                                                                                             |
|                                             Filter: (type = 'compute'::text)                                                                                                                             |
|                                             Buffers: shared hit=7602 read=89                                                                                                                             |
|                                 ->  Index Scan using project_az_resources_resource_id_az_key on project_az_resources par  (cost=0.42..4.33 rows=4 width=58) (actual time=0.008..0.042 rows=4 loops=2563) |
|                                       Index Cond: (resource_id = pr.id)                                                                                                                                  |
|                                       Buffers: shared hit=12627 read=2461                                                                                                                                |
|                           ->  Hash  (cost=315.34..315.34 rows=4535 width=16) (actual time=2.959..2.960 rows=4540 loops=3)                                                                                |
|                                 Buckets: 8192  Batches: 1  Memory Usage: 277kB                                                                                                                           |
|                                 Buffers: shared hit=750                                                                                                                                                  |
|                                 ->  Seq Scan on project_commitments pc  (cost=0.00..315.34 rows=4535 width=16) (actual time=0.237..2.094 rows=4540 loops=3)                                              |
|                                       Filter: (state = 'active'::text)                                                                                                                                   |
|                                       Rows Removed by Filter: 694                                                                                                                                        |
|                                       Buffers: shared hit=750                                                                                                                                            |
| Planning:                                                                                                                                                                                                |
|   Buffers: shared hit=84 read=9                                                                                                                                                                          |
| Planning Time: 1.557 ms                                                                                                                                                                                  |
| Execution Time: 219.270 ms                                                                                                                                                                               |
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
EXPLAIN 45
Time: 0.249s
```