### PR TITLE
Add Duration Extension API

### DIFF
--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -1120,9 +1120,8 @@ func (p *v1Provider) ExtendCommitmentDuration(w http.ResponseWriter, r *http.Req
 	}
 	defer sqlext.RollbackUnlessCommitted(tx)
 
-	now := p.timeNow()
 	dbCommitment.Duration = req.Duration
-	dbCommitment.ExpiresAt = req.Duration.AddTo(unwrapOrDefault(dbCommitment.ConfirmBy, now))
+	dbCommitment.ExpiresAt = req.Duration.AddTo(unwrapOrDefault(dbCommitment.ConfirmBy, dbCommitment.CreatedAt))
 	_, err = tx.Update(&dbCommitment)
 	if respondwith.ErrorText(w, err) {
 		return

--- a/internal/api/commitment_test.go
+++ b/internal/api/commitment_test.go
@@ -1333,7 +1333,6 @@ func Test_ExtendCommitmentDuration(t *testing.T) {
 		test.WithAPIHandler(NewV1API),
 	)
 
-	s.Clock.StepBy(1 * time.Hour)
 	// Positive: Confirmed commitment
 	assert.HTTPRequest{
 		Method: http.MethodPost,
@@ -1350,6 +1349,9 @@ func Test_ExtendCommitmentDuration(t *testing.T) {
 		ExpectStatus: http.StatusCreated,
 	}.Check(t, s.Handler)
 
+	// Fast forward by 1 hour. Creation_time = 0; Now = 1; (Expire = Creation_time + 2 hours)
+	s.Clock.StepBy(1 * time.Hour)
+
 	assert.HTTPRequest{
 		Method: http.MethodPost,
 		Path:   "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/1/extend-duration",
@@ -1362,12 +1364,12 @@ func Test_ExtendCommitmentDuration(t *testing.T) {
 			"amount":            10,
 			"unit":              "B",
 			"duration":          "2 hours",
-			"created_at":        s.Clock.Now().Unix(),
+			"created_at":        s.Clock.Now().Add(-1 * time.Hour).Unix(),
 			"creator_uuid":      "uuid-for-alice",
 			"creator_name":      "alice@Default",
 			"can_be_deleted":    true,
-			"confirmed_at":      s.Clock.Now().Unix(),
-			"expires_at":        s.Clock.Now().Add(2 * time.Hour).Unix(),
+			"confirmed_at":      s.Clock.Now().Add(-1 * time.Hour).Unix(),
+			"expires_at":        s.Clock.Now().Add(1 * time.Hour).Unix(),
 		}},
 		ExpectStatus: http.StatusOK,
 	}.Check(t, s.Handler)

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -167,6 +167,7 @@ func (p *v1Provider) AddTo(r *mux.Router) {
 	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/transfer-commitment/{id}").HandlerFunc(p.TransferCommitment)
 	r.Methods("GET").Path("/v1/commitment-conversion/{service_type}/{resource_name}").HandlerFunc(p.GetCommitmentConversions)
 	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments/{commitment_id}/convert").HandlerFunc(p.ConvertCommitment)
+	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments/{commitment_id}/extend-duration").HandlerFunc(p.ExtendCommitmentDuration)
 }
 
 // RequireJSON will parse the request body into the given data structure, or

--- a/vendor/github.com/sapcc/go-api-declarations/limes/resources/commitment.go
+++ b/vendor/github.com/sapcc/go-api-declarations/limes/resources/commitment.go
@@ -187,6 +187,14 @@ func (d CommitmentDuration) AddTo(t time.Time) time.Time {
 	return t.AddDate(d.Years, d.Months, d.Days).Add(d.Short)
 }
 
+// CompareTo compares its origin with a target duration.
+// Returns: -1 (origin below target), 0 (they are equal), 1 (target above origin)
+func (d CommitmentDuration) CompareTo(cmp CommitmentDuration) int {
+	origin := d.AddTo(time.Time{})
+	target := cmp.AddTo(time.Time{})
+	return origin.Compare(target)
+}
+
 // MarshalJSON implements the json.Marshaler interface.
 func (d CommitmentDuration) MarshalJSON() ([]byte, error) {
 	return json.Marshal(d.String())


### PR DESCRIPTION
This PR introduces an API to extend the duration of a commitment to a valid one provided in its configuration.
This is implemented as a draft, because I'm sure wheter to create a new commitment or overwrite the current one and add a new DB column with  an "Extended_at" field. I would like to hear your oppinion and will implement as desired.

TODO:
- [ ] I updated the documentation to describe the semantical or interface changes I introduced.
