### PR TITLE
Add test cases to prevent future API breaks on AZ separated changes

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1251,8 +1251,8 @@ func (j JSONThatUnmarshalsInto) AssertResponseBody(t *testing.T, requestInfo str
 	return true
 }
 
-func Test_SeparatedToplogyOperations(t *testing.T) {
-	// This test structure ensures that the consumable limes APIs do not break with the introduction (or further changes) of the az separated toplogy.
+func Test_SeparatedTopologyOperations(t *testing.T) {
+	// This test structure ensures that the consumable limes APIs do not break with the introduction (or further changes) of the az separated topology.
 	s := setupTest(t, "fixtures/start-data-az-separated.sql")
 	assert.HTTPRequest{
 		Method:       "GET",

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1250,3 +1250,31 @@ func (j JSONThatUnmarshalsInto) AssertResponseBody(t *testing.T, requestInfo str
 	}
 	return true
 }
+
+func Test_SeparatedToplogyOperations(t *testing.T) {
+	// This test structure ensures that the consumable limes APIs do not break with the introduction (or further changes) of the az separated toplogy.
+	s := setupTest(t, "fixtures/start-data-az-separated.sql")
+	assert.HTTPRequest{
+		Method:       "GET",
+		Path:         "/v1/clusters/current",
+		Header:       map[string]string{"X-Limes-V2-API-Preview": "per-az"},
+		ExpectStatus: 200,
+		ExpectBody:   assert.JSONFixtureFile("fixtures/cluster-get-az-separated.json"),
+	}.Check(t, s.Handler)
+
+	assert.HTTPRequest{
+		Method:       "GET",
+		Path:         "/v1/domains",
+		Header:       map[string]string{"X-Limes-V2-API-Preview": "per-az"},
+		ExpectStatus: 200,
+		ExpectBody:   assert.JSONFixtureFile("./fixtures/domain-list-az-separated.json"),
+	}.Check(t, s.Handler)
+
+	assert.HTTPRequest{
+		Method:       "GET",
+		Path:         "/v1/domains/uuid-for-germany/projects",
+		Header:       map[string]string{"X-Limes-V2-API-Preview": "per-az"},
+		ExpectStatus: 200,
+		ExpectBody:   assert.JSONFixtureFile("./fixtures/project-list-az-separated.json"),
+	}.Check(t, s.Handler)
+}

--- a/internal/api/fixtures/cluster-get-az-separated.json
+++ b/internal/api/fixtures/cluster-get-az-separated.json
@@ -1,0 +1,33 @@
+{
+  "cluster": {
+    "id": "current",
+    "services": [
+      {
+        "type": "shared",
+        "area": "shared",
+        "resources": [
+          {
+            "name": "capacity_portion",
+            "unit": "B",
+            "category": "portion",
+            "per_az": {
+              "az-one": {
+                "capacity": 0,
+                "projects_usage": 1,
+                "uncommitted_usage": 1
+              },
+              "az-two": {
+                "capacity": 0,
+                "projects_usage": 1,
+                "uncommitted_usage": 1
+              }
+            },
+            "usage": 2
+          }
+        ],
+        "max_scraped_at": 22,
+        "min_scraped_at": 22
+      }
+    ]
+  }
+}

--- a/internal/api/fixtures/domain-list-az-separated.json
+++ b/internal/api/fixtures/domain-list-az-separated.json
@@ -1,0 +1,36 @@
+{
+  "domains": [
+    {
+      "id": "uuid-for-germany",
+      "name": "germany",
+      "services": [
+        {
+          "type": "shared",
+          "area": "shared",
+          "resources": [
+            {
+              "name": "capacity_portion",
+              "unit": "B",
+              "category": "portion",
+              "per_az": {
+                "az-one": {
+                  "quota": 5,
+                  "usage": 1,
+                  "uncommitted_usage": 1
+                },
+                "az-two": {
+                  "quota": 5,
+                  "usage": 1,
+                  "uncommitted_usage": 1
+                }
+              },
+              "usage": 2
+            }
+          ],
+          "max_scraped_at": 22,
+          "min_scraped_at": 22
+        }
+      ]
+    }
+  ]
+}

--- a/internal/api/fixtures/project-list-az-separated.json
+++ b/internal/api/fixtures/project-list-az-separated.json
@@ -1,0 +1,34 @@
+{
+  "projects": [
+    {
+      "id": "uuid-for-berlin",
+      "name": "berlin",
+      "parent_id": "uuid-for-germany",
+      "services": [
+        {
+          "type": "shared",
+          "area": "shared",
+          "resources": [
+            {
+              "name": "capacity_portion",
+              "unit": "B",
+              "category": "portion",
+              "per_az": {
+                "az-one": {
+                  "quota": 5,
+                  "usage": 1
+                },
+                "az-two": {
+                  "quota": 5,
+                  "usage": 1
+                }
+              },
+              "usage": 2
+            }
+          ],
+          "scraped_at": 22
+        }
+      ]
+    }
+  ]
+}

--- a/internal/api/fixtures/start-data-az-separated.sql
+++ b/internal/api/fixtures/start-data-az-separated.sql
@@ -1,0 +1,13 @@
+CREATE OR REPLACE FUNCTION unix(i integer) RETURNS timestamp AS $$ SELECT TO_TIMESTAMP(i) AT TIME ZONE 'Etc/UTC' $$ LANGUAGE SQL;
+
+INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
+
+INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany');
+
+INSERT INTO project_services (id, project_id, type, scraped_at, rates_scraped_at, checked_at, rates_checked_at) VALUES (1, 1, 'shared',   UNIX(22), UNIX(23), UNIX(22), UNIX(23));
+
+INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (1,  1, 'capacity_portion', NULL, NULL);
+
+-- AZ separated resource does not include any az.
+INSERT INTO project_az_resources (id, resource_id, az, quota, usage, physical_usage, subresources) VALUES (1,  1,  'az-one', 5,    1, NULL, '');
+INSERT INTO project_az_resources (id, resource_id, az, quota, usage, physical_usage, subresources) VALUES (2,  1,  'az-two', 5,    1, NULL, '');

--- a/internal/api/fixtures/start-data-az-separated.sql
+++ b/internal/api/fixtures/start-data-az-separated.sql
@@ -9,5 +9,5 @@ INSERT INTO project_services (id, project_id, type, scraped_at, rates_scraped_at
 INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (1,  1, 'capacity_portion', NULL, NULL);
 
 -- AZ separated resource does not include any az.
-INSERT INTO project_az_resources (id, resource_id, az, quota, usage, physical_usage, subresources) VALUES (1,  1,  'az-one', 5,    1, NULL, '');
-INSERT INTO project_az_resources (id, resource_id, az, quota, usage, physical_usage, subresources) VALUES (2,  1,  'az-two', 5,    1, NULL, '');
+INSERT INTO project_az_resources (id, resource_id, az, backend_quota, quota, usage, physical_usage, subresources) VALUES (1,  1,  'az-one', 5, 5,    1, NULL, '');
+INSERT INTO project_az_resources (id, resource_id, az, backend_quota, quota, usage, physical_usage, subresources) VALUES (2,  1,  'az-two', 5, 5,    1, NULL, '');

--- a/internal/collector/scrape_test.go
+++ b/internal/collector/scrape_test.go
@@ -750,7 +750,7 @@ func Test_TopologyScrapes(t *testing.T) {
 	mustFailT(t, job.ProcessOne(s.Ctx, withLabel), errors.New("during resource scrape of project germany/berlin: service: unittest, resource: capacity: scrape with topology type: az-separated returned AZs: [unknown]\nservice: unittest, resource: things: scrape with topology type: az-separated returned AZs: [unknown]"))
 
 	s.Clock.StepBy(scrapeInterval)
-	// negative: empty toplogy should be treated as FlatResourceTopology
+	// negative: empty topology should be treated as FlatResourceTopology
 	plugin.LiquidServiceInfo.Resources = map[liquid.ResourceName]liquid.ResourceInfo{"things": {Topology: liquid.FlatResourceTopology}}
 	plugin.ReportedAZs = map[liquid.AvailabilityZone]struct{}{"az-one": {}}
 	mustFailT(t, job.ProcessOne(s.Ctx, withLabel), errors.New("during resource scrape of project germany/dresden: service: unittest, resource: things: scrape with topology type: flat returned AZs: [az-one]"))

--- a/internal/reports/cluster.go
+++ b/internal/reports/cluster.go
@@ -372,7 +372,7 @@ func GetClusterResources(cluster *core.Cluster, now time.Time, dbi db.Interface,
 			// zero and there are other AZs
 			if len(resource.PerAZ) >= 2 {
 				capaInAny := resource.PerAZ[limes.AvailabilityZoneAny]
-				// AZSeparatedToplogy does not provide the "any" AZ.
+				// AZSeparatedTopology does not provide the "any" AZ.
 				if capaInAny == nil {
 					continue
 				}

--- a/internal/reports/cluster.go
+++ b/internal/reports/cluster.go
@@ -372,8 +372,7 @@ func GetClusterResources(cluster *core.Cluster, now time.Time, dbi db.Interface,
 			// zero and there are other AZs
 			if len(resource.PerAZ) >= 2 {
 				capaInAny := resource.PerAZ[limes.AvailabilityZoneAny]
-				// TODO: implement a proper fix and create a test case
-				// AZSeparateToplogy does not contain ANY AZ.
+				// AZSeparatedToplogy does not provide the "any" AZ.
 				if capaInAny == nil {
 					continue
 				}

--- a/internal/reports/domain.go
+++ b/internal/reports/domain.go
@@ -317,7 +317,7 @@ func GetDomains(cluster *core.Cluster, domainID *db.DomainID, now time.Time, dbi
 				for _, resReport := range srvReport.Resources {
 					if len(resReport.PerAZ) >= 2 {
 						reportInAny := resReport.PerAZ[limes.AvailabilityZoneAny]
-						// AZSeparatedToplogy does not provide the "any" AZ.
+						// AZSeparatedTopology does not provide the "any" AZ.
 						if reportInAny == nil {
 							continue
 						}

--- a/internal/reports/domain.go
+++ b/internal/reports/domain.go
@@ -317,6 +317,7 @@ func GetDomains(cluster *core.Cluster, domainID *db.DomainID, now time.Time, dbi
 				for _, resReport := range srvReport.Resources {
 					if len(resReport.PerAZ) >= 2 {
 						reportInAny := resReport.PerAZ[limes.AvailabilityZoneAny]
+						// AZSeparatedToplogy does not provide the "any" AZ.
 						if reportInAny == nil {
 							continue
 						}

--- a/internal/reports/project.go
+++ b/internal/reports/project.go
@@ -401,8 +401,7 @@ func finalizeProjectResourceReport(projectReport *limesresources.ProjectReport, 
 			for _, resReport := range srvReport.Resources {
 				if len(resReport.PerAZ) >= 2 {
 					reportInAny := resReport.PerAZ[limes.AvailabilityZoneAny]
-					// TODO: implement a proper fix and isolate a test case
-					// AZSeparatedToplogy does not provide the any AZ.
+					// AZSeparatedToplogy does not provide the "any" AZ.
 					if reportInAny == nil {
 						continue
 					}

--- a/internal/reports/project.go
+++ b/internal/reports/project.go
@@ -401,7 +401,7 @@ func finalizeProjectResourceReport(projectReport *limesresources.ProjectReport, 
 			for _, resReport := range srvReport.Resources {
 				if len(resReport.PerAZ) >= 2 {
 					reportInAny := resReport.PerAZ[limes.AvailabilityZoneAny]
-					// AZSeparatedToplogy does not provide the "any" AZ.
+					// AZSeparatedTopology does not provide the "any" AZ.
 					if reportInAny == nil {
 						continue
 					}


### PR DESCRIPTION
As promised in previous PRs. A new fixture was added to cover our existing abstraction levels with one dedicated case.