### PR TITLE
plugins: simplify Nova flavor listing

### DIFF
--- a/internal/plugins/capacity_sapcc_ironic.go
+++ b/internal/plugins/capacity_sapcc_ironic.go
@@ -67,6 +67,8 @@ func (p *capacitySapccIronicPlugin) Init(ctx context.Context, provider *gophercl
 	if err != nil {
 		return err
 	}
+	p.NovaV2.Microversion = "2.61" // to include extra specs in flavors.ListDetail()
+
 	p.IronicV1, err = openstack.NewBareMetalV1(provider, eo)
 	if err != nil {
 		return err

--- a/internal/plugins/nova.go
+++ b/internal/plugins/nova.go
@@ -83,7 +83,7 @@ func (p *novaPlugin) Init(ctx context.Context, provider *gophercloud.ProviderCli
 	if err != nil {
 		return err
 	}
-	p.NovaV2.Microversion = "2.60" // to list server groups across projects and get all required server attributes
+	p.NovaV2.Microversion = "2.61" // to include extra specs in flavors.ListDetail()
 	cinderV3, err := openstack.NewBlockStorageV3(provider, eo)
 	if err != nil {
 		return err

--- a/internal/plugins/nova/flavor_translate.go
+++ b/internal/plugins/nova/flavor_translate.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors"
 	"github.com/sapcc/go-api-declarations/liquid"
 )
 
@@ -140,10 +141,10 @@ func (t FlavorTranslationTable) NovaQuotaNameForLimesResourceName(resourceName l
 // quotas, and returns the flavor names that Nova prefers for each.
 func (t FlavorTranslationTable) ListFlavorsWithSeparateInstanceQuota(ctx context.Context, computeV2 *gophercloud.ServiceClient) ([]string, error) {
 	var flavorNames []string
-	err := FlavorSelection{}.ForeachFlavor(ctx, computeV2, func(f FullFlavor) error {
+	err := FlavorSelection{}.ForeachFlavor(ctx, computeV2, func(f flavors.Flavor) error {
 		if f.ExtraSpecs["quota:separate"] == "true" {
-			flavorNames = append(flavorNames, f.Flavor.Name)
-			t.recordNovaPreferredName(f.Flavor.Name)
+			flavorNames = append(flavorNames, f.Name)
+			t.recordNovaPreferredName(f.Name)
 		}
 		return nil
 	})


### PR DESCRIPTION
In Nova microversion 2.61, flavors.ListDetail() includes the extra specs, so we can save a ton of work querying them one flavor at a time. Gophercloud already has support for this, too.

**Draft:** I have not tested this yet. Feel free to have a look at the implementation; I will test this in QA after my leave.