### PR TITLE
add liquids for neutron and octavia

### DIFF
--- a/docs/liquids/index.md
+++ b/docs/liquids/index.md
@@ -7,6 +7,8 @@ deploy a liquid for each OpenStack service whose resources Limes should manage.
 
 If the service does not provide LIQUID support itself, you can use one of the liquids bundled with Limes:
 
+- [`neutron`](./neutron.md) for the networking service Neutron
+- [`octavia`](./octavia.md) for the loadbalancing service Octavia
 - [`swift`](./swift.md) for the object storage service Swift
 
 ## How to run

--- a/docs/liquids/neutron.md
+++ b/docs/liquids/neutron.md
@@ -1,0 +1,29 @@
+# Liquid: `neutron`
+
+This liquid provides support for the networking service Neutron.
+
+- The suggested service type is `liquid-neutron`.
+- The suggested area is `network`.
+
+## Service-specific configuration
+
+None.
+
+## Resources
+
+Some of these resources are provided by optional Neutron extensions.
+Each resource will only be provided if Neutron advertises it in the default quota set.
+
+| Resource               | Unit | Capabilities                         |
+| ---------------------- | ---- | ------------------------------------ |
+| `floating_ips`         | None | HasCapacity = false, HasQuota = true |
+| `networks`             | None | HasCapacity = false, HasQuota = true |
+| `ports`                | None | HasCapacity = false, HasQuota = true |
+| `rbac_policies`        | None | HasCapacity = false, HasQuota = true |
+| `routers`              | None | HasCapacity = false, HasQuota = true |
+| `security_group_rules` | None | HasCapacity = false, HasQuota = true |
+| `security_groups`      | None | HasCapacity = false, HasQuota = true |
+| `subnet_pools`         | None | HasCapacity = false, HasQuota = true |
+| `subnets`              | None | HasCapacity = false, HasQuota = true |
+| `bgpvpns`              | None | HasCapacity = false, HasQuota = true |
+| `trunks`               | None | HasCapacity = false, HasQuota = true |

--- a/docs/liquids/octavia.md
+++ b/docs/liquids/octavia.md
@@ -1,0 +1,23 @@
+# Liquid: `octavia`
+
+This liquid provides support for the loadbalancing service Octavia.
+
+- The suggested service type is `liquid-octavia`.
+- The suggested area is `network`.
+
+## Service-specific configuration
+
+None.
+
+## Resources
+
+Each resource will only be provided if Octavia advertises it in the default quota set.
+
+| Resource         | Unit | Capabilities                         |
+| ---------------- | ---- | ------------------------------------ |
+| `healthmonitors` | None | HasCapacity = false, HasQuota = true |
+| `l7policies`     | None | HasCapacity = false, HasQuota = true |
+| `listeners`      | None | HasCapacity = false, HasQuota = true |
+| `loadbalancers`  | None | HasCapacity = false, HasQuota = true |
+| `pool_members`   | None | HasCapacity = false, HasQuota = true |
+| `pools`          | None | HasCapacity = false, HasQuota = true |

