### PR TITLE
fix fcd pool check

### DIFF
--- a/internal/liquids/cinder/capacity.go
+++ b/internal/liquids/cinder/capacity.go
@@ -77,14 +77,12 @@ func (l *Logic) ScanCapacity(ctx context.Context, req liquid.ServiceCapacityRequ
 		info := VolumeTypeInfo{
 			VolumeBackendName: pool.Capabilities.VolumeBackendName,
 		}
-		remainingInfo := VolumeTypeInfo{
-			StorageProtocol: pool.Capabilities.StorageProtocol,
-			QualityType:     pool.Capabilities.QualityType,
-		}
 
 		_, exists := sortedPools[info]
 		if !exists {
-			remainingPools[pool] = remainingInfo
+			info.StorageProtocol = pool.Capabilities.StorageProtocol
+			info.QualityType = pool.Capabilities.QualityType
+			remainingPools[pool] = info
 			continue
 		}
 		poolMatches[pool] = info

--- a/internal/liquids/cinder/capacity.go
+++ b/internal/liquids/cinder/capacity.go
@@ -39,9 +39,6 @@ func (l *Logic) ScanCapacity(ctx context.Context, req liquid.ServiceCapacityRequ
 	if err != nil {
 		return liquid.ServiceCapacityReport{}, err
 	}
-	for _, pool := range pools {
-		logg.Debug("DEB: %s %s", pool.Name, pool.Capabilities)
-	}
 
 	// list service hosts (the relation of pools to their service hosts is used to establish AZ membership)
 	allPages, err := services.List(l.CinderV3, nil).AllPages(ctx)

--- a/internal/liquids/cinder/capacity.go
+++ b/internal/liquids/cinder/capacity.go
@@ -39,6 +39,9 @@ func (l *Logic) ScanCapacity(ctx context.Context, req liquid.ServiceCapacityRequ
 	if err != nil {
 		return liquid.ServiceCapacityReport{}, err
 	}
+	for _, pool := range pools {
+		logg.Debug("DEB: %s %s", pool.Name, pool.Capabilities)
+	}
 
 	// list service hosts (the relation of pools to their service hosts is used to establish AZ membership)
 	allPages, err := services.List(l.CinderV3, nil).AllPages(ctx)
@@ -77,10 +80,14 @@ func (l *Logic) ScanCapacity(ctx context.Context, req liquid.ServiceCapacityRequ
 		info := VolumeTypeInfo{
 			VolumeBackendName: pool.Capabilities.VolumeBackendName,
 		}
+		remainingInfo := VolumeTypeInfo{
+			StorageProtocol: pool.Capabilities.StorageProtocol,
+			QualityType:     pool.Capabilities.QualityType,
+		}
 
 		_, exists := sortedPools[info]
 		if !exists {
-			remainingPools[pool] = info
+			remainingPools[pool] = remainingInfo
 			continue
 		}
 		poolMatches[pool] = info
@@ -92,6 +99,7 @@ func (l *Logic) ScanCapacity(ctx context.Context, req liquid.ServiceCapacityRequ
 			StorageProtocol: pool.Capabilities.StorageProtocol,
 			QualityType:     pool.Capabilities.QualityType,
 		}
+
 		_, exists := sortedPools[info]
 		if !exists {
 			continue


### PR DESCRIPTION
~~This is a fix to the fcd topic.
In QA it worked, because both, `volume_backend_name` and `storage_protocol + storage_quality_type`.
In `ap-sa-2` the succession of the regular pool check and the fcd pool check is active.~~

EDIT: The implementation as it is works, because during analysis I thought we loop over the infos and not over the pools which threw me off (see last commits). Instead, we add missing info to the output logs.

Checklist:

- [x] If this PR is about a plugin, I tested the plugin against an OpenStack cluster.
