### PR TITLE
avoid backend_quota edit war for AZSeparatedResourceTopology

### DIFF
--- a/internal/collector/scrape.go
+++ b/internal/collector/scrape.go
@@ -257,7 +257,9 @@ func (c *Collector) writeResourceScrapeResult(dbDomain db.Domain, dbProject db.P
 
 		resInfo := c.Cluster.InfoForResource(srv.Type, res.Name)
 		if resInfo.HasQuota {
-			res.BackendQuota = &backendQuota
+			if resInfo.Topology != liquid.AZSeparatedResourceTopology {
+				res.BackendQuota = &backendQuota
+			}
 			res.MinQuotaFromBackend = resourceData[res.Name].MinQuota
 			res.MaxQuotaFromBackend = resourceData[res.Name].MaxQuota
 		}
@@ -437,6 +439,10 @@ func (c *Collector) writeDummyResources(dbDomain db.Domain, dbProject db.Project
 			return err
 		}
 	}
+
+	// FIXME: These dummy resources do not conform to `resInfo.Topology` and are never AZ-aware.
+	//        I'm not fixing this right now because dummy resources are an extremely rare corner-case anyway.
+	// TODO:  When we rework the DB schema next year, we should build it so that dummy resources can be avoided entirely.
 
 	// update scraped_at timestamp and reset stale flag to make sure that we do
 	// not scrape this service again immediately afterwards if there are other

--- a/internal/datamodel/project_resource_update.go
+++ b/internal/datamodel/project_resource_update.go
@@ -141,7 +141,7 @@ func (u ProjectResourceUpdate) Run(dbi db.Interface, cluster *core.Cluster, now 
 		result = append(result, res)
 
 		// check if we need to arrange for SetQuotaJob to look at this project service
-		if resInfo.HasQuota {
+		if resInfo.HasQuota && resInfo.Topology != liquid.AZSeparatedResourceTopology {
 			backendQuota := unwrapOrDefault(res.BackendQuota, -1)
 			quota := *res.Quota // definitely not nil, it was set above in validateResourceConstraints()
 			if backendQuota < 0 || uint64(backendQuota) != quota {
@@ -172,7 +172,7 @@ func unwrapOrDefault[T any](value *T, defaultValue T) T {
 
 // Ensures that `res` conforms to various constraints and validation rules.
 func validateResourceConstraints(res *db.ProjectResource, resInfo liquid.ResourceInfo) {
-	if !resInfo.HasQuota {
+	if !resInfo.HasQuota || resInfo.Topology == liquid.AZSeparatedResourceTopology {
 		// ensure that NoQuota resources do not contain any quota values
 		res.Quota = nil
 		res.BackendQuota = nil

--- a/internal/test/plugins/quota_generic.go
+++ b/internal/test/plugins/quota_generic.go
@@ -195,8 +195,12 @@ func (p *GenericQuotaPlugin) Scrape(ctx context.Context, project core.KeystonePr
 		}
 
 		// populate azSeparatedQuota
-		for az, data := range copyOfVal.UsageData {
-			data.Quota = val.UsageData[az].Quota
+		topology := p.LiquidServiceInfo.Resources[key].Topology
+		if topology == liquid.AZSeparatedResourceTopology {
+			copyOfVal.Quota = 0
+			for az, data := range copyOfVal.UsageData {
+				data.Quota = val.UsageData[az].Quota
+			}
 		}
 
 		// test coverage for PhysicalUsage != Usage


### PR DESCRIPTION
I'm seeing a lot of this in the DB right now:

```
psql> SELECT pr.name, pr.quota, pr.backend_quota, par.az, par.quota, par.usage
        FROM project_resources pr
        LEFT OUTER JOIN project_az_resources par ON par.resource_id = pr.id
       WHERE pr.service_id = (
                 SELECT id FROM project_services
                  WHERE type = 'ceph' AND quota_desynced_at IS NOT NULL
                  ORDER BY quota_desynced_at LIMIT 1
             );
+----------------+--------+---------------+----------+-------+-------+
| name           | quota  | backend_quota | az       | quota | usage |
|----------------+--------+---------------+----------+-------+-------|
| local-premium  | <null> | 0             | qa-de-1a | 0     | 0     |
| local-premium  | <null> | 0             | qa-de-1b | 0     | 0     |
| local-premium  | <null> | 0             | qa-de-1d | 0     | 0     |
| region-premium | 0      | 0             | any      | 0     | 0     |
+----------------+--------+---------------+----------+-------+-------+
```

Scrape wrote a zero into `project_resources.backend_quota` which caused quota-sync to run and write a null again. This would cause neverending unnecessary quota syncs on all project services with AZSeparatedResourceTopology resources.

The second commit fixes the tests by removing a few other places that tried to set `project_resources.{quota,backend_quota}` to non-null values.