### PR TITLE
Add POST API to convert a commitment to a target Resource

### DIFF
--- a/docs/users/api-spec-resources.md
+++ b/docs/users/api-spec-resources.md
@@ -616,7 +616,7 @@ Requires a request body like:
 	"commitment": {
 		"target_service":  "compute",
 		"target_resource": "flavor_c48",
-		"source_amount":   10,
+		"source_amount":   9,
 		"target_amount":   6,
 	},
 }

--- a/docs/users/api-spec-resources.md
+++ b/docs/users/api-spec-resources.md
@@ -606,6 +606,27 @@ Returns 200 (OK) on success, and a JSON document like:
 }
 ```
 
+### POST "/v1/domains/:domain_id/projects/:project_id/commitment-conversion/:commitment_id"
+
+Convert a commitment from a given resource to one of a different type. The target project is defined with the provided `project_id`.
+Requires a request body like:
+
+```json
+{
+	"commitment": {
+		"target_service":  "compute",
+		"target_resource": "flavor_c48",
+		"source_amount":   10,
+		"target_amount":   6,
+	},
+}
+```
+In the example above the commitment that should be converted to the `target_resource` could be from type `flavor_c32` resulting in a conversion of `3:2`.
+
+
+Returns 202 (Accepted) on success, and and returns the converted commitment as a JSON document.
+```
+
 In this example, a commitment for 1 unit of the original resource can be converted into a commitment for 2 units of the target resource.
 
 ### DELETE /v1/domains/:domain\_id/projects/:project\_id/commitments/:id

--- a/docs/users/api-spec-resources.md
+++ b/docs/users/api-spec-resources.md
@@ -606,7 +606,7 @@ Returns 200 (OK) on success, and a JSON document like:
 }
 ```
 
-### POST "/v1/domains/:domain_id/projects/:project_id/commitment-conversion/:commitment_id"
+### POST "/v1/domains/:domain_id/projects/:project_id/commitments/:commitment_id/convert"
 
 Convert a commitment from a given resource to one of a different type. The target project is defined with the provided `project_id`.
 Requires a request body like:
@@ -625,7 +625,6 @@ In the example above the commitment that should be converted to the `target_reso
 
 
 Returns 202 (Accepted) on success, and and returns the converted commitment as a JSON document.
