### PR TITLE
fix commitment move in overcommitted AZ

### DIFF
--- a/internal/datamodel/confirm_project_commitments.go
+++ b/internal/datamodel/confirm_project_commitments.go
@@ -86,7 +86,7 @@ func CanMoveExistingCommitment(amount uint64, loc AZResourceLocation, sourceReso
 	additions := map[db.ProjectResourceID]uint64{targetResourceID: amount}
 	subtractions := map[db.ProjectResourceID]uint64{sourceResourceID: amount}
 	behavior := cluster.BehaviorForResource(loc.ServiceType, loc.ResourceName)
-	logg.Debug("checking CanMoveExistingCommitment in %s/%s/%s: resourceID = %d -> %s, amount = %d",
+	logg.Debug("checking CanMoveExistingCommitment in %s/%s/%s: resourceID = %d -> %d, amount = %d",
 		loc.ServiceType, loc.ResourceName, loc.AvailabilityZone, sourceResourceID, targetResourceID, amount)
 	return stats.CanAcceptCommitmentChanges(additions, subtractions, behavior), nil
 }


### PR DESCRIPTION
I already tried to fix this in 5f75541332d84fc69f669f7eef8257673b10e1a4, but it did not go all the way. We saw this in a debug log:

```
DEBUG: checking CanMoveExistingCommitment in compute/ram/eu-de-1d: resourceID = 3296 -> 187489, amount = 412252
DEBUG: CanAcceptCommitmentChanges: forbidden by commitment target 24429662 > usage 23889216 in resourceID = 3296
```

The problem here is that `committed > usage` was evaluated in the project where `committed` shrinks, even though it is only relevant in the project where `committed` expands.