### PR TITLE
add liquid-cinder and liquid-manila

### DIFF
--- a/docs/liquids/cinder.md
+++ b/docs/liquids/cinder.md
@@ -60,6 +60,7 @@ If a pool has the field `capabilities.custom_attributes.cinder_state` with the v
 
 - This pool will only contribute capacity towards the total to the extent to which it is actually used (i.e., not higher than its `usage` value).
 - Consequently, the `capacity` field of the subcapacity will also show the `usage` value, with the real capacity value relegated to `attributes.real_capacity`.
+
 The `attributes.exclusion_reason` will explain this by showing the value `cinder_state = drain` or `cinder_state = reserved`, respectively.
 
 We use this to avoid double-counting of capacity when a new filer is brought in to replace an old one.

--- a/docs/liquids/cinder.md
+++ b/docs/liquids/cinder.md
@@ -1,0 +1,68 @@
+# Liquid: `cinder`
+
+This liquid provides support for the block storage service Cinder.
+
+- The suggested service type is `liquid-cinder`.
+- The suggested area is `storage`.
+
+## Service-specific configuration
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `with_subcapacities` | boolean | If true, subcapacities are reported. |
+| `with_snapshot_subresources` | boolean | If true, subresources are reported on snapshots resources. |
+| `with_volume_subresources` | boolean | If true, subresources are reported on volumes resources. |
+
+## Resources
+
+For each volume type that can be listed within the project scope of the supplied service user, three resources are reported:
+
+| Resource          | Unit | Capabilities                         |
+| ----------------- | ---- | ------------------------------------ |
+| `capacity_$TYPE`  | GiB  | HasCapacity = true, HasQuota = true  |
+| `snapshots_$TYPE` | None | HasCapacity = false, HasQuota = true |
+| `volumes_$TYPE`   | None | HasCapacity = false, HasQuota = true |
+
+When reading quota, the overall quotas are ignored and only the volume-type-specific quotas are reported.
+When writing quota, the overall quotas are set to the sum of the respective volume-type-specific quotas.
+
+If `with_volume_subresources` and/or `with_snapshot_subresources` is set, the respective resources will have one subresource for each volume/snapshot, with the following fields:
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `id` | string | The UUID of the volume or snapshot. |
+| `name` | string | The human-readable name of the volume or snapshot. |
+| `attributes.size_gib` | uint64 | The logical size of the volume or snapshot. |
+| `attributes.status` | string | The status of the volume or snapshot according to Cinder. |
+
+## Capacity calculation
+
+Capacity is calculated as the sum over all storage pools:
+
+- Pools are grouped into volume types by matching their `volume_backend_name` against `extra_specs.volume_backend_name` of the volume type.
+  Pools without a matching volume type are ignored.
+- Pools are grouped into availability zones by matching the pool's hostname against the list of services configured in Cinder.
+  Pools without a matching AZ are reported in AZ `unknown`.
+
+If `with_subcapacities` is set, the capacity resource will have one subcapacity for each pool, with the following fields:
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `name` | string | The name of the pool. |
+| `capacity` | uint64 | The logical size of the pool, in GiB. |
+| `usage` | uint64 | The logical size of all volumes and snapshots on this pool, in GiB. |
+| `attributes.exclusion_reason` | string or omitted | See below for details. |
+| `attributes.real_capacity` | uint64 or omitted | Only shown if different from `capacity`. See below for details. |
+
+### SAP Converged Cloud extension: Pool exclusion
+
+If a pool has the field `capabilities.custom_attributes.cinder_state` with the value `drain` or `reserved`:
+
+- This pool will only contribute capacity towards the total to the extent to which it is actually used (i.e., not higher than its `usage` value).
+- Consequently, the `capacity` field of the subcapacity will also show the `usage` value, with the real capacity value relegated to `attributes.real_capacity`.
+The `attributes.exclusion_reason` will explain this by showing the value `cinder_state = drain` or `cinder_state = reserved`, respectively.
+
+We use this to avoid double-counting of capacity when a new filer is brought in to replace an old one.
+While the new filer is brought in, it is in state `reserved` to avoid counting its capacity at all.
+Once payload is being moved from the old filer, it will be set to state `drain` to avoid the appearance of capacity opening up there as it is being emptied.
+Once the old filer is gone, the `reserved` state is removed from the new filer to have it count towards capacity in the normal manner.

