### PR TITLE
Add support for AZ-separated quotas

### DIFF
--- a/docs/operators/config.md
+++ b/docs/operators/config.md
@@ -132,7 +132,6 @@ Some special behaviors for resources can be configured in the `resource_behavior
 | `resource_behavior[].resource` | yes | Must contain a regex. The behavior entry applies to all resources where this regex matches against a slash-concatenated pair of service type and resource name. The anchors `^` and `$` are implied at both ends, so the regex must match the entire phrase. |
 | `resource_behavior[].overcommit_factor` | no | If given, capacity for matching resources will be computed as `raw_capacity * overcommit_factor`, where `raw_capacity` is what the capacity plugin reports. |
 | `resource_behavior[].commitment_durations` | no | If given, commitments for this resource can be created with any of the given durations. The duration format is the same as in the `commitments[].duration` attribute that appears on the resource API. If empty, this resource does not accept commitments. |
-| `resource_behavior[].commitment_is_az_aware` | no | If true, commitments for this resource must be created in a specific AZ (i.e. not in a pseudo-AZ). If false, commitments for this resource must be created in the pseudo-AZ `any`. Ignored if `commitment_durations` is empty. |
 | `resource_behavior[].commitment_min_confirm_date` | no | If given, commitments for this resource will always be created with `confirm_by` no earlier than this timestamp. This can be used to plan the introduction of commitments on a specific date. Ignored if `commitment_durations` is empty. |
 | `resource_behavior[].commitment_until_percent` | no | If given, commitments for this resource will only be confirmed while the total of all confirmed commitments or uncommitted usage in the respective AZ is smaller than the respective percentage of the total capacity for that AZ. This is intended to provide a reserved buffer for the growth quota configured by `quota_distribution_configs[].autogrow.growth_multiplier`. Defaults to 100, i.e. all capacity is committable. |
 | `resource_behavior[].commitment_conversion.identifier` | no | If given, must contain a string. Commitments for this resource will then be allowed to be converted into commitments for all resources that set the same conversion identifier. |
@@ -147,7 +146,7 @@ resource_behavior:
   # matches both sharev2/share_capacity and sharev2/snapshot_capacity
   - { resource: sharev2/.*_capacity, overcommit_factor: 2 }
   # starting in 2024, offer commitments for Cinder storage
-  - { resource: volumev2/capacity, commitment_durations: [ 1 year, 2 years, 3 years ], commitment_is_az_aware: true, commitment_min_confirm_date: 2024-01-01T00:00:00Z }
+  - { resource: volumev2/capacity, commitment_durations: [ 1 year, 2 years, 3 years ], commitment_min_confirm_date: 2024-01-01T00:00:00Z }
   # an Ironic flavor has been renamed from "thebigbox" to "baremetal_large"
   - { resource: compute/instances_baremetal_large, identity_in_v1_api: compute/instances_thebigbox }
 ```

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -106,10 +106,6 @@ const (
 			- resource: 'shared/(capacity|things)$'
 				commitment_durations: ["1 hour", "2 hours"]
 				commitment_min_confirm_date: '1970-01-08T00:00:00Z' # one week after start of mock.Clock
-			- resource: 'shared/capacity$'
-				commitment_is_az_aware: true
-			- resource: shared/things
-				commitment_is_az_aware: false
 	`
 )
 

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -240,14 +240,14 @@ func (p *v1Provider) parseAndValidateCommitmentRequest(w http.ResponseWriter, r 
 		http.Error(w, "commitments are not enabled for this resource", http.StatusUnprocessableEntity)
 		return nil, nil, nil
 	}
-	if resInfo.Topology != liquid.FlatResourceTopology {
-		if !slices.Contains(p.Cluster.Config.AvailabilityZones, req.AvailabilityZone) {
-			http.Error(w, "no such availability zone", http.StatusUnprocessableEntity)
+	if resInfo.Topology == liquid.FlatResourceTopology {
+		if req.AvailabilityZone != limes.AvailabilityZoneAny {
+			http.Error(w, `resource does not accept AZ-aware commitments, so the AZ must be set to "any"`, http.StatusUnprocessableEntity)
 			return nil, nil, nil
 		}
 	} else {
-		if req.AvailabilityZone != limes.AvailabilityZoneAny {
-			http.Error(w, `resource does not accept AZ-aware commitments, so the AZ must be set to "any"`, http.StatusUnprocessableEntity)
+		if !slices.Contains(p.Cluster.Config.AvailabilityZones, req.AvailabilityZone) {
+			http.Error(w, "no such availability zone", http.StatusUnprocessableEntity)
 			return nil, nil, nil
 		}
 	}

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -32,6 +32,7 @@ import (
 	"github.com/sapcc/go-api-declarations/cadf"
 	"github.com/sapcc/go-api-declarations/limes"
 	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
+	"github.com/sapcc/go-api-declarations/liquid"
 	"github.com/sapcc/go-bits/audittools"
 	"github.com/sapcc/go-bits/gopherpolicy"
 	"github.com/sapcc/go-bits/httpapi"
@@ -234,11 +235,12 @@ func (p *v1Provider) parseAndValidateCommitmentRequest(w http.ResponseWriter, r 
 		return nil, nil, nil
 	}
 	behavior := p.Cluster.BehaviorForResource(dbServiceType, dbResourceName)
+	resInfo := p.Cluster.InfoForResource(dbServiceType, dbResourceName)
 	if len(behavior.CommitmentDurations) == 0 {
 		http.Error(w, "commitments are not enabled for this resource", http.StatusUnprocessableEntity)
 		return nil, nil, nil
 	}
-	if behavior.CommitmentIsAZAware {
+	if resInfo.Topology != liquid.FlatResourceTopology {
 		if !slices.Contains(p.Cluster.Config.AvailabilityZones, req.AvailabilityZone) {
 			http.Error(w, "no such availability zone", http.StatusUnprocessableEntity)
 			return nil, nil, nil

--- a/internal/api/commitment_test.go
+++ b/internal/api/commitment_test.go
@@ -49,8 +49,6 @@ const testCommitmentsYAML = `
 		- resource: first/.*
 			commitment_durations: ["1 hour", "2 hours"]
 			commitment_min_confirm_date: '1970-01-08T00:00:00Z' # one week after start of mock.Clock
-		- resource: first/things
-		- resource: first/capacity
 `
 const testCommitmentsYAMLWithoutMinConfirmDate = `
 	availability_zones: [ az-one, az-two ]

--- a/internal/collector/capacity_scrape.go
+++ b/internal/collector/capacity_scrape.go
@@ -361,6 +361,7 @@ func (c *Collector) processCapacityScrapeTask(ctx context.Context, task capacity
 
 func (c *Collector) confirmPendingCommitmentsIfNecessary(serviceType db.ServiceType, resourceName liquid.ResourceName) error {
 	behavior := c.Cluster.BehaviorForResource(serviceType, resourceName)
+	resInfo := c.Cluster.InfoForResource(serviceType, resourceName)
 	now := c.MeasureTime()
 
 	// do not run ConfirmPendingCommitments if commitments are not enabled (or not live yet) for this resource
@@ -378,7 +379,7 @@ func (c *Collector) confirmPendingCommitmentsIfNecessary(serviceType db.ServiceT
 	defer sqlext.RollbackUnlessCommitted(tx)
 
 	committableAZs := c.Cluster.Config.AvailabilityZones
-	if !behavior.CommitmentIsAZAware {
+	if resInfo.Topology == liquid.FlatResourceTopology {
 		committableAZs = []liquid.AvailabilityZone{liquid.AvailabilityZoneAny}
 	}
 	for _, az := range committableAZs {

--- a/internal/collector/capacity_scrape_test.go
+++ b/internal/collector/capacity_scrape_test.go
@@ -126,7 +126,7 @@ const (
 					- second/things
 		resource_behavior:
 			# enable commitments for the */capacity resources
-			- { resource: '.*/capacity', commitment_durations: [ '1 hour', '10 days' ], commitment_is_az_aware: true }
+			- { resource: '.*/capacity', commitment_durations: [ '1 hour', '10 days' ] }
 			# test that overcommit factor is considered when confirming commitments
 			- { resource: first/capacity, overcommit_factor: 10.0 }
 		quota_distribution_configs:

--- a/internal/collector/commitment_cleanup_test.go
+++ b/internal/collector/commitment_cleanup_test.go
@@ -41,7 +41,7 @@ const (
 				type: --test-generic
 		resource_behavior:
 			# enable commitments for the */capacity resources
-			- { resource: '.*/capacity', commitment_durations: [ '1 day', '3 years' ], commitment_is_az_aware: true }
+			- { resource: '.*/capacity', commitment_durations: [ '1 day', '3 years' ] }
 	`
 )
 

--- a/internal/collector/scrape.go
+++ b/internal/collector/scrape.go
@@ -303,6 +303,12 @@ func (c *Collector) writeResourceScrapeResult(dbDomain db.Domain, dbProject db.P
 				azRes.Usage = data.Usage
 				azRes.PhysicalUsage = data.PhysicalUsage
 
+				// set AZ backend quota
+				resInfo := c.Cluster.InfoForResource(srv.Type, res.Name)
+				if resInfo.HasQuota && resInfo.Topology == liquid.AZSeparatedResourceTopology {
+					azRes.BackendQuota = &data.Quota
+				}
+
 				// warn when the backend is inconsistent with itself
 				if data.Subresources != nil && uint64(len(data.Subresources)) != data.Usage {
 					logg.Info("resource quantity mismatch in project %s, resource %s/%s, AZ %s: usage = %d, but found %d subresources",

--- a/internal/collector/scrape.go
+++ b/internal/collector/scrape.go
@@ -312,9 +312,7 @@ func (c *Collector) writeResourceScrapeResult(dbDomain db.Domain, dbProject db.P
 				resInfo := c.Cluster.InfoForResource(srv.Type, res.Name)
 				if resInfo.Topology == liquid.AZSeparatedResourceTopology && resInfo.HasQuota {
 					azRes.BackendQuota = data.Quota
-				}
-				// reset backendQuota entries for topology changes
-				if resInfo.Topology != liquid.AZSeparatedResourceTopology {
+				} else {
 					azRes.BackendQuota = nil
 				}
 

--- a/internal/collector/scrape.go
+++ b/internal/collector/scrape.go
@@ -303,10 +303,12 @@ func (c *Collector) writeResourceScrapeResult(dbDomain db.Domain, dbProject db.P
 				azRes.Usage = data.Usage
 				azRes.PhysicalUsage = data.PhysicalUsage
 
-				// set AZ backend quota
+				// set AZ backend quota. Do not set backend quota to the automatically created any AZ.
 				resInfo := c.Cluster.InfoForResource(srv.Type, res.Name)
-				if resInfo.HasQuota && resInfo.Topology == liquid.AZSeparatedResourceTopology {
-					azRes.BackendQuota = &data.Quota
+				if resInfo.Topology == liquid.AZSeparatedResourceTopology && resInfo.HasQuota {
+					if azRes.AvailabilityZone != liquid.AvailabilityZoneAny {
+						azRes.BackendQuota = &data.Quota
+					}
 				}
 
 				// warn when the backend is inconsistent with itself

--- a/internal/collector/scrape.go
+++ b/internal/collector/scrape.go
@@ -311,7 +311,7 @@ func (c *Collector) writeResourceScrapeResult(dbDomain db.Domain, dbProject db.P
 				// set AZ backend quota.
 				resInfo := c.Cluster.InfoForResource(srv.Type, res.Name)
 				if resInfo.Topology == liquid.AZSeparatedResourceTopology && resInfo.HasQuota {
-					azRes.BackendQuota = &data.Quota
+					azRes.BackendQuota = data.Quota
 				}
 				// reset backendQuota entries for topology changes
 				if resInfo.Topology != liquid.AZSeparatedResourceTopology {

--- a/internal/collector/scrape.go
+++ b/internal/collector/scrape.go
@@ -64,12 +64,6 @@ var (
 		WHERE pr.service_id = $1
 	`)
 
-	resetAZBackendQuotas = sqlext.SimplifyWhitespace(`
-		UPDATE project_az_resources 
-			SET backend_quota = NULL
-		WHERE resource_id = $1 and backend_quota IS NOT NULL
-	`)
-
 	writeResourceScrapeSuccessQuery = sqlext.SimplifyWhitespace(`
 		UPDATE project_services SET
 			-- timing information
@@ -318,10 +312,7 @@ func (c *Collector) writeResourceScrapeResult(dbDomain db.Domain, dbProject db.P
 				}
 				// reset backendQuota entries for topology changes
 				if resInfo.Topology != liquid.AZSeparatedResourceTopology {
-					_, err = c.DB.Exec(resetAZBackendQuotas, azRes.ResourceID)
-					if err != nil {
-						return fmt.Errorf("AZ backend quota reset for resource %s failed", resourceName)
-					}
+					azRes.BackendQuota = nil
 				}
 
 				// warn when the backend is inconsistent with itself

--- a/internal/collector/scrape_test.go
+++ b/internal/collector/scrape_test.go
@@ -702,5 +702,4 @@ func Test_TopologyScrapes(t *testing.T) {
 	// negative: reject liquid initialization with invalid topologies
 	plugin.LiquidServiceInfo.Resources = map[liquid.ResourceName]liquid.ResourceInfo{"capacity": {Topology: "invalidAZ1"}, "things": {Topology: "invalidAZ2"}}
 	mustFailT(t, job.ProcessOne(s.Ctx, withLabel), errors.New("during resource scrape of project germany/dresden: invalid toplogy: invalidAZ1 on resource: capacity\ninvalid toplogy: invalidAZ2 on resource: things"))
-
 }

--- a/internal/collector/scrape_test.go
+++ b/internal/collector/scrape_test.go
@@ -679,7 +679,7 @@ func Test_TopologyScrapes(t *testing.T) {
 
 	s.Clock.StepBy(scrapeInterval)
 
-	// toplogy of a resource changes. Reset AZ-separated backend_quota
+	// topology of a resource changes. Reset AZ-separated backend_quota
 	plugin.LiquidServiceInfo.Resources = map[liquid.ResourceName]liquid.ResourceInfo{"capacity": {Topology: liquid.AZSeparatedResourceTopology}, "things": {Topology: liquid.AZAwareResourceTopology}}
 	mustT(t, job.ProcessOne(s.Ctx, withLabel))
 	mustT(t, job.ProcessOne(s.Ctx, withLabel))
@@ -704,26 +704,26 @@ func Test_TopologyScrapes(t *testing.T) {
 	// negative: scrape with flat topology returns invalid AZs
 	plugin.LiquidServiceInfo.Resources = map[liquid.ResourceName]liquid.ResourceInfo{"capacity": {Topology: liquid.FlatResourceTopology}}
 	plugin.ReportedAZs = map[liquid.AvailabilityZone]*any{"az-one": status, "az-two": status}
-	mustFailT(t, job.ProcessOne(s.Ctx, withLabel), errors.New("during resource scrape of project germany/berlin: service: unittest, resource: capacity: scrape with toplogy type: flat returned AZs: [az-one az-two]"))
+	mustFailT(t, job.ProcessOne(s.Ctx, withLabel), errors.New("during resource scrape of project germany/berlin: service: unittest, resource: capacity: scrape with topology type: flat returned AZs: [az-one az-two]"))
 
-	// negative: scrape with az-aware toplogy returns invalid any AZ
+	// negative: scrape with az-aware topology returns invalid any AZ
 	plugin.LiquidServiceInfo.Resources["capacity"] = liquid.ResourceInfo{Topology: liquid.AZAwareResourceTopology}
 	plugin.ReportedAZs = map[liquid.AvailabilityZone]*any{"any": status}
-	mustFailT(t, job.ProcessOne(s.Ctx, withLabel), errors.New("during resource scrape of project germany/dresden: service: unittest, resource: capacity: scrape with toplogy type: az-aware returned AZs: [any]"))
+	mustFailT(t, job.ProcessOne(s.Ctx, withLabel), errors.New("during resource scrape of project germany/dresden: service: unittest, resource: capacity: scrape with topology type: az-aware returned AZs: [any]"))
 
 	s.Clock.StepBy(scrapeInterval)
-	// negative: scrape with az-separated toplogy returns invalid AZs any and unknown
+	// negative: scrape with az-separated topology returns invalid AZs any and unknown
 	plugin.LiquidServiceInfo.Resources["capacity"] = liquid.ResourceInfo{Topology: liquid.AZSeparatedResourceTopology}
 	plugin.ReportedAZs = map[liquid.AvailabilityZone]*any{"az-one": status, "unknown": status}
-	mustFailT(t, job.ProcessOne(s.Ctx, withLabel), errors.New("during resource scrape of project germany/berlin: service: unittest, resource: capacity: scrape with toplogy type: az-separated returned AZs: [az-one unknown]"))
+	mustFailT(t, job.ProcessOne(s.Ctx, withLabel), errors.New("during resource scrape of project germany/berlin: service: unittest, resource: capacity: scrape with topology type: az-separated returned AZs: [az-one unknown]"))
 
 	// negative: reject liquid initialization with invalid topologies
 	plugin.LiquidServiceInfo.Resources = map[liquid.ResourceName]liquid.ResourceInfo{"capacity": {Topology: "invalidAZ1"}, "things": {Topology: "invalidAZ2"}}
-	mustFailT(t, job.ProcessOne(s.Ctx, withLabel), errors.New("during resource scrape of project germany/dresden: invalid toplogy: invalidAZ1 on resource: capacity\ninvalid toplogy: invalidAZ2 on resource: things"))
+	mustFailT(t, job.ProcessOne(s.Ctx, withLabel), errors.New("during resource scrape of project germany/dresden: invalid topology: invalidAZ1 on resource: capacity\ninvalid topology: invalidAZ2 on resource: things"))
 
 	s.Clock.StepBy(scrapeInterval)
 	// negative: multiple resources with mismatching topology to AZ responses
 	plugin.LiquidServiceInfo.Resources = map[liquid.ResourceName]liquid.ResourceInfo{"capacity": {Topology: liquid.AZSeparatedResourceTopology}, "things": {Topology: liquid.AZSeparatedResourceTopology}}
 	plugin.ReportedAZs = map[liquid.AvailabilityZone]*any{"unknown": status}
-	mustFailT(t, job.ProcessOne(s.Ctx, withLabel), errors.New("during resource scrape of project germany/berlin: service: unittest, resource: capacity: scrape with toplogy type: az-separated returned AZs: [unknown]\nservice: unittest, resource: things: scrape with toplogy type: az-separated returned AZs: [unknown]"))
+	mustFailT(t, job.ProcessOne(s.Ctx, withLabel), errors.New("during resource scrape of project germany/berlin: service: unittest, resource: capacity: scrape with topology type: az-separated returned AZs: [unknown]\nservice: unittest, resource: things: scrape with topology type: az-separated returned AZs: [unknown]"))
 }

--- a/internal/collector/scrape_test.go
+++ b/internal/collector/scrape_test.go
@@ -609,24 +609,20 @@ func Test_TopologyScrapes(t *testing.T) {
 	scrapedAt1 := s.Clock.Now().Add(-5 * time.Second)
 	scrapedAt2 := s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`
-		INSERT INTO project_az_resources (id, resource_id, az, usage, historical_usage) VALUES (1, 1, 'any', 0, '{"t":[%[1]d],"v":[0]}');
-		INSERT INTO project_az_resources (id, resource_id, az, usage, historical_usage) VALUES (10, 4, 'any', 0, '{"t":[%[3]d],"v":[0]}');
-		INSERT INTO project_az_resources (id, resource_id, az, usage, physical_usage, historical_usage, backend_quota) VALUES (11, 4, 'az-one', 0, 0, '{"t":[%[3]d],"v":[0]}', 50);
-		INSERT INTO project_az_resources (id, resource_id, az, usage, physical_usage, historical_usage, backend_quota) VALUES (12, 4, 'az-two', 0, 0, '{"t":[%[3]d],"v":[0]}', 50);
-		INSERT INTO project_az_resources (id, resource_id, az, usage, historical_usage) VALUES (13, 5, 'any', 0, '{"t":[%[3]d],"v":[0]}');
-		INSERT INTO project_az_resources (id, resource_id, az, usage, historical_usage) VALUES (14, 5, 'az-one', 0, '{"t":[%[3]d],"v":[0]}');
-		INSERT INTO project_az_resources (id, resource_id, az, usage, historical_usage) VALUES (15, 5, 'az-two', 0, '{"t":[%[3]d],"v":[0]}');
-		INSERT INTO project_az_resources (id, resource_id, az, usage, historical_usage) VALUES (16, 6, 'any', 0, '{"t":[%[3]d],"v":[0]}');
-		INSERT INTO project_az_resources (id, resource_id, az, usage, subresources, historical_usage, backend_quota) VALUES (17, 6, 'az-one', 2, '[{"index":0},{"index":1}]', '{"t":[%[3]d],"v":[2]}', 21);
-		INSERT INTO project_az_resources (id, resource_id, az, usage, subresources, historical_usage, backend_quota) VALUES (18, 6, 'az-two', 2, '[{"index":2},{"index":3}]', '{"t":[%[3]d],"v":[2]}', 21);
-		INSERT INTO project_az_resources (id, resource_id, az, usage, physical_usage, historical_usage, backend_quota) VALUES (2, 1, 'az-one', 0, 0, '{"t":[%[1]d],"v":[0]}', 50);
-		INSERT INTO project_az_resources (id, resource_id, az, usage, physical_usage, historical_usage, backend_quota) VALUES (3, 1, 'az-two', 0, 0, '{"t":[%[1]d],"v":[0]}', 50);
-		INSERT INTO project_az_resources (id, resource_id, az, usage, historical_usage) VALUES (4, 2, 'any', 0, '{"t":[%[1]d],"v":[0]}');
-		INSERT INTO project_az_resources (id, resource_id, az, usage, historical_usage) VALUES (5, 2, 'az-one', 0, '{"t":[%[1]d],"v":[0]}');
-		INSERT INTO project_az_resources (id, resource_id, az, usage, historical_usage) VALUES (6, 2, 'az-two', 0, '{"t":[%[1]d],"v":[0]}');
-		INSERT INTO project_az_resources (id, resource_id, az, usage, historical_usage) VALUES (7, 3, 'any', 0, '{"t":[%[1]d],"v":[0]}');
-		INSERT INTO project_az_resources (id, resource_id, az, usage, subresources, historical_usage, backend_quota) VALUES (8, 3, 'az-one', 2, '[{"index":0},{"index":1}]', '{"t":[%[1]d],"v":[2]}', 21);
-		INSERT INTO project_az_resources (id, resource_id, az, usage, subresources, historical_usage, backend_quota) VALUES (9, 3, 'az-two', 2, '[{"index":2},{"index":3}]', '{"t":[%[1]d],"v":[2]}', 21);
+		INSERT INTO project_az_resources (id, resource_id, az, usage, physical_usage, historical_usage, backend_quota) VALUES (1, 1, 'az-one', 0, 0, '{"t":[%[1]d],"v":[0]}', 50);
+		INSERT INTO project_az_resources (id, resource_id, az, usage, historical_usage) VALUES (10, 5, 'any', 0, '{"t":[%[3]d],"v":[0]}');
+		INSERT INTO project_az_resources (id, resource_id, az, usage, historical_usage) VALUES (11, 5, 'az-one', 0, '{"t":[%[3]d],"v":[0]}');
+		INSERT INTO project_az_resources (id, resource_id, az, usage, historical_usage) VALUES (12, 5, 'az-two', 0, '{"t":[%[3]d],"v":[0]}');
+		INSERT INTO project_az_resources (id, resource_id, az, usage, subresources, historical_usage, backend_quota) VALUES (13, 6, 'az-one', 2, '[{"index":0},{"index":1}]', '{"t":[%[3]d],"v":[2]}', 21);
+		INSERT INTO project_az_resources (id, resource_id, az, usage, subresources, historical_usage, backend_quota) VALUES (14, 6, 'az-two', 2, '[{"index":2},{"index":3}]', '{"t":[%[3]d],"v":[2]}', 21);
+		INSERT INTO project_az_resources (id, resource_id, az, usage, physical_usage, historical_usage, backend_quota) VALUES (2, 1, 'az-two', 0, 0, '{"t":[%[1]d],"v":[0]}', 50);
+		INSERT INTO project_az_resources (id, resource_id, az, usage, historical_usage) VALUES (3, 2, 'any', 0, '{"t":[%[1]d],"v":[0]}');
+		INSERT INTO project_az_resources (id, resource_id, az, usage, historical_usage) VALUES (4, 2, 'az-one', 0, '{"t":[%[1]d],"v":[0]}');
+		INSERT INTO project_az_resources (id, resource_id, az, usage, historical_usage) VALUES (5, 2, 'az-two', 0, '{"t":[%[1]d],"v":[0]}');
+		INSERT INTO project_az_resources (id, resource_id, az, usage, subresources, historical_usage, backend_quota) VALUES (6, 3, 'az-one', 2, '[{"index":0},{"index":1}]', '{"t":[%[1]d],"v":[2]}', 21);
+		INSERT INTO project_az_resources (id, resource_id, az, usage, subresources, historical_usage, backend_quota) VALUES (7, 3, 'az-two', 2, '[{"index":2},{"index":3}]', '{"t":[%[1]d],"v":[2]}', 21);
+		INSERT INTO project_az_resources (id, resource_id, az, usage, physical_usage, historical_usage, backend_quota) VALUES (8, 4, 'az-one', 0, 0, '{"t":[%[3]d],"v":[0]}', 50);
+		INSERT INTO project_az_resources (id, resource_id, az, usage, physical_usage, historical_usage, backend_quota) VALUES (9, 4, 'az-two', 0, 0, '{"t":[%[3]d],"v":[0]}', 50);
 		INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (1, 1, 'capacity', 0, 100);
 		INSERT INTO project_resources (id, service_id, name) VALUES (2, 1, 'capacity_portion');
 		INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (3, 1, 'things', 0, 42);
@@ -665,14 +661,14 @@ func Test_TopologyScrapes(t *testing.T) {
 	mustT(t, syncJob.ProcessOne(s.Ctx, withLabel))
 
 	tr.DBChanges().AssertEqualf(`
-		UPDATE project_az_resources SET backend_quota = 20 WHERE id = 11 AND resource_id = 4 AND az = 'az-one';
-		UPDATE project_az_resources SET backend_quota = 20 WHERE id = 12 AND resource_id = 4 AND az = 'az-two';
-		UPDATE project_az_resources SET backend_quota = 13 WHERE id = 17 AND resource_id = 6 AND az = 'az-one';
-		UPDATE project_az_resources SET backend_quota = 13 WHERE id = 18 AND resource_id = 6 AND az = 'az-two';
-		UPDATE project_az_resources SET backend_quota = 20 WHERE id = 2 AND resource_id = 1 AND az = 'az-one';
-		UPDATE project_az_resources SET backend_quota = 20 WHERE id = 3 AND resource_id = 1 AND az = 'az-two';
-		UPDATE project_az_resources SET backend_quota = 13 WHERE id = 8 AND resource_id = 3 AND az = 'az-one';
-		UPDATE project_az_resources SET backend_quota = 13 WHERE id = 9 AND resource_id = 3 AND az = 'az-two';
+		UPDATE project_az_resources SET backend_quota = 20 WHERE id = 1 AND resource_id = 1 AND az = 'az-one';
+		UPDATE project_az_resources SET backend_quota = 13 WHERE id = 13 AND resource_id = 6 AND az = 'az-one';
+		UPDATE project_az_resources SET backend_quota = 13 WHERE id = 14 AND resource_id = 6 AND az = 'az-two';
+		UPDATE project_az_resources SET backend_quota = 20 WHERE id = 2 AND resource_id = 1 AND az = 'az-two';
+		UPDATE project_az_resources SET backend_quota = 13 WHERE id = 6 AND resource_id = 3 AND az = 'az-one';
+		UPDATE project_az_resources SET backend_quota = 13 WHERE id = 7 AND resource_id = 3 AND az = 'az-two';
+		UPDATE project_az_resources SET backend_quota = 20 WHERE id = 8 AND resource_id = 4 AND az = 'az-one';
+		UPDATE project_az_resources SET backend_quota = 20 WHERE id = 9 AND resource_id = 4 AND az = 'az-two';
 		UPDATE project_resources SET backend_quota = 20 WHERE id = 1 AND service_id = 1 AND name = 'capacity';
 		UPDATE project_resources SET backend_quota = 13 WHERE id = 3 AND service_id = 1 AND name = 'things';
 		UPDATE project_resources SET backend_quota = 20 WHERE id = 4 AND service_id = 2 AND name = 'capacity';
@@ -689,14 +685,16 @@ func Test_TopologyScrapes(t *testing.T) {
 	mustT(t, job.ProcessOne(s.Ctx, withLabel))
 
 	tr.DBChanges().AssertEqualf(`
-		UPDATE project_az_resources SET backend_quota = 50 WHERE id = 11 AND resource_id = 4 AND az = 'az-one';
-		UPDATE project_az_resources SET backend_quota = 50 WHERE id = 12 AND resource_id = 4 AND az = 'az-two';
-		UPDATE project_az_resources SET backend_quota = NULL WHERE id = 17 AND resource_id = 6 AND az = 'az-one';
-		UPDATE project_az_resources SET backend_quota = NULL WHERE id = 18 AND resource_id = 6 AND az = 'az-two';
-		UPDATE project_az_resources SET backend_quota = 50 WHERE id = 2 AND resource_id = 1 AND az = 'az-one';
-		UPDATE project_az_resources SET backend_quota = 50 WHERE id = 3 AND resource_id = 1 AND az = 'az-two';
-		UPDATE project_az_resources SET backend_quota = NULL WHERE id = 8 AND resource_id = 3 AND az = 'az-one';
-		UPDATE project_az_resources SET backend_quota = NULL WHERE id = 9 AND resource_id = 3 AND az = 'az-two';
+		UPDATE project_az_resources SET backend_quota = 50 WHERE id = 1 AND resource_id = 1 AND az = 'az-one';
+		UPDATE project_az_resources SET backend_quota = NULL WHERE id = 13 AND resource_id = 6 AND az = 'az-one';
+		UPDATE project_az_resources SET backend_quota = NULL WHERE id = 14 AND resource_id = 6 AND az = 'az-two';
+		INSERT INTO project_az_resources (id, resource_id, az, usage, historical_usage) VALUES (15, 3, 'any', 0, '{"t":[1825],"v":[0]}');
+		INSERT INTO project_az_resources (id, resource_id, az, usage, historical_usage) VALUES (16, 6, 'any', 0, '{"t":[1830],"v":[0]}');
+		UPDATE project_az_resources SET backend_quota = 50 WHERE id = 2 AND resource_id = 1 AND az = 'az-two';
+		UPDATE project_az_resources SET backend_quota = NULL WHERE id = 6 AND resource_id = 3 AND az = 'az-one';
+		UPDATE project_az_resources SET backend_quota = NULL WHERE id = 7 AND resource_id = 3 AND az = 'az-two';
+		UPDATE project_az_resources SET backend_quota = 50 WHERE id = 8 AND resource_id = 4 AND az = 'az-one';
+		UPDATE project_az_resources SET backend_quota = 50 WHERE id = 9 AND resource_id = 4 AND az = 'az-two';
 		UPDATE project_services SET scraped_at = 1825, checked_at = 1825, next_scrape_at = 3625 WHERE id = 1 AND project_id = 1 AND type = 'unittest';
 		UPDATE project_services SET scraped_at = 1830, checked_at = 1830, next_scrape_at = 3630 WHERE id = 2 AND project_id = 2 AND type = 'unittest';
 	`)

--- a/internal/collector/scrape_test.go
+++ b/internal/collector/scrape_test.go
@@ -722,4 +722,10 @@ func Test_TopologyScrapes(t *testing.T) {
 	// negative: reject liquid initialization with invalid topologies
 	plugin.LiquidServiceInfo.Resources = map[liquid.ResourceName]liquid.ResourceInfo{"capacity": {Topology: "invalidAZ1"}, "things": {Topology: "invalidAZ2"}}
 	mustFailT(t, job.ProcessOne(s.Ctx, withLabel), errors.New("during resource scrape of project germany/dresden: invalid toplogy: invalidAZ1 on resource: capacity\ninvalid toplogy: invalidAZ2 on resource: things"))
+
+	s.Clock.StepBy(scrapeInterval)
+	// negative: multiple resources with mismatching topology to AZ responses
+	plugin.LiquidServiceInfo.Resources = map[liquid.ResourceName]liquid.ResourceInfo{"capacity": {Topology: liquid.AZSeparatedResourceTopology}, "things": {Topology: liquid.AZSeparatedResourceTopology}}
+	plugin.ReportedAZs = map[liquid.AvailabilityZone]*any{"unknown": status}
+	mustFailT(t, job.ProcessOne(s.Ctx, withLabel), errors.New("during resource scrape of project germany/berlin: service: unittest, resource: capacity: scrape with toplogy type: az-separated returned AZs: [unknown]\nservice: unittest, resource: things: scrape with toplogy type: az-separated returned AZs: [unknown]"))
 }

--- a/internal/collector/sync_quota_to_backend.go
+++ b/internal/collector/sync_quota_to_backend.go
@@ -173,7 +173,9 @@ func (c *Collector) performQuotaSync(ctx context.Context, srv db.ProjectService,
 				return fmt.Errorf("detected invalid AZ: %s for resource: %s with topology: %s has backend_quota: %v", availabilityZone, resourceName, resInfo.Topology, currentAZQuota)
 			}
 			azSeparatedResouceIDs = append(azSeparatedResouceIDs, resourceID)
-			targetAZQuotasInDB[resourceName] = make(map[liquid.AvailabilityZone]liquid.AZResourceQuotaRequest)
+			if targetAZQuotasInDB[resourceName] == nil {
+				targetAZQuotasInDB[resourceName] = make(map[liquid.AvailabilityZone]liquid.AZResourceQuotaRequest)
+			}
 			targetAZQuotasInDB[resourceName][availabilityZone] = liquid.AZResourceQuotaRequest{Quota: targetAZQuota}
 			if currentAZQuota == nil || *currentAZQuota < 0 || uint64(*currentAZQuota) != targetAZQuota {
 				azSeparatedNeedsApply = true

--- a/internal/collector/sync_quota_to_backend.go
+++ b/internal/collector/sync_quota_to_backend.go
@@ -193,13 +193,13 @@ func (c *Collector) performQuotaSync(ctx context.Context, srv db.ProjectService,
 
 	if needsApply || azSeparatedNeedsApply {
 		// double-check that we only include quota values for resources that the backend currently knows about
-		targetQuotasForBackend := make(map[liquid.ResourceName]core.Quotas)
+		targetQuotasForBackend := make(map[liquid.ResourceName]liquid.ResourceQuotaRequest)
 		for resName, resInfo := range plugin.Resources() {
 			if !resInfo.HasQuota {
 				continue
 			}
 			//NOTE: If `targetQuotasInDB` does not have an entry for this resource, we will write 0 into the backend.
-			targetQuotasForBackend[resName] = core.Quotas{QuotaForResource: targetQuotasInDB[resName], QuotasForAZs: targetAZQuotasInDB[resName]}
+			targetQuotasForBackend[resName] = liquid.ResourceQuotaRequest{Quota: targetQuotasInDB[resName], PerAZ: targetAZQuotasInDB[resName]}
 		}
 
 		// apply quotas in backend

--- a/internal/core/data.go
+++ b/internal/core/data.go
@@ -190,6 +190,7 @@ func (r ResourceData) AddLocalizedUsage(az limes.AvailabilityZone, usage uint64)
 // UsageData contains usage data for a single project resource.
 // It appears in type ResourceData.
 type UsageData struct {
+	Quota         int64
 	Usage         uint64
 	PhysicalUsage *uint64 // only supported by some plugins
 	Subresources  []any   // only if supported by plugin and enabled in config

--- a/internal/core/data.go
+++ b/internal/core/data.go
@@ -190,7 +190,7 @@ func (r ResourceData) AddLocalizedUsage(az limes.AvailabilityZone, usage uint64)
 // UsageData contains usage data for a single project resource.
 // It appears in type ResourceData.
 type UsageData struct {
-	Quota         int64
+	Quota         *int64
 	Usage         uint64
 	PhysicalUsage *uint64 // only supported by some plugins
 	Subresources  []any   // only if supported by plugin and enabled in config

--- a/internal/core/plugin.go
+++ b/internal/core/plugin.go
@@ -141,7 +141,7 @@ type QuotaPlugin interface {
 	// SetQuota updates the backend service's quotas for the given project in the
 	// given domain to the values specified here. The map is guaranteed to contain
 	// values for all resources defined by Resources().
-	SetQuota(ctx context.Context, project KeystoneProject, quotas map[liquid.ResourceName]Quotas) error
+	SetQuota(ctx context.Context, project KeystoneProject, quotaReq map[liquid.ResourceName]liquid.ResourceQuotaRequest) error
 
 	// Rates returns metadata for all the rates that this plugin scrapes
 	// from the backend service.
@@ -179,11 +179,6 @@ type QuotaPlugin interface {
 	// should be preferred since metrics emitted here won't be lost between
 	// restarts of limes-collect.
 	CollectMetrics(ch chan<- prometheus.Metric, project KeystoneProject, serializedMetrics []byte) error
-}
-
-type Quotas struct {
-	QuotaForResource uint64
-	QuotasForAZs     map[liquid.AvailabilityZone]liquid.AZResourceQuotaRequest
 }
 
 // ServiceInfo is a reduced version of type limes.ServiceInfo, suitable for

--- a/internal/core/plugin.go
+++ b/internal/core/plugin.go
@@ -141,7 +141,7 @@ type QuotaPlugin interface {
 	// SetQuota updates the backend service's quotas for the given project in the
 	// given domain to the values specified here. The map is guaranteed to contain
 	// values for all resources defined by Resources().
-	SetQuota(ctx context.Context, project KeystoneProject, quotas map[liquid.ResourceName]uint64) error
+	SetQuota(ctx context.Context, project KeystoneProject, quotas map[liquid.ResourceName]Quotas) error
 
 	// Rates returns metadata for all the rates that this plugin scrapes
 	// from the backend service.
@@ -179,6 +179,11 @@ type QuotaPlugin interface {
 	// should be preferred since metrics emitted here won't be lost between
 	// restarts of limes-collect.
 	CollectMetrics(ch chan<- prometheus.Metric, project KeystoneProject, serializedMetrics []byte) error
+}
+
+type Quotas struct {
+	QuotaForResource uint64
+	QuotasForAZs     map[liquid.AvailabilityZone]liquid.AZResourceQuotaRequest
 }
 
 // ServiceInfo is a reduced version of type limes.ServiceInfo, suitable for

--- a/internal/core/resource_behavior.go
+++ b/internal/core/resource_behavior.go
@@ -37,7 +37,6 @@ type ResourceBehavior struct {
 	FullResourceNameRx       regexpext.BoundedRegexp             `yaml:"resource"`
 	OvercommitFactor         liquid.OvercommitFactor             `yaml:"overcommit_factor"`
 	CommitmentDurations      []limesresources.CommitmentDuration `yaml:"commitment_durations"`
-	CommitmentIsAZAware      bool                                `yaml:"commitment_is_az_aware"`
 	CommitmentMinConfirmDate *time.Time                          `yaml:"commitment_min_confirm_date"`
 	CommitmentUntilPercent   *float64                            `yaml:"commitment_until_percent"`
 	CommitmentConversion     CommitmentConversion                `yaml:"commitment_conversion"`
@@ -99,9 +98,6 @@ func (b *ResourceBehavior) Merge(other ResourceBehavior, fullResourceName string
 		if b.CommitmentMinConfirmDate == nil || b.CommitmentMinConfirmDate.Before(*other.CommitmentMinConfirmDate) {
 			b.CommitmentMinConfirmDate = other.CommitmentMinConfirmDate
 		}
-	}
-	if other.CommitmentIsAZAware {
-		b.CommitmentIsAZAware = true
 	}
 	if other.CommitmentUntilPercent != nil {
 		if b.CommitmentUntilPercent == nil || *b.CommitmentUntilPercent > *other.CommitmentUntilPercent {

--- a/internal/datamodel/apply_computed_project_quota.go
+++ b/internal/datamodel/apply_computed_project_quota.go
@@ -378,7 +378,7 @@ func acpqComputeQuotas(stats map[limes.AvailabilityZone]clusterAZAllocationStats
 				// AZ separated topology receives the basequota to all available AZs
 				if resInfo.Topology == liquid.AZSeparatedResourceTopology {
 					for az := range isRelevantAZ {
-						target[az][resourceID].Desired = cfg.ProjectBaseQuota - target[az][resourceID].Allocated
+						target[az][resourceID].Desired = cfg.ProjectBaseQuota
 					}
 				} else {
 					target[limes.AvailabilityZoneAny][resourceID].Desired = cfg.ProjectBaseQuota - sumOfLocalizedQuotas

--- a/internal/datamodel/apply_computed_project_quota.go
+++ b/internal/datamodel/apply_computed_project_quota.go
@@ -375,7 +375,7 @@ func acpqComputeQuotas(stats map[limes.AvailabilityZone]clusterAZAllocationStats
 				}
 			}
 			if sumOfLocalizedQuotas < cfg.ProjectBaseQuota {
-				// AZ separated toplogy receives the basequota to all available AZs
+				// AZ separated topology receives the basequota to all available AZs
 				if resInfo.Topology == liquid.AZSeparatedResourceTopology {
 					for az := range isRelevantAZ {
 						target[az][resourceID].Desired = cfg.ProjectBaseQuota - target[az][resourceID].Allocated

--- a/internal/datamodel/apply_computed_project_quota.go
+++ b/internal/datamodel/apply_computed_project_quota.go
@@ -151,7 +151,8 @@ func ApplyComputedProjectQuota(serviceType db.ServiceType, resourceName liquid.R
 	}
 
 	// evaluate QD algorithm
-	target, allowsQuotaOvercommit := acpqComputeQuotas(stats, cfg, constraints)
+	// AZ separated basequota will be assigned to all available AZs
+	target, allowsQuotaOvercommit := acpqComputeQuotas(stats, cfg, constraints, resInfo)
 	if logg.ShowDebug {
 		// NOTE: The structs that contain pointers must be printed as JSON to actually show all values.
 		logg.Debug("ACPQ for %s/%s: stats = %#v", serviceType, resourceName, stats)
@@ -286,7 +287,7 @@ type acpqGlobalTarget map[limes.AvailabilityZone]acpqAZTarget
 // effects (reading the DB, writing the DB, setting quota in the backend).
 // This function is separate because most test cases work on this level.
 // The full ApplyComputedProjectQuota() function is tested during capacity scraping.
-func acpqComputeQuotas(stats map[limes.AvailabilityZone]clusterAZAllocationStats, cfg core.AutogrowQuotaDistributionConfiguration, constraints map[db.ProjectResourceID]projectLocalQuotaConstraints) (target acpqGlobalTarget, allowsQuotaOvercommit map[limes.AvailabilityZone]bool) {
+func acpqComputeQuotas(stats map[limes.AvailabilityZone]clusterAZAllocationStats, cfg core.AutogrowQuotaDistributionConfiguration, constraints map[db.ProjectResourceID]projectLocalQuotaConstraints, resInfo liquid.ResourceInfo) (target acpqGlobalTarget, allowsQuotaOvercommit map[limes.AvailabilityZone]bool) {
 	// enumerate which project resource IDs and AZs are relevant
 	// ("Relevant" AZs are all that have allocation stats available.)
 	isProjectResourceID := make(map[db.ProjectResourceID]struct{})
@@ -300,7 +301,7 @@ func acpqComputeQuotas(stats map[limes.AvailabilityZone]clusterAZAllocationStats
 		}
 	}
 	slices.Sort(allAZsInOrder)
-	if cfg.ProjectBaseQuota > 0 {
+	if cfg.ProjectBaseQuota > 0 && resInfo.Topology != liquid.AZSeparatedResourceTopology {
 		// base quota is given out in the pseudo-AZ "any", so we need to calculate quota for "any", too
 		isRelevantAZ[limes.AvailabilityZoneAny] = struct{}{}
 	}
@@ -321,7 +322,7 @@ func acpqComputeQuotas(stats map[limes.AvailabilityZone]clusterAZAllocationStats
 
 	// in AZ-aware resources, quota for the pseudo-AZ "any" is backed by capacity
 	// in all the real AZs, so it can only allow quota overcommit if all AZs do
-	if isAZAware {
+	if isAZAware && resInfo.Topology != liquid.AZSeparatedResourceTopology {
 		allowsQuotaOvercommit[limes.AvailabilityZoneAny] = allRealAZsAllowQuotaOvercommit
 	}
 
@@ -374,7 +375,14 @@ func acpqComputeQuotas(stats map[limes.AvailabilityZone]clusterAZAllocationStats
 				}
 			}
 			if sumOfLocalizedQuotas < cfg.ProjectBaseQuota {
-				target[limes.AvailabilityZoneAny][resourceID].Desired = cfg.ProjectBaseQuota - sumOfLocalizedQuotas
+				// AZ separated toplogy receives the basequota to all available AZs
+				if resInfo.Topology == liquid.AZSeparatedResourceTopology {
+					for az := range isRelevantAZ {
+						target[az][resourceID].Desired = cfg.ProjectBaseQuota - target[az][resourceID].Allocated
+					}
+				} else {
+					target[limes.AvailabilityZoneAny][resourceID].Desired = cfg.ProjectBaseQuota - sumOfLocalizedQuotas
+				}
 			}
 		}
 		if !slices.Contains(allAZsInOrder, limes.AvailabilityZoneAny) {

--- a/internal/datamodel/apply_computed_project_quota_test.go
+++ b/internal/datamodel/apply_computed_project_quota_test.go
@@ -72,7 +72,7 @@ func TestACPQBasicWithoutAZAwareness(t *testing.T) {
 				405: {Allocated: 10},
 				406: {Allocated: 10},
 			},
-		}, liquid.ResourceInfo{Topology: liquid.AZAwareResourceTopology})
+		}, liquid.ResourceInfo{Topology: liquid.FlatResourceTopology})
 	}
 }
 
@@ -262,7 +262,7 @@ func TestACPQCapacityLimitsQuotaAllocation(t *testing.T) {
 			404: {Allocated: 5},
 			405: {Allocated: 5},
 		},
-	}, liquid.ResourceInfo{Topology: liquid.AZAwareResourceTopology})
+	}, liquid.ResourceInfo{Topology: liquid.FlatResourceTopology})
 
 	// Stage 2: There is enough capacity for the minimum quotas, but not for the
 	// desired quotas.
@@ -281,7 +281,7 @@ func TestACPQCapacityLimitsQuotaAllocation(t *testing.T) {
 			404: {Allocated: 0},
 			405: {Allocated: 0},
 		},
-	}, liquid.ResourceInfo{Topology: liquid.AZAwareResourceTopology})
+	}, liquid.ResourceInfo{Topology: liquid.FlatResourceTopology})
 
 	// Stage 3: There is enough capacity for the hard minimum quotas, but not for
 	// the soft minimum quotas.
@@ -300,7 +300,7 @@ func TestACPQCapacityLimitsQuotaAllocation(t *testing.T) {
 			404: {Allocated: 0},
 			405: {Allocated: 0},
 		},
-	}, liquid.ResourceInfo{Topology: liquid.AZAwareResourceTopology})
+	}, liquid.ResourceInfo{Topology: liquid.FlatResourceTopology})
 
 	// Stage 4: Capacity is SOMEHOW not even enough for the hard minimum quotas.
 	input["any"] = clusterAZAllocationStats{
@@ -318,7 +318,7 @@ func TestACPQCapacityLimitsQuotaAllocation(t *testing.T) {
 			404: {Allocated: 0},
 			405: {Allocated: 0},
 		},
-	}, liquid.ResourceInfo{Topology: liquid.AZAwareResourceTopology})
+	}, liquid.ResourceInfo{Topology: liquid.FlatResourceTopology})
 }
 
 func TestACPQQuotaOvercommitTurnsOffAboveAllocationThreshold(t *testing.T) {

--- a/internal/datamodel/apply_computed_project_quota_test.go
+++ b/internal/datamodel/apply_computed_project_quota_test.go
@@ -208,7 +208,7 @@ func TestACPQBasicWithAZSeparated(t *testing.T) {
 				404: {Allocated: 20},
 				405: {Allocated: 72}, // 60 * 1.2 = 72
 				406: {Allocated: 10}, // Basequota
-				407: {Allocated: 7},  // 2 * 1.2 = 2.4 rounded to 3 (guaranteed minimum growth) -> Basquota: 10 - 3 = 7
+				407: {Allocated: 10}, // Basequota
 			},
 			"az-two": {
 				401: {Allocated: 24},
@@ -217,7 +217,7 @@ func TestACPQBasicWithAZSeparated(t *testing.T) {
 				404: {Allocated: 15},
 				405: {Allocated: 48}, // 40 * 1.2 = 48
 				406: {Allocated: 10}, // Basequota
-				407: {Allocated: 8},  // 1 * 1.2 = 1.2 rounded to 2 (guaranteed minimum growth) -> Basequota: 10 - 2 = 8
+				407: {Allocated: 10}, // Basequota
 			},
 		})
 	}

--- a/internal/datamodel/apply_computed_project_quota_test.go
+++ b/internal/datamodel/apply_computed_project_quota_test.go
@@ -72,7 +72,7 @@ func TestACPQBasicWithoutAZAwareness(t *testing.T) {
 				405: {Allocated: 10},
 				406: {Allocated: 10},
 			},
-		})
+		}, liquid.ResourceInfo{Topology: liquid.AZAwareResourceTopology})
 	}
 }
 
@@ -157,7 +157,7 @@ func TestACPQBasicWithAZAwareness(t *testing.T) {
 				406: {Allocated: 10},
 				407: {Allocated: 5},
 			},
-		})
+		}, liquid.ResourceInfo{Topology: liquid.AZAwareResourceTopology})
 	}
 }
 
@@ -200,7 +200,7 @@ func TestACPQBasicWithAZSeparated(t *testing.T) {
 	}
 
 	for _, cfg.AllowQuotaOvercommitUntilAllocatedPercent = range []float64{0, 10000} {
-		expectACPQResultForAZSeparated(t, input, cfg, nil, acpqGlobalTarget{
+		expectACPQResult(t, input, cfg, nil, acpqGlobalTarget{
 			"az-one": {
 				401: {Allocated: 24},
 				402: {Allocated: 24},
@@ -219,7 +219,7 @@ func TestACPQBasicWithAZSeparated(t *testing.T) {
 				406: {Allocated: 10}, // Basequota
 				407: {Allocated: 10}, // Basequota
 			},
-		})
+		}, liquid.ResourceInfo{Topology: liquid.AZSeparatedResourceTopology})
 	}
 }
 
@@ -262,7 +262,7 @@ func TestACPQCapacityLimitsQuotaAllocation(t *testing.T) {
 			404: {Allocated: 5},
 			405: {Allocated: 5},
 		},
-	})
+	}, liquid.ResourceInfo{Topology: liquid.AZAwareResourceTopology})
 
 	// Stage 2: There is enough capacity for the minimum quotas, but not for the
 	// desired quotas.
@@ -281,7 +281,7 @@ func TestACPQCapacityLimitsQuotaAllocation(t *testing.T) {
 			404: {Allocated: 0},
 			405: {Allocated: 0},
 		},
-	})
+	}, liquid.ResourceInfo{Topology: liquid.AZAwareResourceTopology})
 
 	// Stage 3: There is enough capacity for the hard minimum quotas, but not for
 	// the soft minimum quotas.
@@ -300,7 +300,7 @@ func TestACPQCapacityLimitsQuotaAllocation(t *testing.T) {
 			404: {Allocated: 0},
 			405: {Allocated: 0},
 		},
-	})
+	}, liquid.ResourceInfo{Topology: liquid.AZAwareResourceTopology})
 
 	// Stage 4: Capacity is SOMEHOW not even enough for the hard minimum quotas.
 	input["any"] = clusterAZAllocationStats{
@@ -318,7 +318,7 @@ func TestACPQCapacityLimitsQuotaAllocation(t *testing.T) {
 			404: {Allocated: 0},
 			405: {Allocated: 0},
 		},
-	})
+	}, liquid.ResourceInfo{Topology: liquid.AZAwareResourceTopology})
 }
 
 func TestACPQQuotaOvercommitTurnsOffAboveAllocationThreshold(t *testing.T) {
@@ -369,7 +369,7 @@ func TestACPQQuotaOvercommitTurnsOffAboveAllocationThreshold(t *testing.T) {
 			404: {Allocated: 10},
 			405: {Allocated: 10},
 		},
-	})
+	}, liquid.ResourceInfo{Topology: liquid.AZAwareResourceTopology})
 
 	// test with quota overcommit forbidden (85% allocation is above 80%)
 	cfg.AllowQuotaOvercommitUntilAllocatedPercent = 80
@@ -389,7 +389,7 @@ func TestACPQQuotaOvercommitTurnsOffAboveAllocationThreshold(t *testing.T) {
 			404: {},
 			405: {},
 		},
-	})
+	}, liquid.ResourceInfo{Topology: liquid.AZAwareResourceTopology})
 }
 
 func TestACPQWithProjectLocalQuotaConstraints(t *testing.T) {
@@ -437,7 +437,7 @@ func TestACPQWithProjectLocalQuotaConstraints(t *testing.T) {
 			401: {Allocated: 36},
 			402: {Allocated: 16},
 		},
-	})
+	}, liquid.ResourceInfo{Topology: liquid.AZAwareResourceTopology})
 
 	// test with MinQuota constraints
 	//
@@ -463,7 +463,7 @@ func TestACPQWithProjectLocalQuotaConstraints(t *testing.T) {
 			401: {Allocated: 0},
 			402: {Allocated: 16},
 		},
-	})
+	}, liquid.ResourceInfo{Topology: liquid.AZAwareResourceTopology})
 
 	// test with MaxQuota constraints that constrain the soft minimum (hard minimum is not constrainable)
 	constraints = map[db.ProjectResourceID]projectLocalQuotaConstraints{
@@ -483,7 +483,7 @@ func TestACPQWithProjectLocalQuotaConstraints(t *testing.T) {
 			401: {Allocated: 0},
 			402: {Allocated: 0},
 		},
-	})
+	}, liquid.ResourceInfo{Topology: liquid.AZAwareResourceTopology})
 
 	// test with MaxQuota constraints that constrain the base quota
 	constraints = map[db.ProjectResourceID]projectLocalQuotaConstraints{
@@ -503,7 +503,7 @@ func TestACPQWithProjectLocalQuotaConstraints(t *testing.T) {
 			401: {Allocated: 26},
 			402: {Allocated: 6},
 		},
-	})
+	}, liquid.ResourceInfo{Topology: liquid.AZAwareResourceTopology})
 }
 
 func TestEmptyRegionDoesNotPrecludeQuotaOvercommit(t *testing.T) {
@@ -593,7 +593,7 @@ func TestEmptyRegionDoesNotPrecludeQuotaOvercommit(t *testing.T) {
 			404: {Allocated: 5},
 			405: {Allocated: 5},
 		},
-	})
+	}, liquid.ResourceInfo{Topology: liquid.AZAwareResourceTopology})
 }
 
 // Shortcut to avoid repetition in projectAZAllocationStats literals.
@@ -610,19 +610,9 @@ func withCommitted(committed uint64, stats projectAZAllocationStats) projectAZAl
 	return stats
 }
 
-func expectACPQResultForAZSeparated(t *testing.T, input map[limes.AvailabilityZone]clusterAZAllocationStats, cfg core.AutogrowQuotaDistributionConfiguration, constraints map[db.ProjectResourceID]projectLocalQuotaConstraints, expected acpqGlobalTarget) {
+func expectACPQResult(t *testing.T, input map[limes.AvailabilityZone]clusterAZAllocationStats, cfg core.AutogrowQuotaDistributionConfiguration, constraints map[db.ProjectResourceID]projectLocalQuotaConstraints, expected acpqGlobalTarget, resourceInfo liquid.ResourceInfo) {
 	t.Helper()
-	actual, _ := acpqComputeQuotas(input, cfg, constraints, liquid.ResourceInfo{Topology: liquid.AZSeparatedResourceTopology})
-	createACPQResult(t, input, cfg, actual, expected)
-}
-
-func expectACPQResult(t *testing.T, input map[limes.AvailabilityZone]clusterAZAllocationStats, cfg core.AutogrowQuotaDistributionConfiguration, constraints map[db.ProjectResourceID]projectLocalQuotaConstraints, expected acpqGlobalTarget) {
-	t.Helper()
-	actual, _ := acpqComputeQuotas(input, cfg, constraints, liquid.ResourceInfo{})
-	createACPQResult(t, input, cfg, actual, expected)
-}
-
-func createACPQResult(t *testing.T, input map[limes.AvailabilityZone]clusterAZAllocationStats, cfg core.AutogrowQuotaDistributionConfiguration, actual, expected acpqGlobalTarget) {
+	actual, _ := acpqComputeQuotas(input, cfg, constraints, resourceInfo)
 	// normalize away any left-over intermediate values
 	for _, azTarget := range actual {
 		for _, projectTarget := range azTarget {

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -179,4 +179,12 @@ var sqlMigrations = map[string]string{
 		ALTER TABLE project_resources
 			RENAME COLUMN max_quota_from_admin TO max_quota_from_outside_admin;
 	`,
+	"046_service_specific_quota_constraints.down.sql": `
+		ALTER TABLE project_az_resources
+			ADD backend_quota BIGINT default NULL;
+	`,
+	"046_service_specific_quota_constraints.up.sql": `
+		ALTER TABLE project_az_resources
+			DROP COLUMN backend_quota;
+	`,
 }

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -179,12 +179,12 @@ var sqlMigrations = map[string]string{
 		ALTER TABLE project_resources
 			RENAME COLUMN max_quota_from_admin TO max_quota_from_outside_admin;
 	`,
-	"046_service_specific_quota_constraints.down.sql": `
-		ALTER TABLE project_az_resources
-			ADD backend_quota BIGINT default NULL;
-	`,
-	"046_service_specific_quota_constraints.up.sql": `
+	"046_az_backend_quota.down.sql": `
 		ALTER TABLE project_az_resources
 			DROP COLUMN backend_quota;
+	`,
+	"046_az_backend_quota.up.sql": `
+		ALTER TABLE project_az_resources
+			ADD COLUMN backend_quota BIGINT default NULL;
 	`,
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -138,6 +138,7 @@ type ProjectAZResource struct {
 	ResourceID          ProjectResourceID      `db:"resource_id"`
 	AvailabilityZone    limes.AvailabilityZone `db:"az"`
 	Quota               *uint64                `db:"quota"`
+	BackendQuota        *int64                 `db:"backend_quota"`
 	Usage               uint64                 `db:"usage"`
 	PhysicalUsage       *uint64                `db:"physical_usage"`
 	SubresourcesJSON    string                 `db:"subresources"`

--- a/internal/plugins/capacity_liquid.go
+++ b/internal/plugins/capacity_liquid.go
@@ -75,7 +75,7 @@ func (p *liquidCapacityPlugin) Init(ctx context.Context, client *gophercloud.Pro
 	if err != nil {
 		return err
 	}
-	err = checkResourceTopologies(p.LiquidServiceInfo)
+	err = CheckResourceTopologies(p.LiquidServiceInfo)
 	return err
 }
 
@@ -97,7 +97,7 @@ func (p *liquidCapacityPlugin) Scrape(ctx context.Context, backchannel core.Capa
 	for resourceName, resource := range p.LiquidServiceInfo.Resources {
 		perAZ := resp.Resources[resourceName].PerAZ
 		toplogy := resource.Topology
-		err := matchLiquidReportToTopology(perAZ, toplogy)
+		err := MatchLiquidReportToTopology(perAZ, toplogy)
 		if err != nil {
 			return nil, nil, fmt.Errorf("service: %s, resource: %s: %w", p.LiquidServiceType, resourceName, err)
 		}

--- a/internal/plugins/capacity_liquid.go
+++ b/internal/plugins/capacity_liquid.go
@@ -72,6 +72,10 @@ func (p *liquidCapacityPlugin) Init(ctx context.Context, client *gophercloud.Pro
 		return fmt.Errorf("cannot initialize ServiceClient for %s: %w", p.LiquidServiceType, err)
 	}
 	p.LiquidServiceInfo, err = p.LiquidClient.GetInfo(ctx)
+	if err != nil {
+		return err
+	}
+	err = checkResourceTopologies(p.LiquidServiceInfo)
 	return err
 }
 

--- a/internal/plugins/capacity_liquid.go
+++ b/internal/plugins/capacity_liquid.go
@@ -99,7 +99,7 @@ func (p *liquidCapacityPlugin) Scrape(ctx context.Context, backchannel core.Capa
 		toplogy := resource.Topology
 		err := matchLiquidReportToTopology(perAZ, toplogy)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, fmt.Errorf("service: %s, resource: %s: %w", p.LiquidServiceType, resourceName, err)
 		}
 	}
 

--- a/internal/plugins/capacity_liquid.go
+++ b/internal/plugins/capacity_liquid.go
@@ -94,6 +94,14 @@ func (p *liquidCapacityPlugin) Scrape(ctx context.Context, backchannel core.Capa
 		logg.Fatal("ServiceInfo version for %s changed from %d to %d; restarting now to reload ServiceInfo...",
 			p.LiquidServiceType, p.LiquidServiceInfo.Version, resp.InfoVersion)
 	}
+	for resourceName, resource := range p.LiquidServiceInfo.Resources {
+		perAZ := resp.Resources[resourceName].PerAZ
+		toplogy := resource.Topology
+		err := matchLiquidReportToTopology(perAZ, toplogy)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
 
 	resultInService := make(map[liquid.ResourceName]core.PerAZ[core.CapacityData], len(p.LiquidServiceInfo.Resources))
 	for resName, resInfo := range p.LiquidServiceInfo.Resources {

--- a/internal/plugins/capacity_liquid.go
+++ b/internal/plugins/capacity_liquid.go
@@ -101,7 +101,7 @@ func (p *liquidCapacityPlugin) Scrape(ctx context.Context, backchannel core.Capa
 		topology := p.LiquidServiceInfo.Resources[resourceName].Topology
 		err := MatchLiquidReportToTopology(perAZ, topology)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("service: %s, resource: %s: %w", p.ServiceType, resourceName, err))
+			errs = append(errs, fmt.Errorf("resource: %s: %w", resourceName, err))
 		}
 	}
 	if len(errs) > 0 {

--- a/internal/plugins/capacity_liquid.go
+++ b/internal/plugins/capacity_liquid.go
@@ -94,7 +94,7 @@ func (p *liquidCapacityPlugin) Scrape(ctx context.Context, backchannel core.Capa
 		logg.Fatal("ServiceInfo version for %s changed from %d to %d; restarting now to reload ServiceInfo...",
 			p.LiquidServiceType, p.LiquidServiceInfo.Version, resp.InfoVersion)
 	}
-	resourceNames := SortMapKeys(p.LiquidServiceInfo.Resources)
+	resourceNames := SortedMapKeys(p.LiquidServiceInfo.Resources)
 	var errs []error
 	for _, resourceName := range resourceNames {
 		perAZ := resp.Resources[resourceName].PerAZ

--- a/internal/plugins/capacity_liquid.go
+++ b/internal/plugins/capacity_liquid.go
@@ -97,8 +97,8 @@ func (p *liquidCapacityPlugin) Scrape(ctx context.Context, backchannel core.Capa
 	resourceNames := SortMapKeys(p.LiquidServiceInfo.Resources)
 	var errs []error
 	for _, resourceName := range resourceNames {
-		perAZ := resp.Resources[liquid.ResourceName(resourceName)].PerAZ
-		toplogy := p.LiquidServiceInfo.Resources[liquid.ResourceName(resourceName)].Topology
+		perAZ := resp.Resources[resourceName].PerAZ
+		toplogy := p.LiquidServiceInfo.Resources[resourceName].Topology
 		err := MatchLiquidReportToTopology(perAZ, toplogy)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("service: %s, resource: %s: %w", p.ServiceType, resourceName, err))

--- a/internal/plugins/capacity_liquid.go
+++ b/internal/plugins/capacity_liquid.go
@@ -98,8 +98,8 @@ func (p *liquidCapacityPlugin) Scrape(ctx context.Context, backchannel core.Capa
 	var errs []error
 	for _, resourceName := range resourceNames {
 		perAZ := resp.Resources[resourceName].PerAZ
-		toplogy := p.LiquidServiceInfo.Resources[resourceName].Topology
-		err := MatchLiquidReportToTopology(perAZ, toplogy)
+		topology := p.LiquidServiceInfo.Resources[resourceName].Topology
+		err := MatchLiquidReportToTopology(perAZ, topology)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("service: %s, resource: %s: %w", p.ServiceType, resourceName, err))
 		}

--- a/internal/plugins/capacity_liquid.go
+++ b/internal/plugins/capacity_liquid.go
@@ -95,17 +95,17 @@ func (p *liquidCapacityPlugin) Scrape(ctx context.Context, backchannel core.Capa
 			p.LiquidServiceType, p.LiquidServiceInfo.Version, resp.InfoVersion)
 	}
 	resourceNames := SortMapKeys(p.LiquidServiceInfo.Resources)
+	var errs []error
 	for _, resourceName := range resourceNames {
-		errs := []error{}
 		perAZ := resp.Resources[liquid.ResourceName(resourceName)].PerAZ
 		toplogy := p.LiquidServiceInfo.Resources[liquid.ResourceName(resourceName)].Topology
 		err := MatchLiquidReportToTopology(perAZ, toplogy)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("service: %s, resource: %s: %w", p.ServiceType, resourceName, err))
 		}
-		if len(errs) > 0 {
-			return nil, nil, errors.Join(errs...)
-		}
+	}
+	if len(errs) > 0 {
+		return nil, nil, errors.Join(errs...)
 	}
 
 	resultInService := make(map[liquid.ResourceName]core.PerAZ[core.CapacityData], len(p.LiquidServiceInfo.Resources))

--- a/internal/plugins/liquid.go
+++ b/internal/plugins/liquid.go
@@ -123,12 +123,17 @@ func (p *liquidQuotaPlugin) Scrape(ctx context.Context, project core.KeystonePro
 		logg.Fatal("ServiceInfo version for %s changed from %d to %d; restarting now to reload ServiceInfo...",
 			p.LiquidServiceType, p.LiquidServiceInfo.Version, resp.InfoVersion)
 	}
-	for resourceName, resource := range p.LiquidServiceInfo.Resources {
-		perAZ := resp.Resources[resourceName].PerAZ
-		toplogy := resource.Topology
+	resourceNames := SortMapKeys(p.LiquidServiceInfo.Resources)
+	for _, resourceName := range resourceNames {
+		errs := []error{}
+		perAZ := resp.Resources[liquid.ResourceName(resourceName)].PerAZ
+		toplogy := p.LiquidServiceInfo.Resources[liquid.ResourceName(resourceName)].Topology
 		err := MatchLiquidReportToTopology(perAZ, toplogy)
 		if err != nil {
-			return nil, nil, fmt.Errorf("service: %s, resource: %s: %w", p.ServiceType, resourceName, err)
+			errs = append(errs, fmt.Errorf("service: %s, resource: %s: %w", p.ServiceType, resourceName, err))
+		}
+		if len(errs) > 0 {
+			return nil, nil, errors.Join(errs...)
 		}
 	}
 

--- a/internal/plugins/liquid.go
+++ b/internal/plugins/liquid.go
@@ -124,17 +124,17 @@ func (p *liquidQuotaPlugin) Scrape(ctx context.Context, project core.KeystonePro
 			p.LiquidServiceType, p.LiquidServiceInfo.Version, resp.InfoVersion)
 	}
 	resourceNames := SortMapKeys(p.LiquidServiceInfo.Resources)
+	var errs []error
 	for _, resourceName := range resourceNames {
-		errs := []error{}
 		perAZ := resp.Resources[liquid.ResourceName(resourceName)].PerAZ
 		toplogy := p.LiquidServiceInfo.Resources[liquid.ResourceName(resourceName)].Topology
 		err := MatchLiquidReportToTopology(perAZ, toplogy)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("service: %s, resource: %s: %w", p.ServiceType, resourceName, err))
 		}
-		if len(errs) > 0 {
-			return nil, nil, errors.Join(errs...)
-		}
+	}
+	if len(errs) > 0 {
+		return nil, nil, errors.Join(errs...)
 	}
 
 	result = make(map[liquid.ResourceName]core.ResourceData, len(p.LiquidServiceInfo.Resources))

--- a/internal/plugins/liquid.go
+++ b/internal/plugins/liquid.go
@@ -123,7 +123,7 @@ func (p *liquidQuotaPlugin) Scrape(ctx context.Context, project core.KeystonePro
 		logg.Fatal("ServiceInfo version for %s changed from %d to %d; restarting now to reload ServiceInfo...",
 			p.LiquidServiceType, p.LiquidServiceInfo.Version, resp.InfoVersion)
 	}
-	resourceNames := SortMapKeys(p.LiquidServiceInfo.Resources)
+	resourceNames := SortedMapKeys(p.LiquidServiceInfo.Resources)
 	var errs []error
 	for _, resourceName := range resourceNames {
 		perAZ := resp.Resources[resourceName].PerAZ
@@ -198,9 +198,7 @@ func (p *liquidQuotaPlugin) SetQuota(ctx context.Context, project core.KeystoneP
 	req := liquid.ServiceQuotaRequest{
 		Resources: make(map[liquid.ResourceName]liquid.ResourceQuotaRequest, len(quotaReq)),
 	}
-	for resName, request := range quotaReq {
-		req.Resources[resName] = liquid.ResourceQuotaRequest{Quota: request.Quota, PerAZ: request.PerAZ}
-	}
+	req = liquid.ServiceQuotaRequest{Resources: quotaReq}
 	if p.LiquidServiceInfo.QuotaUpdateNeedsProjectMetadata {
 		req.ProjectMetadata = project.ForLiquid()
 	}

--- a/internal/plugins/liquid.go
+++ b/internal/plugins/liquid.go
@@ -127,8 +127,8 @@ func (p *liquidQuotaPlugin) Scrape(ctx context.Context, project core.KeystonePro
 	var errs []error
 	for _, resourceName := range resourceNames {
 		perAZ := resp.Resources[resourceName].PerAZ
-		toplogy := p.LiquidServiceInfo.Resources[resourceName].Topology
-		err := MatchLiquidReportToTopology(perAZ, toplogy)
+		topology := p.LiquidServiceInfo.Resources[resourceName].Topology
+		err := MatchLiquidReportToTopology(perAZ, topology)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("service: %s, resource: %s: %w", p.ServiceType, resourceName, err))
 		}

--- a/internal/plugins/liquid.go
+++ b/internal/plugins/liquid.go
@@ -123,6 +123,14 @@ func (p *liquidQuotaPlugin) Scrape(ctx context.Context, project core.KeystonePro
 		logg.Fatal("ServiceInfo version for %s changed from %d to %d; restarting now to reload ServiceInfo...",
 			p.LiquidServiceType, p.LiquidServiceInfo.Version, resp.InfoVersion)
 	}
+	for resourceName, resource := range p.LiquidServiceInfo.Resources {
+		perAZ := resp.Resources[resourceName].PerAZ
+		toplogy := resource.Topology
+		err := matchLiquidReportToTopology(perAZ, toplogy)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
 
 	result = make(map[liquid.ResourceName]core.ResourceData, len(p.LiquidServiceInfo.Resources))
 	for resName := range p.LiquidServiceInfo.Resources {

--- a/internal/plugins/liquid.go
+++ b/internal/plugins/liquid.go
@@ -133,7 +133,7 @@ func (p *liquidQuotaPlugin) Scrape(ctx context.Context, project core.KeystonePro
 	}
 
 	result = make(map[liquid.ResourceName]core.ResourceData, len(p.LiquidServiceInfo.Resources))
-	for resName := range p.LiquidServiceInfo.Resources {
+	for resName, resInfo := range p.LiquidServiceInfo.Resources {
 		resReport := resp.Resources[resName]
 		if resReport == nil {
 			return nil, nil, fmt.Errorf("missing report for resource %q", resName)
@@ -153,6 +153,9 @@ func (p *liquidQuotaPlugin) Scrape(ctx context.Context, project core.KeystonePro
 				Usage:         azReport.Usage,
 				PhysicalUsage: azReport.PhysicalUsage,
 				Subresources:  castSliceToAny(azReport.Subresources),
+			}
+			if resInfo.Topology == liquid.AZSeparatedResourceTopology && azReport.Quota != nil {
+				resData.UsageData[az].Quota = *azReport.Quota
 			}
 		}
 

--- a/internal/plugins/liquid.go
+++ b/internal/plugins/liquid.go
@@ -83,6 +83,10 @@ func (p *liquidQuotaPlugin) Init(ctx context.Context, client *gophercloud.Provid
 		return fmt.Errorf("cannot initialize ServiceClient for liquid-%s: %w", serviceType, err)
 	}
 	p.LiquidServiceInfo, err = p.LiquidClient.GetInfo(ctx)
+	if err != nil {
+		return err
+	}
+	err = checkResourceTopologies(p.LiquidServiceInfo)
 	return err
 }
 

--- a/internal/plugins/liquid.go
+++ b/internal/plugins/liquid.go
@@ -126,8 +126,8 @@ func (p *liquidQuotaPlugin) Scrape(ctx context.Context, project core.KeystonePro
 	resourceNames := SortMapKeys(p.LiquidServiceInfo.Resources)
 	var errs []error
 	for _, resourceName := range resourceNames {
-		perAZ := resp.Resources[liquid.ResourceName(resourceName)].PerAZ
-		toplogy := p.LiquidServiceInfo.Resources[liquid.ResourceName(resourceName)].Topology
+		perAZ := resp.Resources[resourceName].PerAZ
+		toplogy := p.LiquidServiceInfo.Resources[resourceName].Topology
 		err := MatchLiquidReportToTopology(perAZ, toplogy)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("service: %s, resource: %s: %w", p.ServiceType, resourceName, err))

--- a/internal/plugins/liquid.go
+++ b/internal/plugins/liquid.go
@@ -194,12 +194,12 @@ func castSliceToAny[T any](input []T) (output []any) {
 }
 
 // SetQuota implements the core.QuotaPlugin interface.
-func (p *liquidQuotaPlugin) SetQuota(ctx context.Context, project core.KeystoneProject, quotas map[liquid.ResourceName]core.Quotas) error {
+func (p *liquidQuotaPlugin) SetQuota(ctx context.Context, project core.KeystoneProject, quotaReq map[liquid.ResourceName]liquid.ResourceQuotaRequest) error {
 	req := liquid.ServiceQuotaRequest{
-		Resources: make(map[liquid.ResourceName]liquid.ResourceQuotaRequest, len(quotas)),
+		Resources: make(map[liquid.ResourceName]liquid.ResourceQuotaRequest, len(quotaReq)),
 	}
-	for resName, quotas := range quotas {
-		req.Resources[resName] = liquid.ResourceQuotaRequest{Quota: quotas.QuotaForResource, PerAZ: quotas.QuotasForAZs}
+	for resName, request := range quotaReq {
+		req.Resources[resName] = liquid.ResourceQuotaRequest{Quota: request.Quota, PerAZ: request.PerAZ}
 	}
 	if p.LiquidServiceInfo.QuotaUpdateNeedsProjectMetadata {
 		req.ProjectMetadata = project.ForLiquid()

--- a/internal/plugins/liquid.go
+++ b/internal/plugins/liquid.go
@@ -130,7 +130,7 @@ func (p *liquidQuotaPlugin) Scrape(ctx context.Context, project core.KeystonePro
 		topology := p.LiquidServiceInfo.Resources[resourceName].Topology
 		err := MatchLiquidReportToTopology(perAZ, topology)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("service: %s, resource: %s: %w", p.ServiceType, resourceName, err))
+			errs = append(errs, fmt.Errorf("resource: %s: %w", resourceName, err))
 		}
 	}
 	if len(errs) > 0 {

--- a/internal/plugins/liquid.go
+++ b/internal/plugins/liquid.go
@@ -189,12 +189,12 @@ func castSliceToAny[T any](input []T) (output []any) {
 }
 
 // SetQuota implements the core.QuotaPlugin interface.
-func (p *liquidQuotaPlugin) SetQuota(ctx context.Context, project core.KeystoneProject, quotas map[liquid.ResourceName]uint64) error {
+func (p *liquidQuotaPlugin) SetQuota(ctx context.Context, project core.KeystoneProject, quotas map[liquid.ResourceName]core.Quotas) error {
 	req := liquid.ServiceQuotaRequest{
 		Resources: make(map[liquid.ResourceName]liquid.ResourceQuotaRequest, len(quotas)),
 	}
-	for resName, quota := range quotas {
-		req.Resources[resName] = liquid.ResourceQuotaRequest{Quota: quota}
+	for resName, quotas := range quotas {
+		req.Resources[resName] = liquid.ResourceQuotaRequest{Quota: quotas.QuotaForResource, PerAZ: quotas.QuotasForAZs}
 	}
 	if p.LiquidServiceInfo.QuotaUpdateNeedsProjectMetadata {
 		req.ProjectMetadata = project.ForLiquid()

--- a/internal/plugins/liquid.go
+++ b/internal/plugins/liquid.go
@@ -195,10 +195,7 @@ func castSliceToAny[T any](input []T) (output []any) {
 
 // SetQuota implements the core.QuotaPlugin interface.
 func (p *liquidQuotaPlugin) SetQuota(ctx context.Context, project core.KeystoneProject, quotaReq map[liquid.ResourceName]liquid.ResourceQuotaRequest) error {
-	req := liquid.ServiceQuotaRequest{
-		Resources: make(map[liquid.ResourceName]liquid.ResourceQuotaRequest, len(quotaReq)),
-	}
-	req = liquid.ServiceQuotaRequest{Resources: quotaReq}
+	req := liquid.ServiceQuotaRequest{Resources: quotaReq}
 	if p.LiquidServiceInfo.QuotaUpdateNeedsProjectMetadata {
 		req.ProjectMetadata = project.ForLiquid()
 	}

--- a/internal/plugins/liquid.go
+++ b/internal/plugins/liquid.go
@@ -86,7 +86,7 @@ func (p *liquidQuotaPlugin) Init(ctx context.Context, client *gophercloud.Provid
 	if err != nil {
 		return err
 	}
-	err = checkResourceTopologies(p.LiquidServiceInfo)
+	err = CheckResourceTopologies(p.LiquidServiceInfo)
 	return err
 }
 
@@ -126,7 +126,7 @@ func (p *liquidQuotaPlugin) Scrape(ctx context.Context, project core.KeystonePro
 	for resourceName, resource := range p.LiquidServiceInfo.Resources {
 		perAZ := resp.Resources[resourceName].PerAZ
 		toplogy := resource.Topology
-		err := matchLiquidReportToTopology(perAZ, toplogy)
+		err := MatchLiquidReportToTopology(perAZ, toplogy)
 		if err != nil {
 			return nil, nil, fmt.Errorf("service: %s, resource: %s: %w", p.ServiceType, resourceName, err)
 		}

--- a/internal/plugins/liquid.go
+++ b/internal/plugins/liquid.go
@@ -128,7 +128,7 @@ func (p *liquidQuotaPlugin) Scrape(ctx context.Context, project core.KeystonePro
 		toplogy := resource.Topology
 		err := matchLiquidReportToTopology(perAZ, toplogy)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, fmt.Errorf("service: %s, resource: %s: %w", p.ServiceType, resourceName, err)
 		}
 	}
 

--- a/internal/plugins/liquid.go
+++ b/internal/plugins/liquid.go
@@ -160,7 +160,7 @@ func (p *liquidQuotaPlugin) Scrape(ctx context.Context, project core.KeystonePro
 				Subresources:  castSliceToAny(azReport.Subresources),
 			}
 			if resInfo.Topology == liquid.AZSeparatedResourceTopology && azReport.Quota != nil {
-				resData.UsageData[az].Quota = *azReport.Quota
+				resData.UsageData[az].Quota = azReport.Quota
 			}
 		}
 

--- a/internal/plugins/nova.go
+++ b/internal/plugins/nova.go
@@ -345,11 +345,11 @@ func (p *novaPlugin) pooledResourceName(hwVersion string, base liquid.ResourceNa
 }
 
 // SetQuota implements the core.QuotaPlugin interface.
-func (p *novaPlugin) SetQuota(ctx context.Context, project core.KeystoneProject, quotas map[liquid.ResourceName]uint64) error {
+func (p *novaPlugin) SetQuota(ctx context.Context, project core.KeystoneProject, quotas map[liquid.ResourceName]core.Quotas) error {
 	// translate Limes resource names for separate instance quotas into Nova quota names
 	novaQuotas := make(novaQuotaUpdateOpts, len(quotas))
-	for resourceName, quota := range quotas {
-		novaQuotas[string(resourceName)] = quota
+	for resourceName, quotas := range quotas {
+		novaQuotas[string(resourceName)] = quotas.QuotaForResource
 	}
 
 	return quotasets.Update(ctx, p.NovaV2, project.UUID, novaQuotas).Err

--- a/internal/plugins/nova.go
+++ b/internal/plugins/nova.go
@@ -60,11 +60,11 @@ type novaPlugin struct {
 }
 
 var novaDefaultResources = map[liquid.ResourceName]liquid.ResourceInfo{
-	"cores":                {Unit: limes.UnitNone, HasQuota: true},
-	"instances":            {Unit: limes.UnitNone, HasQuota: true},
-	"ram":                  {Unit: limes.UnitMebibytes, HasQuota: true},
-	"server_groups":        {Unit: limes.UnitNone, HasQuota: true},
-	"server_group_members": {Unit: limes.UnitNone, HasQuota: true},
+	"cores":                {Unit: limes.UnitNone, HasQuota: true, Topology: liquid.AZAwareResourceTopology},
+	"instances":            {Unit: limes.UnitNone, HasQuota: true, Topology: liquid.AZAwareResourceTopology},
+	"ram":                  {Unit: limes.UnitMebibytes, HasQuota: true, Topology: liquid.AZAwareResourceTopology},
+	"server_groups":        {Unit: limes.UnitNone, HasQuota: true, Topology: liquid.FlatResourceTopology},
+	"server_group_members": {Unit: limes.UnitNone, HasQuota: true, Topology: liquid.FlatResourceTopology},
 }
 
 func init() {
@@ -121,6 +121,7 @@ func (p *novaPlugin) Init(ctx context.Context, provider *gophercloud.ProviderCli
 		p.resources[liquid.ResourceName(resourceName)] = liquid.ResourceInfo{
 			Unit:     unit,
 			HasQuota: true,
+			Topology: liquid.AZAwareResourceTopology,
 		}
 	}
 
@@ -134,6 +135,7 @@ func (p *novaPlugin) Init(ctx context.Context, provider *gophercloud.ProviderCli
 				p.resources[resName] = liquid.ResourceInfo{
 					Unit:     limes.UnitNone,
 					HasQuota: true,
+					Topology: liquid.AZAwareResourceTopology,
 				}
 			}
 		}

--- a/internal/plugins/nova.go
+++ b/internal/plugins/nova.go
@@ -345,11 +345,11 @@ func (p *novaPlugin) pooledResourceName(hwVersion string, base liquid.ResourceNa
 }
 
 // SetQuota implements the core.QuotaPlugin interface.
-func (p *novaPlugin) SetQuota(ctx context.Context, project core.KeystoneProject, quotas map[liquid.ResourceName]core.Quotas) error {
+func (p *novaPlugin) SetQuota(ctx context.Context, project core.KeystoneProject, quotaReq map[liquid.ResourceName]liquid.ResourceQuotaRequest) error {
 	// translate Limes resource names for separate instance quotas into Nova quota names
-	novaQuotas := make(novaQuotaUpdateOpts, len(quotas))
-	for resourceName, quotas := range quotas {
-		novaQuotas[string(resourceName)] = quotas.QuotaForResource
+	novaQuotas := make(novaQuotaUpdateOpts, len(quotaReq))
+	for resourceName, request := range quotaReq {
+		novaQuotas[string(resourceName)] = request.Quota
 	}
 
 	return quotasets.Update(ctx, p.NovaV2, project.UUID, novaQuotas).Err

--- a/internal/plugins/utils.go
+++ b/internal/plugins/utils.go
@@ -46,7 +46,7 @@ func checkResourceTopologies(serviceInfo liquid.ServiceInfo) (err error) {
 
 func matchLiquidReportToTopology[V any](perAZReport map[liquid.AvailabilityZone]*V, topology liquid.ResourceTopology) (err error) {
 	_, anyExists := perAZReport[liquid.AvailabilityZoneAny]
-	_, unknownExsits := perAZReport[liquid.AvailabilityZoneUnknown]
+	_, unknownExists := perAZReport[liquid.AvailabilityZoneUnknown]
 	switch topology {
 	case liquid.FlatResourceTopology:
 		if len(perAZReport) == 1 && anyExists {
@@ -57,7 +57,7 @@ func matchLiquidReportToTopology[V any](perAZReport map[liquid.AvailabilityZone]
 			return
 		}
 	case liquid.AZSeparatedResourceTopology:
-		if len(perAZReport) > 0 && !anyExists && !unknownExsits {
+		if len(perAZReport) > 0 && !anyExists && !unknownExists {
 			return
 		}
 	}

--- a/internal/plugins/utils.go
+++ b/internal/plugins/utils.go
@@ -50,7 +50,7 @@ func CheckResourceTopologies(serviceInfo liquid.ServiceInfo) (err error) {
 			logg.Error("missing topology on resource: %s", resourceName)
 		}
 		if !topology.IsValid() {
-			errs = append(errs, fmt.Errorf("invalid toplogy: %s on resource: %s", topology, resourceName))
+			errs = append(errs, fmt.Errorf("invalid topology: %s on resource: %s", topology, resourceName))
 		}
 	}
 	if len(errs) > 0 {
@@ -80,5 +80,5 @@ func MatchLiquidReportToTopology[V any](perAZReport map[liquid.AvailabilityZone]
 	}
 
 	reportedAZs := SortMapKeys(perAZReport)
-	return fmt.Errorf("scrape with toplogy type: %s returned AZs: %v", topology, reportedAZs)
+	return fmt.Errorf("scrape with topology type: %s returned AZs: %v", topology, reportedAZs)
 }

--- a/internal/plugins/utils.go
+++ b/internal/plugins/utils.go
@@ -46,7 +46,7 @@ func CheckResourceTopologies(serviceInfo liquid.ServiceInfo) (err error) {
 	for _, resourceName := range resourceNames {
 		topology := resources[resourceName].Topology
 		if topology == "" {
-			continue
+			logg.Error("missing topology on resource: %s", resourceName)
 		}
 		if !topology.IsValid() {
 			errs = append(errs, fmt.Errorf("invalid toplogy: %s on resource: %s", topology, resourceName))

--- a/internal/plugins/utils.go
+++ b/internal/plugins/utils.go
@@ -43,6 +43,9 @@ func CheckResourceTopologies(serviceInfo liquid.ServiceInfo) (err error) {
 
 	for _, resourceName := range resourceNames {
 		topology := resources[liquid.ResourceName(resourceName)].Topology
+		if topology == "" {
+			continue
+		}
 		if !topology.IsValid() {
 			errs = append(errs, fmt.Errorf("invalid toplogy: %s on resource: %s", topology, resourceName))
 		}

--- a/internal/plugins/utils.go
+++ b/internal/plugins/utils.go
@@ -33,7 +33,7 @@ func p2u64(val uint64) *uint64 {
 	return &val
 }
 
-func SortMapKeys[M map[K]V, K ~string, V any](mapToSort M) []K {
+func SortedMapKeys[M map[K]V, K ~string, V any](mapToSort M) []K {
 	sortedKeys := slices.Collect(maps.Keys(mapToSort))
 	slices.Sort(sortedKeys)
 	return sortedKeys
@@ -43,7 +43,7 @@ func CheckResourceTopologies(serviceInfo liquid.ServiceInfo) (err error) {
 	var errs []error
 	resources := serviceInfo.Resources
 
-	resourceNames := SortMapKeys(resources)
+	resourceNames := SortedMapKeys(resources)
 	for _, resourceName := range resourceNames {
 		topology := resources[resourceName].Topology
 		if topology == "" {
@@ -84,6 +84,6 @@ func MatchLiquidReportToTopology[V any](perAZReport map[liquid.AvailabilityZone]
 		return
 	}
 
-	reportedAZs := SortMapKeys(perAZReport)
+	reportedAZs := SortedMapKeys(perAZReport)
 	return fmt.Errorf("scrape with topology type: %s returned AZs: %v", topology, reportedAZs)
 }

--- a/internal/plugins/utils.go
+++ b/internal/plugins/utils.go
@@ -42,7 +42,7 @@ func SortMapKeys[M map[K]V, K ~string, V any](mapToSort M) []string {
 }
 
 func CheckResourceTopologies(serviceInfo liquid.ServiceInfo) (err error) {
-	errs := []error{}
+	var errs []error
 	resources := serviceInfo.Resources
 
 	resourceNames := SortMapKeys(resources)

--- a/internal/plugins/utils.go
+++ b/internal/plugins/utils.go
@@ -59,7 +59,7 @@ func CheckResourceTopologies(serviceInfo liquid.ServiceInfo) (err error) {
 	return
 }
 
-func MatchLiquidReportToTopology[V any](perAZReport map[liquid.AvailabilityZone]*V, topology liquid.ResourceTopology) (err error) {
+func MatchLiquidReportToTopology[V any](perAZReport map[liquid.AvailabilityZone]V, topology liquid.ResourceTopology) (err error) {
 	_, anyExists := perAZReport[liquid.AvailabilityZoneAny]
 	_, unknownExists := perAZReport[liquid.AvailabilityZoneUnknown]
 	switch topology {

--- a/internal/plugins/utils.go
+++ b/internal/plugins/utils.go
@@ -26,6 +26,7 @@ import (
 	"slices"
 
 	"github.com/sapcc/go-api-declarations/liquid"
+	"github.com/sapcc/go-bits/logg"
 )
 
 func p2u64(val uint64) *uint64 {

--- a/internal/plugins/utils.go
+++ b/internal/plugins/utils.go
@@ -81,11 +81,6 @@ func MatchLiquidReportToTopology[V any](perAZReport map[liquid.AvailabilityZone]
 		return
 	}
 
-	var reportedAZs []string
-	for az := range perAZReport {
-		reportedAZs = append(reportedAZs, string(az))
-	}
-	sort.Strings(reportedAZs)
-
+	reportedAZs := SortMapKeys(perAZReport)
 	return fmt.Errorf("scrape with toplogy type: %s returned AZs: %v", topology, reportedAZs)
 }

--- a/internal/plugins/utils.go
+++ b/internal/plugins/utils.go
@@ -44,7 +44,7 @@ func CheckResourceTopologies(serviceInfo liquid.ServiceInfo) (err error) {
 
 	resourceNames := SortMapKeys(resources)
 	for _, resourceName := range resourceNames {
-		topology := resources[liquid.ResourceName(resourceName)].Topology
+		topology := resources[resourceName].Topology
 		if topology == "" {
 			continue
 		}

--- a/internal/plugins/utils.go
+++ b/internal/plugins/utils.go
@@ -47,7 +47,12 @@ func CheckResourceTopologies(serviceInfo liquid.ServiceInfo) (err error) {
 	for _, resourceName := range resourceNames {
 		topology := resources[resourceName].Topology
 		if topology == "" {
-			logg.Error("missing topology on resource: %s", resourceName)
+			// several algorithms inside Limes depend on a topology being chosen, so we have to pick a default for now
+			// TODO: make this a fatal error once liquid-ceph has rolled out their Topology patch
+			logg.Error("missing topology on resource: %s (assuming %q)", resourceName, liquid.FlatResourceTopology)
+			resInfo := resources[resourceName]
+			resInfo.Topology = liquid.FlatResourceTopology
+			resources[resourceName] = resInfo
 		}
 		if !topology.IsValid() {
 			errs = append(errs, fmt.Errorf("invalid topology: %s on resource: %s", topology, resourceName))

--- a/internal/plugins/utils.go
+++ b/internal/plugins/utils.go
@@ -22,7 +22,8 @@ package plugins
 import (
 	"errors"
 	"fmt"
-	"sort"
+	"maps"
+	"slices"
 
 	"github.com/sapcc/go-api-declarations/liquid"
 )
@@ -31,13 +32,9 @@ func p2u64(val uint64) *uint64 {
 	return &val
 }
 
-func SortMapKeys[M map[K]V, K ~string, V any](mapToSort M) []string {
-	var sortedKeys []string
-	for key := range mapToSort {
-		sortedKeys = append(sortedKeys, string(key))
-	}
-	sort.Strings(sortedKeys)
-
+func SortMapKeys[M map[K]V, K ~string, V any](mapToSort M) []K {
+	sortedKeys := slices.Collect(maps.Keys(mapToSort))
+	slices.Sort(sortedKeys)
 	return sortedKeys
 }
 

--- a/internal/plugins/utils.go
+++ b/internal/plugins/utils.go
@@ -61,5 +61,5 @@ func matchLiquidReportToTopology[V any](perAZReport map[liquid.AvailabilityZone]
 			return
 		}
 	}
-	return fmt.Errorf("scrape with toplogy type: %v returned AZs: %v", topology, reflect.ValueOf(perAZReport).MapKeys())
+	return fmt.Errorf("scrape with toplogy type: %s returned AZs: %v", topology, reflect.ValueOf(perAZReport).MapKeys())
 }

--- a/internal/plugins/utils.go
+++ b/internal/plugins/utils.go
@@ -19,6 +19,25 @@
 
 package plugins
 
+import (
+	"fmt"
+	"github.com/sapcc/go-api-declarations/liquid"
+)
+
 func p2u64(val uint64) *uint64 {
 	return &val
+}
+
+func checkResourceTopologies(serviceInfo liquid.ServiceInfo) (err error) {
+	invalidTopologies := map[liquid.ResourceName]liquid.ResourceTopology{}
+	resources := serviceInfo.Resources
+	for k, v := range resources {
+		if !v.Topology.IsValid() || v.Topology != "" {
+			invalidTopologies[k] = v.Topology
+		}
+	}
+	if len(invalidTopologies) > 0 {
+		return fmt.Errorf("invalid topologies detected: %v", invalidTopologies)
+	}
+	return
 }

--- a/internal/plugins/utils.go
+++ b/internal/plugins/utils.go
@@ -31,16 +31,21 @@ func p2u64(val uint64) *uint64 {
 	return &val
 }
 
+func SortMapKeys[M map[K]V, K ~string, V any](mapToSort M) []string {
+	var sortedKeys []string
+	for key := range mapToSort {
+		sortedKeys = append(sortedKeys, string(key))
+	}
+	sort.Strings(sortedKeys)
+
+	return sortedKeys
+}
+
 func CheckResourceTopologies(serviceInfo liquid.ServiceInfo) (err error) {
 	errs := []error{}
 	resources := serviceInfo.Resources
 
-	var resourceNames []string
-	for resource := range resources {
-		resourceNames = append(resourceNames, string(resource))
-	}
-	sort.Strings(resourceNames)
-
+	resourceNames := SortMapKeys(resources)
 	for _, resourceName := range resourceNames {
 		topology := resources[liquid.ResourceName(resourceName)].Topology
 		if topology == "" {

--- a/internal/test/plugins/quota_generic.go
+++ b/internal/test/plugins/quota_generic.go
@@ -174,8 +174,8 @@ func (p *GenericQuotaPlugin) Scrape(ctx context.Context, project core.KeystonePr
 		var errs []error
 		resourceNames := plugins.SortMapKeys(p.LiquidServiceInfo.Resources)
 		for _, resourceName := range resourceNames {
-			toplogy := p.LiquidServiceInfo.Resources[resourceName].Topology
-			err := plugins.MatchLiquidReportToTopology(p.ReportedAZs, toplogy)
+			topology := p.LiquidServiceInfo.Resources[resourceName].Topology
+			err := plugins.MatchLiquidReportToTopology(p.ReportedAZs, topology)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("service: %s, resource: %s: %w", p.ServiceType, resourceName, err))
 			}

--- a/internal/test/plugins/quota_generic.go
+++ b/internal/test/plugins/quota_generic.go
@@ -174,7 +174,7 @@ func (p *GenericQuotaPlugin) Scrape(ctx context.Context, project core.KeystonePr
 		var errs []error
 		resourceNames := plugins.SortMapKeys(p.LiquidServiceInfo.Resources)
 		for _, resourceName := range resourceNames {
-			toplogy := p.LiquidServiceInfo.Resources[liquid.ResourceName(resourceName)].Topology
+			toplogy := p.LiquidServiceInfo.Resources[resourceName].Topology
 			err := plugins.MatchLiquidReportToTopology(p.ReportedAZs, toplogy)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("service: %s, resource: %s: %w", p.ServiceType, resourceName, err))

--- a/internal/test/plugins/quota_generic.go
+++ b/internal/test/plugins/quota_generic.go
@@ -171,7 +171,7 @@ func (p *GenericQuotaPlugin) Scrape(ctx context.Context, project core.KeystonePr
 	}
 
 	if len(p.ReportedAZs) > 0 {
-		errs := []error{}
+		var errs []error
 		resourceNames := plugins.SortMapKeys(p.LiquidServiceInfo.Resources)
 		for _, resourceName := range resourceNames {
 			toplogy := p.LiquidServiceInfo.Resources[liquid.ResourceName(resourceName)].Topology

--- a/internal/test/plugins/quota_generic.go
+++ b/internal/test/plugins/quota_generic.go
@@ -174,7 +174,7 @@ func (p *GenericQuotaPlugin) Scrape(ctx context.Context, project core.KeystonePr
 
 	if len(p.ReportedAZs) > 0 {
 		var errs []error
-		resourceNames := plugins.SortMapKeys(p.LiquidServiceInfo.Resources)
+		resourceNames := plugins.SortedMapKeys(p.LiquidServiceInfo.Resources)
 		for _, resourceName := range resourceNames {
 			topology := p.LiquidServiceInfo.Resources[resourceName].Topology
 			err := plugins.MatchLiquidReportToTopology(p.ReportedAZs, topology)

--- a/internal/test/plugins/quota_generic.go
+++ b/internal/test/plugins/quota_generic.go
@@ -62,19 +62,21 @@ type GenericQuotaPlugin struct {
 // Init implements the core.QuotaPlugin interface.
 func (p *GenericQuotaPlugin) Init(ctx context.Context, provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, serviceType db.ServiceType) error {
 	p.ServiceType = serviceType
+	thingsAZQuota := int64(21)
+	capacityAZQuota := int64(50)
 	p.StaticResourceData = map[liquid.ResourceName]*core.ResourceData{
 		"things": {
 			Quota: 42,
 			UsageData: core.PerAZ[core.UsageData]{
-				"az-one": {Usage: 2, Quota: 21},
-				"az-two": {Usage: 2, Quota: 21},
+				"az-one": {Usage: 2, Quota: &thingsAZQuota},
+				"az-two": {Usage: 2, Quota: &thingsAZQuota},
 			},
 		},
 		"capacity": {
 			Quota: 100,
 			UsageData: core.PerAZ[core.UsageData]{
-				"az-one": {Usage: 0, Quota: 50},
-				"az-two": {Usage: 0, Quota: 50},
+				"az-one": {Usage: 0, Quota: &capacityAZQuota},
+				"az-two": {Usage: 0, Quota: &capacityAZQuota},
 			},
 		},
 	}

--- a/internal/test/plugins/quota_generic.go
+++ b/internal/test/plugins/quota_generic.go
@@ -52,11 +52,11 @@ type GenericQuotaPlugin struct {
 	StaticResourceAttributes map[liquid.ResourceName]map[string]any                         `yaml:"-"`
 	OverrideQuota            map[string]map[liquid.ResourceName]liquid.ResourceQuotaRequest `yaml:"-"` // first key is project UUID
 	// behavior flags that can be set by a unit test
-	ReportedAZs   map[liquid.AvailabilityZone]*any `yaml:"-"`
-	ScrapeFails   bool                             `yaml:"-"`
-	SetQuotaFails bool                             `yaml:"-"`
-	MinQuota      map[liquid.ResourceName]uint64   `yaml:"-"`
-	MaxQuota      map[liquid.ResourceName]uint64   `yaml:"-"`
+	ReportedAZs   map[liquid.AvailabilityZone]struct{} `yaml:"-"`
+	ScrapeFails   bool                                 `yaml:"-"`
+	SetQuotaFails bool                                 `yaml:"-"`
+	MinQuota      map[liquid.ResourceName]uint64       `yaml:"-"`
+	MaxQuota      map[liquid.ResourceName]uint64       `yaml:"-"`
 }
 
 // Init implements the core.QuotaPlugin interface.

--- a/internal/test/plugins/quota_noop.go
+++ b/internal/test/plugins/quota_noop.go
@@ -120,6 +120,6 @@ func (p *NoopQuotaPlugin) BuildServiceUsageRequest(project core.KeystoneProject,
 }
 
 // SetQuota implements the core.QuotaPlugin interface.
-func (p *NoopQuotaPlugin) SetQuota(ctx context.Context, project core.KeystoneProject, quotas map[liquid.ResourceName]uint64) error {
+func (p *NoopQuotaPlugin) SetQuota(ctx context.Context, project core.KeystoneProject, quotas map[liquid.ResourceName]core.Quotas) error {
 	return nil
 }

--- a/internal/test/plugins/quota_noop.go
+++ b/internal/test/plugins/quota_noop.go
@@ -120,6 +120,6 @@ func (p *NoopQuotaPlugin) BuildServiceUsageRequest(project core.KeystoneProject,
 }
 
 // SetQuota implements the core.QuotaPlugin interface.
-func (p *NoopQuotaPlugin) SetQuota(ctx context.Context, project core.KeystoneProject, quotas map[liquid.ResourceName]core.Quotas) error {
+func (p *NoopQuotaPlugin) SetQuota(ctx context.Context, project core.KeystoneProject, quotas map[liquid.ResourceName]liquid.ResourceQuotaRequest) error {
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -453,7 +453,7 @@ func taskTestSetQuota(ctx context.Context, cluster *core.Cluster, args []string)
 	project := must.Return(findProjectForTesting(ctx, cluster, args[0]))
 
 	quotaValueRx := regexp.MustCompile(`^([^=]+)=(\d+)$`)
-	quotaValues := make(map[liquid.ResourceName]core.Quotas)
+	quotaValues := make(map[liquid.ResourceName]liquid.ResourceQuotaRequest)
 	for _, arg := range args[2:] {
 		match := quotaValueRx.FindStringSubmatch(arg)
 		if match == nil {
@@ -463,7 +463,7 @@ func taskTestSetQuota(ctx context.Context, cluster *core.Cluster, args []string)
 		if err != nil {
 			logg.Fatal(err.Error())
 		}
-		quotaValues[liquid.ResourceName(match[1])] = core.Quotas{QuotaForResource: val}
+		quotaValues[liquid.ResourceName(match[1])] = liquid.ResourceQuotaRequest{Quota: val}
 	}
 
 	must.Succeed(cluster.QuotaPlugins[serviceType].SetQuota(ctx, project, quotaValues))

--- a/main.go
+++ b/main.go
@@ -453,7 +453,7 @@ func taskTestSetQuota(ctx context.Context, cluster *core.Cluster, args []string)
 	project := must.Return(findProjectForTesting(ctx, cluster, args[0]))
 
 	quotaValueRx := regexp.MustCompile(`^([^=]+)=(\d+)$`)
-	quotaValues := make(map[liquid.ResourceName]uint64)
+	quotaValues := make(map[liquid.ResourceName]core.Quotas)
 	for _, arg := range args[2:] {
 		match := quotaValueRx.FindStringSubmatch(arg)
 		if match == nil {
@@ -463,7 +463,7 @@ func taskTestSetQuota(ctx context.Context, cluster *core.Cluster, args []string)
 		if err != nil {
 			logg.Fatal(err.Error())
 		}
-		quotaValues[liquid.ResourceName(match[1])] = val
+		quotaValues[liquid.ResourceName(match[1])] = core.Quotas{QuotaForResource: val}
 	}
 
 	must.Succeed(cluster.QuotaPlugins[serviceType].SetQuota(ctx, project, quotaValues))


### PR DESCRIPTION
This implementation handles the introduction of resource topologies. This allows the handling of synchronizing AZ-aware and AZ-separated quotas with the backend. 
The plugins will check if a liquid provides a valid toplogy. Invalid AZ's that are detected during scrapes will be rejected. Scraped AZ-separated quota will be included into the `backend_quota` column that resides in the `project_az_resources` table. From limes quota will then be synced with the backend if necessary. The `backend_quota` values will then be updated to the calculated `quota` values.

Things to note:
~* The AZ key sorting in the uitlity functions might be able to be improved.~
~* `MatchLiquidReportToTopology` might collect the errors for all resources instead of failing at the first mismatch.~
~* SetQuota required a new type to support passing through the AZ-aware qutoas to the backend. We might have to adjust the naming of the structure and its contents.~

TODOS:
- [x] Adjust the algorithm to not provide base quota in any for az-separated resources. (Requires additional agreement on how to approach this topic.) -> The base quota value will now be provided to all AZs if the topology is AZSeparated.
- [x] Cleanup steps involving `ResourceBehavior.CommitmentIsAZAware`