--- a/internal/liquids/neutron/liquid.go
+++ b/internal/liquids/neutron/liquid.go
@@ -1,0 +1,154 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package neutron
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack"
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/quotas"
+	"github.com/sapcc/go-api-declarations/limes"
+	"github.com/sapcc/go-api-declarations/liquid"
+
+	"github.com/sapcc/limes/internal/liquids"
+)
+
+type Logic struct {
+	// connections
+	NeutronV2 *gophercloud.ServiceClient `yaml:"-"`
+	// state
+	OwnProjectID string `yaml:"-"`
+}
+
+var neutronNameForResource = map[liquid.ResourceName]string{
+	// core feature set
+	"floating_ips":         "floatingip",
+	"networks":             "network",
+	"ports":                "port",
+	"rbac_policies":        "rbac_policy",
+	"routers":              "router",
+	"security_group_rules": "security_group_rule",
+	"security_groups":      "security_group",
+	"subnet_pools":         "subnetpool",
+	"subnets":              "subnet",
+	// extensions
+	"bgpvpns": "bgpvpn",
+	"trunks":  "trunk",
+}
+
+// Init implements the liquidapi.Logic interface.
+func (l *Logic) Init(ctx context.Context, provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (err error) {
+	l.NeutronV2, err = openstack.NewNetworkV2(provider, eo)
+	if err != nil {
+		return fmt.Errorf("cannot initialize Neutron v2 client: %w", err)
+	}
+	l.OwnProjectID, err = liquids.GetProjectIDFromTokenScope(provider)
+	if err != nil {
+		return fmt.Errorf("cannot find project scope of own token: %w", err)
+	}
+	return nil
+}
+
+// BuildServiceInfo implements the liquidapi.Logic interface.
+func (l *Logic) BuildServiceInfo(ctx context.Context) (liquid.ServiceInfo, error) {
+	// probe default quotas to see which resources are supported by Neutron
+	url := l.NeutronV2.ServiceURL("quotas", l.OwnProjectID, "default")
+	var r gophercloud.Result
+	_, r.Header, r.Err = gophercloud.ParseResponse(l.NeutronV2.Get(ctx, url, &r.Body, nil))
+	var data struct {
+		Quota map[string]int `json:"quota"`
+	}
+	err := r.ExtractInto(&data)
+	if err != nil {
+		return liquid.ServiceInfo{}, err
+	}
+
+	// we support all resources that Neutron supports and that we also know about
+	resources := make(map[liquid.ResourceName]liquid.ResourceInfo, len(neutronNameForResource))
+	for resName, neutronName := range neutronNameForResource {
+		_, exists := data.Quota[neutronName]
+		if exists {
+			resources[resName] = liquid.ResourceInfo{
+				Unit:        limes.UnitNone,
+				HasCapacity: false,
+				HasQuota:    true,
+			}
+		}
+	}
+
+	return liquid.ServiceInfo{
+		Version:   time.Now().Unix(),
+		Resources: resources,
+	}, nil
+}
+
+// ScanCapacity implements the liquidapi.Logic interface.
+func (l *Logic) ScanCapacity(ctx context.Context, req liquid.ServiceCapacityRequest, serviceInfo liquid.ServiceInfo) (liquid.ServiceCapacityReport, error) {
+	// no resources report capacity
+	return liquid.ServiceCapacityReport{InfoVersion: serviceInfo.Version}, nil
+}
+
+// ScanUsage implements the liquidapi.Logic interface.
+func (l *Logic) ScanUsage(ctx context.Context, projectUUID string, req liquid.ServiceUsageRequest, serviceInfo liquid.ServiceInfo) (liquid.ServiceUsageReport, error) {
+	var data struct {
+		Resources map[string]struct {
+			Quota int64  `json:"limit"`
+			Usage uint64 `json:"used"`
+		} `json:"quota"`
+	}
+	err := quotas.GetDetail(ctx, l.NeutronV2, projectUUID).ExtractInto(&data)
+	if err != nil {
+		return liquid.ServiceUsageReport{}, err
+	}
+
+	resourceReports := make(map[liquid.ResourceName]*liquid.ResourceUsageReport, len(serviceInfo.Resources))
+	for resName := range serviceInfo.Resources {
+		resData := data.Resources[neutronNameForResource[resName]]
+		resourceReports[resName] = &liquid.ResourceUsageReport{
+			Quota: &resData.Quota,
+			PerAZ: liquid.InAnyAZ(liquid.AZResourceUsageReport{Usage: resData.Usage}),
+		}
+	}
+
+	return liquid.ServiceUsageReport{
+		InfoVersion: serviceInfo.Version,
+		Resources:   resourceReports,
+	}, nil
+}
+
+// SetQuota implements the liquidapi.Logic interface.
+func (l *Logic) SetQuota(ctx context.Context, projectUUID string, req liquid.ServiceQuotaRequest, serviceInfo liquid.ServiceInfo) error {
+	neutronQuotas := make(quotaSet, len(serviceInfo.Resources))
+	for resName := range serviceInfo.Resources {
+		neutronQuotas[neutronNameForResource[resName]] = req.Resources[resName].Quota
+	}
+	_, err := quotas.Update(ctx, l.NeutronV2, projectUUID, neutronQuotas).Extract()
+	return err
+}
+
+type quotaSet map[string]uint64
+
+// ToQuotaUpdateMap implements the neutron_quotas.UpdateOpts and octavia_quotas.UpdateOpts interfaces.
+func (q quotaSet) ToQuotaUpdateMap() (map[string]any, error) {
+	return map[string]any{"quota": map[string]uint64(q)}, nil
+}

--- a/internal/liquids/octavia/client.go
+++ b/internal/liquids/octavia/client.go
@@ -1,0 +1,55 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package octavia
+
+import (
+	"context"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/quotas"
+)
+
+func getQuota(ctx context.Context, client *gophercloud.ServiceClient, projectUUID string) (map[string]int64, error) {
+	var data struct {
+		Quota map[string]int64 `json:"quota"`
+	}
+	err := quotas.Get(ctx, client, projectUUID).ExtractInto(&data)
+	return data.Quota, err
+}
+
+func getUsage(ctx context.Context, client *gophercloud.ServiceClient, projectUUID string) (map[string]uint64, error) {
+	// NOTE: This API endpoint is a custom extension in SAP Converged Cloud.
+	var r gophercloud.Result
+	url := client.ServiceURL("quota_usage", projectUUID)
+	_, r.Header, r.Err = gophercloud.ParseResponse(client.Get(ctx, url, &r.Body, nil))
+
+	var data struct {
+		Usage map[string]uint64 `json:"quota_usage"`
+	}
+	err := r.ExtractInto(&data)
+	return data.Usage, err
+}
+
+type quotaSet map[string]uint64
+
+// ToQuotaUpdateMap implements the quotas.UpdateOpts interfaces.
+func (q quotaSet) ToQuotaUpdateMap() (map[string]any, error) {
+	return map[string]any{"quota": map[string]uint64(q)}, nil
+}

--- a/internal/liquids/octavia/liquid.go
+++ b/internal/liquids/octavia/liquid.go
@@ -1,0 +1,148 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package octavia
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack"
+	"github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/quotas"
+	"github.com/sapcc/go-api-declarations/limes"
+	"github.com/sapcc/go-api-declarations/liquid"
+
+	"github.com/sapcc/limes/internal/liquids"
+)
+
+type Logic struct {
+	// connections
+	OctaviaV2 *gophercloud.ServiceClient `yaml:"-"`
+	// state
+	OwnProjectID string `yaml:"-"`
+}
+
+// On reading quota, we will accept any of the given names.
+// On reading usage and writing quota, we will use the first name in the list.
+//
+// It appears that the names with underscore are deprecated since Rocky, but
+// their removal has been procrastinated since then. Worse yet, GET requests on
+// Yoga still return the supposedly deprecated fields only, not the intended names.
+var octaviaNamesForResource = map[liquid.ResourceName][]string{
+	"healthmonitors": {"healthmonitor", "health_monitor"},
+	"l7policies":     {"l7policy"},
+	"listeners":      {"listener"},
+	"loadbalancers":  {"loadbalancer", "load_balancer"},
+	"pool_members":   {"member"},
+	"pools":          {"pool"},
+}
+
+// Init implements the liquidapi.Logic interface.
+func (l *Logic) Init(ctx context.Context, provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (err error) {
+	l.OctaviaV2, err = openstack.NewLoadBalancerV2(provider, eo)
+	if err != nil {
+		return fmt.Errorf("cannot initialize Octavia v2 client: %w", err)
+	}
+	l.OwnProjectID, err = liquids.GetProjectIDFromTokenScope(provider)
+	if err != nil {
+		return fmt.Errorf("cannot find project scope of own token: %w", err)
+	}
+	return nil
+}
+
+// BuildServiceInfo implements the liquidapi.Logic interface.
+func (l *Logic) BuildServiceInfo(ctx context.Context) (liquid.ServiceInfo, error) {
+	// probe default quotas to see which resources are supported by Octavia
+	defaultQuota, err := getQuota(ctx, l.OctaviaV2, "defaults")
+	if err != nil {
+		return liquid.ServiceInfo{}, err
+	}
+
+	// we support all resources that Octavia supports and that we also know about
+	resources := make(map[liquid.ResourceName]liquid.ResourceInfo, len(octaviaNamesForResource))
+	for resName, octaviaNames := range octaviaNamesForResource {
+		for _, octaviaName := range octaviaNames {
+			_, exists := defaultQuota[octaviaName]
+			if exists {
+				resources[resName] = liquid.ResourceInfo{
+					Unit:        limes.UnitNone,
+					HasCapacity: false,
+					HasQuota:    true,
+				}
+				break // from inner loop
+			}
+		}
+	}
+
+	return liquid.ServiceInfo{
+		Version:   time.Now().Unix(),
+		Resources: resources,
+	}, nil
+}
+
+// ScanCapacity implements the liquidapi.Logic interface.
+func (l *Logic) ScanCapacity(ctx context.Context, req liquid.ServiceCapacityRequest, serviceInfo liquid.ServiceInfo) (liquid.ServiceCapacityReport, error) {
+	// no resources report capacity
+	return liquid.ServiceCapacityReport{InfoVersion: serviceInfo.Version}, nil
+}
+
+// ScanUsage implements the liquidapi.Logic interface.
+func (l *Logic) ScanUsage(ctx context.Context, projectUUID string, req liquid.ServiceUsageRequest, serviceInfo liquid.ServiceInfo) (liquid.ServiceUsageReport, error) {
+	octaviaQuotas, err := getQuota(ctx, l.OctaviaV2, projectUUID)
+	if err != nil {
+		return liquid.ServiceUsageReport{}, err
+	}
+	octaviaUsage, err := getUsage(ctx, l.OctaviaV2, projectUUID)
+	if err != nil {
+		return liquid.ServiceUsageReport{}, err
+	}
+
+	resourceReports := make(map[liquid.ResourceName]*liquid.ResourceUsageReport, len(serviceInfo.Resources))
+	for resName := range serviceInfo.Resources {
+		octaviaNames := octaviaNamesForResource[resName]
+		report := liquid.ResourceUsageReport{
+			PerAZ: liquid.InAnyAZ(liquid.AZResourceUsageReport{Usage: octaviaUsage[octaviaNames[0]]}),
+		}
+		for _, octaviaName := range octaviaNames {
+			quota, exists := octaviaQuotas[octaviaName]
+			if exists {
+				report.Quota = &quota
+				break
+			}
+		}
+		resourceReports[resName] = &report
+	}
+
+	return liquid.ServiceUsageReport{
+		InfoVersion: serviceInfo.Version,
+		Resources:   resourceReports,
+	}, nil
+}
+
+// SetQuota implements the liquidapi.Logic interface.
+func (l *Logic) SetQuota(ctx context.Context, projectUUID string, req liquid.ServiceQuotaRequest, serviceInfo liquid.ServiceInfo) error {
+	octaviaQuotas := make(quotaSet, len(serviceInfo.Resources))
+	for resName := range serviceInfo.Resources {
+		octaviaQuotas[octaviaNamesForResource[resName][0]] = req.Resources[resName].Quota
+	}
+	_, err := quotas.Update(ctx, l.OctaviaV2, projectUUID, octaviaQuotas).Extract()
+	return err
+}

--- a/internal/liquids/utils.go
+++ b/internal/liquids/utils.go
@@ -1,0 +1,46 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package liquids
+
+import (
+	"fmt"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/tokens"
+)
+
+// GetProjectIDFromTokenScope returns the project ID from the client's token scope.
+//
+// This is useful if a request in a non-project-scoped method like Init() or
+// BuildServiceInfo() needs to make a request using some project ID.
+func GetProjectIDFromTokenScope(provider *gophercloud.ProviderClient) (string, error) {
+	result, ok := provider.GetAuthResult().(tokens.CreateResult)
+	if !ok {
+		return "", fmt.Errorf("%T is not a %T", provider.GetAuthResult(), tokens.CreateResult{})
+	}
+	project, err := result.ExtractProject()
+	if err != nil {
+		return "", err
+	}
+	if project == nil || project.ID == "" {
+		return "", fmt.Errorf(`expected "id" attribute in "project" section, but got %#v`, project)
+	}
+	return project.ID, nil
+}

--- a/main.go
+++ b/main.go
@@ -59,6 +59,8 @@ import (
 	"github.com/sapcc/limes/internal/collector"
 	"github.com/sapcc/limes/internal/core"
 	"github.com/sapcc/limes/internal/db"
+	"github.com/sapcc/limes/internal/liquids/neutron"
+	"github.com/sapcc/limes/internal/liquids/octavia"
 	"github.com/sapcc/limes/internal/liquids/swift"
 	"github.com/sapcc/limes/internal/util"
 
@@ -90,13 +92,18 @@ func main() {
 		bininfo.SetTaskName("liquid-" + liquidName)
 		wrap.SetOverrideUserAgent(bininfo.Component(), bininfo.VersionOr("rolling"))
 
+		opts := liquidapi.RunOpts{
+			ServiceInfoRefreshInterval: 0,
+			MaxConcurrentRequests:      5,
+			DefaultListenAddress:       ":80",
+		}
 		switch liquidName {
+		case "neutron":
+			must.Succeed(liquidapi.Run(ctx, &neutron.Logic{}, opts))
+		case "octavia":
+			must.Succeed(liquidapi.Run(ctx, &octavia.Logic{}, opts))
 		case "swift":
-			must.Succeed(liquidapi.Run(ctx, &swift.Logic{}, liquidapi.RunOpts{
-				ServiceInfoRefreshInterval: 0,
-				MaxConcurrentRequests:      5,
-				DefaultListenAddress:       ":80",
-			}))
+			must.Succeed(liquidapi.Run(ctx, &swift.Logic{}, opts))
 		default:
 			printUsageAndExit(1)
 		}


### PR DESCRIPTION
To simplify, the Neutron liquid eschews the extension querying that the old QuotaPlugin does, and instead looks at the default quota set to observe which resources exist.

I checked both of these against QA (both to get quota/usage and set quota) and they work as intended.