-```
 
 In this example, a commitment for 1 unit of the original resource can be converted into a commitment for 2 units of the target resource.
 

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -904,7 +904,7 @@ func (p *v1Provider) ConvertCommitment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if dbCommitment.ConfirmBy != nil {
-		http.Error(w, "unable to convert unconfirmed commitments", http.StatusNotFound)
+		http.Error(w, "unable to convert unconfirmed commitments", http.StatusConflict)
 		return
 	}
 

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -927,7 +927,7 @@ func (p *v1Provider) ConvertCommitment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if sourceBehavior.CommitmentConversion.Identifier == "" || sourceBehavior.CommitmentConversion.Identifier != targetBehavior.CommitmentConversion.Identifier {
-		msg := fmt.Sprintf("commitment is not convertible into target resource: %s", req.TargetResource)
+		msg := fmt.Sprintf("commitment is not convertible into resource %s/%s", req.TargetService, req.TargetResource)
 		http.Error(w, msg, http.StatusUnprocessableEntity)
 		return
 	}

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -940,7 +940,7 @@ func (p *v1Provider) ConvertCommitment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// conversion
-	if req.SourceAmount <= 0 || req.SourceAmount > dbCommitment.Amount {
+	if req.SourceAmount > dbCommitment.Amount {
 		msg := fmt.Sprintf("unprocessable source amount. provided: %v, commitment: %v", req.SourceAmount, dbCommitment.Amount)
 		http.Error(w, msg, http.StatusConflict)
 		return

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -979,7 +979,7 @@ func (p *v1Provider) ConvertCommitment(w http.ResponseWriter, r *http.Request) {
 	}
 	// The commitment at the source resource was already confirmed and checked.
 	// Therefore only the addition to the target resource has to be checked against.
-	if dbCommitment.ConfirmBy == nil {
+	if dbCommitment.ConfirmedAt != nil {
 		ok, err := datamodel.CanConfirmNewCommitment(targetLoc, targetResourceID, conversionAmount, p.Cluster, p.DB)
 		if respondwith.ErrorText(w, err) {
 			return

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -931,7 +931,8 @@ func (p *v1Provider) ConvertCommitment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if sourceBehavior.CommitmentConversion.Identifier == "" || sourceBehavior.CommitmentConversion.Identifier != targetBehavior.CommitmentConversion.Identifier {
-		http.Error(w, "commitment is not convertible", http.StatusUnprocessableEntity)
+		msg := fmt.Sprintf("commitments are not enabled for resource into target resource: %s", req.TargetResource)
+		http.Error(w, msg, http.StatusUnprocessableEntity)
 		return
 	}
 

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -523,12 +523,10 @@ func (p *v1Provider) StartCommitmentTransfer(w http.ResponseWriter, r *http.Requ
 	}
 	dbDomain := p.FindDomainFromRequest(w, r)
 	if dbDomain == nil {
-		http.Error(w, "domain not found.", http.StatusNotFound)
 		return
 	}
 	dbProject := p.FindProjectFromRequest(w, r, dbDomain)
 	if dbProject == nil {
-		http.Error(w, "project not found.", http.StatusNotFound)
 		return
 	}
 	// TODO: eventually migrate this struct into go-api-declarations
@@ -705,12 +703,10 @@ func (p *v1Provider) TransferCommitment(w http.ResponseWriter, r *http.Request) 
 	}
 	dbDomain := p.FindDomainFromRequest(w, r)
 	if dbDomain == nil {
-		http.Error(w, "domain not found.", http.StatusNotFound)
 		return
 	}
 	targetProject := p.FindProjectFromRequest(w, r, dbDomain)
 	if targetProject == nil {
-		http.Error(w, "project not found.", http.StatusNotFound)
 		return
 	}
 
@@ -870,12 +866,10 @@ func (p *v1Provider) ConvertCommitment(w http.ResponseWriter, r *http.Request) {
 	}
 	dbDomain := p.FindDomainFromRequest(w, r)
 	if dbDomain == nil {
-		http.Error(w, "domain not found.", http.StatusNotFound)
 		return
 	}
 	targetProject := p.FindProjectFromRequest(w, r, dbDomain)
 	if targetProject == nil {
-		http.Error(w, "project not found.", http.StatusNotFound)
 		return
 	}
 

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -930,7 +930,8 @@ func (p *v1Provider) ConvertCommitment(w http.ResponseWriter, r *http.Request) {
 	}
 	targetBehavior := p.Cluster.BehaviorForResource(targetServiceType, targetResourceName)
 	if len(targetBehavior.CommitmentDurations) == 0 {
-		http.Error(w, "commitments are not enabled for this resource", http.StatusUnprocessableEntity)
+                msg := fmt.Sprintf("commitments are not enabled for resource %s/%s", req.TargetService, req.TargetResource)
+		http.Error(w, msg, http.StatusUnprocessableEntity)
 		return
 	}
 	if (sourceBehavior.CommitmentConversion == core.CommitmentConversion{} || targetBehavior.CommitmentConversion == core.CommitmentConversion{}) {

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -809,10 +809,6 @@ func (p *v1Provider) GetCommitmentConversions(w http.ResponseWriter, r *http.Req
 		return
 	}
 	sourceBehavior := p.Cluster.BehaviorForResource(sourceServiceType, sourceResourceName)
-	if len(sourceBehavior.CommitmentDurations) == 0 {
-		http.Error(w, "commitments are not enabled for this resource", http.StatusUnprocessableEntity)
-		return
-	}
 	sourceResInfo := p.Cluster.InfoForResource(sourceServiceType, sourceResourceName)
 
 	// enumerate possible conversions
@@ -899,10 +895,6 @@ func (p *v1Provider) ConvertCommitment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	sourceBehavior := p.Cluster.BehaviorForResource(sourceLoc.ServiceType, sourceLoc.ResourceName)
-	if len(sourceBehavior.CommitmentDurations) == 0 {
-		http.Error(w, "commitments are not enabled for this resource", http.StatusUnprocessableEntity)
-		return
-	}
 
 	// section: targetBehavior
 	var parseTarget struct {

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -993,11 +993,14 @@ func (p *v1Provider) ConvertCommitment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	remainingAmount := dbCommitment.Amount - req.SourceAmount
-	remainingCommitment := p.buildSplitCommitment(dbCommitment, remainingAmount)
-	err = tx.Insert(&remainingCommitment)
-	if respondwith.ErrorText(w, err) {
-		return
+	if remainingAmount > 0 {
+		remainingCommitment := p.buildSplitCommitment(dbCommitment, remainingAmount)
+		err = tx.Insert(&remainingCommitment)
+		if respondwith.ErrorText(w, err) {
+			return
+		}
 	}
+
 	convertedCommitment := p.buildConvertedCommitment(dbCommitment, targetAZResourceID, conversionAmount)
 	err = tx.Insert(&convertedCommitment)
 	if respondwith.ErrorText(w, err) {

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -917,8 +917,8 @@ func (p *v1Provider) ConvertCommitment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	req := parseTarget.Request
-	nm := core.BuildNameMapping(p.Cluster)
-	targetServiceType, targetResourceName, exists := nm.MapResourceFromV1API(req.TargetService, req.TargetResource)
+	nm := core.BuildResourceNameMapping(p.Cluster)
+	targetServiceType, targetResourceName, exists := nm.MapFromV1API(req.TargetService, req.TargetResource)
 	if !exists {
 		msg := fmt.Sprintf("no such service and/or resource: %s/%s", req.TargetService, req.TargetResource)
 		http.Error(w, msg, http.StatusUnprocessableEntity)

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -934,7 +934,7 @@ func (p *v1Provider) ConvertCommitment(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, msg, http.StatusUnprocessableEntity)
 		return
 	}
-	if (sourceBehavior.CommitmentConversion == core.CommitmentConversion{} || targetBehavior.CommitmentConversion == core.CommitmentConversion{}) {
+	if sourceBehavior.CommitmentConversion.Identifier == "" || sourceBehavior.CommitmentConversion.Identifier != targetBehavior.CommitmentConversion.Identifier {
 		http.Error(w, "commitment is not convertible", http.StatusUnprocessableEntity)
 		return
 	}

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -930,7 +930,7 @@ func (p *v1Provider) ConvertCommitment(w http.ResponseWriter, r *http.Request) {
 	}
 	targetBehavior := p.Cluster.BehaviorForResource(targetServiceType, targetResourceName)
 	if len(targetBehavior.CommitmentDurations) == 0 {
-                msg := fmt.Sprintf("commitments are not enabled for resource %s/%s", req.TargetService, req.TargetResource)
+		msg := fmt.Sprintf("commitments are not enabled for resource %s/%s", req.TargetService, req.TargetResource)
 		http.Error(w, msg, http.StatusUnprocessableEntity)
 		return
 	}

--- a/internal/api/commitment_test.go
+++ b/internal/api/commitment_test.go
@@ -994,18 +994,14 @@ func Test_TransferCommitment(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if supersededCommitment.State != db.CommitmentStateSuperseded {
-		t.Fatalf("commitment state should be %v. Received %v instead.", db.CommitmentStateSuperseded, supersededCommitment.State)
-	}
+	assert.DeepEqual(t, "commitment state", supersededCommitment.State, db.CommitmentStateSuperseded)
 
 	var splitCommitment db.ProjectCommitment
 	err = s.DB.SelectOne(&splitCommitment, `SELECT * FROM project_commitments where ID = 2`)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if splitCommitment.State != db.CommitmentStateActive {
-		t.Fatalf("commitment state should be %v. Received %v instead.", db.CommitmentStateActive, splitCommitment.State)
-	}
+	assert.DeepEqual(t, "commitment state", splitCommitment.State, db.CommitmentStateActive)
 
 	// wrong token
 	assert.HTTPRequest{
@@ -1252,9 +1248,7 @@ func Test_ConvertCommitments(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if originalCommitment.State != db.CommitmentStateSuperseded {
-		t.Fatalf("commitment state should be %v. Received %v instead.", db.CommitmentStateSuperseded, originalCommitment.State)
-	}
+	assert.DeepEqual(t, "commitment state", originalCommitment.State, db.CommitmentStateSuperseded)
 	err = s.DB.SelectOne(&originalCommitment, `SELECT * FROM project_commitments where ID = 2`)
 	if err != nil {
 		t.Fatal(err)
@@ -1302,7 +1296,7 @@ func Test_ConvertCommitments(t *testing.T) {
 		Method:       http.MethodPost,
 		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/2/convert",
 		Body:         req("third", "capacity2_c144", 1, 3),
-		ExpectBody:   assert.StringData("commitment is not convertible into target resource: capacity2_c144\n"),
+		ExpectBody:   assert.StringData("commitment is not convertible into resource third/capacity2_c144\n"),
 		ExpectStatus: http.StatusUnprocessableEntity,
 	}.Check(t, s.Handler)
 

--- a/internal/api/commitment_test.go
+++ b/internal/api/commitment_test.go
@@ -1158,26 +1158,6 @@ func Test_ConvertCommitments(t *testing.T) {
 		test.WithAPIHandler(NewV1API),
 	)
 
-	commitment := assert.JSONObject{
-		"commitment": assert.JSONObject{
-			"service_type":      "second",
-			"resource_name":     "capacity",
-			"availability_zone": "az-one",
-			"amount":            21,
-			"duration":          "1 hour",
-		},
-	}
-	commitmentWithConfirmBy := assert.JSONObject{
-		"commitment": assert.JSONObject{
-			"service_type":      "second",
-			"resource_name":     "capacity",
-			"availability_zone": "az-one",
-			"amount":            3,
-			"duration":          "1 hour",
-			"confirm_by":        s.Clock.Now().Add(14 * day).Unix(),
-		},
-	}
-
 	req := func(targetService, targetResource string, sourceAmount, TargetAmount uint64) assert.JSONObject {
 		return assert.JSONObject{
 			"commitment": assert.JSONObject{
@@ -1226,9 +1206,17 @@ func Test_ConvertCommitments(t *testing.T) {
 
 	// conversion rate is (second: 3 to first: 2)
 	assert.HTTPRequest{
-		Method:       http.MethodPost,
-		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/new",
-		Body:         commitment,
+		Method: http.MethodPost,
+		Path:   "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/new",
+		Body: assert.JSONObject{
+			"commitment": assert.JSONObject{
+				"service_type":      "second",
+				"resource_name":     "capacity",
+				"availability_zone": "az-one",
+				"amount":            21,
+				"duration":          "1 hour",
+			},
+		},
 		ExpectStatus: http.StatusCreated,
 	}.Check(t, s.Handler)
 
@@ -1320,9 +1308,18 @@ func Test_ConvertCommitments(t *testing.T) {
 
 	// test commitment conversion with confirmBy field (unconfirmed commitment)
 	assert.HTTPRequest{
-		Method:       http.MethodPost,
-		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/new",
-		Body:         commitmentWithConfirmBy,
+		Method: http.MethodPost,
+		Path:   "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/new",
+		Body: assert.JSONObject{
+			"commitment": assert.JSONObject{
+				"service_type":      "second",
+				"resource_name":     "capacity",
+				"availability_zone": "az-one",
+				"amount":            3,
+				"duration":          "1 hour",
+				"confirm_by":        s.Clock.Now().Add(14 * day).Unix(),
+			},
+		},
 		ExpectStatus: http.StatusCreated,
 	}.Check(t, s.Handler)
 

--- a/internal/api/commitment_test.go
+++ b/internal/api/commitment_test.go
@@ -78,6 +78,8 @@ const testConvertCommitmentsYAML = `
 	discovery:
 		method: --test-static
 	services:
