### PR TITLE
liquids: add topology declaration

### DIFF
--- a/internal/liquids/archer/liquid.go
+++ b/internal/liquids/archer/liquid.go
@@ -23,7 +23,6 @@ import (
 	"context"
 
 	"github.com/gophercloud/gophercloud/v2"
-	"github.com/sapcc/go-api-declarations/limes"
 	"github.com/sapcc/go-api-declarations/liquid"
 )
 
@@ -44,11 +43,13 @@ func (l *Logic) BuildServiceInfo(ctx context.Context) (liquid.ServiceInfo, error
 		Version: 1,
 		Resources: map[liquid.ResourceName]liquid.ResourceInfo{
 			"endpoints": {
-				Unit:     limes.UnitNone,
+				Unit:     liquid.UnitNone,
+				Topology: liquid.FlatResourceTopology,
 				HasQuota: true,
 			},
 			"services": {
-				Unit:     limes.UnitNone,
+				Unit:     liquid.UnitNone,
+				Topology: liquid.FlatResourceTopology,
 				HasQuota: true,
 			},
 		},

--- a/internal/liquids/cinder/liquid.go
+++ b/internal/liquids/cinder/liquid.go
@@ -101,11 +101,13 @@ func (l *Logic) BuildServiceInfo(ctx context.Context) (liquid.ServiceInfo, error
 	// build ResourceInfo set
 	resInfoForCapacity := liquid.ResourceInfo{
 		Unit:        liquid.UnitGibibytes,
+		Topology:    liquid.AZAwareResourceTopology,
 		HasCapacity: true,
 		HasQuota:    true,
 	}
 	resInfoForObjects := liquid.ResourceInfo{
 		Unit:        liquid.UnitNone,
+		Topology:    liquid.AZAwareResourceTopology,
 		HasCapacity: false,
 		HasQuota:    true,
 	}

--- a/internal/liquids/cronus/liquid.go
+++ b/internal/liquids/cronus/liquid.go
@@ -26,7 +26,6 @@ import (
 	"math/big"
 
 	"github.com/gophercloud/gophercloud/v2"
-	"github.com/sapcc/go-api-declarations/limes"
 	"github.com/sapcc/go-api-declarations/liquid"
 	"github.com/sapcc/go-bits/logg"
 )
@@ -47,10 +46,10 @@ func (l *Logic) BuildServiceInfo(ctx context.Context) (liquid.ServiceInfo, error
 	return liquid.ServiceInfo{
 		Version: 1,
 		Rates: map[liquid.RateName]liquid.RateInfo{
-			"attachment_size":   {HasUsage: true, Unit: limes.UnitBytes},
-			"data_transfer_in":  {HasUsage: true, Unit: limes.UnitBytes},
-			"data_transfer_out": {HasUsage: true, Unit: limes.UnitBytes},
-			"recipients":        {HasUsage: true, Unit: limes.UnitNone},
+			"attachment_size":   {HasUsage: true, Unit: liquid.UnitBytes},
+			"data_transfer_in":  {HasUsage: true, Unit: liquid.UnitBytes},
+			"data_transfer_out": {HasUsage: true, Unit: liquid.UnitBytes},
+			"recipients":        {HasUsage: true, Unit: liquid.UnitNone},
 		},
 	}, nil
 }

--- a/internal/liquids/designate/liquid.go
+++ b/internal/liquids/designate/liquid.go
@@ -23,7 +23,6 @@ import (
 	"context"
 
 	"github.com/gophercloud/gophercloud/v2"
-	"github.com/sapcc/go-api-declarations/limes"
 	"github.com/sapcc/go-api-declarations/liquid"
 )
 
@@ -44,11 +43,13 @@ func (l *Logic) BuildServiceInfo(ctx context.Context) (liquid.ServiceInfo, error
 		Version: 1,
 		Resources: map[liquid.ResourceName]liquid.ResourceInfo{
 			"zones": {
-				Unit:     limes.UnitNone,
+				Unit:     liquid.UnitNone,
+				Topology: liquid.FlatResourceTopology,
 				HasQuota: true,
 			},
 			"recordsets_per_zone": {
-				Unit:     limes.UnitNone,
+				Unit:     liquid.UnitNone,
+				Topology: liquid.FlatResourceTopology,
 				HasQuota: true,
 			},
 		},

--- a/internal/liquids/ironic/liquid.go
+++ b/internal/liquids/ironic/liquid.go
@@ -111,6 +111,7 @@ func (l *Logic) BuildServiceInfo(ctx context.Context) (liquid.ServiceInfo, error
 
 		resources[resourceNameForFlavorName(flavor.Name)] = liquid.ResourceInfo{
 			Unit:        liquid.UnitNone,
+			Topology:    liquid.AZAwareResourceTopology,
 			HasCapacity: true,
 			HasQuota:    true,
 			Attributes:  json.RawMessage(buf),

--- a/internal/liquids/neutron/liquid.go
+++ b/internal/liquids/neutron/liquid.go
@@ -27,7 +27,6 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/quotas"
-	"github.com/sapcc/go-api-declarations/limes"
 	"github.com/sapcc/go-api-declarations/liquid"
 
 	"github.com/sapcc/limes/internal/liquids"
@@ -89,7 +88,8 @@ func (l *Logic) BuildServiceInfo(ctx context.Context) (liquid.ServiceInfo, error
 		_, exists := data.Quota[neutronName]
 		if exists {
 			resources[resName] = liquid.ResourceInfo{
-				Unit:        limes.UnitNone,
+				Unit:        liquid.UnitNone,
+				Topology:    liquid.FlatResourceTopology,
 				HasCapacity: false,
 				HasQuota:    true,
 			}

--- a/internal/liquids/octavia/liquid.go
+++ b/internal/liquids/octavia/liquid.go
@@ -27,7 +27,6 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack"
 	"github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/quotas"
-	"github.com/sapcc/go-api-declarations/limes"
 	"github.com/sapcc/go-api-declarations/liquid"
 
 	"github.com/sapcc/limes/internal/liquids"
@@ -83,7 +82,8 @@ func (l *Logic) BuildServiceInfo(ctx context.Context) (liquid.ServiceInfo, error
 			_, exists := defaultQuota[octaviaName]
 			if exists {
 				resources[resName] = liquid.ResourceInfo{
-					Unit:        limes.UnitNone,
+					Unit:        liquid.UnitNone,
+					Topology:    liquid.FlatResourceTopology,
 					HasCapacity: false,
 					HasQuota:    true,
 				}

--- a/internal/liquids/swift/liquid.go
+++ b/internal/liquids/swift/liquid.go
@@ -28,7 +28,6 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack"
 	"github.com/majewsky/schwift/v2"
 	"github.com/majewsky/schwift/v2/gopherschwift"
-	"github.com/sapcc/go-api-declarations/limes"
 	"github.com/sapcc/go-api-declarations/liquid"
 	"github.com/sapcc/go-bits/logg"
 )
@@ -54,7 +53,8 @@ func (l *Logic) BuildServiceInfo(ctx context.Context) (liquid.ServiceInfo, error
 		Version: 1,
 		Resources: map[liquid.ResourceName]liquid.ResourceInfo{
 			"capacity": {
-				Unit:        limes.UnitBytes,
+				Unit:        liquid.UnitBytes,
+				Topology:    liquid.FlatResourceTopology,
 				HasCapacity: false,
 				HasQuota:    true,
 			},


### PR DESCRIPTION
This is a new capability added in go-api-declarations 1.13.0 which will eventually become mandatory in Limes.

While I was at it, I replaced references to go-api-declarations/limes in the liquids' implementation with the synonymous types in go-api-declarations/liquid.