### PR TITLE
Liquid Cinder: Add FCD support

### DIFF
--- a/docs/liquids/cinder.md
+++ b/docs/liquids/cinder.md
@@ -47,7 +47,7 @@ The following methods to assign pools to volume types are implemented:
 | Matching | Volume Type         | Pools               |
 | -------- | ------------------- | ------------------- |
 | Type 1   | volume_backend_name | volume_backend_name |
-| Type2    | storage_protocol    | storage_protocol    |
+| Type 2   | storage_protocol    | storage_protocol    |
 |          | quality_type        | quality_type        |
 
 Pools without a matching volume type are ignored.

--- a/docs/liquids/cinder.md
+++ b/docs/liquids/cinder.md
@@ -47,8 +47,7 @@ The following methods to assign pools to volume types are implemented:
 | Matching | Volume Type         | Pools               |
 | -------- | ------------------- | ------------------- |
 | Type 1   | volume_backend_name | volume_backend_name |
-| Type 2   | storage_protocol    | storage_protocol    |
-|          | quality_type        | quality_type        |
+| Type 2   | storage_protocol<br>quality_type    | storage_protocol<br>quality_type    |
 
 Pools without a matching volume type are ignored.
 

--- a/internal/liquids/cinder/capacity.go
+++ b/internal/liquids/cinder/capacity.go
@@ -60,7 +60,6 @@ func (l *Logic) ScanCapacity(ctx context.Context, req liquid.ServiceCapacityRequ
 
 	// sort volume types by VolumeTypeInfo (if multiple volume types have the same VolumeTypeInfo, they need to share the same pools)
 	volumeTypesByInfo := make(map[VolumeTypeInfo][]VolumeType)
-
 	for volumeType, info := range l.VolumeTypes.Get() {
 		volumeTypesByInfo[info] = append(volumeTypesByInfo[info], volumeType)
 	}

--- a/internal/liquids/cinder/capacity.go
+++ b/internal/liquids/cinder/capacity.go
@@ -60,6 +60,12 @@ func (l *Logic) ScanCapacity(ctx context.Context, req liquid.ServiceCapacityRequ
 
 	// sort volume types by VolumeTypeInfo (if multiple volume types have the same VolumeTypeInfo, they need to share the same pools)
 	volumeTypesByInfo := make(map[VolumeTypeInfo][]VolumeType)
+	//volumeFCDInfoByType := make(map[VolumeType][]VolumeTypeFCDInfo)
+
+	for volumeType, info := range l.VolumeFCDTypes.Get() {
+		logg.Info("fcdVolType: %s, vcdInfo: %s", volumeType, info)
+	}
+
 	for volumeType, info := range l.VolumeTypes.Get() {
 		volumeTypesByInfo[info] = append(volumeTypesByInfo[info], volumeType)
 	}
@@ -255,6 +261,8 @@ type StoragePool struct {
 		VolumeBackendName   string                          `json:"volume_backend_name"`
 		TotalCapacityGB     liquids.Float64WithStringErrors `json:"total_capacity_gb"`
 		AllocatedCapacityGB liquids.Float64WithStringErrors `json:"allocated_capacity_gb"`
+		StorageProtocol     string                          `json:"storage_protocol"`
+		QualityType         string                          `json:"quality_type"`
 
 		// SAP Converged Cloud extension
 		CustomAttributes struct {

--- a/internal/liquids/cinder/liquid.go
+++ b/internal/liquids/cinder/liquid.go
@@ -108,7 +108,6 @@ func (l *Logic) BuildServiceInfo(ctx context.Context) (liquid.ServiceInfo, error
 			QualityType:       vtSpec.ExtraSpecs["quality_type"],
 		}
 	}
-
 	l.VolumeTypes.Set(volumeTypes)
 
 	// build ResourceInfo set


### PR DESCRIPTION
This PR aims to support FCD checks from Pools to VolumeTypes via the `StorageProtocol` and the `QualityType`.
The old way of matching against the `volumeBackendName` is still available for the current Pools.

The catch on the new approach is that `VolumeTypes` might a `Encryption` attribute attachted to them at some point. Those will have the same `StorageProtocol` and `QualityType` as the the one without encryption.
This behavior is similar how we treat `volumeBackendName` already. The collected Pool capacity will just be split into the matching volumeTypes.

I tested the implementation against the cluster and yes, we do retrieve non-matching Pools into the resultset now. 
Please have a look at this, there might be optimization that I can do. Other than that I will update the documentation for the new matching tomorrow.

Checklist:
- [x] If this PR is about a plugin, I tested the plugin against an OpenStack cluster.
TODO:
- [x] I updated the documentation to describe the semantical or interface changes I introduced.
