### PR TITLE
[campfire] chose the project uuid for the query body

### DIFF
--- a/internal/collector/mail_delivery_test.go
+++ b/internal/collector/mail_delivery_test.go
@@ -51,11 +51,11 @@ type MockMail struct{}
 
 func (m *MockMail) PostMail(ctx context.Context, req MailRequest) error {
 	switch req.ProjectID {
-	case 1:
+	case "uuid-for-waldorf":
 		return nil
-	case 2:
+	case "uuid-for-berlin":
 		return errors.New("fail project id 1")
-	case 3:
+	case "uuid-for-dresden":
 		return nil
 	}
 	return nil


### PR DESCRIPTION
The previous implementation assumed to deliverr the projectID which was the ID within the database. The API requires the UUID.