### PR TITLE
add ironic node to az assignment override

### DIFF
--- a/internal/liquids/ironic/capacity.go
+++ b/internal/liquids/ironic/capacity.go
@@ -136,6 +136,10 @@ func (l *Logic) ScanCapacity(ctx context.Context, req liquid.ServiceCapacityRequ
 			}
 
 			az := azForResourceProviderUUID[node.UUID]
+			azOverwrite, ok := l.NodeToAZOvewrites[node.UUID]
+			if ok {
+				az = azOverwrite
+			}
 			if !slices.Contains(req.AllAZs, az) {
 				az = liquid.AvailabilityZoneUnknown
 				if perAZ[az] == nil {

--- a/internal/liquids/ironic/capacity.go
+++ b/internal/liquids/ironic/capacity.go
@@ -136,9 +136,10 @@ func (l *Logic) ScanCapacity(ctx context.Context, req liquid.ServiceCapacityRequ
 			}
 
 			az := azForResourceProviderUUID[node.UUID]
-			azOverwrite, ok := l.NodeToAZOvewrites[node.UUID]
+			// NOTE: An override covers a legacy deployment which is not matched by a resource provider.
+			azOverride, ok := l.NodeToAZOverrides[node.UUID]
 			if ok {
-				az = azOverwrite
+				az = azOverride
 			}
 			if !slices.Contains(req.AllAZs, az) {
 				az = liquid.AvailabilityZoneUnknown

--- a/internal/liquids/ironic/liquid.go
+++ b/internal/liquids/ironic/liquid.go
@@ -39,7 +39,7 @@ type Logic struct {
 	// configuration
 	WithSubcapacities bool                               `json:"with_subcapacities"`
 	WithSubresources  bool                               `json:"with_subresources"`
-	NodeToAZOvewrites map[string]liquid.AvailabilityZone `json:"node_to_az_overwrites"`
+	NodeToAZOverrides map[string]liquid.AvailabilityZone `json:"node_to_az_overrides"`
 	// connections
 	NovaV2       *gophercloud.ServiceClient `json:"-"`
 	IronicV1     *gophercloud.ServiceClient `json:"-"`

--- a/internal/liquids/ironic/liquid.go
+++ b/internal/liquids/ironic/liquid.go
@@ -37,8 +37,9 @@ import (
 
 type Logic struct {
 	// configuration
-	WithSubcapacities bool `json:"with_subcapacities"`
-	WithSubresources  bool `json:"with_subresources"`
+	WithSubcapacities bool                               `json:"with_subcapacities"`
+	WithSubresources  bool                               `json:"with_subresources"`
+	NodeToAZOvewrites map[string]liquid.AvailabilityZone `json:"node_to_az_overwrites"`
 	// connections
 	NovaV2       *gophercloud.ServiceClient `json:"-"`
 	IronicV1     *gophercloud.ServiceClient `json:"-"`


### PR DESCRIPTION
The assignment of baremetal nodes to an AZ is solved via the ID matching to resource providers. Because the resource provider IDs might mismatch to the node IDs, a manual config override will be provided for the ironic liquid.

Checklist:
- [x] If this PR is about a plugin, I tested the plugin against an OpenStack cluster.
