### PR TITLE
add core.RateBehavior

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -567,9 +567,9 @@ func Test_ProjectOperations(t *testing.T) {
 	assert.HTTPRequest{
 		Method:       "PUT",
 		Path:         "/rates/v1/domains/uuid-for-germany/projects/uuid-for-berlin",
-		ExpectStatus: 403,
+		ExpectStatus: 500, // TODO: should be 403 (I don't care about fixing this in v1; v2 will be structured differently to allow for a fix)
 		ExpectBody: assert.StringData(
-			"cannot change shared/service/shared/notexistent:bogus rate limits: user is not allowed to create new rate limits\n",
+			"no such rate: shared/service/shared/notexistent:bogus\n",
 		),
 		Body: assert.JSONObject{
 			"project": assert.JSONObject{
@@ -1111,7 +1111,7 @@ func TestResourceRenaming(t *testing.T) {
 	s.Cluster.Config.ResourceBehaviors = append(slices.Clone(baseBehaviors),
 		core.ResourceBehavior{
 			FullResourceNameRx: "shared/things",
-			IdentityInV1API:    core.ResourceRef{ServiceType: "shared", ResourceName: "items"},
+			IdentityInV1API:    core.ResourceRef{ServiceType: "shared", Name: "items"},
 		},
 	)
 	expect("?",
@@ -1138,7 +1138,7 @@ func TestResourceRenaming(t *testing.T) {
 	s.Cluster.Config.ResourceBehaviors = append(slices.Clone(baseBehaviors),
 		core.ResourceBehavior{
 			FullResourceNameRx: "shared/things",
-			IdentityInV1API:    core.ResourceRef{ServiceType: "unshared", ResourceName: "other_things"},
+			IdentityInV1API:    core.ResourceRef{ServiceType: "unshared", Name: "other_things"},
 		},
 	)
 	expect("?",
@@ -1170,11 +1170,11 @@ func TestResourceRenaming(t *testing.T) {
 	s.Cluster.Config.ResourceBehaviors = append(slices.Clone(baseBehaviors),
 		core.ResourceBehavior{
 			FullResourceNameRx: "shared/capacity",
-			IdentityInV1API:    core.ResourceRef{ServiceType: "shared_capacity", ResourceName: "all"},
+			IdentityInV1API:    core.ResourceRef{ServiceType: "shared_capacity", Name: "all"},
 		},
 		core.ResourceBehavior{
 			FullResourceNameRx: "shared/capacity_portion",
-			IdentityInV1API:    core.ResourceRef{ServiceType: "shared_capacity", ResourceName: "part"},
+			IdentityInV1API:    core.ResourceRef{ServiceType: "shared_capacity", Name: "part"},
 		},
 	)
 	expect("?",

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -217,8 +217,8 @@ func (p *v1Provider) parseAndValidateCommitmentRequest(w http.ResponseWriter, r 
 	req := parseTarget.Request
 
 	// validate request
-	nm := core.BuildNameMapping(p.Cluster)
-	dbServiceType, dbResourceName, ok := nm.MapResourceFromV1API(req.ServiceType, req.ResourceName)
+	nm := core.BuildResourceNameMapping(p.Cluster)
+	dbServiceType, dbResourceName, ok := nm.MapFromV1API(req.ServiceType, req.ResourceName)
 	if !ok {
 		msg := fmt.Sprintf("no such service and/or resource: %s/%s", req.ServiceType, req.ResourceName)
 		http.Error(w, msg, http.StatusUnprocessableEntity)
@@ -790,8 +790,8 @@ func (p *v1Provider) GetCommitmentConversions(w http.ResponseWriter, r *http.Req
 
 	// validate request
 	vars := mux.Vars(r)
-	nm := core.BuildNameMapping(p.Cluster)
-	sourceServiceType, sourceResourceName, exists := nm.MapResourceFromV1API(
+	nm := core.BuildResourceNameMapping(p.Cluster)
+	sourceServiceType, sourceResourceName, exists := nm.MapFromV1API(
 		limes.ServiceType(vars["service_type"]),
 		limesresources.ResourceName(vars["resource_name"]),
 	)
@@ -826,7 +826,7 @@ func (p *v1Provider) GetCommitmentConversions(w http.ResponseWriter, r *http.Req
 			}
 
 			fromAmount, toAmount := p.getCommitmentConversionRate(sourceBehavior, targetBehavior)
-			apiServiceType, apiResourceName, ok := nm.MapResourceToV1API(targetServiceType, targetResourceName)
+			apiServiceType, apiResourceName, ok := nm.MapToV1API(targetServiceType, targetResourceName)
 			if ok {
 				conversions = append(conversions, limesresources.CommitmentConversionRule{
 					FromAmount:     fromAmount,

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -189,7 +189,7 @@ func (p *v1Provider) convertCommitmentToDisplayForm(c db.ProjectCommitment, loc 
 	return limesresources.Commitment{
 		ID:               int64(c.ID),
 		ServiceType:      apiIdentity.ServiceType,
-		ResourceName:     apiIdentity.ResourceName,
+		ResourceName:     apiIdentity.Name,
 		AvailabilityZone: loc.AvailabilityZone,
 		Amount:           c.Amount,
 		Unit:             resInfo.Unit,

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -214,11 +214,11 @@ func (p *v1Provider) PutProjectMaxQuota(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// validate request
-	nm := core.BuildNameMapping(p.Cluster)
+	nm := core.BuildResourceNameMapping(p.Cluster)
 	requested := make(map[db.ServiceType]map[liquid.ResourceName]*maxQuotaChange)
 	for _, srvRequest := range parseTarget.Project.Services {
 		for _, resRequest := range srvRequest.Resources {
-			dbServiceType, dbResourceName, exists := nm.MapResourceFromV1API(srvRequest.Type, resRequest.Name)
+			dbServiceType, dbResourceName, exists := nm.MapFromV1API(srvRequest.Type, resRequest.Name)
 			if !exists {
 				msg := fmt.Sprintf("no such service and/or resource: %s/%s", srvRequest.Type, resRequest.Name)
 				http.Error(w, msg, http.StatusUnprocessableEntity)
@@ -300,7 +300,7 @@ func (p *v1Provider) PutProjectMaxQuota(w http.ResponseWriter, r *http.Request) 
 	// write audit trail
 	for dbServiceType, requestedInService := range requested {
 		for dbResourceName, requestedChange := range requestedInService {
-			apiServiceType, apiResourceName, exists := nm.MapResourceToV1API(dbServiceType, dbResourceName)
+			apiServiceType, apiResourceName, exists := nm.MapToV1API(dbServiceType, dbResourceName)
 			if exists {
 				logAndPublishEvent(requestTime, r, token, http.StatusOK,
 					maxQuotaEventTarget{

--- a/internal/api/rate_updater.go
+++ b/internal/api/rate_updater.go
@@ -83,10 +83,16 @@ func (u *RateLimitUpdater) ValidateInput(input limesrates.RateRequest, dbi db.In
 	// Go through all services and validate the requested rate limits.
 	for apiServiceType, in := range input {
 		for apiRateName, newRateLimit := range in {
-			dbServiceType, dbRateName := nm.MapRateFromV1API(apiServiceType, apiRateName)
+			dbServiceType, dbRateName, exists := nm.MapRateFromV1API(apiServiceType, apiRateName)
+			if !exists {
+				// it is ugly that this breaks the existing error reporting format, but
+				// since we don't have a DB-level identifier, we cannot record this in
+				// our usual structure
+				return fmt.Errorf("no such rate: %s/%s", apiServiceType, apiRateName)
+			}
 			serviceConfig, ok := u.Cluster.Config.GetServiceConfigurationForType(dbServiceType)
 			if !ok {
-				// Skip service if not configured.
+				// defense in depth: should not occur because then we should have had `!exists` above
 				continue
 			}
 			if u.Requests[dbServiceType] == nil {
@@ -172,16 +178,15 @@ func (u RateLimitUpdater) WriteSimulationReport(w http.ResponseWriter) {
 	}
 	result.IsValid = true // until proven otherwise
 
-	nm := core.BuildNameMapping(u.Cluster)
 	for dbServiceType, reqs := range u.Requests {
 		for dbRateName, req := range reqs {
 			if req.ValidationError != nil {
 				result.IsValid = false
-				apiServiceType, apiRateName := nm.MapRateToV1API(dbServiceType, dbRateName)
+				apiIdentity := u.Cluster.BehaviorForRate(dbServiceType, dbRateName).IdentityInV1API
 				result.UnacceptableRateLimits = append(result.UnacceptableRateLimits,
 					unacceptableRateLimit{
-						ServiceType:         apiServiceType,
-						Name:                apiRateName,
+						ServiceType:         apiIdentity.ServiceType,
+						Name:                apiIdentity.Name,
 						RateValidationError: *req.ValidationError,
 					},
 				)
@@ -211,15 +216,14 @@ func (u RateLimitUpdater) WritePutErrorResponse(w http.ResponseWriter) {
 	hasSubstatus := make(map[int]bool)
 
 	// collect error messages
-	nm := core.BuildNameMapping(u.Cluster)
 	for dbServiceType, reqs := range u.Requests {
 		for dbRateName, req := range reqs {
 			if err := req.ValidationError; err != nil {
-				apiServiceType, apiRateName := nm.MapRateToV1API(dbServiceType, dbRateName)
+				apiIdentity := u.Cluster.BehaviorForRate(dbServiceType, dbRateName).IdentityInV1API
 				hasSubstatus[err.Status] = true
 				lines = append(
 					lines,
-					fmt.Sprintf("cannot change %s/%s rate limits: %s", apiServiceType, apiRateName, err.Message),
+					fmt.Sprintf("cannot change %s/%s rate limits: %s", apiIdentity.ServiceType, apiIdentity.Name, err.Message),
 				)
 			}
 		}
@@ -250,7 +254,6 @@ func (u RateLimitUpdater) CommitAuditTrail(token *gopherpolicy.Token, r *http.Re
 		statusCode = http.StatusUnprocessableEntity
 	}
 
-	nm := core.BuildNameMapping(u.Cluster)
 	for dbServiceType, reqs := range u.Requests {
 		for dbRateName, req := range reqs {
 			// if !u.IsValid(), then all requested quotas in this PUT are considered
@@ -264,15 +267,15 @@ func (u RateLimitUpdater) CommitAuditTrail(token *gopherpolicy.Token, r *http.Re
 				}
 			}
 
-			apiServiceType, apiRateName := nm.MapRateToV1API(dbServiceType, dbRateName)
+			apiIdentity := u.Cluster.BehaviorForRate(dbServiceType, dbRateName).IdentityInV1API
 			logAndPublishEvent(requestTime, r, token, statusCode,
 				rateLimitEventTarget{
 					DomainID:     u.Domain.UUID,
 					DomainName:   u.Domain.Name,
 					ProjectID:    u.Project.UUID,
 					ProjectName:  u.Project.Name,
-					ServiceType:  apiServiceType,
-					Name:         apiRateName,
+					ServiceType:  apiIdentity.ServiceType,
+					Name:         apiIdentity.Name,
 					OldLimit:     req.OldLimit,
 					NewLimit:     req.NewLimit,
 					OldWindow:    req.OldWindow,

--- a/internal/api/rate_updater.go
+++ b/internal/api/rate_updater.go
@@ -77,13 +77,13 @@ func (u *RateLimitUpdater) ValidateInput(input limesrates.RateRequest, dbi db.In
 		return err
 	}
 
-	nm := core.BuildNameMapping(u.Cluster)
+	nm := core.BuildRateNameMapping(u.Cluster)
 	u.Requests = make(map[db.ServiceType]map[db.RateName]RateLimitRequest)
 
 	// Go through all services and validate the requested rate limits.
 	for apiServiceType, in := range input {
 		for apiRateName, newRateLimit := range in {
-			dbServiceType, dbRateName, exists := nm.MapRateFromV1API(apiServiceType, apiRateName)
+			dbServiceType, dbRateName, exists := nm.MapFromV1API(apiServiceType, apiRateName)
 			if !exists {
 				// it is ugly that this breaks the existing error reporting format, but
 				// since we don't have a DB-level identifier, we cannot record this in

--- a/internal/core/cluster.go
+++ b/internal/core/cluster.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/sapcc/go-api-declarations/limes"
+	limesrates "github.com/sapcc/go-api-declarations/limes/rates"
 	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
 	"github.com/sapcc/go-api-declarations/liquid"
 	"github.com/sapcc/go-bits/errext"
@@ -194,8 +195,8 @@ func (c *Cluster) BehaviorForResource(serviceType db.ServiceType, resourceName l
 	result := ResourceBehavior{
 		IdentityInV1API: ResourceRef{
 			// NOTE: This is the only place where these particular cross-type casts are allowed.
-			ServiceType:  limes.ServiceType(serviceType),
-			ResourceName: limesresources.ResourceName(resourceName),
+			ServiceType: limes.ServiceType(serviceType),
+			Name:        limesresources.ResourceName(resourceName),
 		},
 	}
 
@@ -203,6 +204,29 @@ func (c *Cluster) BehaviorForResource(serviceType db.ServiceType, resourceName l
 	fullName := string(serviceType) + "/" + string(resourceName)
 	for _, behavior := range c.Config.ResourceBehaviors {
 		if behavior.FullResourceNameRx.MatchString(fullName) {
+			result.Merge(behavior, fullName)
+		}
+	}
+
+	return result
+}
+
+// BehaviorForRate returns the RateBehavior for the given rate in
+// the given scope.
+func (c *Cluster) BehaviorForRate(serviceType db.ServiceType, rateName db.RateName) RateBehavior {
+	// default behavior
+	result := RateBehavior{
+		IdentityInV1API: RateRef{
+			// NOTE: This is the only place where these particular cross-type casts are allowed.
+			ServiceType: limes.ServiceType(serviceType),
+			Name:        limesrates.RateName(rateName),
+		},
+	}
+
+	// check for specific behavior
+	fullName := string(serviceType) + "/" + string(rateName)
+	for _, behavior := range c.Config.RateBehaviors {
+		if behavior.FullRateNameRx.MatchString(fullName) {
 			result.Merge(behavior, fullName)
 		}
 	}

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -44,6 +44,7 @@ type ClusterConfiguration struct {
 	Capacitors        []CapacitorConfiguration `yaml:"capacitors"`
 	// ^ Sorry for the stupid pun. Not.
 	ResourceBehaviors        []ResourceBehavior                `yaml:"resource_behavior"`
+	RateBehaviors            []RateBehavior                    `yaml:"rate_behavior"`
 	QuotaDistributionConfigs []*QuotaDistributionConfiguration `yaml:"quota_distribution_configs"`
 }
 
@@ -203,6 +204,9 @@ func (cluster ClusterConfiguration) validateConfig() (errs errext.ErrorSet) {
 
 	for idx, behavior := range cluster.ResourceBehaviors {
 		errs.Append(behavior.Validate(fmt.Sprintf("resource_behavior[%d]", idx)))
+	}
+	for idx, behavior := range cluster.RateBehaviors {
+		errs.Append(behavior.Validate(fmt.Sprintf("rate_behavior[%d]", idx)))
 	}
 
 	for idx, qdCfg := range cluster.QuotaDistributionConfigs {

--- a/internal/core/rate_behavior.go
+++ b/internal/core/rate_behavior.go
@@ -1,0 +1,57 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package core
+
+import (
+	"github.com/sapcc/go-api-declarations/limes"
+	limesrates "github.com/sapcc/go-api-declarations/limes/rates"
+	"github.com/sapcc/go-bits/errext"
+	"github.com/sapcc/go-bits/regexpext"
+)
+
+// RateBehavior contains the configuration options for specialized behavior of
+// a single rate (or a set thereof).
+type RateBehavior struct {
+	FullRateNameRx  regexpext.BoundedRegexp `yaml:"rate"`
+	IdentityInV1API RateRef                 `yaml:"identity_in_v1_api"`
+}
+
+// Validate returns a list of all errors in this behavior configuration.
+//
+// The `path` argument denotes the location of this behavior in the
+// configuration file, and will be used when generating error messages.
+func (b *RateBehavior) Validate(path string) (errs errext.ErrorSet) {
+	if b.FullRateNameRx == "" {
+		errs.Addf("missing configuration value: %s.rate", path)
+	}
+
+	return errs
+}
+
+// RateRef is an instance of RefInService. It appears in type RateBehavior.
+type RateRef = RefInService[limes.ServiceType, limesrates.RateName]
+
+// Merge computes the union of both given resource behaviors.
+func (b *RateBehavior) Merge(other RateBehavior, fullRateName string) {
+	if other.IdentityInV1API != (RateRef{}) {
+		b.IdentityInV1API.ServiceType = interpolateFromNameMatch(other.FullRateNameRx, other.IdentityInV1API.ServiceType, fullRateName)
+		b.IdentityInV1API.Name = interpolateFromNameMatch(other.FullRateNameRx, other.IdentityInV1API.Name, fullRateName)
+	}
+}

--- a/internal/reports/cluster.go
+++ b/internal/reports/cluster.go
@@ -344,10 +344,10 @@ func GetClusterResources(cluster *core.Cluster, now time.Time, dbi db.Interface,
 	}
 
 	//epilogue: perform some calculations that require the full sum over all AZs to be done
-	nm := core.BuildNameMapping(cluster)
+	nm := core.BuildResourceNameMapping(cluster)
 	for apiServiceType, service := range report.Services {
 		for apiResourceName, resource := range service.Resources {
-			dbServiceType, dbResourceName, exists := nm.MapResourceFromV1API(apiServiceType, apiResourceName)
+			dbServiceType, dbResourceName, exists := nm.MapFromV1API(apiServiceType, apiResourceName)
 			if !exists {
 				// defense in depth: should not happen; we should not have created entries for non-existent resources
 				continue
@@ -383,7 +383,7 @@ func GetClusterResources(cluster *core.Cluster, now time.Time, dbi db.Interface,
 
 // GetClusterRates returns the rate data report for the whole cluster.
 func GetClusterRates(cluster *core.Cluster, dbi db.Interface, filter Filter) (*limesrates.ClusterReport, error) {
-	nm := core.BuildNameMapping(cluster)
+	nm := core.BuildRateNameMapping(cluster)
 	report := &limesrates.ClusterReport{
 		ClusterInfo: limes.ClusterInfo{
 			ID: "current", // multi-cluster support has been removed; this value is only included for backwards-compatibility
@@ -408,7 +408,7 @@ func GetClusterRates(cluster *core.Cluster, dbi db.Interface, filter Filter) (*l
 		if !cluster.HasService(dbServiceType) {
 			return nil
 		}
-		apiServiceType, _, exists := nm.MapRateToV1API(dbServiceType, dbRateName)
+		apiServiceType, _, exists := nm.MapToV1API(dbServiceType, dbRateName)
 		if !exists {
 			return nil
 		}
@@ -436,7 +436,7 @@ func GetClusterRates(cluster *core.Cluster, dbi db.Interface, filter Filter) (*l
 		dbServiceType := serviceConfig.ServiceType
 		for _, rateConfig := range serviceConfig.RateLimits.Global {
 			dbRateName := rateConfig.Name
-			apiServiceType, apiRateName, exists := nm.MapRateToV1API(dbServiceType, dbRateName)
+			apiServiceType, apiRateName, exists := nm.MapToV1API(dbServiceType, dbRateName)
 			if !exists {
 				continue // defense in depth: should not happen because NameMapping iterated through the same structure
 			}

--- a/internal/reports/domain.go
+++ b/internal/reports/domain.go
@@ -351,11 +351,11 @@ func findInDomainReport(domain *limesresources.DomainReport, cluster *core.Clust
 		domain.Services[apiIdentity.ServiceType] = service
 	}
 
-	resource, exists := service.Resources[apiIdentity.ResourceName]
+	resource, exists := service.Resources[apiIdentity.Name]
 	if !exists {
 		resInfo := cluster.InfoForResource(dbServiceType, dbResourceName)
 		resource = &limesresources.DomainResourceReport{
-			ResourceInfo:     behavior.BuildAPIResourceInfo(apiIdentity.ResourceName, resInfo),
+			ResourceInfo:     behavior.BuildAPIResourceInfo(apiIdentity.Name, resInfo),
 			CommitmentConfig: behavior.ToCommitmentConfig(now),
 		}
 		if !resource.NoQuota {
@@ -365,7 +365,7 @@ func findInDomainReport(domain *limesresources.DomainReport, cluster *core.Clust
 			defaultQuota := uint64(0)
 			resource.DomainQuota = &defaultQuota
 		}
-		service.Resources[apiIdentity.ResourceName] = resource
+		service.Resources[apiIdentity.Name] = resource
 	}
 
 	return service, resource

--- a/internal/reports/filter.go
+++ b/internal/reports/filter.go
@@ -81,7 +81,7 @@ func ReadFilter(r *http.Request, cluster *core.Cluster) Filter {
 			if f.Includes[dbServiceType] == nil {
 				f.Includes[dbServiceType] = make(map[liquid.ResourceName]bool)
 			}
-			f.Includes[dbServiceType][dbResourceName] = apiResourceNames.Matches(string(apiIdentity.ResourceName))
+			f.Includes[dbServiceType][dbResourceName] = apiResourceNames.Matches(string(apiIdentity.Name))
 		}
 	}
 

--- a/internal/reports/inconsistency.go
+++ b/internal/reports/inconsistency.go
@@ -94,7 +94,7 @@ func GetInconsistencies(cluster *core.Cluster, dbi db.Interface, filter Filter) 
 		OverspentQuotas:     []OverspentProjectQuota{},
 		MismatchQuotas:      []MismatchProjectQuota{},
 	}
-	nm := core.BuildNameMapping(cluster)
+	nm := core.BuildResourceNameMapping(cluster)
 
 	//ospqReportQuery: data for overspent project quota inconsistencies
 	queryStr, joinArgs := filter.PrepareQuery(ospqReportQuery)
@@ -115,7 +115,7 @@ func GetInconsistencies(cluster *core.Cluster, dbi db.Interface, filter Filter) 
 		}
 
 		var exists bool
-		ospq.Service, ospq.Resource, exists = nm.MapResourceToV1API(dbServiceType, dbResourceName)
+		ospq.Service, ospq.Resource, exists = nm.MapToV1API(dbServiceType, dbResourceName)
 		if !exists {
 			return nil
 		}
@@ -148,7 +148,7 @@ func GetInconsistencies(cluster *core.Cluster, dbi db.Interface, filter Filter) 
 		}
 
 		var exists bool
-		mmpq.Service, mmpq.Resource, exists = nm.MapResourceToV1API(dbServiceType, dbResourceName)
+		mmpq.Service, mmpq.Resource, exists = nm.MapToV1API(dbServiceType, dbResourceName)
 		if !exists {
 			return nil
 		}


### PR DESCRIPTION
This is the same as core.ResourceBehavior, but for rates. I'm adding this now to support rate renaming in the same way as resource renaming (as a prerequisite for transitioning the Cronus plugin to LIQUID in the same way as for the resource-bearing plugins that were already converted).

There is one clearly ugly part where one specific error message in the PUT endpoint for rate limits now generates a 500 error in a specific case that should be a 4xx error. I don't care about fixing this in the v1 API because nobody is using this at the moment anyway. In the v2 API, we will transition PUT on rate limits to only work on one rate at the time in order to simplify the entire RateUpdater thing.