### PR TITLE
parse quota-overrides using API-level resource renaming

### DIFF
--- a/docs/operators/config.md
+++ b/docs/operators/config.md
@@ -50,8 +50,10 @@ Limes logs all quota changes at the domain and project level in an Open Standard
 | `LIMES_QUOTA_OVERRIDES_PATH` | *(optional)* | Path to a JSON file containing the quota overrides for this cluster. |
 
 If present, the quota overrides file must be a four-leveled object, with the keys being domain name, project name,
-service type and resource name in that order. The values are either numbers (to override quotas on counted resources) or
-strings of the form `<number> <unit>` (to override quotas on measured resources). For example:
+service type and resource name in that order. If API-level resource renaming is used (see configuration option
+`resource_behavior[].identity_in_v1_api`), the service type and resource name refer to the renamed identifiers used by
+the v1 API. The values are either numbers (to override quotas on counted resources) or strings of the form
+`<number> <unit>` (to override quotas on measured resources). For example:
 
 ```json
 {

--- a/internal/core/cluster.go
+++ b/internal/core/cluster.go
@@ -158,21 +158,68 @@ func (c *Cluster) loadQuotaOverrides(path string) (result map[string]map[string]
 		return
 	}
 
+	resInfosByIdentityInV1API := make(map[ResourceRef]liquid.ResourceInfo)
+	dbIdentitiesByIdentityInV1API := make(map[ResourceRef]ResourceRef)
+	for dbServiceType, quotaPlugin := range c.QuotaPlugins {
+		for dbResourceName, resInfo := range quotaPlugin.Resources() {
+			apiIdentity := c.BehaviorForResource(dbServiceType, dbResourceName).IdentityInV1API
+			resInfosByIdentityInV1API[apiIdentity] = resInfo
+
+			dbIdentity := ResourceRef{ServiceType: dbServiceType, ResourceName: dbResourceName}
+			dbIdentitiesByIdentityInV1API[apiIdentity] = dbIdentity
+		}
+	}
+
+	// the quota-overrides.json file refers to services and resources using IdentityInV1API, so we:
+	// a) need to lookup by API identity
+	// b) get a result that is structured by API identity and needs to be mapped back to DB identity afterwards
 	getUnit := func(serviceType limes.ServiceType, resourceName limesresources.ResourceName) (limes.Unit, error) {
-		if !c.HasResource(serviceType, resourceName) {
+		apiIdentity := ResourceRef{ServiceType: serviceType, ResourceName: resourceName}
+		resInfo, exists := resInfosByIdentityInV1API[apiIdentity]
+		if !exists {
 			return limes.UnitUnspecified, fmt.Errorf("%s/%s is not a valid resource", serviceType, resourceName)
 		}
-		resInfo := c.InfoForResource(serviceType, resourceName)
 		if !resInfo.HasQuota {
 			return limes.UnitUnspecified, fmt.Errorf("%s/%s does not track quota", serviceType, resourceName)
 		}
 		return resInfo.Unit, nil
 	}
-	result, suberrs := limesresources.ParseQuotaOverrides(buf, getUnit)
+	parsed, suberrs := limesresources.ParseQuotaOverrides(buf, getUnit)
 	for _, suberr := range suberrs {
 		errs.Addf("while parsing %s: %w", path, suberr)
 	}
-	return result, errs
+	if !errs.IsEmpty() {
+		return nil, errs
+	}
+
+	result = make(map[string]map[string]map[limes.ServiceType]map[limesresources.ResourceName]uint64, len(parsed))
+	for domainName, parsedInDomain := range parsed {
+		result[domainName] = make(map[string]map[limes.ServiceType]map[limesresources.ResourceName]uint64, len(parsedInDomain))
+		for projectName, parsedInProject := range parsedInDomain {
+			result[domainName][projectName] = translateQuotaOverrides(parsedInProject, dbIdentitiesByIdentityInV1API)
+		}
+	}
+	return result, nil
+}
+
+func translateQuotaOverrides(overrides map[limes.ServiceType]map[limesresources.ResourceName]uint64, dbIdentitiesByIdentityInV1API map[ResourceRef]ResourceRef) map[limes.ServiceType]map[limesresources.ResourceName]uint64 {
+	result := make(map[limes.ServiceType]map[limesresources.ResourceName]uint64)
+	for apiServiceType, overridesByService := range overrides {
+		for apiResourceName, overrideQuota := range overridesByService {
+			apiIdentity := ResourceRef{ServiceType: apiServiceType, ResourceName: apiResourceName}
+			dbIdentity, ok := dbIdentitiesByIdentityInV1API[apiIdentity]
+			if !ok {
+				// defense in depth: this branch should be impossible to reach because ParseQuotaOverrides() rejected unknown resources
+				dbIdentity = apiIdentity
+			}
+
+			if result[dbIdentity.ServiceType] == nil {
+				result[dbIdentity.ServiceType] = make(map[limesresources.ResourceName]uint64)
+			}
+			result[dbIdentity.ServiceType][dbIdentity.ResourceName] = overrideQuota
+		}
+	}
+	return result
 }
 
 // ServiceTypesInAlphabeticalOrder can be used when service types need to be

--- a/internal/core/cluster_test.go
+++ b/internal/core/cluster_test.go
@@ -1,0 +1,110 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+// NOTE: This needs to be in a separate package to avoid an import cycle when
+// importing from internal/test.
+package core_test
+
+import (
+	"testing"
+
+	"github.com/sapcc/go-api-declarations/limes"
+	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
+	"github.com/sapcc/go-bits/assert"
+
+	"github.com/sapcc/limes/internal/test"
+)
+
+const (
+	testQuotaOverridesNoRenamingConfigYAML = `
+		availability_zones: [ az-one, az-two ]
+		discovery:
+			method: --test-static
+		services:
+			- service_type: first
+				type: --test-generic
+			- service_type: second
+				type: --test-generic
+	`
+
+	testQuotaOverridesWithRenamingConfigYAML = `
+		availability_zones: [ az-one, az-two ]
+		discovery:
+			method: --test-static
+		services:
+			- service_type: first
+				type: --test-generic
+			- service_type: second
+				type: --test-generic
+		resource_behavior:
+		- resource: first/capacity
+			identity_in_v1_api: capacities/first
+		- resource: first/things
+			identity_in_v1_api: things/first
+	`
+)
+
+var expectedQuotaOverrides = map[string]map[string]map[limes.ServiceType]map[limesresources.ResourceName]uint64{
+	"firstdomain": {
+		"firstproject": {
+			"first": {
+				"capacity": 10,
+				"things":   20,
+			},
+			"second": {
+				"capacity": 30,
+				"things":   40,
+			},
+		},
+		"secondproject": {
+			"first": {
+				"capacity": 50,
+			},
+			"second": {
+				"capacity": 60,
+			},
+		},
+	},
+	"seconddomain": {
+		"thirdproject": {
+			"first": {
+				"things": 70,
+			},
+			"second": {
+				"things": 80,
+			},
+		},
+	},
+}
+
+func TestQuotaOverridesWithoutResourceRenaming(t *testing.T) {
+	t.Setenv("LIMES_QUOTA_OVERRIDES_PATH", "fixtures/quota-overrides-no-renaming.json")
+	s := test.NewSetup(t,
+		test.WithConfig(testQuotaOverridesNoRenamingConfigYAML),
+	)
+	assert.DeepEqual(t, "quota overrides", s.Cluster.QuotaOverrides, expectedQuotaOverrides)
+}
+
+func TestQuotaOverridesWithResourceRenaming(t *testing.T) {
+	t.Setenv("LIMES_QUOTA_OVERRIDES_PATH", "fixtures/quota-overrides-with-renaming.json")
+	s := test.NewSetup(t,
+		test.WithConfig(testQuotaOverridesWithRenamingConfigYAML),
+	)
+	assert.DeepEqual(t, "quota overrides", s.Cluster.QuotaOverrides, expectedQuotaOverrides)
+}

--- a/internal/core/fixtures/quota-overrides-no-renaming.json
+++ b/internal/core/fixtures/quota-overrides-no-renaming.json
@@ -1,0 +1,32 @@
+{
+  "firstdomain": {
+    "firstproject": {
+      "first": {
+        "capacity": "10 B",
+        "things": 20
+      },
+      "second": {
+        "capacity": "30 B",
+        "things": 40
+      }
+    },
+    "secondproject": {
+      "first": {
+        "capacity": "50 B"
+      },
+      "second": {
+        "capacity": "60 B"
+      }
+    }
+  },
+  "seconddomain": {
+    "thirdproject": {
+      "first": {
+        "things": 70
+      },
+      "second": {
+        "things": 80
+      }
+    }
+  }
+}

--- a/internal/core/fixtures/quota-overrides-with-renaming.json
+++ b/internal/core/fixtures/quota-overrides-with-renaming.json
@@ -1,0 +1,34 @@
+{
+  "firstdomain": {
+    "firstproject": {
+      "capacities": {
+        "first": "10 B"
+      },
+      "second": {
+        "capacity": "30 B",
+        "things": 40
+      },
+      "things": {
+        "first": 20
+      }
+    },
+    "secondproject": {
+      "capacities": {
+        "first": "50 B"
+      },
+      "second": {
+        "capacity": "60 B"
+      }
+    }
+  },
+  "seconddomain": {
+    "thirdproject": {
+      "things": {
+        "first": 70
+      },
+      "second": {
+        "things": 80
+      }
+    }
+  }
+}


### PR DESCRIPTION
It is useful for us to use the API-level names here because:

1. some quota overrides are shared between all clusters (so renaming must be carefully coordinated here, same as for the API), and
2. this config file is maintained by a wider operator audience (so any renaming here should be properly communicated with advance notice).