### PR TITLE
fix: project report. AZSeparatedToplogy does not provide any az

### DIFF
--- a/internal/reports/cluster.go
+++ b/internal/reports/cluster.go
@@ -372,6 +372,11 @@ func GetClusterResources(cluster *core.Cluster, now time.Time, dbi db.Interface,
 			// zero and there are other AZs
 			if len(resource.PerAZ) >= 2 {
 				capaInAny := resource.PerAZ[limes.AvailabilityZoneAny]
+				// TODO: implement a proper fix and create a test case
+				// AZSeparateToplogy does not contain ANY AZ.
+				if capaInAny == nil {
+					continue
+				}
 				if capaInAny.Capacity == 0 && capaInAny.Usage == nil && capaInAny.ProjectsUsage == 0 {
 					delete(resource.PerAZ, limes.AvailabilityZoneAny)
 				}

--- a/internal/reports/project.go
+++ b/internal/reports/project.go
@@ -401,6 +401,11 @@ func finalizeProjectResourceReport(projectReport *limesresources.ProjectReport, 
 			for _, resReport := range srvReport.Resources {
 				if len(resReport.PerAZ) >= 2 {
 					reportInAny := resReport.PerAZ[limes.AvailabilityZoneAny]
+					// TODO: implement a proper fix and isolate a test case
+					// AZSeparatedToplogy does not provide the any AZ.
+					if reportInAny == nil {
+						return nil
+					}
 					if (reportInAny.Quota == nil || *reportInAny.Quota == 0) && reportInAny.Usage == 0 {
 						delete(resReport.PerAZ, limes.AvailabilityZoneAny)
 					}

--- a/internal/reports/project.go
+++ b/internal/reports/project.go
@@ -404,7 +404,7 @@ func finalizeProjectResourceReport(projectReport *limesresources.ProjectReport, 
 					// TODO: implement a proper fix and isolate a test case
 					// AZSeparatedToplogy does not provide the any AZ.
 					if reportInAny == nil {
-						return nil
+						continue
 					}
 					if (reportInAny.Quota == nil || *reportInAny.Quota == 0) && reportInAny.Usage == 0 {
 						delete(resReport.PerAZ, limes.AvailabilityZoneAny)


### PR DESCRIPTION
This is a temporary fix to ensure that AZSeparatedTopology resources do not get checked for their ANY az. A proper test case and a proper handling will be implemented as a follow up.
