### PR TITLE
plugins/nova: fix ignoring of baremetal instances in liquid-ironic compat mode

### DIFF
--- a/internal/plugins/capacity_nova.go
+++ b/internal/plugins/capacity_nova.go
@@ -111,7 +111,7 @@ func (p *capacityNovaPlugin) PluginTypeID() string {
 func (p *capacityNovaPlugin) Scrape(ctx context.Context, backchannel core.CapacityPluginBackchannel, allAZs []limes.AvailabilityZone) (result map[db.ServiceType]map[liquid.ResourceName]core.PerAZ[core.CapacityData], serializedMetrics []byte, err error) {
 	// collect info about flavors with separate instance quota
 	// (we are calling these "split flavors" here, as opposed to "pooled flavors" that share a common pool of CPU/instances/RAM capacity)
-	allSplitFlavorNames, err := p.FlavorAliases.ListFlavorsWithSeparateInstanceQuota(ctx, p.NovaV2, true) // true = ignore Ironic flavors
+	allSplitFlavorNames, _, err := p.FlavorAliases.ListFlavorsWithSeparateInstanceQuota(ctx, p.NovaV2, true) // true = ignore Ironic flavors
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/plugins/capacity_sapcc_ironic.go
+++ b/internal/plugins/capacity_sapcc_ironic.go
@@ -159,7 +159,7 @@ var cpNodeNameRx = regexp.MustCompile(`^node(?:swift)?\d+-(cp\d+)$`)
 // Scrape implements the core.CapacityPlugin interface.
 func (p *capacitySapccIronicPlugin) Scrape(ctx context.Context, _ core.CapacityPluginBackchannel, allAZs []limes.AvailabilityZone) (result map[db.ServiceType]map[liquid.ResourceName]core.PerAZ[core.CapacityData], serializedMetrics []byte, err error) {
 	// collect info about flavors with separate instance quota
-	flavorNames, err := p.FlavorAliases.ListFlavorsWithSeparateInstanceQuota(ctx, p.NovaV2, false) // false = do not ignore Ironic flavors
+	flavorNames, _, err := p.FlavorAliases.ListFlavorsWithSeparateInstanceQuota(ctx, p.NovaV2, false) // false = do not ignore Ironic flavors
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Just skipping the flavors when enumerating split flavors is not enough. We need to actively ignore quotas and instances associated with those ignored flavors as well.

Checklist:

- [x] If this PR is about a plugin, I tested the plugin against an OpenStack cluster.
- [ ] ~~I updated the documentation to describe the semantical or interface changes I introduced.~~