+		- service_type: first
+			type: --test-generic
 		- service_type: second
 			type: --test-generic
 		- service_type: third
@@ -86,10 +88,15 @@ const testConvertCommitmentsYAML = `
 				with_empty_resource: true
 				with_convert_commitments: true
 	resource_behavior:
+		- resource: first/.*
+			commitment_durations: ["1 hour", "2 hours"]
 		- resource: second/.*
 			commitment_durations: ["1 hour", "2 hours"]
 		- resource: third/.*
 			commitment_durations: ["1 hour", "2 hours"]
+		- resource: first/capacity
+			commitment_is_az_aware: true
+			commitment_conversion: {identifier: flavor1, weight: 48}
 		- resource: second/capacity
 			commitment_is_az_aware: true
 			commitment_conversion: {identifier: flavor1, weight: 32}
@@ -1104,6 +1111,12 @@ func Test_GetCommitmentConversion(t *testing.T) {
 	// capacity_c120 uses a different Unit than the source and is therefore ignored.
 	resp1 := []assert.JSONObject{
 		{
+			"from":            1,
+			"to":              1,
+			"target_service":  "first",
+			"target_resource": "capacity",
+		},
+		{
 			"from":            2,
 			"to":              3,
 			"target_service":  "second",
@@ -1150,15 +1163,15 @@ func Test_ConvertCommitments(t *testing.T) {
 			"service_type":      "second",
 			"resource_name":     "capacity",
 			"availability_zone": "az-one",
-			"amount":            10,
+			"amount":            13,
 			"duration":          "1 hour",
 		},
 	}
 
 	req := assert.JSONObject{
 		"commitment": assert.JSONObject{
-			"target_service":  "third",
-			"target_resource": "capacity_c48",
+			"target_service":  "first",
+			"target_resource": "capacity",
 			"source_amount":   10,
 			"target_amount":   6,
 		},

--- a/internal/api/commitment_test.go
+++ b/internal/api/commitment_test.go
@@ -1209,7 +1209,7 @@ func Test_ConvertCommitments(t *testing.T) {
 	// Converted commitment does not fit into the capacity (amount: 12, capacity: 10)
 	assert.HTTPRequest{
 		Method:       http.MethodPost,
-		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitment-conversion/1",
+		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/1/convert",
 		Body:         req("first", 20, 12),
 		ExpectBody:   assert.StringData("not enough capacity to confirm the commitment\n"),
 		ExpectStatus: http.StatusUnprocessableEntity,
@@ -1218,7 +1218,7 @@ func Test_ConvertCommitments(t *testing.T) {
 	// Conversion with remainder
 	assert.HTTPRequest{
 		Method:       http.MethodPost,
-		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitment-conversion/1",
+		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/1/convert",
 		Body:         req("first", 10, 6),
 		ExpectBody:   assert.JSONObject{"commitment": resp(2, 6, "first", "capacity")},
 		ExpectStatus: http.StatusAccepted,
@@ -1236,7 +1236,7 @@ func Test_ConvertCommitments(t *testing.T) {
 	// Conversion without remainder (from: 2 to: 3)
 	assert.HTTPRequest{
 		Method:       http.MethodPost,
-		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitment-conversion/2",
+		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/2/convert",
 		Body:         req("second", 6, 9),
 		ExpectBody:   assert.JSONObject{"commitment": resp(3, 9, "second", "capacity")},
 		ExpectStatus: http.StatusAccepted,
@@ -1252,7 +1252,7 @@ func Test_ConvertCommitments(t *testing.T) {
 	// Convert to another project
 	assert.HTTPRequest{
 		Method:       http.MethodPost,
-		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-dresden/commitment-conversion/3",
+		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-dresden/commitments/3/convert",
 		Body:         req("first", 9, 6),
 		ExpectBody:   assert.JSONObject{"commitment": resp(4, 6, "first", "capacity")},
 		ExpectStatus: http.StatusAccepted,
@@ -1268,7 +1268,7 @@ func Test_ConvertCommitments(t *testing.T) {
 	// Reject conversion at the same project to the same resource.
 	assert.HTTPRequest{
 		Method:       http.MethodPost,
-		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-dresden/commitment-conversion/4",
+		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-dresden/commitments/4/convert",
 		Body:         req("first", 6, 6),
 		ExpectBody:   assert.StringData("conversion attempt to the same resource.\n"),
 		ExpectStatus: http.StatusConflict,
@@ -1277,7 +1277,7 @@ func Test_ConvertCommitments(t *testing.T) {
 	// Mismatching target amount
 	assert.HTTPRequest{
 		Method:       http.MethodPost,
-		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitment-conversion/4",
+		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/4/convert",
 		Body:         req("second", 6, 8),
 		ExpectBody:   assert.StringData("conversion mismatch. provided: 8, calculated: 9\n"),
 		ExpectStatus: http.StatusConflict,
@@ -1286,7 +1286,7 @@ func Test_ConvertCommitments(t *testing.T) {
 	// Check resulting empty commitment from conversion calculation (from amount > source amount)
 	assert.HTTPRequest{
 		Method:       http.MethodPost,
-		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitment-conversion/4",
+		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/4/convert",
 		Body:         req("second", 1, 3),
 		ExpectBody:   assert.StringData("amount: 1 does not match conversion rate of: 2\n"),
 		ExpectStatus: http.StatusConflict,

--- a/internal/api/commitment_test.go
+++ b/internal/api/commitment_test.go
@@ -1271,9 +1271,7 @@ func Test_ConvertCommitments(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if originalCommitment.Amount != 18 {
-		t.Fatalf("commitment amount should be %v. Received %v instead.", 18, originalCommitment.Amount)
-	}
+	assert.DeepEqual(t, "commitment amount", originalCommitment.Amount, 18)
 
 	// Reject conversion attempt to a different project.
 	assert.HTTPRequest{

--- a/internal/api/commitment_test.go
+++ b/internal/api/commitment_test.go
@@ -1302,7 +1302,7 @@ func Test_ConvertCommitments(t *testing.T) {
 		ExpectStatus: http.StatusConflict,
 	}.Check(t, s.Handler)
 
-	// Check resulting empty commitment from conversion calculation (remainderAmount > 0)
+	// Reject an amount that doesn't fit into the conversion rate (remainder > 0).
 	assert.HTTPRequest{
 		Method:       http.MethodPost,
 		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/2/convert",
@@ -1316,7 +1316,7 @@ func Test_ConvertCommitments(t *testing.T) {
 		Method:       http.MethodPost,
 		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/2/convert",
 		Body:         req("third", "capacity2_c144", 1, 3),
-		ExpectBody:   assert.StringData("commitment is not convertible\n"),
+		ExpectBody:   assert.StringData("commitment is not convertible into target resource: capacity2_c144\n"),
 		ExpectStatus: http.StatusUnprocessableEntity,
 	}.Check(t, s.Handler)
 

--- a/internal/api/commitment_test.go
+++ b/internal/api/commitment_test.go
@@ -1145,32 +1145,39 @@ func Test_ConvertCommitments(t *testing.T) {
 		test.WithAPIHandler(NewV1API),
 	)
 
-	req := assert.JSONObject{
+	commitment := assert.JSONObject{
 		"commitment": assert.JSONObject{
 			"service_type":      "second",
 			"resource_name":     "capacity",
 			"availability_zone": "az-one",
-			"amount":            11,
+			"amount":            10,
 			"duration":          "1 hour",
+		},
+	}
+
+	req := assert.JSONObject{
+		"commitment": assert.JSONObject{
+			"target_service":  "third",
+			"target_resource": "capacity_c48",
+			"source_amount":   10,
+			"target_amount":   6,
 		},
 	}
 
 	assert.HTTPRequest{
 		Method:       http.MethodPost,
 		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/new",
-		Body:         req,
+		Body:         commitment,
 		ExpectStatus: http.StatusCreated,
 	}.Check(t, s.Handler)
 
 	// TODO: Test for a real result set.
-	/*
-		assert.HTTPRequest{
-			Method:       http.MethodPost,
-			Path:         "/v1/commitment-conversion/1/third/capacity_c48",
-			ExpectStatus: http.StatusOK,
-			Body:         req,
-			ExpectBody:   assert.JSONObject{"conversions": ""},
-		}.Check(t, s.Handler)
-	*/
 
+	assert.HTTPRequest{
+		Method:       http.MethodPost,
+		Path:         "/v1/commitment-conversion/1",
+		ExpectStatus: http.StatusOK,
+		Body:         req,
+		ExpectBody:   assert.JSONObject{"commitment": 0},
+	}.Check(t, s.Handler)
 }

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -166,7 +166,7 @@ func (p *v1Provider) AddTo(r *mux.Router) {
 	r.Methods("GET").Path("/v1/commitments/{token}").HandlerFunc(p.GetCommitmentByTransferToken)
 	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/transfer-commitment/{id}").HandlerFunc(p.TransferCommitment)
 	r.Methods("GET").Path("/v1/commitment-conversion/{service_type}/{resource_name}").HandlerFunc(p.GetCommitmentConversions)
-	r.Methods("POST").Path("/v1/commitment-conversion/{commitment_id}/{service_type}/{resource_name}").HandlerFunc(p.ConvertCommitment)
+	r.Methods("POST").Path("/v1/commitment-conversion/{commitment_id}").HandlerFunc(p.ConvertCommitment)
 }
 
 // RequireJSON will parse the request body into the given data structure, or

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -166,6 +166,7 @@ func (p *v1Provider) AddTo(r *mux.Router) {
 	r.Methods("GET").Path("/v1/commitments/{token}").HandlerFunc(p.GetCommitmentByTransferToken)
 	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/transfer-commitment/{id}").HandlerFunc(p.TransferCommitment)
 	r.Methods("GET").Path("/v1/commitment-conversion/{service_type}/{resource_name}").HandlerFunc(p.GetCommitmentConversions)
+	r.Methods("POST").Path("/v1/commitment-conversion/{commitment_id}/{service_type}/{resource_name}").HandlerFunc(p.ConvertCommitment)
 }
 
 // RequireJSON will parse the request body into the given data structure, or

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -166,7 +166,7 @@ func (p *v1Provider) AddTo(r *mux.Router) {
 	r.Methods("GET").Path("/v1/commitments/{token}").HandlerFunc(p.GetCommitmentByTransferToken)
 	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/transfer-commitment/{id}").HandlerFunc(p.TransferCommitment)
 	r.Methods("GET").Path("/v1/commitment-conversion/{service_type}/{resource_name}").HandlerFunc(p.GetCommitmentConversions)
-	r.Methods("POST").Path("/v1/commitment-conversion/{commitment_id}").HandlerFunc(p.ConvertCommitment)
+	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/commitment-conversion/{commitment_id}").HandlerFunc(p.ConvertCommitment)
 }
 
 // RequireJSON will parse the request body into the given data structure, or

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -166,7 +166,7 @@ func (p *v1Provider) AddTo(r *mux.Router) {
 	r.Methods("GET").Path("/v1/commitments/{token}").HandlerFunc(p.GetCommitmentByTransferToken)
 	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/transfer-commitment/{id}").HandlerFunc(p.TransferCommitment)
 	r.Methods("GET").Path("/v1/commitment-conversion/{service_type}/{resource_name}").HandlerFunc(p.GetCommitmentConversions)
-	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/commitment-conversion/{commitment_id}").HandlerFunc(p.ConvertCommitment)
+	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments/{commitment_id}/convert").HandlerFunc(p.ConvertCommitment)
 }
 
 // RequireJSON will parse the request body into the given data structure, or


### PR DESCRIPTION
This PR aims to introduce the POST API to convert a supported commitment from a source to a target resource.
