### PR TITLE
liquids/cinder: fix capacity for volume types sharing the same backend name

### DIFF
--- a/internal/liquids/cinder/liquid.go
+++ b/internal/liquids/cinder/liquid.go
@@ -21,6 +21,7 @@ package cinder
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/gophercloud/gophercloud/v2"
@@ -71,6 +72,11 @@ type VolumeTypeInfo struct {
 	VolumeBackendName string
 }
 
+// String returns a string representation of this VolumeTypeInfo for log messages.
+func (i VolumeTypeInfo) String() string {
+	return fmt.Sprintf("volume_backend_name = %q", i.VolumeBackendName)
+}
+
 // Init implements the liquidapi.Logic interface.
 func (l *Logic) Init(ctx context.Context, provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (err error) {
 	l.CinderV3, err = openstack.NewBlockStorageV3(provider, eo)
@@ -100,10 +106,11 @@ func (l *Logic) BuildServiceInfo(ctx context.Context) (liquid.ServiceInfo, error
 
 	// build ResourceInfo set
 	resInfoForCapacity := liquid.ResourceInfo{
-		Unit:        liquid.UnitGibibytes,
-		Topology:    liquid.AZAwareResourceTopology,
-		HasCapacity: true,
-		HasQuota:    true,
+		Unit:                liquid.UnitGibibytes,
+		Topology:            liquid.AZAwareResourceTopology,
+		HasCapacity:         true,
+		NeedsResourceDemand: true,
+		HasQuota:            true,
 	}
 	resInfoForObjects := liquid.ResourceInfo{
 		Unit:        liquid.UnitNone,


### PR DESCRIPTION
This diff is way more intrusive than I would have liked, but the basic structure is retained. Instead of drilling down into volume type and then into AZ, we need to drill down into volume backend name and AZ.

Then at the lowest level, a single volume backend name can be shared by multiple volume types, so the reported capacity and usage need to be balanced by demand (in the same way as we do in liquid-manila between share capacity and snapshot capacity). This then gets bubbled back up all the way.

Checklist:

- [x] If this PR is about a plugin, I tested the plugin against an OpenStack cluster.
- [ ] ~~I updated the documentation to describe the semantical or interface changes I introduced.~~
