### PR TITLE
fix TranslationRule placement for Cinder

### DIFF
--- a/internal/api/translation_test.go
+++ b/internal/api/translation_test.go
@@ -50,7 +50,7 @@ func TestTranslateManilaSubcapacities(t *testing.T) {
 	)
 	s.Cluster.Config.ResourceBehaviors = []core.ResourceBehavior{{
 		FullResourceNameRx:     "first/capacity",
-		TranslationRuleInV1API: must.Return(core.NewTranslationRule("manila")),
+		TranslationRuleInV1API: must.Return(core.NewTranslationRule("cinder-manila-capacity")),
 	}}
 
 	// this is what liquid-manila (or liquid-cinder) writes into the DB

--- a/internal/core/translation_rule.go
+++ b/internal/core/translation_rule.go
@@ -45,10 +45,10 @@ func NewTranslationRule(id string) (TranslationRule, error) {
 		// the default is to not do any translation
 		return TranslationRule{nil, nil}, nil
 	case "cinder-volumes":
-		return TranslationRule{translateCinderOrManilaSubcapacities, translateCinderVolumeSubresources}, nil
+		return TranslationRule{nil, translateCinderVolumeSubresources}, nil
 	case "cinder-snapshots":
-		return TranslationRule{translateCinderOrManilaSubcapacities, translateCinderSnapshotSubresources}, nil
-	case "manila":
+		return TranslationRule{nil, translateCinderSnapshotSubresources}, nil
+	case "cinder-manila-capacity":
 		return TranslationRule{translateCinderOrManilaSubcapacities, nil}, nil
 	default:
 		return TranslationRule{}, fmt.Errorf("no such TranslationRule: %q", id)


### PR DESCRIPTION
We need this on the capacity resources, not on the volumes/snapshots resources.