--- a/docs/liquids/index.md
+++ b/docs/liquids/index.md
@@ -8,6 +8,7 @@ deploy a liquid for each OpenStack service whose resources Limes should manage.
 If the service does not provide LIQUID support itself, you can use one of the liquids bundled with Limes:
 
 - [`archer`](./archer.md) for the endpoint injection service [Archer](https://github.com/sapcc/archer)
+- [`cinder`](./cinder.md) for the block storage service Cinder
 - [`designate`](./designate.md) for the DNS service Designate
 - [`neutron`](./neutron.md) for the networking service Neutron
 - [`octavia`](./octavia.md) for the loadbalancing service Octavia

--- a/docs/liquids/index.md
+++ b/docs/liquids/index.md
@@ -10,6 +10,7 @@ If the service does not provide LIQUID support itself, you can use one of the li
 - [`archer`](./archer.md) for the endpoint injection service [Archer](https://github.com/sapcc/archer)
 - [`cinder`](./cinder.md) for the block storage service Cinder
 - [`designate`](./designate.md) for the DNS service Designate
+- [`manila`](./manila.md) for the shared file system storage service Manila
 - [`neutron`](./neutron.md) for the networking service Neutron
 - [`octavia`](./octavia.md) for the loadbalancing service Octavia
 - [`swift`](./swift.md) for the object storage service Swift

--- a/docs/liquids/manila.md
+++ b/docs/liquids/manila.md
@@ -1,0 +1,163 @@
+# Liquid: `manila`
+
+This liquid provides support for the shared file system storage service Manila.
+
+- The suggested service type is `liquid-manila`.
+- The suggested area is `storage`.
+
+## Service-specific configuration
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `capacity_calculation` | object | Various options relating to capacity calculation. [See "Capacity calculation" for details.](#capacity-calculation) |
+| `capacity_calculation.capacity_balance` | float64 | A ratio describing how unused capacity will be distributed between shares and snapshots. |
+| `capacity_calculation.share_networks` | uint64 | The reported capacity value for the `share_networks` resource. |
+| `capacity_calculation.shares_per_pool` | uint64 | A multiplicative factor for computing capacity for the `shares_$TYPE` resources. |
+| `capacity_calculation.snapshots_per_share` | uint64 | A multiplicative factor for computing capacity for the `snapshots_$TYPE` resources. |
+| `capacity_calculation.with_subcapacities` | boolean | If set to true, subcapacities will be reported on all resources that have "capacity" in their name. |
+| `prometheus_api_for_az_awareness` | object | If given, specifies a connection to a Prometheus API providing AZ awareness metrics. [See "AZ awareness metrics" for details.](#sap-converged-cloud-extension-az-awareness-metrics) |
+| `prometheus_api_for_netapp_metrics` | object | If given, specifies a connection to a Prometheus API providing NetApp metrics. [See "NetApp metrics" for details.](#sap-converged-cloud-extension-netapp-metrics) |
+| `share_types` | list of objects | Required. Each object contains configuration for one share type that the liquid manages. |
+| `share_types[].name` | string | Required. The name of the share type on the Manila API. |
+| `share_types[].replication_enabled` | boolean | Whether this share type supports share replicas. This affects usage measurements and quota application as described below. |
+| `share_types[].mapping_rules` | list of objects | If given, this share type is a virtual share type mapping to multiple actual share types. [See "Virtual Share Types" for details.](#virtual-share-types) |
+
+The two `prometheus_api_...` objects may contain the following fields (if they are present at all):
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `url` | string | Required. The base URL of the Prometheus API, usually without any subpath (e.g. `https://metrics.example.com`). |
+| `cacert` | string | If given, must contain a path to a PEM-encoded certificate bundle. Must be given if the Prometheus API is behind TLS, using a server certificate not signed by a CA in the system-wide trust root bundle. |
+| `cert` | string | If given, must contain a path to a PEM-encoded certificate bundle. The first certificate in the bundle will be presented as client certificate when connecting to the Prometheus API. The bundle may contain additional certificates as required to establish a trust chain from the client certificate to a CA trusted by the server. |
+| `key` | string | Required if and only if `cert` is given. Must contain a path to a PEM-encoded private key belonging to the client certificate from `cert`. |
+
+## Resources
+
+One resource is always reported:
+
+| Resource         | Unit | Capabilities                        |
+| ---------------- | ---- | ----------------------------------- |
+| `share_networks` | GiB  | HasCapacity = true, HasQuota = true |
+
+For each configured share type, the following resources are reported:
+
+| Resource                    | Unit | Capabilities                         | Notes                         |
+| --------------------------- | ---- | ------------------------------------ | ----------------------------- |
+| `shares_$TYPE`              | None | HasCapacity = true, HasQuota = true  |                               |
+| `snapshots_$TYPE`           | None | HasCapacity = true, HasQuota = true  |                               |
+| `share_capacity_$TYPE`      | GiB  | HasCapacity = true, HasQuota = true  |                               |
+| `snapshot_capacity_$TYPE`   | GiB  | HasCapacity = true, HasQuota = true  |                               |
+| `snapmirror_capacity_$TYPE` | GiB  | HasCapacity = true, HasQuota = true  | only if configured, see below |
+
+When the share type is configured as `replication_enabled`, quota and usage for replicas is considered as follows:
+
+- On read, the resource `shares_$TYPE` will report quota and usage for the number of replicas instead of for the number of shares.
+  If these two quotas are not identical in Manila, a quota value of -1 will be reported instead to force an immediate resync in Limes.
+- On write, the quota for the resource `shares_$TYPE` will be written as the quota for both the number of shares and the number of replicas.
+- The same rules apply for the `share_capacity_$TYPE` resource, which models quota and usage for both share capacity and replica capacity.
+
+The intent of these rules is to ensure that users do not have to manage the shares and replicas resources separately.
+Managing quotas like this works because shares also count towards the replica quota (a share is considered its own first replica).
+
+### Virtual share types
+
+Multiple Manila share types can be grouped into a single **virtual share type** by adding mapping rules to the share type configuration as
+in the following example:
+
+```json
+{
+  "share_types": [
+    {
+      "name": "default",
+      "replication_enabled": true
+    },
+    {
+      "name": "hypervisor_storage",
+      "mapping_rules": [
+        { "match_project_name": "fooproject-.*", "name": "hypervisor_storage_foo" },
+        { "match_project_name": ".*@bardomain",  "name": "hypervisor_storage_bar" },
+        { "match_project_name": ".*",            "name": "" }
+      ]
+    }
+  ]
+}
+```
+
+In this case, `hypervisor_storage` is the share type name from which the Limes resource names are derived,
+but the actual Manila share types (for which quota is set and for which usage is retrieved)
+are `hypervisor_storage_foo` and `hypervisor_storage_bar`.
+
+In each mapping rule, `match_project_name` is a regex that is matched against `$PROJECT_NAME@$DOMAIN_NAME`
+(with `^` and `$` automatically implied at the end of the regex).
+Mapping rules are evaluated in order: The first matching pattern determines the Manila share type for that particular project scope.
+If no mapping rule matches, the main share type name is used.
+
+If the matching mapping rule sets the share type to the empty string, the `forbidden` flag will be set on all relevant resources
+to hide the share type from the respective project in Limes.
+
+Capacity calculation disregards the mapping rules and queries for pools using the virtual share type.
+The intent of this facility is to provide specialized share types to different projects that access the same capacity.
+
+### SAP Converged Cloud extension: AZ awareness metrics
+
+By default, all resources are non-AZ-aware, and report their usage into AZ `unknown` (except for share networks which are reported in AZ `any`).
+If `prometheus_api_for_az_awareness` is configured, this Prometheus instance will be queried to breakdown the overall usage numbers into AZ-aware usage numbers.
+For this, the following metric families must be present in Prometheus, each with label dimensions `project_id`, `availability_zone_name` and `share_type_id`:
+
+- `openstack_manila_replicas_count_gauge` (number of shares incl. replicas)
+- `openstack_manila_replicas_size_gauge` (size in GiB of shares incl. replicas)
+- `openstack_manila_snapshot_count_gauge` (number of snapshots)
+- `openstack_manila_snapshot_size_gauge` (size in GiB of snapshots)
+
+### SAP Converged Cloud extension: NetApp metrics
+
+In SAP Converged Cloud, Manila is backed by NetApp storages.
+The custom [netapp-api-exporter](https://github.com/sapcc/netapp-api-exporter) is used to enhance the usage data reported by this liquid:
+
+- Physical usage can be reported for the `share_capacity_${TYPE}` and `snapshot_capacity_${TYPE}` resources.
+- Additional resources `snapmirror_capacity_${TYPE}` will be present on each share type to count the usage and physical usage by replicas that are created through the NetApp snapmirror mechanism without being known to Manila.
+
+## Capacity calculation
+
+Capacity within each virtual share type is calculated as the sum over all storage pools:
+
+- Pools are queried for each relevant real share type, and the results are merged into a single list.
+  Pools that do not match any of the configured real share types across all virtual share types are ignored.
+- Pools are grouped into availability zones by matching the pool's hostname against the list of services configured in Manila.
+  Pools without a matching AZ are reported in AZ `unknown`.
+
+The sum of all pool capacities is then divided up between share capacity, snapshot capacity and (if enabled) snapmirror capacity according to the resource demand signaled by Limes.
+If any capacity remains unallocated afterwards because there was no demand for it, it is split between share capacity and snapshot capacity according to the `capacity_balance` configuration parameter.
+The capacity balance is defined as the ratio between capacity given to snapshots and capacity to shares.
+For example, a capacity balance of 2 will result in twice as much capacity given to snapshots than to shares (i.e. two thirds of the unallocated capacity are given to snapshots, and one third to shares).
+
+Within each AZ, the countable resources are assigned capacity as follows:
+
+```
+shares := max(0, shares_per_pool * number of pools - share_networks / number of AZs)
+snapshots := snapshots_per_share * snapshots
+```
+
+If `with_subcapacities` is set, the share capacity resource will have one subcapacity for each pool, with the following fields:
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `name` | string | The name of the pool. |
+| `capacity` | uint64 | The logical size of the pool, in GiB. |
+| `usage` | uint64 | The logical size of all volumes and snapshots on this pool, in GiB. |
+| `attributes.exclusion_reason` | string or omitted | See below for details. |
+| `attributes.real_capacity` | uint64 or omitted | Only shown if different from `capacity`. See below for details. |
+
+### SAP Converged Cloud extension: Pool exclusion
+
+If a pool has the field `capabilities.hardware_state` with the value `in_build`, `in_decom` or `replacing_decom`:
+
+- This pool will only contribute capacity towards the total to the extent to which it is actually used (i.e., not higher than its `usage` value).
+- Consequently, the `capacity` field of the subcapacity will also show the `usage` value, with the real capacity value relegated to `attributes.real_capacity`.
+
+The `attributes.exclusion_reason` will explain this by showing a value like `hardware_state = in_build`.
+
+We use this to avoid double-counting of capacity when a new filer is brought in to replace an old one.
+While the new filer is brought in, it is in state `in_build` to avoid counting its capacity at all.
+Once payload is being moved from the old filer, the old and new filer will be set to state `in_decom` and `replacing_decom`, respectively, to avoid the appearance of capacity opening up on the old filer as it is being emptied.
+Once the old filer is gone, the `replacing_decom` state is updated to `live` on the new filer to have it count towards capacity in the normal manner.

--- a/internal/liquids/cinder/capacity.go
+++ b/internal/liquids/cinder/capacity.go
@@ -1,0 +1,201 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package cinder
+
+import (
+	"context"
+	"strings"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/schedulerstats"
+	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/services"
+	"github.com/sapcc/go-api-declarations/liquid"
+	"github.com/sapcc/go-bits/logg"
+
+	"github.com/sapcc/limes/internal/liquids"
+)
+
+// ScanCapacity implements the liquidapi.Logic interface.
+func (l *Logic) ScanCapacity(ctx context.Context, req liquid.ServiceCapacityRequest, serviceInfo liquid.ServiceInfo) (liquid.ServiceCapacityReport, error) {
+	pools, err := l.listStoragePools(ctx)
+	if err != nil {
+		return liquid.ServiceCapacityReport{}, err
+	}
+
+	// list service hosts (the relation of pools to their service hosts is used to establish AZ membership)
+	allPages, err := services.List(l.CinderV3, nil).AllPages(ctx)
+	if err != nil {
+		return liquid.ServiceCapacityReport{}, err
+	}
+	allServices, err := services.ExtractServices(allPages)
+	if err != nil {
+		return liquid.ServiceCapacityReport{}, err
+	}
+	serviceHostsPerAZ := make(map[liquid.AvailabilityZone][]string)
+	for _, element := range allServices {
+		az := liquid.AvailabilityZone(element.Zone)
+		if element.Binary == "cinder-volume" {
+			// element.Host has the format backendHostname@backendName
+			serviceHostsPerAZ[az] = append(serviceHostsPerAZ[az], element.Host)
+		}
+	}
+
+	// sort pools by volume type and AZ
+	volumeTypesByBackendName := make(map[string]VolumeType)
+	sortedPools := make(map[VolumeType]map[liquid.AvailabilityZone][]StoragePool)
+	for volumeType, cfg := range l.VolumeTypes.Get() {
+		volumeTypesByBackendName[cfg.VolumeBackendName] = volumeType
+		sortedPools[volumeType] = make(map[liquid.AvailabilityZone][]StoragePool)
+	}
+	for _, pool := range pools {
+		volumeType, ok := volumeTypesByBackendName[pool.Capabilities.VolumeBackendName]
+		if !ok {
+			logg.Info("ScanCapacity: skipping pool %q with unknown volume_backend_name %q", pool.Name, pool.Capabilities.VolumeBackendName)
+			continue
+		}
+
+		poolAZ := liquid.AvailabilityZoneUnknown
+		for az, hosts := range serviceHostsPerAZ {
+			for _, v := range hosts {
+				// pool.Name has the format backendHostname@backendName#backendPoolName
+				if strings.Contains(pool.Name, v) {
+					poolAZ = az
+					break
+				}
+			}
+		}
+		if poolAZ == liquid.AvailabilityZoneUnknown {
+			logg.Info("ScanCapacity: pool %q does not match any service host", pool.Name)
+		}
+		logg.Debug("ScanCapacity: considering pool %q for volume type %q in AZ %q", pool.Name, volumeType, poolAZ)
+
+		sortedPools[volumeType][poolAZ] = append(sortedPools[volumeType][poolAZ], pool)
+	}
+
+	// render result
+	result := liquid.ServiceCapacityReport{
+		InfoVersion: serviceInfo.Version,
+		Resources:   make(map[liquid.ResourceName]*liquid.ResourceCapacityReport),
+	}
+	for volumeType := range l.VolumeTypes.Get() {
+		poolsForVolumeType := liquids.RestrictToKnownAZs(sortedPools[volumeType], req.AllAZs)
+		result.Resources[volumeType.CapacityResourceName()], err = l.buildResourceCapacityReport(poolsForVolumeType)
+		if err != nil {
+			return liquid.ServiceCapacityReport{}, err
+		}
+	}
+	return result, nil
+}
+
+func (l *Logic) buildResourceCapacityReport(pools map[liquid.AvailabilityZone][]StoragePool) (result *liquid.ResourceCapacityReport, err error) {
+	perAZ := make(map[liquid.AvailabilityZone]*liquid.AZResourceCapacityReport, len(pools))
+	for az, azPools := range pools {
+		perAZ[az], err = l.buildAZResourceCapacityReport(azPools)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &liquid.ResourceCapacityReport{PerAZ: perAZ}, nil
+}
+
+func (l *Logic) buildAZResourceCapacityReport(pools []StoragePool) (*liquid.AZResourceCapacityReport, error) {
+	var subcapacities []liquid.Subcapacity
+
+	// prepare information for each pool
+	for _, pool := range pools {
+		usage := uint64(pool.Capabilities.AllocatedCapacityGB)
+		builder := liquid.SubcapacityBuilder[StoragePoolAttributes]{
+			Name:       pool.Name,
+			Capacity:   uint64(pool.Capabilities.TotalCapacityGB),
+			Usage:      &usage,
+			Attributes: StoragePoolAttributes{},
+		}
+
+		state := pool.Capabilities.CustomAttributes.CinderState
+		if state == "drain" || state == "reserved" {
+			logg.Info("ScanCapacity: pool %q with %g GiB capacity has cinder_state %q -- only considering %g GiB used capacity",
+				pool.Name, pool.Capabilities.TotalCapacityGB, state, pool.Capabilities.AllocatedCapacityGB)
+			builder.Attributes.ExclusionReason = "cinder_state = " + state
+			builder.Attributes.RealCapacity = builder.Capacity
+			builder.Capacity = usage // this is what counts towards the total capacity down below
+		}
+
+		subcapacity, err := builder.Finalize()
+		if err != nil {
+			return nil, err
+		}
+		subcapacities = append(subcapacities, subcapacity)
+	}
+
+	// compute overall numbers
+	result := &liquid.AZResourceCapacityReport{
+		Capacity: 0,
+		Usage:    liquids.PointerTo(uint64(0)),
+	}
+	for _, sub := range subcapacities {
+		result.Capacity += sub.Capacity
+		*result.Usage += *sub.Usage
+	}
+	if l.WithSubcapacities {
+		result.Subcapacities = subcapacities
+	}
+
+	return result, nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// internal types for capacity reporting
+
+// StoragePoolAttributes is the Attributes payload type for a Cinder subcapacity.
+type StoragePoolAttributes struct {
+	ExclusionReason string `json:"exclusion_reason,omitempty"`
+	// Only set when ExclusionReason is set.
+	RealCapacity uint64 `json:"real_capacity,omitempty"`
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// custom types for Cinder APIs
+
+// StoragePool is a custom deserialization target type that replaces
+// type schedulerstats.StoragePool.
+type StoragePool struct {
+	Name         string `json:"name"`
+	Capabilities struct {
+		VolumeBackendName   string                          `json:"volume_backend_name"`
+		TotalCapacityGB     liquids.Float64WithStringErrors `json:"total_capacity_gb"`
+		AllocatedCapacityGB liquids.Float64WithStringErrors `json:"allocated_capacity_gb"`
+
+		// SAP Converged Cloud extension
+		CustomAttributes struct {
+			CinderState string `json:"cinder_state"`
+		} `json:"custom_attributes"`
+	} `json:"capabilities"`
+}
+
+func (l *Logic) listStoragePools(ctx context.Context) ([]StoragePool, error) {
+	var poolData struct {
+		StoragePools []StoragePool `json:"pools"`
+	}
+	allPages, err := schedulerstats.List(l.CinderV3, schedulerstats.ListOpts{Detail: true}).AllPages(ctx)
+	if err != nil {
+		return nil, err
+	}
+	err = allPages.(schedulerstats.StoragePoolPage).ExtractInto(&poolData)
+	return poolData.StoragePools, err
+}

--- a/internal/liquids/cinder/liquid.go
+++ b/internal/liquids/cinder/liquid.go
@@ -1,0 +1,152 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package cinder
+
+import (
+	"context"
+	"time"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack"
+	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumetypes"
+	"github.com/sapcc/go-api-declarations/liquid"
+	"github.com/sapcc/limes/internal/liquids"
+)
+
+// NOTE: this will render subresources and subcapacities in the LIQUID format - to maintain compatibility within the v1 API, we will use a translation layer on the API level to translate subresources and subcapacities back into the known formats
+// TODO: if you see this comment, reject the PR review
+
+type Logic struct {
+	// configuration
+	WithSubcapacities        bool `json:"with_subcapacities"`
+	WithVolumeSubresources   bool `json:"with_volume_subresources"`
+	WithSnapshotSubresources bool `json:"with_snapshot_subresources"`
+	// connections
+	CinderV3 *gophercloud.ServiceClient `json:"-"`
+	// state
+	VolumeTypes liquids.State[map[VolumeType]VolumeTypeInfo] `json:"-"`
+}
+
+// VolumeType is a type with convenience functions for deriving resource names.
+type VolumeType string
+
+func (vt VolumeType) CapacityResourceName() liquid.ResourceName {
+	return liquid.ResourceName("capacity_" + string(vt))
+}
+func (vt VolumeType) SnapshotsResourceName() liquid.ResourceName {
+	return liquid.ResourceName("snapshots_" + string(vt))
+}
+func (vt VolumeType) VolumesResourceName() liquid.ResourceName {
+	return liquid.ResourceName("volumes_" + string(vt))
+}
+
+func (vt VolumeType) CapacityQuotaName() string {
+	return "gigabytes_" + string(vt)
+}
+func (vt VolumeType) SnapshotsQuotaName() string {
+	return "snapshots_" + string(vt)
+}
+func (vt VolumeType) VolumesQuotaName() string {
+	return "volumes_" + string(vt)
+}
+
+// VolumeTypeInfo contains configuration for a VolumeType.
+// We need this for matching pools with their VolumeType.
+type VolumeTypeInfo struct {
+	VolumeBackendName string
+}
+
+// Init implements the liquidapi.Logic interface.
+func (l *Logic) Init(ctx context.Context, provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (err error) {
+	l.CinderV3, err = openstack.NewBlockStorageV3(provider, eo)
+	return err
+}
+
+// BuildServiceInfo implements the liquidapi.Logic interface.
+func (l *Logic) BuildServiceInfo(ctx context.Context) (liquid.ServiceInfo, error) {
+	// discover volume types
+	allPages, err := volumetypes.List(l.CinderV3, volumetypes.ListOpts{}).AllPages(ctx)
+	if err != nil {
+		return liquid.ServiceInfo{}, err
+	}
+	vtSpecs, err := volumetypes.ExtractVolumeTypes(allPages)
+	if err != nil {
+		return liquid.ServiceInfo{}, err
+	}
+	volumeTypes := make(map[VolumeType]VolumeTypeInfo, len(vtSpecs))
+	for _, vtSpec := range vtSpecs {
+		if vtSpec.IsPublic && vtSpec.PublicAccess {
+			volumeTypes[VolumeType(vtSpec.Name)] = VolumeTypeInfo{
+				VolumeBackendName: vtSpec.ExtraSpecs["volume_backend_name"],
+			}
+		}
+	}
+	l.VolumeTypes.Set(volumeTypes)
+
+	// build ResourceInfo set
+	resInfoForCapacity := liquid.ResourceInfo{
+		Unit:        liquid.UnitGibibytes,
+		HasCapacity: true,
+		HasQuota:    true,
+	}
+	resInfoForObjects := liquid.ResourceInfo{
+		Unit:        liquid.UnitNone,
+		HasCapacity: false,
+		HasQuota:    true,
+	}
+	resources := make(map[liquid.ResourceName]liquid.ResourceInfo, 3*len(volumeTypes))
+	for volumeType := range volumeTypes {
+		resources[volumeType.CapacityResourceName()] = resInfoForCapacity
+		resources[volumeType.SnapshotsResourceName()] = resInfoForObjects
+		resources[volumeType.VolumesResourceName()] = resInfoForObjects
+	}
+
+	return liquid.ServiceInfo{
+		Version:   time.Now().Unix(),
+		Resources: resources,
+	}, nil
+}
+
+// SetQuota implements the liquidapi.Logic interface.
+func (l *Logic) SetQuota(ctx context.Context, projectUUID string, req liquid.ServiceQuotaRequest, serviceInfo liquid.ServiceInfo) error {
+	var requestData struct {
+		QuotaSet map[string]uint64 `json:"quota_set"`
+	}
+	requestData.QuotaSet = make(map[string]uint64)
+
+	for volumeType := range l.VolumeTypes.Get() {
+		quotaCapacity := req.Resources[volumeType.CapacityResourceName()].Quota
+		requestData.QuotaSet[volumeType.CapacityQuotaName()] = quotaCapacity
+		requestData.QuotaSet["gigabytes"] += quotaCapacity
+
+		quotaSnapshots := req.Resources[volumeType.SnapshotsResourceName()].Quota
+		requestData.QuotaSet[volumeType.SnapshotsQuotaName()] = quotaSnapshots
+		requestData.QuotaSet["snapshots"] += quotaSnapshots
+
+		quotaVolumes := req.Resources[volumeType.VolumesResourceName()].Quota
+		requestData.QuotaSet[volumeType.VolumesQuotaName()] = quotaVolumes
+		requestData.QuotaSet["volumes"] += quotaVolumes
+	}
+
+	url := l.CinderV3.ServiceURL("os-quota-sets", projectUUID)
+	opts := gophercloud.RequestOpts{OkCodes: []int{200}}
+	_, err := l.CinderV3.Put(ctx, url, requestData, nil, &opts)
+	return err
+}

--- a/internal/liquids/cinder/liquid.go
+++ b/internal/liquids/cinder/liquid.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack"
 	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumetypes"
 	"github.com/sapcc/go-api-declarations/liquid"
+
 	"github.com/sapcc/limes/internal/liquids"
 )
 
@@ -112,10 +113,10 @@ func (l *Logic) BuildServiceInfo(ctx context.Context) (liquid.ServiceInfo, error
 		HasQuota:    true,
 	}
 	resources := make(map[liquid.ResourceName]liquid.ResourceInfo, 3*len(volumeTypes))
-	for volumeType := range volumeTypes {
-		resources[volumeType.CapacityResourceName()] = resInfoForCapacity
-		resources[volumeType.SnapshotsResourceName()] = resInfoForObjects
-		resources[volumeType.VolumesResourceName()] = resInfoForObjects
+	for vt := range volumeTypes {
+		resources[vt.CapacityResourceName()] = resInfoForCapacity
+		resources[vt.SnapshotsResourceName()] = resInfoForObjects
+		resources[vt.VolumesResourceName()] = resInfoForObjects
 	}
 
 	return liquid.ServiceInfo{

--- a/internal/liquids/cinder/usage.go
+++ b/internal/liquids/cinder/usage.go
@@ -1,0 +1,226 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package cinder
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/quotasets"
+	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/snapshots"
+	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumes"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+	"github.com/sapcc/go-api-declarations/liquid"
+)
+
+// ScanUsage implements the liquidapi.Logic interface.
+func (l *Logic) ScanUsage(ctx context.Context, projectUUID string, req liquid.ServiceUsageRequest, serviceInfo liquid.ServiceInfo) (liquid.ServiceUsageReport, error) {
+	var data struct {
+		QuotaSet map[string]QuotaSetField `json:"quota_set"`
+	}
+	err := quotasets.GetUsage(ctx, l.CinderV3, projectUUID).ExtractInto(&data)
+	if err != nil {
+		return liquid.ServiceUsageReport{}, err
+	}
+
+	resources := make(map[liquid.ResourceName]*liquid.ResourceUsageReport)
+	for volumeType := range l.VolumeTypes.Get() {
+		resources[volumeType.CapacityResourceName()] = data.QuotaSet[volumeType.CapacityQuotaName()].ToResourceReport(req.AllAZs)
+		resources[volumeType.SnapshotsResourceName()] = data.QuotaSet[volumeType.SnapshotsQuotaName()].ToResourceReport(req.AllAZs)
+		resources[volumeType.VolumesResourceName()] = data.QuotaSet[volumeType.VolumesQuotaName()].ToResourceReport(req.AllAZs)
+	}
+
+	// NOTE: We always enumerate volume subresources because we need them for the
+	// AZ breakdown, even if we don't end up reporting them.
+	placementForVolumeUUID, err := l.collectVolumeSubresources(ctx, projectUUID, req.AllAZs, resources)
+	if err != nil {
+		return liquid.ServiceUsageReport{}, err
+	}
+	if l.WithSnapshotSubresources {
+		err = l.collectSnapshotSubresources(ctx, projectUUID, placementForVolumeUUID, resources)
+		if err != nil {
+			return liquid.ServiceUsageReport{}, err
+		}
+	}
+
+	return liquid.ServiceUsageReport{
+		InfoVersion: serviceInfo.Version,
+		Resources:   resources,
+	}, nil
+}
+
+func (l *Logic) collectVolumeSubresources(ctx context.Context, projectUUID string, allAZs []liquid.AvailabilityZone, resources map[liquid.ResourceName]*liquid.ResourceUsageReport) (placementForVolumeUUID map[string]VolumePlacement, err error) {
+	placementForVolumeUUID = make(map[string]VolumePlacement)
+	isKnownVolumeType := make(map[VolumeType]bool)
+	for vt := range l.VolumeTypes.Get() {
+		isKnownVolumeType[vt] = true
+	}
+
+	listOpts := volumes.ListOpts{
+		AllTenants: true,
+		TenantID:   projectUUID,
+	}
+
+	err = volumes.List(l.CinderV3, listOpts).EachPage(ctx, func(ctx context.Context, page pagination.Page) (bool, error) {
+		vols, err := volumes.ExtractVolumes(page)
+		if err != nil {
+			return false, err
+		}
+
+		for _, volume := range vols {
+			vt := VolumeType(volume.VolumeType)
+			if !isKnownVolumeType[vt] {
+				return false, fmt.Errorf("volume %s in project %s has unknown volume type %q", volume.ID, projectUUID, volume.VolumeType)
+			}
+
+			az := liquid.AvailabilityZone(volume.AvailabilityZone)
+			if !slices.Contains(allAZs, az) {
+				az = liquid.AvailabilityZoneUnknown
+			}
+
+			placementForVolumeUUID[volume.ID] = VolumePlacement{vt, az}
+			if az != liquid.AvailabilityZoneUnknown {
+				resources[vt.CapacityResourceName()].AddLocalizedUsage(az, uint64(volume.Size))
+				resources[vt.VolumesResourceName()].AddLocalizedUsage(az, 1)
+			}
+
+			if l.WithVolumeSubresources {
+				subresource, err := liquid.SubresourceBuilder[VolumeAttributes]{
+					ID:   volume.ID,
+					Name: volume.Name,
+					Attributes: VolumeAttributes{
+						SizeGiB: uint64(volume.Size),
+						Status:  volume.Status,
+					},
+				}.Finalize()
+				if err != nil {
+					return false, err
+				}
+				usageData := resources[vt.VolumesResourceName()].PerAZ[az]
+				usageData.Subresources = append(usageData.Subresources, subresource)
+			}
+		}
+		return true, nil
+	})
+	return placementForVolumeUUID, err
+}
+
+func (l *Logic) collectSnapshotSubresources(ctx context.Context, projectUUID string, placementForVolumeUUID map[string]VolumePlacement, resources map[liquid.ResourceName]*liquid.ResourceUsageReport) error {
+	listOpts := snapshots.ListOpts{
+		AllTenants: true,
+		TenantID:   projectUUID,
+	}
+
+	err := snapshots.List(l.CinderV3, listOpts).EachPage(ctx, func(ctx context.Context, page pagination.Page) (bool, error) {
+		snaps, err := snapshots.ExtractSnapshots(page)
+		if err != nil {
+			return false, err
+		}
+
+		for _, snapshot := range snaps {
+			placement, exists := placementForVolumeUUID[snapshot.VolumeID]
+			if !exists {
+				return false, fmt.Errorf("snapshot %s in project %s belongs to unknown volume %s", snapshot.ID, projectUUID, snapshot.VolumeID)
+			}
+
+			vt := placement.VolumeType
+			az := placement.AvailabilityZone
+			if az != liquid.AvailabilityZoneUnknown {
+				resources[vt.CapacityResourceName()].AddLocalizedUsage(az, uint64(snapshot.Size))
+				resources[vt.SnapshotsResourceName()].AddLocalizedUsage(az, 1)
+			}
+
+			if l.WithSnapshotSubresources {
+				subresource, err := liquid.SubresourceBuilder[SnapshotAttributes]{
+					ID:   snapshot.ID,
+					Name: snapshot.Name,
+					Attributes: SnapshotAttributes{
+						SizeGiB: uint64(snapshot.Size),
+						Status:  snapshot.Status,
+					},
+				}.Finalize()
+				if err != nil {
+					return false, err
+				}
+				usageData := resources[vt.SnapshotsResourceName()].PerAZ[az]
+				usageData.Subresources = append(usageData.Subresources, subresource)
+			}
+		}
+		return true, nil
+	})
+	return err
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// internal types for usage measurement and reporting
+
+type VolumePlacement struct {
+	VolumeType       VolumeType
+	AvailabilityZone liquid.AvailabilityZone
+}
+
+// VolumeAttributes is the Attributes payload for a Cinder volume subresource.
+type VolumeAttributes struct {
+	SizeGiB uint64 `json:"size_gib"`
+	Status  string `json:"status"`
+}
+
+// SnapshotAttributes is the Attributes payload for a Cinder snapshot subresource.
+type SnapshotAttributes struct {
+	SizeGiB uint64 `json:"size_gib"`
+	Status  string `json:"status"`
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// custom types for Cinder APIs
+
+type QuotaSetField struct {
+	Quota int64
+	Usage uint64
+}
+
+func (f *QuotaSetField) UnmarshalJSON(buf []byte) error {
+	// The `quota_set` field in the os-quota-sets response is mostly
+	// map[string]quotaSetField, but there is also an "id" key containing a
+	// string. Skip deserialization of that value.
+	if buf[0] == '"' {
+		return nil
+	}
+
+	var data struct {
+		Quota int64  `json:"limit"`
+		Usage uint64 `json:"in_use"`
+	}
+	err := json.Unmarshal(buf, &data)
+	if err == nil {
+		f.Quota = data.Quota
+		f.Usage = data.Usage
+	}
+	return err
+}
+
+func (f QuotaSetField) ToResourceReport(allAZs []liquid.AvailabilityZone) *liquid.ResourceUsageReport {
+	return &liquid.ResourceUsageReport{
+		Quota: &f.Quota,
+		PerAZ: liquid.AZResourceUsageReport{Usage: f.Usage}.PrepareForBreakdownInto(allAZs),
+	}
+}

--- a/internal/liquids/manila/capacity.go
+++ b/internal/liquids/manila/capacity.go
@@ -1,0 +1,414 @@
+/******************************************************************************
+*
+*  Copyright 2024 SAP SE
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+******************************************************************************/
+
+package manila
+
+import (
+	"context"
+	"encoding/json"
+	"slices"
+	"strings"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/sharedfilesystems/v2/schedulerstats"
+	"github.com/gophercloud/gophercloud/v2/openstack/sharedfilesystems/v2/services"
+	"github.com/sapcc/go-api-declarations/liquid"
+	"github.com/sapcc/go-bits/logg"
+
+	"github.com/sapcc/limes/internal/liquids"
+	"github.com/sapcc/limes/internal/util"
+)
+
+// ScanCapacity implements the liquidapi.Logic interface.
+func (l *Logic) ScanCapacity(ctx context.Context, req liquid.ServiceCapacityRequest, serviceInfo liquid.ServiceInfo) (liquid.ServiceCapacityReport, error) {
+	allPages, err := services.List(l.ManilaV2, nil).AllPages(ctx)
+	if err != nil {
+		return liquid.ServiceCapacityReport{}, err
+	}
+	allServices, err := services.ExtractServices(allPages)
+	if err != nil {
+		return liquid.ServiceCapacityReport{}, err
+	}
+
+	azForServiceHost := make(map[string]liquid.AvailabilityZone)
+	for _, element := range allServices {
+		if element.Binary == "manila-share" {
+			// element.Host has the format backendHostname@backendName
+			fields := strings.Split(element.Host, "@")
+			if len(fields) != 2 {
+				logg.Error("Expected a Manila service host in the format \"backendHostname@backendName\", got %q with ID %d", element.Host, element.ID)
+			} else {
+				azForServiceHost[fields[0]] = liquid.AvailabilityZone(element.Zone)
+			}
+		}
+	}
+
+	resources := map[liquid.ResourceName]*liquid.ResourceCapacityReport{
+		"share_networks": {
+			PerAZ: liquid.InAnyAZ(liquid.AZResourceCapacityReport{Capacity: l.CapacityCalculation.ShareNetworks}),
+		},
+	}
+	for _, vst := range l.VirtualShareTypes {
+		shareCapacityDemand := convertToRawDemand(req.DemandByResource[vst.ShareCapacityResourceName()])
+		snapshotCapacityDemand := convertToRawDemand(req.DemandByResource[vst.SnapshotCapacityResourceName()])
+		var snapmirrorCapacityDemand map[liquid.AvailabilityZone]liquid.ResourceDemandInAZ
+		if l.NetappMetrics != nil {
+			snapmirrorCapacityDemand = convertToRawDemand(req.DemandByResource[vst.SnapmirrorCapacityResourceName()])
+		}
+		// ^ NOTE: If l.NetappMetrics == nil, `snapmirrorCapacityDemand[az]` is always zero-valued
+		// and thus no capacity will be allocated to the snapmirror_capacity resource.
+
+		subresult, err := l.scanCapacityForShareType(ctx, vst, azForServiceHost, req.AllAZs, shareCapacityDemand, snapshotCapacityDemand, snapmirrorCapacityDemand)
+		if err != nil {
+			return liquid.ServiceCapacityReport{}, err
+		}
+
+		resources[vst.SharesResourceName()] = &subresult.Shares
+		resources[vst.SnapshotsResourceName()] = &subresult.Snapshots
+		resources[vst.ShareCapacityResourceName()] = &subresult.ShareCapacity
+		resources[vst.SnapshotCapacityResourceName()] = &subresult.SnapshotCapacity
+		if l.NetappMetrics != nil {
+			resources[vst.SnapmirrorCapacityResourceName()] = &subresult.SnapmirrorCapacity
+		}
+	}
+
+	return liquid.ServiceCapacityReport{
+		InfoVersion: serviceInfo.Version,
+		Resources:   resources,
+	}, nil
+}
+
+func convertToRawDemand(demand liquid.ResourceDemand) map[liquid.AvailabilityZone]liquid.ResourceDemandInAZ {
+	rawDemand := make(map[liquid.AvailabilityZone]liquid.ResourceDemandInAZ, len(demand.PerAZ))
+	for az, effectiveDemand := range demand.PerAZ {
+		rawDemand[az] = demand.OvercommitFactor.ApplyInReverseToDemand(effectiveDemand)
+	}
+	return rawDemand
+}
+
+type capacityForShareType struct {
+	Shares             liquid.ResourceCapacityReport
+	Snapshots          liquid.ResourceCapacityReport
+	ShareCapacity      liquid.ResourceCapacityReport
+	SnapshotCapacity   liquid.ResourceCapacityReport
+	SnapmirrorCapacity liquid.ResourceCapacityReport
+}
+
+type azCapacityForShareType struct {
+	Shares             liquid.AZResourceCapacityReport
+	Snapshots          liquid.AZResourceCapacityReport
+	ShareCapacity      liquid.AZResourceCapacityReport
+	SnapshotCapacity   liquid.AZResourceCapacityReport
+	SnapmirrorCapacity liquid.AZResourceCapacityReport
+}
+
+func (l *Logic) scanCapacityForShareType(ctx context.Context, vst VirtualShareType, azForServiceHost map[string]liquid.AvailabilityZone, allAZs []liquid.AvailabilityZone, shareCapacityDemand, snapshotCapacityDemand, snapmirrorCapacityDemand map[liquid.AvailabilityZone]liquid.ResourceDemandInAZ) (capacityForShareType, error) {
+	// list all pools for the Manila share types corresponding to this virtual share type
+	allPoolsByAZ := make(map[liquid.AvailabilityZone][]*Pool)
+	for _, rst := range vst.AllRealShareTypes() {
+		pools, err := l.getPools(ctx, rst)
+		if err != nil {
+			return capacityForShareType{}, err
+		}
+
+		// sort pools by AZ
+		for _, pool := range pools {
+			poolAZ := azForServiceHost[pool.Host]
+			if poolAZ == "" {
+				logg.Info("storage pool %q (share type %q) does not match any service host", pool.Name, rst)
+				poolAZ = liquid.AvailabilityZoneUnknown
+			}
+			if !slices.Contains(allAZs, poolAZ) {
+				logg.Info("storage pool %q (share type %q) belongs to unknown AZ %q", pool.Name, rst, poolAZ)
+				poolAZ = liquid.AvailabilityZoneUnknown
+			}
+			allPoolsByAZ[poolAZ] = append(allPoolsByAZ[poolAZ], &pool)
+		}
+	}
+
+	// the following computations are performed for each AZ separately
+	result := capacityForShareType{
+		Shares:             liquid.ResourceCapacityReport{PerAZ: make(map[liquid.AvailabilityZone]*liquid.AZResourceCapacityReport)},
+		Snapshots:          liquid.ResourceCapacityReport{PerAZ: make(map[liquid.AvailabilityZone]*liquid.AZResourceCapacityReport)},
+		ShareCapacity:      liquid.ResourceCapacityReport{PerAZ: make(map[liquid.AvailabilityZone]*liquid.AZResourceCapacityReport)},
+		SnapshotCapacity:   liquid.ResourceCapacityReport{PerAZ: make(map[liquid.AvailabilityZone]*liquid.AZResourceCapacityReport)},
+		SnapmirrorCapacity: liquid.ResourceCapacityReport{PerAZ: make(map[liquid.AvailabilityZone]*liquid.AZResourceCapacityReport)},
+	}
+	for az, azPools := range allPoolsByAZ {
+		azResult, err := l.scanCapacityForShareTypeAndAZ(vst, uint64(len(allAZs)), az, azPools, shareCapacityDemand[az], snapshotCapacityDemand[az], snapmirrorCapacityDemand[az])
+		if err != nil {
+			return capacityForShareType{}, err
+		}
+		result.Shares.PerAZ[az] = &azResult.Shares
+		result.Snapshots.PerAZ[az] = &azResult.Snapshots
+		result.ShareCapacity.PerAZ[az] = &azResult.ShareCapacity
+		result.SnapshotCapacity.PerAZ[az] = &azResult.SnapshotCapacity
+		result.SnapmirrorCapacity.PerAZ[az] = &azResult.SnapmirrorCapacity
+	}
+
+	return result, nil
+}
+
+func (l *Logic) scanCapacityForShareTypeAndAZ(vst VirtualShareType, azCount uint64, az liquid.AvailabilityZone, pools []*Pool, shareCapacityDemand, snapshotCapacityDemand, snapmirrorCapacityDemand liquid.ResourceDemandInAZ) (azCapacityForShareType, error) {
+	// count pools and sum their capacities if they are included
+	var (
+		poolCount           uint64
+		totalCapacityGB     float64
+		allocatedCapacityGB float64
+	)
+	for _, pool := range pools {
+		poolCount++
+		allocatedCapacityGB += float64(pool.Capabilities.AllocatedCapacityGB)
+
+		if pool.CountsUnusedCapacity() {
+			totalCapacityGB += float64(pool.Capabilities.TotalCapacityGB)
+		} else {
+			totalCapacityGB += float64(pool.Capabilities.AllocatedCapacityGB)
+			logg.Info("ignoring unused capacity in Manila storage pool %q (share type %q) in AZ %q because of hardware_state value: %q",
+				pool.Name, vst.Name, az, pool.Capabilities.HardwareState)
+		}
+	}
+
+	// distribute capacity and usage between the various resource types
+	logg.Debug("distributing capacity for share_type %q, AZ %q", vst.Name, az)
+	distributedCapacityGiB := l.distributeByDemand(uint64(totalCapacityGB), map[string]liquid.ResourceDemandInAZ{
+		"shares":      shareCapacityDemand,
+		"snapshots":   snapshotCapacityDemand,
+		"snapmirrors": snapmirrorCapacityDemand,
+	})
+	logg.Debug("distributing usage for share_type %q, AZ %q", vst.Name, az)
+	distributedUsageGiB := l.distributeByDemand(uint64(allocatedCapacityGB), map[string]liquid.ResourceDemandInAZ{
+		"shares":      {Usage: shareCapacityDemand.Usage},
+		"snapshots":   {Usage: snapshotCapacityDemand.Usage},
+		"snapmirrors": {Usage: snapmirrorCapacityDemand.Usage},
+	})
+
+	// build overall result
+	params := l.CapacityCalculation
+	var result azCapacityForShareType
+	result.Shares = liquid.AZResourceCapacityReport{
+		Capacity: liquids.SaturatingSub(params.SharesPerPool*poolCount, params.ShareNetworks/azCount),
+	}
+	result.Snapshots = liquid.AZResourceCapacityReport{
+		Capacity: result.Shares.Capacity * params.SnapshotsPerShare,
+	}
+	result.ShareCapacity = liquid.AZResourceCapacityReport{
+		Capacity: distributedCapacityGiB["shares"],
+		Usage:    liquids.PointerTo(distributedUsageGiB["shares"]),
+	}
+	result.SnapshotCapacity = liquid.AZResourceCapacityReport{
+		Capacity: distributedCapacityGiB["snapshots"],
+		Usage:    liquids.PointerTo(distributedUsageGiB["snapshots"]),
+	}
+	result.SnapmirrorCapacity = liquid.AZResourceCapacityReport{
+		Capacity: distributedCapacityGiB["snapmirrors"],
+		Usage:    liquids.PointerTo(distributedUsageGiB["snapmirrors"]),
+	}
+
+	// render subcapacities (these are not split between share_capacity and
+	// snapshot_capacity because that quickly turns into an algorithmic
+	// nightmare, and we have no demand (pun intended) for that right now)
+	if params.WithSubcapacities {
+		slices.SortFunc(pools, func(lhs, rhs *Pool) int {
+			return strings.Compare(lhs.Name, rhs.Name)
+		})
+		for _, pool := range pools {
+			usage := uint64(pool.Capabilities.AllocatedCapacityGB)
+			builder := liquid.SubcapacityBuilder[StoragePoolAttributes]{
+				Name:       pool.Name,
+				Capacity:   uint64(pool.Capabilities.TotalCapacityGB),
+				Usage:      liquids.PointerTo(usage),
+				Attributes: StoragePoolAttributes{},
+			}
+
+			if !pool.CountsUnusedCapacity() {
+				builder.Attributes.ExclusionReason = "hardware_state = " + pool.Capabilities.HardwareState
+				builder.Attributes.RealCapacity = builder.Capacity
+				builder.Capacity = usage
+			}
+
+			subcapacity, err := builder.Finalize()
+			if err != nil {
+				return azCapacityForShareType{}, err
+			}
+			result.ShareCapacity.Subcapacities = append(result.ShareCapacity.Subcapacities, subcapacity)
+		}
+	}
+
+	return result, nil
+}
+
+// This implements the method we use to distribute capacity and usage between shares and snapshots:
+// Each tier of demand is distributed fairly (while supplies last).
+// Then anything that is not covered by demand is distributed according to the configured CapacityBalance.
+//
+// For capacity, each tier of demand is considered.
+// For usage, the caller will set all demand fields except for Usage to 0.
+func (l *Logic) distributeByDemand(totalAmount uint64, demands map[string]liquid.ResourceDemandInAZ) map[string]uint64 {
+	// setup phase to make each of the paragraphs below as identical as possible (for clarity)
+	requests := make(map[string]uint64)
+	result := make(map[string]uint64)
+	remaining := totalAmount
+
+	// tier 1: usage
+	for k, demand := range demands {
+		requests[k] = demand.Usage
+	}
+	grantedAmount := util.DistributeFairly(remaining, requests)
+	for k := range demands {
+		remaining -= grantedAmount[k]
+		result[k] += grantedAmount[k]
+	}
+	if logg.ShowDebug {
+		resultJSON, _ := json.Marshal(result) //nolint:errcheck // no reasonable way for this to fail, also only debug log
+		logg.Debug("distributeByDemand after phase 1: " + string(resultJSON))
+	}
+
+	// tier 2: unused commitments
+	for k, demand := range demands {
+		requests[k] = demand.UnusedCommitments
+	}
+	grantedAmount = util.DistributeFairly(remaining, requests)
+	for k := range demands {
+		remaining -= grantedAmount[k]
+		result[k] += grantedAmount[k]
+	}
+	if logg.ShowDebug {
+		resultJSON, _ := json.Marshal(result) //nolint:errcheck // no reasonable way for this to fail, also only debug log
+		logg.Debug("distributeByDemand after phase 2: " + string(resultJSON))
+	}
+
+	// tier 3: pending commitments
+	for k, demand := range demands {
+		requests[k] = demand.PendingCommitments
+	}
+	grantedAmount = util.DistributeFairly(remaining, requests)
+	for k := range demands {
+		remaining -= grantedAmount[k]
+		result[k] += grantedAmount[k]
+	}
+	if logg.ShowDebug {
+		resultJSON, _ := json.Marshal(result) //nolint:errcheck // no reasonable way for this to fail, also only debug log
+		logg.Debug("distributeByDemand after phase 2: " + string(resultJSON))
+	}
+
+	// final phase: distribute all remaining capacity according to the configured CapacityBalance
+	//
+	// NOTE: The CapacityBalance value says how much capacity we give out
+	// to snapshots as a fraction of the capacity given out to shares. For
+	// example, with CapacityBalance = 2, we allocate 2/3 of the total capacity to
+	// snapshots, and 1/3 to shares.
+	if remaining > 0 {
+		cb := l.CapacityCalculation.CapacityBalance
+		portionForSnapshots := uint64(cb / (cb + 1) * float64(remaining))
+		portionForShares := remaining - portionForSnapshots
+
+		result["snapshots"] += portionForSnapshots
+		result["shares"] += portionForShares
+	}
+	if logg.ShowDebug {
+		resultJSON, _ := json.Marshal(result) //nolint:errcheck // no reasonable way for this to fail, also only debug log
+		logg.Debug("distributeByDemand after CapacityBalance: " + string(resultJSON))
+	}
+
+	return result
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// internal types for capacity reporting
+
+// StoragePoolAttributes is the Attributes payload type for a Manila subcapacity.
+type StoragePoolAttributes struct {
+	ExclusionReason string `json:"exclusion_reason,omitempty"`
+	// Only set when ExclusionReason is set.
+	RealCapacity uint64 `json:"real_capacity,omitempty"`
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// custom types for Manila APIs (to work around Gophercloud limitations)
+
+// PoolsListDetailOpts fixes the broken structure of schedulerstats.ListDetailOpts.
+type poolsListDetailOpts struct {
+	// TODO: remove when https://github.com/gophercloud/gophercloud/pull/3167 was merged
+	ShareType string `q:"share_type,omitempty"`
+}
+
+// ToPoolsListQuery implements the schedulerstats.ListDetailOptsBuilder interface.
+func (opts poolsListDetailOpts) ToPoolsListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// Pool is a custom extension of the type `schedulerstats.Pool`.
+type Pool struct {
+	Name         string `json:"name"`
+	Host         string `json:"host"`
+	Capabilities struct {
+		// standard fields
+		TotalCapacityGB     liquids.Float64WithStringErrors `json:"total_capacity_gb"`
+		AllocatedCapacityGB liquids.Float64WithStringErrors `json:"allocated_capacity_gb"`
+		// CCloud extension fields
+		HardwareState string `json:"hardware_state"`
+	} `json:"capabilities,omitempty"`
+}
+
+// CountsUnusedCapacity returns whether this pool has all its capacity count
+// towards the total (instead of just the used capacity).
+func (p Pool) CountsUnusedCapacity() bool {
+	switch p.Capabilities.HardwareState {
+	// Pool is in buildup. At that phase, Manila already knows this storage
+	// backend, but it is not handed out to customers. Shares are only deployable
+	// with custom share type `integration` for integration testing. Capacity
+	// should not yet be handed out.
+	case "in_build":
+		return false
+	// Pool will be decommissioned soon. Still serving customer shares, but drain
+	// is ongoing. Unused capacity should no longer be handed out.
+	case "in_decom":
+		return false
+	// Pool is meant as replacement for another pool in_decom. Capacity should
+	// not be handed out. Will only be used in tight situations to ensure there
+	// is enough capacity to drain backend in decommissioning.
+	case "replacing_decom":
+		return false
+	// Default value on deployments using the HardwareState field.
+	case "live":
+		return true
+	// Default value on deployments not using the HardwareState field.
+	case "":
+		return true
+	default:
+		logg.Info("Manila storage pool %q has unknown hardware_state value: %q",
+			p.Name, p.Capabilities.HardwareState)
+		return false
+	}
+}
+
+// Lists all pools for the given real share type.
+func (l *Logic) getPools(ctx context.Context, rst RealShareType) ([]Pool, error) {
+	allPages, err := schedulerstats.ListDetail(l.ManilaV2, poolsListDetailOpts{ShareType: string(rst)}).AllPages(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var s struct {
+		Pools []Pool `json:"pools"`
+	}
+	err = (allPages.(schedulerstats.PoolPage)).ExtractInto(&s)
+	return s.Pools, err
+}

--- a/internal/liquids/manila/liquid.go
+++ b/internal/liquids/manila/liquid.go
@@ -1,0 +1,334 @@
+/******************************************************************************
+*
+*  Copyright 2024 SAP SE
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+******************************************************************************/
+
+package manila
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack"
+	"github.com/gophercloud/gophercloud/v2/openstack/sharedfilesystems/apiversions"
+	"github.com/gophercloud/gophercloud/v2/openstack/sharedfilesystems/v2/sharetypes"
+	"github.com/prometheus/common/model"
+	"github.com/sapcc/go-api-declarations/limes"
+	"github.com/sapcc/go-api-declarations/liquid"
+	"github.com/sapcc/go-bits/promquery"
+
+	"github.com/sapcc/limes/internal/liquids"
+)
+
+// NOTE: this will render subresources and subcapacities in the LIQUID format - to maintain compatibility within the v1 API, we will use a translation layer on the API level to translate subresources and subcapacities back into the known formats
+// TODO: if you see this comment, reject the PR review
+
+type Logic struct {
+	// configuration
+	CapacityCalculation struct {
+		CapacityBalance   float64 `json:"capacity_balance"`
+		ShareNetworks     uint64  `json:"share_networks"`
+		SharesPerPool     uint64  `json:"shares_per_pool"`
+		SnapshotsPerShare uint64  `json:"snapshots_per_share"`
+		WithSubcapacities bool    `json:"with_subcapacities"`
+	} `json:"capacity_calculation"`
+	VirtualShareTypes                   []VirtualShareType `json:"share_types"`
+	PrometheusAPIConfigForAZAwareness   *promquery.Config  `json:"prometheus_api_for_az_awareness"`
+	PrometheusAPIConfigForNetappMetrics *promquery.Config  `json:"prometheus_api_for_netapp_metrics"`
+	// connections
+	ManilaV2      *gophercloud.ServiceClient                                 `json:"-"`
+	AZMetrics     *promquery.BulkQueryCache[azMetricsKey, azMetrics]         `json:"-"`
+	NetappMetrics *promquery.BulkQueryCache[netappMetricsKey, netappMetrics] `json:"-"`
+	// caches
+	ShareTypeIDByName liquids.State[map[RealShareType]string] `json:"-"`
+}
+
+// Init implements the liquidapi.Logic interface.
+func (l *Logic) Init(ctx context.Context, provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (err error) {
+	if len(l.VirtualShareTypes) == 0 {
+		return errors.New("missing required configuration field: share_types")
+	}
+	if l.CapacityCalculation.ShareNetworks == 0 {
+		return errors.New("missing required configuration field: capacity_calculation.share_networks")
+	}
+	if l.CapacityCalculation.SharesPerPool == 0 {
+		return errors.New("missing required configuration field: capacity_calculation.shares_per_pool")
+	}
+	if l.CapacityCalculation.SnapshotsPerShare == 0 {
+		return errors.New("missing required configuration field: capacity_calculation.snapshots_per_share")
+	}
+
+	// initialize connection to Manila
+	l.ManilaV2, err = openstack.NewSharedFileSystemV2(provider, eo)
+	if err != nil {
+		return err
+	}
+	microversion, err := l.findMicroversion(ctx, l.ManilaV2)
+	if err != nil {
+		return err
+	}
+	if microversion == 0 {
+		return errors.New(`cannot find API microversion: no version of the form "2.x" found in advertisement`)
+	}
+	if microversion < 53 {
+		return fmt.Errorf("need at least Manila microversion 2.53 (for replica quotas), but got 2.%d", microversion)
+	}
+	l.ManilaV2.Microversion = "2.53"
+
+	// initialize connection to Prometheus
+	if l.PrometheusAPIConfigForAZAwareness != nil {
+		promClientForAZAwareness, err := l.PrometheusAPIConfigForAZAwareness.Connect()
+		if err != nil {
+			return err
+		}
+		l.AZMetrics = promquery.NewBulkQueryCache(azMetricsQueries, 2*time.Minute, promClientForAZAwareness)
+	}
+
+	if l.PrometheusAPIConfigForNetappMetrics != nil {
+		promClientForNetappMetrics, err := l.PrometheusAPIConfigForNetappMetrics.Connect()
+		if err != nil {
+			return err
+		}
+		l.NetappMetrics = promquery.NewBulkQueryCache(netappMetricsQueries, 2*time.Minute, promClientForNetappMetrics)
+	}
+
+	return nil
+}
+
+func (l *Logic) findMicroversion(ctx context.Context, client *gophercloud.ServiceClient) (int, error) {
+	pager, err := apiversions.List(client).AllPages(ctx)
+	if err != nil {
+		return 0, err
+	}
+	versions, err := apiversions.ExtractAPIVersions(pager)
+	if err != nil {
+		return 0, err
+	}
+
+	versionRx := regexp.MustCompile(`^2\.(\d+)$`)
+	for _, version := range versions {
+		match := versionRx.FindStringSubmatch(version.Version)
+		if match != nil {
+			return strconv.Atoi(match[1])
+		}
+	}
+
+	// no 2.x version found at all
+	return 0, nil
+}
+
+// BuildServiceInfo implements the liquidapi.Logic interface.
+func (l *Logic) BuildServiceInfo(ctx context.Context) (liquid.ServiceInfo, error) {
+	// enumerate all share types to establish an ID-name mapping
+	// (the Manila quota API exclusively deals with share type names,
+	// but some Prometheus metrics need the share type ID)
+	pager, err := sharetypes.List(l.ManilaV2, &sharetypes.ListOpts{IsPublic: "all"}).AllPages(ctx)
+	if err != nil {
+		return liquid.ServiceInfo{}, fmt.Errorf("cannot enumerate Manila share types: %w", err)
+	}
+	shareTypes, err := sharetypes.ExtractShareTypes(pager)
+	if err != nil {
+		return liquid.ServiceInfo{}, fmt.Errorf("cannot unmarshal Manila share types: %w", err)
+	}
+	shareTypeIDByName := make(map[RealShareType]string)
+	for _, shareType := range shareTypes {
+		shareTypeIDByName[RealShareType(shareType.Name)] = shareType.ID
+	}
+	l.ShareTypeIDByName.Set(shareTypeIDByName)
+
+	// build ResourceInfo set
+	resInfoForCapacity := liquid.ResourceInfo{
+		Unit:                liquid.UnitGibibytes,
+		HasCapacity:         true,
+		HasQuota:            true,
+		NeedsResourceDemand: true,
+	}
+	resInfoForObjects := liquid.ResourceInfo{
+		Unit:        liquid.UnitNone,
+		HasCapacity: true,
+		HasQuota:    true,
+	}
+	resources := make(map[liquid.ResourceName]liquid.ResourceInfo, 5*len(l.VirtualShareTypes)+1)
+	resources["share_networks"] = resInfoForObjects
+	for _, vst := range l.VirtualShareTypes {
+		resources[vst.SharesResourceName()] = resInfoForObjects
+		resources[vst.SnapshotsResourceName()] = resInfoForObjects
+		resources[vst.ShareCapacityResourceName()] = resInfoForCapacity
+		resources[vst.SnapshotCapacityResourceName()] = resInfoForCapacity
+		if l.NetappMetrics != nil {
+			resources[vst.SnapmirrorCapacityResourceName()] = resInfoForCapacity
+		}
+	}
+
+	return liquid.ServiceInfo{
+		Version:                         time.Now().Unix(),
+		Resources:                       resources,
+		UsageReportNeedsProjectMetadata: true,
+		QuotaUpdateNeedsProjectMetadata: true,
+	}, nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Prometheus queries
+
+const (
+	// NOTE: In these queries, the `last_over_time(...[15m])` part guards against temporary unavailability of metrics resulting in spurious zero values.
+
+	// queries for AZ awareness metrics
+	shareCountQuery       = `count by (availability_zone_name, project_id, share_type_id) (max by (availability_zone_name, id, project_id, share_id, share_type_id) (last_over_time(openstack_manila_replicas_count_gauge[15m])))`
+	shareCapacityQuery    = `sum   by (availability_zone_name, project_id, share_type_id) (max by (availability_zone_name, id, project_id, share_id, share_type_id) (last_over_time(openstack_manila_replicas_size_gauge[15m])))`
+	snapshotCountQuery    = `count by (availability_zone_name, project_id, share_type_id) (max by (availability_zone_name, id, project_id, share_id, share_type_id) (last_over_time(openstack_manila_snapshot_count_gauge[15m])))`
+	snapshotCapacityQuery = `sum   by (availability_zone_name, project_id, share_type_id) (max by (availability_zone_name, id, project_id, share_id, share_type_id) (last_over_time(openstack_manila_snapshot_size_gauge[15m])))`
+
+	// queries for netapp-exporter metrics
+	sharePhysicalUsageQuery      = `sum by (availability_zone, project_id, share_type) (max by (availability_zone, project_id, share_id, share_type) (last_over_time(netapp_volume_used_bytes         {project_id!="",share_type!="",volume_type!="dp",volume_state="online"}[15m])))`
+	snapshotPhysicalUsageQuery   = `sum by (availability_zone, project_id, share_type) (max by (availability_zone, project_id, share_id, share_type) (last_over_time(netapp_volume_snapshot_used_bytes{project_id!="",share_type!="",volume_type!="dp",volume_state="online"}[15m])))`
+	snapmirrorUsageQuery         = `sum by (availability_zone, project_id, share_type) (max by (availability_zone, project_id, share_id, share_type) (last_over_time(netapp_volume_total_bytes        {project_id!="",share_type!="",volume_type!="dp",volume_state="online",snapshot_policy="EC2_Backups"}[15m])))`
+	snapmirrorPhysicalUsageQuery = `sum by (availability_zone, project_id, share_type) (max by (availability_zone, project_id, share_id, share_type) (last_over_time(netapp_volume_used_bytes         {project_id!="",share_type!="",volume_type!="dp",volume_state="online",snapshot_policy="EC2_Backups"}[15m])))`
+)
+
+type azMetricsKey struct {
+	AvailabilityZone limes.AvailabilityZone
+	ProjectUUID      string
+	ShareTypeID      string
+}
+
+func azMetricsKeyer(sample *model.Sample) azMetricsKey {
+	return azMetricsKey{
+		AvailabilityZone: limes.AvailabilityZone(sample.Metric["availability_zone_name"]),
+		ProjectUUID:      string(sample.Metric["project_id"]),
+		ShareTypeID:      string(sample.Metric["share_type_id"]),
+	}
+}
+
+type netappMetricsKey struct {
+	AvailabilityZone limes.AvailabilityZone
+	ProjectUUID      string
+	ShareTypeName    RealShareType
+}
+
+func netappMetricsKeyer(sample *model.Sample) netappMetricsKey {
+	return netappMetricsKey{
+		AvailabilityZone: limes.AvailabilityZone(sample.Metric["availability_zone"]),
+		ProjectUUID:      string(sample.Metric["project_id"]),
+		ShareTypeName:    RealShareType(sample.Metric["share_type"]),
+	}
+}
+
+type azMetrics struct {
+	ShareCount          uint64
+	ShareCapacityGiB    uint64
+	SnapshotCount       uint64
+	SnapshotCapacityGiB uint64
+}
+
+type netappMetrics struct {
+	// all in GiB
+	SharePhysicalUsage      uint64
+	SnapshotPhysicalUsage   uint64
+	SnapmirrorUsage         uint64
+	SnapmirrorPhysicalUsage uint64
+}
+
+var (
+	azMetricsQueries = []promquery.BulkQuery[azMetricsKey, azMetrics]{
+		{
+			Query:       shareCountQuery,
+			Description: "shares usage data",
+			Keyer:       azMetricsKeyer,
+			Filler: func(entry *azMetrics, sample *model.Sample) {
+				entry.ShareCount = roundUp(float64(sample.Value))
+			},
+		},
+		{
+			Query:       shareCapacityQuery,
+			Description: "share_capacity usage data",
+			Keyer:       azMetricsKeyer,
+			Filler: func(entry *azMetrics, sample *model.Sample) {
+				entry.ShareCapacityGiB = roundUp(float64(sample.Value))
+			},
+		},
+		{
+			Query:       snapshotCountQuery,
+			Description: "share_snapshots usage data",
+			Keyer:       azMetricsKeyer,
+			Filler: func(entry *azMetrics, sample *model.Sample) {
+				entry.SnapshotCount = roundUp(float64(sample.Value))
+			},
+			ZeroResultsIsNotAnError: true, // some regions legitimately do not have any snapshots
+		},
+		{
+			Query:       snapshotCapacityQuery,
+			Description: "snapshot_capacity usage data",
+			Keyer:       azMetricsKeyer,
+			Filler: func(entry *azMetrics, sample *model.Sample) {
+				entry.SnapshotCapacityGiB = roundUp(float64(sample.Value))
+			},
+			ZeroResultsIsNotAnError: true, // some regions legitimately do not have any snapshots
+		},
+	}
+	netappMetricsQueries = []promquery.BulkQuery[netappMetricsKey, netappMetrics]{
+		{
+			Query:       sharePhysicalUsageQuery,
+			Description: "share_capacity physical usage data",
+			Keyer:       netappMetricsKeyer,
+			Filler: func(entry *netappMetrics, sample *model.Sample) {
+				entry.SharePhysicalUsage = roundUpIntoGigabytes(float64(sample.Value))
+			},
+		},
+		{
+			Query:       snapshotPhysicalUsageQuery,
+			Description: "snapshot_capacity physical usage data",
+			Keyer:       netappMetricsKeyer,
+			Filler: func(entry *netappMetrics, sample *model.Sample) {
+				entry.SnapshotPhysicalUsage = roundUpIntoGigabytes(float64(sample.Value))
+			},
+			ZeroResultsIsNotAnError: true, // some regions legitimately do not have any snapshots
+		},
+		{
+			Query:       snapmirrorUsageQuery,
+			Description: "snapmirror_capacity usage data",
+			Keyer:       netappMetricsKeyer,
+			Filler: func(entry *netappMetrics, sample *model.Sample) {
+				entry.SnapmirrorUsage = roundUpIntoGigabytes(float64(sample.Value))
+			},
+			ZeroResultsIsNotAnError: true, // some regions legitimately do not have any snapmirror deployments
+		},
+		{
+			Query:       snapmirrorPhysicalUsageQuery,
+			Description: "snapmirror_capacity physical usage data",
+			Keyer:       netappMetricsKeyer,
+			Filler: func(entry *netappMetrics, sample *model.Sample) {
+				entry.SnapmirrorPhysicalUsage = roundUpIntoGigabytes(float64(sample.Value))
+			},
+			ZeroResultsIsNotAnError: true, // some regions legitimately do not have any snapmirror deployments
+		},
+	}
+)
+
+func roundUp(number float64) uint64 {
+	return uint64(math.Ceil(number))
+}
+
+func roundUpIntoGigabytes(bytes float64) uint64 {
+	return uint64(math.Ceil(bytes / (1 << 30)))
+}

--- a/internal/liquids/manila/sharetype.go
+++ b/internal/liquids/manila/sharetype.go
@@ -1,0 +1,98 @@
+/******************************************************************************
+*
+*  Copyright 2024 SAP SE
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+******************************************************************************/
+
+package manila
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/sapcc/go-api-declarations/liquid"
+	"github.com/sapcc/go-bits/regexpext"
+)
+
+// RealShareType is a share type name that can be used in the Manila API.
+type RealShareType string
+
+// VirtualShareType is the configuration for a virtual share type.
+type VirtualShareType struct {
+	Name               RealShareType `json:"name"`
+	ReplicationEnabled bool          `json:"replication_enabled"` // only used by QuotaPlugin
+	MappingRules       []struct {
+		FullProjectNamePattern regexpext.BoundedRegexp `json:"match_project_name"`
+		Name                   RealShareType           `json:"name"`
+	} `json:"mapping_rules"`
+}
+
+func (vst VirtualShareType) SharesResourceName() liquid.ResourceName {
+	return liquid.ResourceName("shares_" + string(vst.Name))
+}
+func (vst VirtualShareType) SnapshotsResourceName() liquid.ResourceName {
+	return liquid.ResourceName("snapshots_" + string(vst.Name))
+}
+func (vst VirtualShareType) ShareCapacityResourceName() liquid.ResourceName {
+	return liquid.ResourceName("share_capacity_" + string(vst.Name))
+}
+func (vst VirtualShareType) SnapshotCapacityResourceName() liquid.ResourceName {
+	return liquid.ResourceName("snapshot_capacity_" + string(vst.Name))
+}
+func (vst VirtualShareType) SnapmirrorCapacityResourceName() liquid.ResourceName {
+	return liquid.ResourceName("snapmirror_capacity_" + string(vst.Name))
+}
+
+// RealShareTypeIn returns the real share type that we have to use on the Manila
+// API for this particular project, or "" if this share type shall be skipped
+// for this project.
+func (vst VirtualShareType) RealShareTypeIn(project liquid.ProjectMetadata) (rst RealShareType, omit bool) {
+	fullName := fmt.Sprintf(`%s@%s`, project.Name, project.Domain.Name)
+	for _, rule := range vst.MappingRules {
+		if rule.FullProjectNamePattern.MatchString(fullName) {
+			return rule.Name, rule.Name == ""
+		}
+	}
+	return vst.Name, false
+}
+
+// AllRealShareTypes returns all real share types that can be used on the
+// Manila API to set quota or read usage for this virtual share type.
+func (vst VirtualShareType) AllRealShareTypes() (result []RealShareType) {
+	for _, rule := range vst.MappingRules {
+		// rules that make the share type inaccessible should not be considered
+		if rule.Name == "" {
+			continue
+		}
+
+		// only enter unique values into the result
+		if !slices.Contains(result, rule.Name) {
+			result = append(result, rule.Name)
+		}
+
+		// if there is a catch-all rule, no rules afterwards will have any effect
+		if rule.FullProjectNamePattern == `.*` || rule.FullProjectNamePattern == `.+` {
+			return result
+		}
+	}
+
+	// if there is no pattern like `.*`, projects that do not match any of the
+	// mapping rules will use the name of the virtual share type as the actual
+	// Manila-level share type
+	if !slices.Contains(result, vst.Name) {
+		result = append(result, vst.Name)
+	}
+	return result
+}

--- a/internal/liquids/manila/usage.go
+++ b/internal/liquids/manila/usage.go
@@ -1,0 +1,361 @@
+/******************************************************************************
+*
+*  Copyright 2024 SAP SE
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+******************************************************************************/
+
+package manila
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/sapcc/go-api-declarations/liquid"
+	"github.com/sapcc/go-bits/logg"
+
+	"github.com/sapcc/limes/internal/liquids"
+)
+
+// ScanUsage implements the liquidapi.Logic interface.
+func (l *Logic) ScanUsage(ctx context.Context, projectUUID string, req liquid.ServiceUsageRequest, serviceInfo liquid.ServiceInfo) (liquid.ServiceUsageReport, error) {
+	if req.ProjectMetadata == nil {
+		return liquid.ServiceUsageReport{}, errors.New("projectMetadata is missing")
+	}
+
+	// the share_networks quota is only shown when querying for no share_type in particular
+	qs, err := l.getQuotaSet(ctx, projectUUID, "")
+	if err != nil {
+		return liquid.ServiceUsageReport{}, err
+	}
+	resources := map[liquid.ResourceName]*liquid.ResourceUsageReport{
+		"share_networks": {
+			Quota: &qs.ShareNetworks.Quota,
+			PerAZ: liquid.InAnyAZ(liquid.AZResourceUsageReport{Usage: qs.ShareNetworks.Usage}),
+		},
+	}
+
+	// all other quotas and usages are grouped under their respective share types
+	for _, vst := range l.VirtualShareTypes {
+		subresult, err := l.scanUsageForShareType(ctx, projectUUID, vst, req)
+		if err != nil {
+			return liquid.ServiceUsageReport{}, err
+		}
+		resources[vst.SharesResourceName()] = subresult.Shares
+		resources[vst.SnapshotsResourceName()] = subresult.Snapshots
+		resources[vst.ShareCapacityResourceName()] = subresult.ShareCapacity
+		resources[vst.SnapshotCapacityResourceName()] = subresult.SnapshotCapacity
+		if l.NetappMetrics != nil {
+			resources[vst.SnapmirrorCapacityResourceName()] = subresult.SnapmirrorCapacity
+		}
+	}
+
+	return liquid.ServiceUsageReport{
+		InfoVersion: serviceInfo.Version,
+		Resources:   resources,
+	}, nil
+}
+
+type shareTypeUsageReport struct {
+	Shares             *liquid.ResourceUsageReport
+	Snapshots          *liquid.ResourceUsageReport
+	ShareCapacity      *liquid.ResourceUsageReport
+	SnapshotCapacity   *liquid.ResourceUsageReport
+	SnapmirrorCapacity *liquid.ResourceUsageReport
+}
+
+func (l *Logic) scanUsageForShareType(ctx context.Context, projectUUID string, vst VirtualShareType, req liquid.ServiceUsageRequest) (shareTypeUsageReport, error) {
+	rst, omit := vst.RealShareTypeIn(*req.ProjectMetadata)
+	if omit {
+		return l.reportShareTypeAsForbidden(req), nil
+	}
+
+	// start with the quota data from Manila
+	qs, err := l.getQuotaSet(ctx, projectUUID, rst)
+	if err != nil {
+		return shareTypeUsageReport{}, err
+	}
+
+	withAZMetrics := l.AZMetrics != nil
+	result := shareTypeUsageReport{
+		Shares:           qs.Shares.ToResourceReport(req.AllAZs, withAZMetrics),
+		Snapshots:        qs.Snapshots.ToResourceReport(req.AllAZs, withAZMetrics),
+		ShareCapacity:    qs.Gigabytes.ToResourceReport(req.AllAZs, withAZMetrics),
+		SnapshotCapacity: qs.SnapshotGigabytes.ToResourceReport(req.AllAZs, withAZMetrics),
+	}
+	if vst.ReplicationEnabled {
+		result.Shares = qs.Replicas.ToResourceReport(req.AllAZs, withAZMetrics)
+		result.ShareCapacity = qs.ReplicaGigabytes.ToResourceReport(req.AllAZs, withAZMetrics)
+
+		// if share quotas and replica quotas disagree, report quota = -1 to force Limes to reapply the replica quota
+		if qs.Shares.Quota != *result.Shares.Quota {
+			logg.Info("found mismatch between share quota (%d) and replica quota (%d) for share type %q in project %s",
+				*result.Shares.Quota, qs.Replicas.Quota, rst, projectUUID)
+			result.Shares.Quota = liquids.PointerTo(int64(-1))
+		}
+		if qs.Gigabytes.Quota != *result.ShareCapacity.Quota {
+			logg.Info("found mismatch between share capacity quota (%d) and replica capacity quota (%d) for share type %q in project %s",
+				*result.ShareCapacity.Quota, qs.ReplicaGigabytes.Quota, rst, projectUUID)
+			result.ShareCapacity.Quota = liquids.PointerTo(int64(-1))
+		}
+	}
+
+	// add data from Prometheus metrics to break down usage by AZ, if available
+	if l.AZMetrics != nil {
+		shareTypeID, exists := l.ShareTypeIDByName.Get()[rst]
+		if !exists {
+			return shareTypeUsageReport{}, fmt.Errorf("cannot find ID for share type with name %q", rst)
+		}
+		for _, az := range req.AllAZs {
+			azm, err := l.AZMetrics.Get(ctx, azMetricsKey{
+				AvailabilityZone: az,
+				ProjectUUID:      projectUUID,
+				ShareTypeID:      shareTypeID,
+			})
+			if err != nil {
+				return shareTypeUsageReport{}, err
+			}
+
+			result.Shares.AddLocalizedUsage(az, azm.ShareCount)
+			result.ShareCapacity.AddLocalizedUsage(az, azm.ShareCapacityGiB)
+			result.Snapshots.AddLocalizedUsage(az, azm.SnapshotCount)
+			result.SnapshotCapacity.AddLocalizedUsage(az, azm.SnapshotCapacityGiB)
+		}
+	}
+
+	// add data from Netapp metrics, if available
+	if l.NetappMetrics != nil {
+		result.SnapmirrorCapacity = &liquid.ResourceUsageReport{
+			Quota: nil,
+			PerAZ: make(map[liquid.AvailabilityZone]*liquid.AZResourceUsageReport),
+		}
+
+		for _, az := range req.AllAZs {
+			nm, err := l.NetappMetrics.Get(ctx, netappMetricsKey{
+				AvailabilityZone: az,
+				ProjectUUID:      projectUUID,
+				ShareTypeName:    rst,
+			})
+			if err != nil {
+				return shareTypeUsageReport{}, err
+			}
+
+			result.ShareCapacity.PerAZ[az].PhysicalUsage = &nm.SharePhysicalUsage
+			result.SnapshotCapacity.PerAZ[az].PhysicalUsage = &nm.SnapshotPhysicalUsage
+			result.SnapmirrorCapacity.PerAZ[az] = &liquid.AZResourceUsageReport{
+				Usage:         nm.SnapmirrorUsage,
+				PhysicalUsage: &nm.SnapmirrorPhysicalUsage,
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func (l *Logic) reportShareTypeAsForbidden(req liquid.ServiceUsageRequest) shareTypeUsageReport {
+	withAZMetrics := l.AZMetrics != nil
+	emptyQuotaDetail := QuotaDetail{Quota: 0, Usage: 0}
+	forbiddenWithQuota := emptyQuotaDetail.ToResourceReport(req.AllAZs, withAZMetrics)
+	forbiddenWithQuota.Forbidden = true
+	forbiddenWithoutQuota := emptyQuotaDetail.ToResourceReport(req.AllAZs, withAZMetrics)
+	forbiddenWithoutQuota.Forbidden = true
+	forbiddenWithoutQuota.Quota = nil
+
+	return shareTypeUsageReport{
+		Shares:             forbiddenWithQuota,
+		Snapshots:          forbiddenWithQuota,
+		ShareCapacity:      forbiddenWithQuota,
+		SnapshotCapacity:   forbiddenWithQuota,
+		SnapmirrorCapacity: forbiddenWithoutQuota,
+	}
+}
+
+// SetQuota implements the liquidapi.Logic interface.
+func (l *Logic) SetQuota(ctx context.Context, projectUUID string, req liquid.ServiceQuotaRequest, serviceInfo liquid.ServiceInfo) error {
+	if req.ProjectMetadata == nil {
+		return errors.New("projectMetadata is missing")
+	}
+
+	// collect quotas by share type
+	quotaSets := make(map[RealShareType]QuotaSet)
+	anyReplicationEnabled := false
+	for _, vst := range l.VirtualShareTypes {
+		quotaSet := QuotaSet{
+			Shares:            req.Resources[vst.SharesResourceName()].Quota,
+			Snapshots:         req.Resources[vst.SnapshotsResourceName()].Quota,
+			Gigabytes:         req.Resources[vst.ShareCapacityResourceName()].Quota,
+			SnapshotGigabytes: req.Resources[vst.SnapshotCapacityResourceName()].Quota,
+		}
+		if vst.ReplicationEnabled {
+			anyReplicationEnabled = true
+			quotaSet.Replicas = &quotaSet.Shares
+			quotaSet.ReplicaGigabytes = &quotaSet.Gigabytes
+		}
+
+		rst, omit := vst.RealShareTypeIn(*req.ProjectMetadata)
+		if omit {
+			if !quotaSet.IsEmpty() {
+				return fmt.Errorf("share type %q may not be used in this project", vst.Name)
+			}
+		} else {
+			quotaSets[rst] = quotaSet
+		}
+	}
+
+	// compute overall quotas
+	overallQuotas := QuotaSet{
+		ShareNetworks: liquids.PointerTo(req.Resources["share_networks"].Quota),
+	}
+	if anyReplicationEnabled {
+		overallQuotas.Replicas = liquids.PointerTo(uint64(0))
+		overallQuotas.ReplicaGigabytes = liquids.PointerTo(uint64(0))
+	}
+	for _, vst := range l.VirtualShareTypes {
+		rst, omit := vst.RealShareTypeIn(*req.ProjectMetadata)
+		if omit {
+			continue
+		}
+
+		quotaSet := quotaSets[rst]
+		overallQuotas.Shares += quotaSet.Shares
+		overallQuotas.Snapshots += quotaSet.Snapshots
+		overallQuotas.Gigabytes += quotaSet.Gigabytes
+		overallQuotas.SnapshotGigabytes += quotaSet.SnapshotGigabytes
+		if vst.ReplicationEnabled {
+			*overallQuotas.Replicas += *quotaSet.Replicas
+			*overallQuotas.ReplicaGigabytes += *quotaSet.ReplicaGigabytes
+		}
+	}
+
+	// we need to set overall quotas first, otherwise share-type-specific quotas
+	// may get rejected for not fitting in the overall quota
+	err := l.putQuotaSet(ctx, projectUUID, "", overallQuotas)
+	if err != nil {
+		return err
+	}
+	for rst, qs := range quotaSets {
+		err := l.putQuotaSet(ctx, projectUUID, rst, qs)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// custom types for Manila APIs (the quota API is not modeled in Gophercloud upstream)
+
+// QuotaSetDetail is used when reading quota and usage.
+type QuotaSetDetail struct {
+	Shares            QuotaDetail `json:"shares"`
+	Snapshots         QuotaDetail `json:"snapshots"`
+	Gigabytes         QuotaDetail `json:"gigabytes"`
+	SnapshotGigabytes QuotaDetail `json:"snapshot_gigabytes"`
+	ShareNetworks     QuotaDetail `json:"share_networks,omitempty"`
+	Replicas          QuotaDetail `json:"share_replicas"`
+	ReplicaGigabytes  QuotaDetail `json:"replica_gigabytes"`
+}
+
+// QuotaDetail appears in type QuotaSetDetail.
+type QuotaDetail struct {
+	Quota int64  `json:"limit"`
+	Usage uint64 `json:"in_use"`
+}
+
+// ToResourceReport converts this QuotaDetail into a ResourceUsageReport.
+func (q QuotaDetail) ToResourceReport(allAZs []liquid.AvailabilityZone, withAZMetrics bool) *liquid.ResourceUsageReport {
+	var perAZ map[liquid.AvailabilityZone]*liquid.AZResourceUsageReport
+	if withAZMetrics {
+		// if we have AZ metrics, we initially put usage into "unknown",
+		// to be shifted into the correct AZs via AddLocalizedUsage()
+		perAZ = liquid.AZResourceUsageReport{Usage: q.Usage}.PrepareForBreakdownInto(allAZs)
+	} else {
+		perAZ = liquid.InAnyAZ(liquid.AZResourceUsageReport{Usage: q.Usage})
+	}
+	return &liquid.ResourceUsageReport{
+		Quota: &q.Quota,
+		PerAZ: perAZ,
+	}
+}
+
+// PrepareForBreakdownInto converts this QuotaDetail into a ResourceUsageReport.
+func (q QuotaDetail) PrepareForBreakdownInto(allAZs []liquid.AvailabilityZone) *liquid.ResourceUsageReport {
+	return &liquid.ResourceUsageReport{
+		Quota: &q.Quota,
+		PerAZ: liquid.AZResourceUsageReport{Usage: q.Usage}.PrepareForBreakdownInto(allAZs),
+	}
+}
+
+// Returns the quota for a specific share type in the given project
+// (or the overall quota, if the share type is the empty string).
+func (l *Logic) getQuotaSet(ctx context.Context, projectUUID string, st RealShareType) (QuotaSetDetail, error) {
+	url := l.ManilaV2.ServiceURL("quota-sets", projectUUID, "detail")
+	if st != "" {
+		url += "?share_type=" + string(st)
+	}
+
+	var result gophercloud.Result
+	_, result.Err = l.ManilaV2.Get(ctx, url, &result.Body, nil) //nolint:bodyclose // already closed by gophercloud
+	var data struct {
+		QuotaSet QuotaSetDetail `json:"quota_set"`
+	}
+	err := result.ExtractInto(&data)
+	return data.QuotaSet, err
+}
+
+// QuotaSet is used when writing quotas.
+type QuotaSet struct {
+	Shares            uint64  `json:"shares"`
+	Snapshots         uint64  `json:"snapshots"`
+	Gigabytes         uint64  `json:"gigabytes"`
+	SnapshotGigabytes uint64  `json:"snapshot_gigabytes"`
+	ShareNetworks     *uint64 `json:"share_networks,omitempty"`
+	Replicas          *uint64 `json:"share_replicas,omitempty"`
+	ReplicaGigabytes  *uint64 `json:"replica_gigabytes,omitempty"`
+}
+
+// IsEmpty returns whether there is no non-zero value in this QuotaSet.
+func (qs QuotaSet) IsEmpty() bool {
+	return qs.Shares == 0 &&
+		qs.Snapshots == 0 &&
+		qs.Gigabytes == 0 &&
+		qs.SnapshotGigabytes == 0 &&
+		(qs.ShareNetworks == nil || *qs.ShareNetworks == 0) &&
+		(qs.Replicas == nil || *qs.Replicas == 0) &&
+		(qs.ReplicaGigabytes == nil || *qs.ReplicaGigabytes == 0)
+}
+
+// Writes the quota for a specific share type in the given project
+// (or the overall quota, if the share type is the empty string).
+func (l *Logic) putQuotaSet(ctx context.Context, projectUUID string, rst RealShareType, qs QuotaSet) error {
+	if logg.ShowDebug {
+		buf, err := json.Marshal(qs)
+		if err == nil {
+			logg.Debug("manila: PUT quota-sets project_id=%q share_type=%q: %s", projectUUID, string(rst), string(buf))
+		}
+	}
+
+	url := l.ManilaV2.ServiceURL("quota-sets", projectUUID)
+	if rst != "" {
+		url += "?share_type=" + string(rst)
+	}
+
+	opts := gophercloud.RequestOpts{OkCodes: []int{http.StatusOK}}
+	_, err := l.ManilaV2.Put(ctx, url, map[string]any{"quota_set": qs}, nil, &opts) //nolint:bodyclose // already closed by gophercloud
+	return err
+}

--- a/internal/liquids/types.go
+++ b/internal/liquids/types.go
@@ -1,0 +1,58 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package liquids
+
+import (
+	"encoding/json"
+	"math"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+// OpenStack is being a mess once again
+
+// Used for the "total_capacity_gb" field in Cinder and Manila pools,
+// which may be a string like "infinite", "unknown" or "".
+type Float64WithStringErrors float64
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (f *Float64WithStringErrors) UnmarshalJSON(buf []byte) error {
+	// Ref: <https://github.com/gophercloud/gophercloud/blob/7137f0845e8cf2210601f867e7ddd9f54bb72859/openstack/blockstorage/extensions/schedulerstats/results.go#L60-L74>
+	// Ref: <https://github.com/sapcc/manila/blob/688d856f31597ff27f678df6452e2c53aa4008eb/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py#L532-L533>
+
+	if buf[0] == '"' {
+		var str string
+		err := json.Unmarshal(buf, &str)
+		if err != nil {
+			return err
+		}
+
+		if str == "infinite" {
+			*f = Float64WithStringErrors(math.Inf(+1))
+		} else {
+			*f = 0
+		}
+		return nil
+	}
+
+	var val float64
+	err := json.Unmarshal(buf, &val)
+	*f = Float64WithStringErrors(val)
+	return err
+}

--- a/internal/liquids/utils.go
+++ b/internal/liquids/utils.go
@@ -21,9 +21,12 @@ package liquids
 
 import (
 	"fmt"
+	"slices"
+	"sync"
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/tokens"
+	"github.com/sapcc/go-api-declarations/liquid"
 )
 
 // GetProjectIDFromTokenScope returns the project ID from the client's token scope.
@@ -43,4 +46,49 @@ func GetProjectIDFromTokenScope(provider *gophercloud.ProviderClient) (string, e
 		return "", fmt.Errorf(`expected "id" attribute in "project" section, but got %#v`, project)
 	}
 	return project.ID, nil
+}
+
+// RestrictToKnownAZs takes a mapping of objects sorted by AZ, and moves all
+// objects in unknown AZs into the pseudo-AZ "unknown".
+//
+// The resulting map will have an entry for each known AZ (possibly a nil slice),
+// and at most one additional key (the well-known value "unknown").
+func RestrictToKnownAZs[T any](input map[liquid.AvailabilityZone][]T, allAZs []liquid.AvailabilityZone) map[liquid.AvailabilityZone][]T {
+	output := make(map[liquid.AvailabilityZone][]T, len(allAZs))
+	for _, az := range allAZs {
+		output[az] = input[az]
+	}
+	for az, items := range input {
+		if !slices.Contains(allAZs, az) {
+			output[liquid.AvailabilityZoneUnknown] = append(output[liquid.AvailabilityZoneUnknown], items...)
+		}
+	}
+	return output
+}
+
+// PointerTo casts T into *T without going through a named variable.
+func PointerTo[T any](value T) *T {
+	return &value
+}
+
+// State contains data that is guarded by an RWMutex,
+// such that the data cannot be accessed without using the mutex.
+// A zero-initialized State contains a zero-initialized piece of data.
+type State[T any] struct {
+	mutex sync.RWMutex
+	data  T
+}
+
+// Set replaces the contained value.
+func (s *State[T]) Set(value T) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.data = value
+}
+
+// Get returns a shallow copy of the contained value.
+func (s *State[T]) Get() T {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	return s.data
 }

--- a/internal/liquids/utils.go
+++ b/internal/liquids/utils.go
@@ -71,6 +71,14 @@ func PointerTo[T any](value T) *T {
 	return &value
 }
 
+// SaturatingSub is like `lhs - rhs`, but never underflows below 0.
+func SaturatingSub(lhs, rhs uint64) uint64 {
+	if lhs < rhs {
+		return 0
+	}
+	return lhs - rhs
+}
+
 // State contains data that is guarded by an RWMutex,
 // such that the data cannot be accessed without using the mutex.
 // A zero-initialized State contains a zero-initialized piece of data.

--- a/internal/plugins/capacity_manila.go
+++ b/internal/plugins/capacity_manila.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/sapcc/limes/internal/core"
 	"github.com/sapcc/limes/internal/db"
+	"github.com/sapcc/limes/internal/liquids"
 	"github.com/sapcc/limes/internal/util"
 )
 
@@ -273,12 +274,12 @@ func (p *capacityManilaPlugin) scrapeForShareTypeAndAZ(shareType ManilaShareType
 	)
 	for _, pool := range pools {
 		poolCount++
-		allocatedCapacityGB += pool.Capabilities.AllocatedCapacityGB
+		allocatedCapacityGB += float64(pool.Capabilities.AllocatedCapacityGB)
 
 		if pool.CountsUnusedCapacity() {
-			totalCapacityGB += pool.Capabilities.TotalCapacityGB
+			totalCapacityGB += float64(pool.Capabilities.TotalCapacityGB)
 		} else {
-			totalCapacityGB += pool.Capabilities.AllocatedCapacityGB
+			totalCapacityGB += float64(pool.Capabilities.AllocatedCapacityGB)
 			logg.Info("ignoring unused capacity in Manila storage pool %q (share type %q) in AZ %q because of hardware_state value: %q",
 				pool.Name, shareType.Name, az, pool.Capabilities.HardwareState)
 		}
@@ -429,8 +430,8 @@ type manilaPool struct {
 	Host         string `json:"host"`
 	Capabilities struct {
 		// standard fields
-		TotalCapacityGB     float64 `json:"total_capacity_gb"`
-		AllocatedCapacityGB float64 `json:"allocated_capacity_gb"`
+		TotalCapacityGB     liquids.Float64WithStringErrors `json:"total_capacity_gb"`
+		AllocatedCapacityGB liquids.Float64WithStringErrors `json:"allocated_capacity_gb"`
 		// CCloud extension fields
 		HardwareState string `json:"hardware_state"`
 	} `json:"capabilities,omitempty"`

--- a/main.go
+++ b/main.go
@@ -61,6 +61,7 @@ import (
 	"github.com/sapcc/limes/internal/liquids/archer"
 	"github.com/sapcc/limes/internal/liquids/cinder"
 	"github.com/sapcc/limes/internal/liquids/designate"
+	"github.com/sapcc/limes/internal/liquids/manila"
 	"github.com/sapcc/limes/internal/liquids/neutron"
 	"github.com/sapcc/limes/internal/liquids/octavia"
 	"github.com/sapcc/limes/internal/liquids/swift"
@@ -108,6 +109,9 @@ func main() {
 			must.Succeed(liquidapi.Run(ctx, &cinder.Logic{}, opts))
 		case "designate":
 			must.Succeed(liquidapi.Run(ctx, &designate.Logic{}, opts))
+		case "manila":
+			opts.TakesConfiguration = true
+			must.Succeed(liquidapi.Run(ctx, &manila.Logic{}, opts))
 		case "neutron":
 			must.Succeed(liquidapi.Run(ctx, &neutron.Logic{}, opts))
 		case "octavia":

--- a/main.go
+++ b/main.go
@@ -59,6 +59,7 @@ import (
 	"github.com/sapcc/limes/internal/core"
 	"github.com/sapcc/limes/internal/db"
 	"github.com/sapcc/limes/internal/liquids/archer"
+	"github.com/sapcc/limes/internal/liquids/cinder"
 	"github.com/sapcc/limes/internal/liquids/designate"
 	"github.com/sapcc/limes/internal/liquids/neutron"
 	"github.com/sapcc/limes/internal/liquids/octavia"
@@ -94,13 +95,17 @@ func main() {
 		wrap.SetOverrideUserAgent(bininfo.Component(), bininfo.VersionOr("rolling"))
 
 		opts := liquidapi.RunOpts{
-			ServiceInfoRefreshInterval: 0,
+			TakesConfiguration:         false,
+			ServiceInfoRefreshInterval: 0, // TODO: enable for services that can benefit from it, once limes-collect can reload on the fly
 			MaxConcurrentRequests:      5,
 			DefaultListenAddress:       ":80",
 		}
 		switch liquidName {
 		case "archer":
 			must.Succeed(liquidapi.Run(ctx, &archer.Logic{}, opts))
+		case "cinder":
+			opts.TakesConfiguration = true
+			must.Succeed(liquidapi.Run(ctx, &cinder.Logic{}, opts))
 		case "designate":
 			must.Succeed(liquidapi.Run(ctx, &designate.Logic{}, opts))
 		case "neutron":

--- a/vendor/github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumetypes/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumetypes/doc.go
@@ -1,0 +1,220 @@
+/*
+Package volumetypes provides information and interaction with volume types in the
+OpenStack Block Storage service. A volume type is a collection of specs used to
+define the volume capabilities.
+
+Example to list Volume Types
+
+	allPages, err := volumetypes.List(client, volumetypes.ListOpts{}).AllPages(context.TODO())
+	if err != nil{
+		panic(err)
+	}
+	volumeTypes, err := volumetypes.ExtractVolumeTypes(allPages)
+	if err != nil{
+		panic(err)
+	}
+	for _,vt := range volumeTypes{
+		fmt.Println(vt)
+	}
+
+Example to show a Volume Type
+
+	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+	volumeType, err := volumetypes.Get(context.TODO(), client, typeID).Extract()
+	if err != nil{
+		panic(err)
+	}
+	fmt.Println(volumeType)
+
+Example to create a Volume Type
+
+	volumeType, err := volumetypes.Create(context.TODO(), client, volumetypes.CreateOpts{
+		Name:"volume_type_001",
+		IsPublic:true,
+		Description:"description_001",
+	}).Extract()
+	if err != nil{
+		panic(err)
+	}
+	fmt.Println(volumeType)
+
+Example to delete a Volume Type
+
+	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+	err := volumetypes.Delete(context.TODO(), client, typeID).ExtractErr()
+	if err != nil{
+		panic(err)
+	}
+
+Example to update a Volume Type
+
+	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+	volumetype, err = volumetypes.Update(context.TODO(), client, typeID, volumetypes.UpdateOpts{
+		Name: "volume_type_002",
+		Description:"description_002",
+		IsPublic:false,
+	}).Extract()
+	if err != nil{
+		panic(err)
+	}
+	fmt.Println(volumetype)
+
+Example to Create Extra Specs for a Volume Type
+
+	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+
+	createOpts := volumetypes.ExtraSpecsOpts{
+		"capabilities": "gpu",
+	}
+	createdExtraSpecs, err := volumetypes.CreateExtraSpecs(context.TODO(), client, typeID, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v", createdExtraSpecs)
+
+Example to Get Extra Specs for a Volume Type
+
+	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+
+	extraSpecs, err := volumetypes.ListExtraSpecs(context.TODO(), client, typeID).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v", extraSpecs)
+
+Example to Get specific Extra Spec for a Volume Type
+
+	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+
+	extraSpec, err := volumetypes.GetExtraSpec(context.TODO(), client, typeID, "capabilities").Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v", extraSpec)
+
+Example to Update Extra Specs for a Volume Type
+
+	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+
+	updateOpts := volumetypes.ExtraSpecsOpts{
+		"capabilities": "capabilities-updated",
+	}
+	updatedExtraSpec, err := volumetypes.UpdateExtraSpec(context.TODO(), client, typeID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v", updatedExtraSpec)
+
+Example to Delete an Extra Spec for a Volume Type
+
+	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+	err := volumetypes.DeleteExtraSpec(context.TODO(), client, typeID, "capabilities").ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to List Volume Type Access
+
+	typeID := "e91758d6-a54a-4778-ad72-0c73a1cb695b"
+
+	allPages, err := volumetypes.ListAccesses(client, typeID).AllPages(context.TODO())
+	if err != nil {
+		panic(err)
+	}
+
+	allAccesses, err := volumetypes.ExtractAccesses(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, access := range allAccesses {
+		fmt.Printf("%+v", access)
+	}
+
+Example to Grant Access to a Volume Type
+
+	typeID := "e91758d6-a54a-4778-ad72-0c73a1cb695b"
+
+	accessOpts := volumetypes.AddAccessOpts{
+		Project: "15153a0979884b59b0592248ef947921",
+	}
+
+	err := volumetypes.AddAccess(context.TODO(), client, typeID, accessOpts).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Remove/Revoke Access to a Volume Type
+
+	typeID := "e91758d6-a54a-4778-ad72-0c73a1cb695b"
+
+	accessOpts := volumetypes.RemoveAccessOpts{
+		Project: "15153a0979884b59b0592248ef947921",
+	}
+
+	err := volumetypes.RemoveAccess(context.TODO(), client, typeID, accessOpts).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Create the Encryption of a Volume Type
+
+	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+	volumeType, err := volumetypes.CreateEncryption(context.TODO(), client, typeID, .CreateEncryptionOpts{
+		KeySize:      256,
+		Provider:    "luks",
+		ControlLocation: "front-end",
+		Cipher:  "aes-xts-plain64",
+	}).Extract()
+	if err != nil{
+		panic(err)
+	}
+	fmt.Println(volumeType)
+
+Example to Delete the Encryption of a Volume Type
+
+	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+	encryptionID := ""81e069c6-7394-4856-8df7-3b237ca61f74
+	err := volumetypes.DeleteEncryption(context.TODO(), client, typeID, encryptionID).ExtractErr()
+	if err != nil{
+		panic(err)
+	}
+
+Example to Update the Encryption of a Volume Type
+
+	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+	volumetype, err = volumetypes.UpdateEncryption(context.TODO(), client, typeID, volumetypes.UpdateEncryptionOpts{
+		KeySize:      256,
+		Provider:    "luks",
+		ControlLocation: "front-end",
+		Cipher:  "aes-xts-plain64",
+	}).Extract()
+	if err != nil{
+		panic(err)
+	}
+	fmt.Println(volumetype)
+
+Example to Show an Encryption of a Volume Type
+
+	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+	volumeType, err := volumetypes.GetEncrytpion(client, typeID).Extract()
+	if err != nil{
+		panic(err)
+	}
+	fmt.Println(volumeType)
+
+Example to Show an Encryption Spec of a Volume Type
+
+	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+	key := "cipher"
+	volumeType, err := volumetypes.GetEncrytpionSpec(client, typeID).Extract()
+	if err != nil{
+		panic(err)
+	}
+	fmt.Println(volumeType)
+*/
+package volumetypes

--- a/vendor/github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumetypes/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumetypes/requests.go
@@ -1,0 +1,413 @@
+package volumetypes
+
+import (
+	"context"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToVolumeTypeCreateMap() (map[string]any, error)
+}
+
+// CreateOpts contains options for creating a Volume Type. This object is passed to
+// the volumetypes.Create function. For more information about these parameters,
+// see the Volume Type object.
+type CreateOpts struct {
+	// The name of the volume type
+	Name string `json:"name" required:"true"`
+	// The volume type description
+	Description string `json:"description,omitempty"`
+	// the ID of the existing volume snapshot
+	IsPublic *bool `json:"os-volume-type-access:is_public,omitempty"`
+	// Extra spec key-value pairs defined by the user.
+	ExtraSpecs map[string]string `json:"extra_specs,omitempty"`
+}
+
+// ToVolumeTypeCreateMap assembles a request body based on the contents of a
+// CreateOpts.
+func (opts CreateOpts) ToVolumeTypeCreateMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "volume_type")
+}
+
+// Create will create a new Volume Type based on the values in CreateOpts. To extract
+// the Volume Type object from the response, call the Extract method on the
+// CreateResult.
+func Create(ctx context.Context, client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToVolumeTypeCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(ctx, createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Delete will delete the existing Volume Type with the provided ID.
+func Delete(ctx context.Context, client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	resp, err := client.Delete(ctx, deleteURL(client, id), nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Get retrieves the Volume Type with the provided ID. To extract the Volume Type object
+// from the response, call the Extract method on the GetResult.
+func Get(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetResult) {
+	resp, err := client.Get(ctx, getURL(client, id), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// ListOptsBuilder allows extensions to add additional parameters to the List
+// request.
+type ListOptsBuilder interface {
+	ToVolumeTypeListQuery() (string, error)
+}
+
+// ListOpts holds options for listing Volume Types. It is passed to the volumetypes.List
+// function.
+type ListOpts struct {
+	// Comma-separated list of sort keys and optional sort directions in the
+	// form of <key>[:<direction>].
+	Sort string `q:"sort"`
+	// Requests a page size of items.
+	Limit int `q:"limit"`
+	// Used in conjunction with limit to return a slice of items.
+	Offset int `q:"offset"`
+	// The ID of the last-seen item.
+	Marker string `q:"marker"`
+}
+
+// ToVolumeTypeListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToVolumeTypeListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns Volume types.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+
+	if opts != nil {
+		query, err := opts.ToVolumeTypeListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return VolumeTypePage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToVolumeTypeUpdateMap() (map[string]any, error)
+}
+
+// UpdateOpts contain options for updating an existing Volume Type. This object is passed
+// to the volumetypes.Update function. For more information about the parameters, see
+// the Volume Type object.
+type UpdateOpts struct {
+	Name        *string `json:"name,omitempty"`
+	Description *string `json:"description,omitempty"`
+	IsPublic    *bool   `json:"is_public,omitempty"`
+}
+
+// ToVolumeTypeUpdateMap assembles a request body based on the contents of an
+// UpdateOpts.
+func (opts UpdateOpts) ToVolumeTypeUpdateMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "volume_type")
+}
+
+// Update will update the Volume Type with provided information. To extract the updated
+// Volume Type from the response, call the Extract method on the UpdateResult.
+func Update(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToVolumeTypeUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Put(ctx, updateURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// ListExtraSpecs requests all the extra-specs for the given volume type ID.
+func ListExtraSpecs(ctx context.Context, client *gophercloud.ServiceClient, volumeTypeID string) (r ListExtraSpecsResult) {
+	resp, err := client.Get(ctx, extraSpecsListURL(client, volumeTypeID), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// GetExtraSpec requests an extra-spec specified by key for the given volume type ID
+func GetExtraSpec(ctx context.Context, client *gophercloud.ServiceClient, volumeTypeID string, key string) (r GetExtraSpecResult) {
+	resp, err := client.Get(ctx, extraSpecsGetURL(client, volumeTypeID, key), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// CreateExtraSpecsOptsBuilder allows extensions to add additional parameters to the
+// CreateExtraSpecs requests.
+type CreateExtraSpecsOptsBuilder interface {
+	ToVolumeTypeExtraSpecsCreateMap() (map[string]any, error)
+}
+
+// ExtraSpecsOpts is a map that contains key-value pairs.
+type ExtraSpecsOpts map[string]string
+
+// ToVolumeTypeExtraSpecsCreateMap assembles a body for a Create request based on
+// the contents of ExtraSpecsOpts.
+func (opts ExtraSpecsOpts) ToVolumeTypeExtraSpecsCreateMap() (map[string]any, error) {
+	return map[string]any{"extra_specs": opts}, nil
+}
+
+// CreateExtraSpecs will create or update the extra-specs key-value pairs for
+// the specified volume type.
+func CreateExtraSpecs(ctx context.Context, client *gophercloud.ServiceClient, volumeTypeID string, opts CreateExtraSpecsOptsBuilder) (r CreateExtraSpecsResult) {
+	b, err := opts.ToVolumeTypeExtraSpecsCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(ctx, extraSpecsCreateURL(client, volumeTypeID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// UpdateExtraSpecOptsBuilder allows extensions to add additional parameters to
+// the Update request.
+type UpdateExtraSpecOptsBuilder interface {
+	ToVolumeTypeExtraSpecUpdateMap() (map[string]string, string, error)
+}
+
+// ToVolumeTypeExtraSpecUpdateMap assembles a body for an Update request based on
+// the contents of a ExtraSpecOpts.
+func (opts ExtraSpecsOpts) ToVolumeTypeExtraSpecUpdateMap() (map[string]string, string, error) {
+	if len(opts) != 1 {
+		err := gophercloud.ErrInvalidInput{}
+		err.Argument = "volumetypes.ExtraSpecOpts"
+		err.Info = "Must have one and only one key-value pair"
+		return nil, "", err
+	}
+
+	var key string
+	for k := range opts {
+		key = k
+	}
+
+	return opts, key, nil
+}
+
+// UpdateExtraSpec will updates the value of the specified volume type's extra spec
+// for the key in opts.
+func UpdateExtraSpec(ctx context.Context, client *gophercloud.ServiceClient, volumeTypeID string, opts UpdateExtraSpecOptsBuilder) (r UpdateExtraSpecResult) {
+	b, key, err := opts.ToVolumeTypeExtraSpecUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Put(ctx, extraSpecUpdateURL(client, volumeTypeID, key), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// DeleteExtraSpec will delete the key-value pair with the given key for the given
+// volume type ID.
+func DeleteExtraSpec(ctx context.Context, client *gophercloud.ServiceClient, volumeTypeID, key string) (r DeleteExtraSpecResult) {
+	resp, err := client.Delete(ctx, extraSpecDeleteURL(client, volumeTypeID, key), &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// ListAccesses retrieves the tenants which have access to a volume type.
+func ListAccesses(client *gophercloud.ServiceClient, id string) pagination.Pager {
+	url := accessURL(client, id)
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return AccessPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// AddAccessOptsBuilder allows extensions to add additional parameters to the
+// AddAccess requests.
+type AddAccessOptsBuilder interface {
+	ToVolumeTypeAddAccessMap() (map[string]any, error)
+}
+
+// AddAccessOpts represents options for adding access to a volume type.
+type AddAccessOpts struct {
+	// Project is the project/tenant ID to grant access.
+	Project string `json:"project"`
+}
+
+// ToVolumeTypeAddAccessMap constructs a request body from AddAccessOpts.
+func (opts AddAccessOpts) ToVolumeTypeAddAccessMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "addProjectAccess")
+}
+
+// AddAccess grants a tenant/project access to a volume type.
+func AddAccess(ctx context.Context, client *gophercloud.ServiceClient, id string, opts AddAccessOptsBuilder) (r AddAccessResult) {
+	b, err := opts.ToVolumeTypeAddAccessMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(ctx, accessActionURL(client, id), b, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// RemoveAccessOptsBuilder allows extensions to add additional parameters to the
+// RemoveAccess requests.
+type RemoveAccessOptsBuilder interface {
+	ToVolumeTypeRemoveAccessMap() (map[string]any, error)
+}
+
+// RemoveAccessOpts represents options for removing access to a volume type.
+type RemoveAccessOpts struct {
+	// Project is the project/tenant ID to remove access.
+	Project string `json:"project"`
+}
+
+// ToVolumeTypeRemoveAccessMap constructs a request body from RemoveAccessOpts.
+func (opts RemoveAccessOpts) ToVolumeTypeRemoveAccessMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "removeProjectAccess")
+}
+
+// RemoveAccess removes/revokes a tenant/project access to a volume type.
+func RemoveAccess(ctx context.Context, client *gophercloud.ServiceClient, id string, opts RemoveAccessOptsBuilder) (r RemoveAccessResult) {
+	b, err := opts.ToVolumeTypeRemoveAccessMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(ctx, accessActionURL(client, id), b, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// CreateEncryptionOptsBuilder allows extensions to add additional parameters to the
+// Create Encryption request.
+type CreateEncryptionOptsBuilder interface {
+	ToEncryptionCreateMap() (map[string]any, error)
+}
+
+// CreateEncryptionOpts contains options for creating an Encryption Type object.
+// This object is passed to the volumetypes.CreateEncryption function.
+// For more information about these parameters,see the Encryption Type object.
+type CreateEncryptionOpts struct {
+	// The size of the encryption key.
+	KeySize int `json:"key_size"`
+	// The class of that provides the encryption support.
+	Provider string `json:"provider" required:"true"`
+	// Notional service where encryption is performed.
+	ControlLocation string `json:"control_location"`
+	// The encryption algorithm or mode.
+	Cipher string `json:"cipher"`
+}
+
+// ToEncryptionCreateMap assembles a request body based on the contents of a
+// CreateEncryptionOpts.
+func (opts CreateEncryptionOpts) ToEncryptionCreateMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "encryption")
+}
+
+// CreateEncryption will creates an Encryption Type object based on the CreateEncryptionOpts.
+// To extract the Encryption Type object from the response, call the Extract method on the
+// EncryptionCreateResult.
+func CreateEncryption(ctx context.Context, client *gophercloud.ServiceClient, id string, opts CreateEncryptionOptsBuilder) (r CreateEncryptionResult) {
+	b, err := opts.ToEncryptionCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(ctx, createEncryptionURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Delete will delete an encryption type for an existing Volume Type with the provided ID.
+func DeleteEncryption(ctx context.Context, client *gophercloud.ServiceClient, id, encryptionID string) (r DeleteEncryptionResult) {
+	resp, err := client.Delete(ctx, deleteEncryptionURL(client, id, encryptionID), nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// GetEncryption retrieves the encryption type for an existing VolumeType with the provided ID.
+func GetEncryption(ctx context.Context, client *gophercloud.ServiceClient, id string) (r GetEncryptionResult) {
+	resp, err := client.Get(ctx, getEncryptionURL(client, id), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// GetEncryptionSpecs retrieves the encryption type specs for an existing VolumeType with the provided ID.
+func GetEncryptionSpec(ctx context.Context, client *gophercloud.ServiceClient, id, key string) (r GetEncryptionSpecResult) {
+	resp, err := client.Get(ctx, getEncryptionSpecURL(client, id, key), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// UpdateEncryptionOptsBuilder allows extensions to add additional parameters to the
+// Update encryption request.
+type UpdateEncryptionOptsBuilder interface {
+	ToUpdateEncryptionMap() (map[string]any, error)
+}
+
+// Update Encryption Opts contains options for creating an Update Encryption Type. This object is passed to
+// the volumetypes.UpdateEncryption function. For more information about these parameters,
+// see the Update Encryption Type object.
+type UpdateEncryptionOpts struct {
+	// The size of the encryption key.
+	KeySize int `json:"key_size"`
+	// The class of that provides the encryption support.
+	Provider string `json:"provider"`
+	// Notional service where encryption is performed.
+	ControlLocation string `json:"control_location"`
+	// The encryption algorithm or mode.
+	Cipher string `json:"cipher"`
+}
+
+// ToEncryptionCreateMap assembles a request body based on the contents of a
+// UpdateEncryptionOpts.
+func (opts UpdateEncryptionOpts) ToUpdateEncryptionMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "encryption")
+}
+
+// Update will update an existing encryption for a Volume Type based on the values in UpdateEncryptionOpts.
+// To extract the UpdateEncryption Type object from the response, call the Extract method on the
+// UpdateEncryptionResult.
+func UpdateEncryption(ctx context.Context, client *gophercloud.ServiceClient, id, encryptionID string, opts UpdateEncryptionOptsBuilder) (r UpdateEncryptionResult) {
+	b, err := opts.ToUpdateEncryptionMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Put(ctx, updateEncryptionURL(client, id, encryptionID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumetypes/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumetypes/results.go
@@ -1,0 +1,299 @@
+package volumetypes
+
+import (
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+)
+
+// VolumeType contains all the information associated with an OpenStack Volume Type.
+type VolumeType struct {
+	// Unique identifier for the volume type.
+	ID string `json:"id"`
+	// Human-readable display name for the volume type.
+	Name string `json:"name"`
+	// Human-readable description for the volume type.
+	Description string `json:"description"`
+	// Arbitrary key-value pairs defined by the user.
+	ExtraSpecs map[string]string `json:"extra_specs"`
+	// Whether the volume type is publicly visible.
+	IsPublic bool `json:"is_public"`
+	// Qos Spec ID
+	QosSpecID string `json:"qos_specs_id"`
+	// Volume Type access public attribute
+	PublicAccess bool `json:"os-volume-type-access:is_public"`
+}
+
+// VolumeTypePage is a pagination.pager that is returned from a call to the List function.
+type VolumeTypePage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty returns true if a ListResult contains no Volume Types.
+func (r VolumeTypePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
+	volumetypes, err := ExtractVolumeTypes(r)
+	return len(volumetypes) == 0, err
+}
+
+func (page VolumeTypePage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"volume_type_links"`
+	}
+	err := page.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// ExtractVolumeTypes extracts and returns Volumes. It is used while iterating over a volumetypes.List call.
+func ExtractVolumeTypes(r pagination.Page) ([]VolumeType, error) {
+	var s []VolumeType
+	err := ExtractVolumeTypesInto(r, &s)
+	return s, err
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract will get the Volume Type object out of the commonResult object.
+func (r commonResult) Extract() (*VolumeType, error) {
+	var s VolumeType
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// ExtractInto converts our response data into a volume type struct
+func (r commonResult) ExtractInto(v any) error {
+	return r.Result.ExtractIntoStructPtr(v, "volume_type")
+}
+
+// ExtractVolumeTypesInto similar to ExtractInto but operates on a `list` of volume types
+func ExtractVolumeTypesInto(r pagination.Page, v any) error {
+	return r.(VolumeTypePage).Result.ExtractIntoSlicePtr(v, "volume_types")
+}
+
+// GetResult contains the response body and error from a Get request.
+type GetResult struct {
+	commonResult
+}
+
+// CreateResult contains the response body and error from a Create request.
+type CreateResult struct {
+	commonResult
+}
+
+// DeleteResult contains the response body and error from a Delete request.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// UpdateResult contains the response body and error from an Update request.
+type UpdateResult struct {
+	commonResult
+}
+
+// extraSpecsResult contains the result of a call for (potentially) multiple
+// key-value pairs. Call its Extract method to interpret it as a
+// map[string]interface.
+type extraSpecsResult struct {
+	gophercloud.Result
+}
+
+// ListExtraSpecsResult contains the result of a Get operation. Call its Extract
+// method to interpret it as a map[string]interface.
+type ListExtraSpecsResult struct {
+	extraSpecsResult
+}
+
+// CreateExtraSpecsResult contains the result of a Create operation. Call its
+// Extract method to interpret it as a map[string]interface.
+type CreateExtraSpecsResult struct {
+	extraSpecsResult
+}
+
+// Extract interprets any extraSpecsResult as ExtraSpecs, if possible.
+func (r extraSpecsResult) Extract() (map[string]string, error) {
+	var s struct {
+		ExtraSpecs map[string]string `json:"extra_specs"`
+	}
+	err := r.ExtractInto(&s)
+	return s.ExtraSpecs, err
+}
+
+// extraSpecResult contains the result of a call for individual a single
+// key-value pair.
+type extraSpecResult struct {
+	gophercloud.Result
+}
+
+// GetExtraSpecResult contains the result of a Get operation. Call its Extract
+// method to interpret it as a map[string]interface.
+type GetExtraSpecResult struct {
+	extraSpecResult
+}
+
+// UpdateExtraSpecResult contains the result of an Update operation. Call its
+// Extract method to interpret it as a map[string]interface.
+type UpdateExtraSpecResult struct {
+	extraSpecResult
+}
+
+// DeleteExtraSpecResult contains the result of a Delete operation. Call its
+// ExtractErr method to determine if the call succeeded or failed.
+type DeleteExtraSpecResult struct {
+	gophercloud.ErrResult
+}
+
+// Extract interprets any extraSpecResult as an ExtraSpec, if possible.
+func (r extraSpecResult) Extract() (map[string]string, error) {
+	var s map[string]string
+	err := r.ExtractInto(&s)
+	return s, err
+}
+
+// VolumeTypeAccess represents an ACL of project access to a specific Volume Type.
+type VolumeTypeAccess struct {
+	// VolumeTypeID is the unique ID of the volume type.
+	VolumeTypeID string `json:"volume_type_id"`
+
+	// ProjectID is the unique ID of the project.
+	ProjectID string `json:"project_id"`
+}
+
+// AccessPage contains a single page of all VolumeTypeAccess entries for a volume type.
+type AccessPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty indicates whether an AccessPage is empty.
+func (page AccessPage) IsEmpty() (bool, error) {
+	if page.StatusCode == 204 {
+		return true, nil
+	}
+
+	v, err := ExtractAccesses(page)
+	return len(v) == 0, err
+}
+
+// ExtractAccesses interprets a page of results as a slice of VolumeTypeAccess.
+func ExtractAccesses(r pagination.Page) ([]VolumeTypeAccess, error) {
+	var s struct {
+		VolumeTypeAccesses []VolumeTypeAccess `json:"volume_type_access"`
+	}
+	err := (r.(AccessPage)).ExtractInto(&s)
+	return s.VolumeTypeAccesses, err
+}
+
+// AddAccessResult is the response from a AddAccess request. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type AddAccessResult struct {
+	gophercloud.ErrResult
+}
+
+// RemoveAccessResult is the response from a RemoveAccess request. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type RemoveAccessResult struct {
+	gophercloud.ErrResult
+}
+
+type EncryptionType struct {
+	// Unique identifier for the volume type.
+	VolumeTypeID string `json:"volume_type_id"`
+	// Notional service where encryption is performed.
+	ControlLocation string `json:"control_location"`
+	// Unique identifier for encryption type.
+	EncryptionID string `json:"encryption_id"`
+	// Size of encryption key.
+	KeySize int `json:"key_size"`
+	// Class that provides encryption support.
+	Provider string `json:"provider"`
+	// The encryption algorithm or mode.
+	Cipher string `json:"cipher"`
+}
+
+type encryptionResult struct {
+	gophercloud.Result
+}
+
+func (r encryptionResult) Extract() (*EncryptionType, error) {
+	var s EncryptionType
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// ExtractInto converts our response data into a volume type struct
+func (r encryptionResult) ExtractInto(v any) error {
+	return r.Result.ExtractIntoStructPtr(v, "encryption")
+}
+
+type CreateEncryptionResult struct {
+	encryptionResult
+}
+
+// UpdateResult contains the response body and error from an UpdateEncryption request.
+type UpdateEncryptionResult struct {
+	encryptionResult
+}
+
+// DeleteEncryptionResult contains the response body and error from a DeleteEncryprion request.
+type DeleteEncryptionResult struct {
+	gophercloud.ErrResult
+}
+
+type GetEncryptionType struct {
+	// Unique identifier for the volume type.
+	VolumeTypeID string `json:"volume_type_id"`
+	// Notional service where encryption is performed.
+	ControlLocation string `json:"control_location"`
+	// Shows if the resource is deleted or Notional
+	Deleted bool `json:"deleted"`
+	// Shows the date and time the resource was created.
+	CreatedAt string `json:"created_at"`
+	// Shows the date and time when resource was updated.
+	UpdatedAt string `json:"updated_at"`
+	// Unique identifier for encryption type.
+	EncryptionID string `json:"encryption_id"`
+	// Size of encryption key.
+	KeySize int `json:"key_size"`
+	// Class that provides encryption support.
+	Provider string `json:"provider"`
+	// Shows the date and time the reousrce was deleted.
+	DeletedAt string `json:"deleted_at"`
+	// The encryption algorithm or mode.
+	Cipher string `json:"cipher"`
+}
+
+type encryptionShowResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets any extraSpecResult as an ExtraSpec, if possible.
+func (r encryptionShowResult) Extract() (*GetEncryptionType, error) {
+	var s GetEncryptionType
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+type GetEncryptionResult struct {
+	encryptionShowResult
+}
+
+type encryptionShowSpecResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets any empty interface Result as an empty interface.
+func (r encryptionShowSpecResult) Extract() (map[string]any, error) {
+	var s map[string]any
+	err := r.ExtractInto(&s)
+	return s, err
+}
+
+type GetEncryptionSpecResult struct {
+	encryptionShowSpecResult
+}

--- a/vendor/github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumetypes/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumetypes/urls.go
@@ -1,0 +1,71 @@
+package volumetypes
+
+import "github.com/gophercloud/gophercloud/v2"
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("types")
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("types", id)
+}
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("types")
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("types", id)
+}
+
+func updateURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("types", id)
+}
+
+func extraSpecsListURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("types", id, "extra_specs")
+}
+
+func extraSpecsGetURL(client *gophercloud.ServiceClient, id, key string) string {
+	return client.ServiceURL("types", id, "extra_specs", key)
+}
+
+func extraSpecsCreateURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("types", id, "extra_specs")
+}
+
+func extraSpecUpdateURL(client *gophercloud.ServiceClient, id, key string) string {
+	return client.ServiceURL("types", id, "extra_specs", key)
+}
+
+func extraSpecDeleteURL(client *gophercloud.ServiceClient, id, key string) string {
+	return client.ServiceURL("types", id, "extra_specs", key)
+}
+
+func accessURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("types", id, "os-volume-type-access")
+}
+
+func accessActionURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("types", id, "action")
+}
+
+func createEncryptionURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("types", id, "encryption")
+}
+
+func deleteEncryptionURL(client *gophercloud.ServiceClient, id, encryptionID string) string {
+	return client.ServiceURL("types", id, "encryption", encryptionID)
+}
+
+func getEncryptionURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("types", id, "encryption")
+}
+
+func getEncryptionSpecURL(client *gophercloud.ServiceClient, id, key string) string {
+	return client.ServiceURL("types", id, "encryption", key)
+}
+
+func updateEncryptionURL(client *gophercloud.ServiceClient, id, encryptionID string) string {
+	return client.ServiceURL("types", id, "encryption", encryptionID)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -37,6 +37,7 @@ github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/schedulerstats
 github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/services
 github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/snapshots
 github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumes
+github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumetypes
 github.com/gophercloud/gophercloud/v2/openstack/common/extensions
 github.com/gophercloud/gophercloud/v2/openstack/compute/v2/aggregates
 github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors


### PR DESCRIPTION
For the most part, this is a straight port of the respective QuotaPlugin and CapacityPlugin implementations (so I recommend reading these side-by-side with the new code as necessary to follow along), but I used the opportunity to streamline some parts of the implementation. Most notably:

- The Cinder liquid discovers available volume types via the API instead of taking them as configuration.
- In the Manila liquid, I introduced new terminology to more clearly distinguish `VirtualShareType` (the share type names that appear in Limes resources) from `RealShareType` (the share type names that are used on the Manila API).