### PR TITLE
adjust ironic limit

### DIFF
--- a/docs/liquids/ironic.md
+++ b/docs/liquids/ironic.md
@@ -11,6 +11,7 @@ This liquid provides support for the baremetal compute service Ironic.
 | ----- | ---- | ----------- |
 | `with_subcapacities` | boolean | If true, subcapacities are reported. |
 | `with_subresources` | boolean | If true, subresources are reported. |
+| `node_page_limit` | integer | When listing baremetal nodes during capacity calculation, only this many nodes will be listed at once. Defaults to 100. This number has a major impact on the peak memory usage of this liquid, because Ironic nodes often have an absurd amount of metadata on them that we need to parse temporarily. Reducing this number reduces memory consumption nearly linearly, at the cost of linearly increasing the amount of requests that need to be made to Ironic. |
 
 ## Resources
 

--- a/internal/liquids/ironic/capacity.go
+++ b/internal/liquids/ironic/capacity.go
@@ -87,7 +87,11 @@ func (l *Logic) ScanCapacity(ctx context.Context, req liquid.ServiceCapacityRequ
 	// - EachPage (limit = 100):   20.21MB
 	//
 	nodesByFlavorName := make(map[string][]Node)
-	opts := &nodes.ListOpts{Limit: 50}
+	// set a base value if the value is not provided by config
+	if l.NodeDetailPageLimit == 0 {
+		l.NodeDetailPageLimit = 100
+	}
+	opts := &nodes.ListOpts{Limit: l.NodeDetailPageLimit}
 	err = ListNodesDetail(l.IronicV1, opts).EachPage(ctx, func(ctx context.Context, page pagination.Page) (bool, error) {
 		var nodes []Node
 		err = ExtractNodesInto(page, &nodes)

--- a/internal/liquids/ironic/capacity.go
+++ b/internal/liquids/ironic/capacity.go
@@ -87,7 +87,7 @@ func (l *Logic) ScanCapacity(ctx context.Context, req liquid.ServiceCapacityRequ
 	// - EachPage (limit = 100):   20.21MB
 	//
 	nodesByFlavorName := make(map[string][]Node)
-	opts := &nodes.ListOpts{Limit: 100}
+	opts := &nodes.ListOpts{Limit: 50}
 	err = ListNodesDetail(l.IronicV1, opts).EachPage(ctx, func(ctx context.Context, page pagination.Page) (bool, error) {
 		var nodes []Node
 		err = ExtractNodesInto(page, &nodes)

--- a/internal/liquids/ironic/capacity.go
+++ b/internal/liquids/ironic/capacity.go
@@ -88,10 +88,10 @@ func (l *Logic) ScanCapacity(ctx context.Context, req liquid.ServiceCapacityRequ
 	//
 	nodesByFlavorName := make(map[string][]Node)
 	// set a base value if the value is not provided by config
-	if l.NodeDetailPageLimit == 0 {
-		l.NodeDetailPageLimit = 100
+	opts := &nodes.ListOpts{Limit: 100}
+	if l.NodePageLimit > 0 {
+		opts.Limit = l.NodePageLimit
 	}
-	opts := &nodes.ListOpts{Limit: l.NodeDetailPageLimit}
 	err = ListNodesDetail(l.IronicV1, opts).EachPage(ctx, func(ctx context.Context, page pagination.Page) (bool, error) {
 		var nodes []Node
 		err = ExtractNodesInto(page, &nodes)

--- a/internal/liquids/ironic/liquid.go
+++ b/internal/liquids/ironic/liquid.go
@@ -37,10 +37,10 @@ import (
 
 type Logic struct {
 	// configuration
-	WithSubcapacities   bool                               `json:"with_subcapacities"`
-	WithSubresources    bool                               `json:"with_subresources"`
-	NodeToAZOverrides   map[string]liquid.AvailabilityZone `json:"node_to_az_overrides"`
-	NodeDetailPageLimit int                                `json:"node_detail_page_limit"`
+	WithSubcapacities bool                               `json:"with_subcapacities"`
+	WithSubresources  bool                               `json:"with_subresources"`
+	NodeToAZOverrides map[string]liquid.AvailabilityZone `json:"node_to_az_overrides"`
+	NodePageLimit     int                                `json:"node_page_limit"`
 	// connections
 	NovaV2       *gophercloud.ServiceClient `json:"-"`
 	IronicV1     *gophercloud.ServiceClient `json:"-"`

--- a/internal/liquids/ironic/liquid.go
+++ b/internal/liquids/ironic/liquid.go
@@ -37,9 +37,10 @@ import (
 
 type Logic struct {
 	// configuration
-	WithSubcapacities bool                               `json:"with_subcapacities"`
-	WithSubresources  bool                               `json:"with_subresources"`
-	NodeToAZOverrides map[string]liquid.AvailabilityZone `json:"node_to_az_overrides"`
+	WithSubcapacities   bool                               `json:"with_subcapacities"`
+	WithSubresources    bool                               `json:"with_subresources"`
+	NodeToAZOverrides   map[string]liquid.AvailabilityZone `json:"node_to_az_overrides"`
+	NodeDetailPageLimit int                                `json:"node_detail_page_limit"`
 	// connections
 	NovaV2       *gophercloud.ServiceClient `json:"-"`
 	IronicV1     *gophercloud.ServiceClient `json:"-"`


### PR DESCRIPTION
New baremetal deployments in eu-de-1 cause memory allocation spikes for the ironic liquid. 
We already had an optimization for the taxing node details in [in ths commit](https://github.com/sapcc/limes/pull/608/files).
I would like to try and reduce hte paging limit for node details. Local tests are too fluctuating to make a clear difference, the memory allocations to each page seem to decrease tho. If this has no notable impact, I will revert this change.

- [x] If this PR is about a plugin, I tested the plugin against an OpenStack cluster.
