### PR TITLE
Fix docs TOC icon URL

### DIFF
--- a/docs/operators/config.md
+++ b/docs/operators/config.md
@@ -4,7 +4,7 @@ Limes accepts configuration options via environment variables for some component
 requires a configuration file ([see below](#configuration-file)) for cluster options in the [YAML format][yaml].
 
 Use the table of contents icon
-<img src="https://github.com/github/docs/raw/main/assets/images/table-of-contents.png" width="25" height="25" />
+<img src="https://github.com/github/docs/raw/main/contributing/images/table-of-contents.png" width="25" height="25" />
 on the top left corner of this document to get to a specific section of this guide quickly.
 
 ## Common environment variables

--- a/docs/users/api-spec-rates.md
+++ b/docs/users/api-spec-rates.md
@@ -7,7 +7,7 @@ Where permission requirements are indicated, they refer to the default policy. L
 policy differently, so that certain requests may require other roles or token scopes.
 
 Use the table of contents icon
-<img src="https://github.com/github/docs/raw/main/assets/images/table-of-contents.png" width="25" height="25" />
+<img src="https://github.com/github/docs/raw/main/contributing/images/table-of-contents.png" width="25" height="25" />
 near the top left corner of this document to jump to a specific section on this page.
 
 ## Concepts

--- a/docs/users/api-spec-resources.md
+++ b/docs/users/api-spec-resources.md
@@ -7,7 +7,7 @@ Where permission requirements are indicated, they refer to the default policy. L
 policy differently, so that certain requests may require other roles or token scopes.
 
 Use the table of contents icon
-<img src="https://github.com/github/docs/raw/main/assets/images/table-of-contents.png" width="25" height="25" />
+<img src="https://github.com/github/docs/raw/main/contributing/images/table-of-contents.png" width="25" height="25" />
 near the top left corner of this document to jump to a specific section on this page.
 
 ## Concepts


### PR DESCRIPTION
This PR fixes a URL to the table of contents icon in docs