### PR TITLE
update coverage check exclusion rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ ifeq ($(GO_TESTPKGS),)
 GO_TESTPKGS := ./...
 endif
 # which packages to measure coverage for
-GO_COVERPKGS := $(shell go list ./... | grep -Ev '/plugins')
+GO_COVERPKGS := $(shell go list ./... | grep -Ev '/plugins|/liquids')
 # to get around weird Makefile syntax restrictions, we need variables containing nothing, a space and comma
 null :=
 space := $(null) $(null)

--- a/Makefile.maker.yaml
+++ b/Makefile.maker.yaml
@@ -9,7 +9,7 @@ binaries:
     installTo:   bin/
 
 coverageTest:
-  except: '/plugins'
+  except: '/plugins|/liquids'
 
 dockerfile:
   enabled: true


### PR DESCRIPTION
Currently, only `internal/plugins` is excluded because we test plugin implementations manually. This includes `internal/liquids/*` based on the same reasoning.