### PR TITLE
liquid-cinder: do not fail on unknown volume types

### DIFF
--- a/internal/liquids/cinder/liquid.go
+++ b/internal/liquids/cinder/liquid.go
@@ -119,6 +119,16 @@ func (l *Logic) BuildServiceInfo(ctx context.Context) (liquid.ServiceInfo, error
 	return liquid.ServiceInfo{
 		Version:   time.Now().Unix(),
 		Resources: resources,
+		UsageMetricFamilies: map[liquid.MetricName]liquid.MetricFamilyInfo{
+			"liquid_cinder_snapshots_with_unknown_volume_type_size": {
+				Type: liquid.MetricTypeGauge,
+				Help: "Total size of snapshots that do not have a volume type known to liquid-cinder (and thus Limes), grouped per project.",
+			},
+			"liquid_cinder_volumes_with_unknown_volume_type_size": {
+				Type: liquid.MetricTypeGauge,
+				Help: "Total size of volumes that do not have a volume type known to liquid-cinder (and thus Limes), grouped per project.",
+			},
+		},
 	}, nil
 }
 


### PR DESCRIPTION
liquid-cinder only reports resources for public volume types, so private volume types will be counted as unknown by ReportUsage(). Private volume types can legitimately occur in QA, as leftovers from Tempest runs. Instead of failing when any volume or snapshot refers to a private volume type, we now emit metrics reporting how much unknown stuff was ignored. My plan is to have an alert about these unbilled resources, but only on prod.

I tested this in QA against the one project that currently has volumes like this, and it looks good there.