### PR TITLE
allow regex replacement in ResourceBehavior.IdentityInV1API

### DIFF
--- a/docs/operators/config.md
+++ b/docs/operators/config.md
@@ -152,6 +152,16 @@ resource_behavior:
   - { resource: compute/instances_baremetal_large, identity_in_v1_api: compute/instances_thebigbox }
 ```
 
+The fields `category` and `identity_in_v1_api` can be templated with placeholders `$1`, `$2`, etc., which will be filled with the respective match groups from the `resource` regex. For example:
+
+```yaml
+resource_behavior:
+  # this entire service was renamed
+  - { resource: 'volumev2/(.*)', identity_in_v1_api: 'cinder/$1' }
+  # this service contains sets of resources for each share type
+  - { resource: 'manila/(shares|snapshots|share_capacity|snapshot_capacity)_(.+)', category: 'share_type_$2' }
+```
+
 #### Resource renaming
 
 Limes provides amenities for renaming and restructuring services and resources in a way where the backwards-incompatible

--- a/internal/core/cluster.go
+++ b/internal/core/cluster.go
@@ -203,7 +203,7 @@ func (c *Cluster) BehaviorForResource(serviceType db.ServiceType, resourceName l
 	fullName := string(serviceType) + "/" + string(resourceName)
 	for _, behavior := range c.Config.ResourceBehaviors {
 		if behavior.FullResourceNameRx.MatchString(fullName) {
-			result.Merge(behavior)
+			result.Merge(behavior, fullName)
 		}
 	}
 

--- a/internal/datamodel/quota_overrides_test.go
+++ b/internal/datamodel/quota_overrides_test.go
@@ -53,8 +53,8 @@ const (
 		resource_behavior:
 		- resource: first/capacity
 			identity_in_v1_api: capacities/first
-		- resource: first/things
-			identity_in_v1_api: things/first
+		- resource: (first)/thi(ngs)
+			identity_in_v1_api: thi$2/$1
 	`
 )
 


### PR DESCRIPTION
This is somewhere between useful and required for services that have a large number of resources generated from a pattern, e.g. in Cinder where there is `{capacity,snapshots,volumes}_$TYPE` for each volume type, where we may not even know the specific list of volume types ahead of time.