### PR TITLE
Fix: Check resource toplogy

### DIFF
--- a/internal/collector/scrape_test.go
+++ b/internal/collector/scrape_test.go
@@ -754,4 +754,10 @@ func Test_TopologyScrapes(t *testing.T) {
 	plugin.LiquidServiceInfo.Resources = map[liquid.ResourceName]liquid.ResourceInfo{"capacity": {Topology: liquid.AZSeparatedResourceTopology}, "things": {Topology: liquid.AZSeparatedResourceTopology}}
 	plugin.ReportedAZs = map[liquid.AvailabilityZone]struct{}{"unknown": {}}
 	mustFailT(t, job.ProcessOne(s.Ctx, withLabel), errors.New("during resource scrape of project germany/berlin: service: unittest, resource: capacity: scrape with topology type: az-separated returned AZs: [unknown]\nservice: unittest, resource: things: scrape with topology type: az-separated returned AZs: [unknown]"))
+
+	s.Clock.StepBy(scrapeInterval)
+	// negative: empty toplogy should be treated as FlatResourceTopology
+	plugin.LiquidServiceInfo.Resources = map[liquid.ResourceName]liquid.ResourceInfo{"things": {Topology: ""}}
+	plugin.ReportedAZs = map[liquid.AvailabilityZone]struct{}{"az-one": {}}
+	mustFailT(t, job.ProcessOne(s.Ctx, withLabel), errors.New("during resource scrape of project germany/dresden: service: unittest, resource: things: scrape with topology type: flat returned AZs: [az-one]"))
 }

--- a/internal/plugins/utils.go
+++ b/internal/plugins/utils.go
@@ -45,17 +45,16 @@ func CheckResourceTopologies(serviceInfo liquid.ServiceInfo) (err error) {
 
 	resourceNames := SortedMapKeys(resources)
 	for _, resourceName := range resourceNames {
-		topology := resources[resourceName].Topology
-		if topology == "" {
+		resInfo := resources[resourceName]
+		if resInfo.Topology == "" {
 			// several algorithms inside Limes depend on a topology being chosen, so we have to pick a default for now
 			// TODO: make this a fatal error once liquid-ceph has rolled out their Topology patch
 			logg.Error("missing topology on resource: %s (assuming %q)", resourceName, liquid.FlatResourceTopology)
-			resInfo := resources[resourceName]
 			resInfo.Topology = liquid.FlatResourceTopology
 			resources[resourceName] = resInfo
 		}
-		if !topology.IsValid() {
-			errs = append(errs, fmt.Errorf("invalid topology: %s on resource: %s", topology, resourceName))
+		if !resInfo.Topology.IsValid() {
+			errs = append(errs, fmt.Errorf("invalid topology: %s on resource: %s", resInfo.Topology, resourceName))
 		}
 	}
 	if len(errs) > 0 {


### PR DESCRIPTION
The previous implementation checked against a copied value. The default value was therfore discarded which resulted in an undesired error state.