### PR TITLE
[mail] handle queue for projects without metadata

### DIFF
--- a/internal/collector/fixtures/mail_delivery.sql
+++ b/internal/collector/fixtures/mail_delivery.sql
@@ -4,6 +4,8 @@ INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
 INSERT INTO projects(id, domain_id, name, uuid, parent_uuid) VALUES (1, 1, 'waldorf', 'uuid-for-waldorf', 'uuid-for-germany');
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (2, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-waldorf');
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (3, 1, 'dresden', 'uuid-for-dresden', 'uuid-for-berlin');
+INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (4, 1, 'frankfurt', 'uuid-for-frankfurt', 'uuid-for-dresden');
 INSERT INTO project_mail_notifications (id, project_id, subject, body, next_submission_at) VALUES (1, 1, 'dummy', 'dummy', UNIX(0));
 INSERT INTO project_mail_notifications (id, project_id, subject, body, next_submission_at) VALUES (2, 2, 'dummy', 'dummy', UNIX(86400));
 INSERT INTO project_mail_notifications (id, project_id, subject, body, next_submission_at) VALUES (3, 3, 'dummy', 'dummy', UNIX(172800));
+INSERT INTO project_mail_notifications (id, project_id, subject, body, next_submission_at) VALUES (4, 3, 'dummy', 'dummy', UNIX(259200));

--- a/internal/collector/fixtures/mail_delivery.sql
+++ b/internal/collector/fixtures/mail_delivery.sql
@@ -8,4 +8,4 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (4, 1, 'fra
 INSERT INTO project_mail_notifications (id, project_id, subject, body, next_submission_at) VALUES (1, 1, 'dummy', 'dummy', UNIX(0));
 INSERT INTO project_mail_notifications (id, project_id, subject, body, next_submission_at) VALUES (2, 2, 'dummy', 'dummy', UNIX(86400));
 INSERT INTO project_mail_notifications (id, project_id, subject, body, next_submission_at) VALUES (3, 3, 'dummy', 'dummy', UNIX(172800));
-INSERT INTO project_mail_notifications (id, project_id, subject, body, next_submission_at) VALUES (4, 3, 'dummy', 'dummy', UNIX(259200));
+INSERT INTO project_mail_notifications (id, project_id, subject, body, next_submission_at) VALUES (4, 4, 'dummy', 'dummy', UNIX(259200));

--- a/internal/collector/mail_client.go
+++ b/internal/collector/mail_client.go
@@ -29,7 +29,7 @@ import (
 // MailClient is an interface that provides the methods to communicate with a mail backend service.
 type MailClient interface {
 	// Builds the request to sent the mail content to a mail API.
-	PostMail(ctx context.Context, req MailRequest) error
+	PostMail(ctx context.Context, req MailRequest) (*http.Response, error)
 }
 
 // mailClientImpl is an implmentation of MailClient.
@@ -54,10 +54,8 @@ func NewMailClient(provider *gophercloud.ProviderClient, endpoint string) (MailC
 }
 
 // PostMail implements the method of MailClient to sent the mail content to the mail API.
-func (c mailClientImpl) PostMail(ctx context.Context, req MailRequest) error {
+func (c mailClientImpl) PostMail(ctx context.Context, req MailRequest) (*http.Response, error) {
 	url := c.ServiceURL("v1", "send-email?from=limes")
 	opts := gophercloud.RequestOpts{KeepResponseBody: true, OkCodes: []int{http.StatusOK}}
-	resp, err := c.Post(ctx, url, req, nil, &opts)
-	resp.Body.Close()
-	return err
+	return c.Post(ctx, url, req, nil, &opts)
 }

--- a/internal/collector/mail_client.go
+++ b/internal/collector/mail_client.go
@@ -66,7 +66,7 @@ func (c mailClientImpl) PostMail(ctx context.Context, req MailRequest) error {
 }
 
 // UndeliverableMailError is a custom error type to define udeliverable mails.
-// Used in the MailClient interface.
+// Used in the MailClient interface implementations.
 type UndeliverableMailError struct {
 	Inner error
 }

--- a/internal/collector/mail_delivery.go
+++ b/internal/collector/mail_delivery.go
@@ -101,7 +101,7 @@ func (c *Collector) processMailDeliveryTask(ctx context.Context, task db.MailNot
 				return err
 			}
 			logg.Error("Mail delivery detected a project with no managed metadata. ProjectID: %v with Error: %s", task.ProjectID, uerr)
-			return mailErr
+			return uerr
 		}
 		task.NextSubmissionAt = c.MeasureTime().Add(c.AddJitter(mailDeliveryErrorInterval))
 		task.FailedSubmissions++

--- a/internal/collector/mail_delivery_test.go
+++ b/internal/collector/mail_delivery_test.go
@@ -47,7 +47,7 @@ const (
 `
 )
 
-var errMailUnderliverable = errors.New("mail underliverable")
+var errMailUndeliverable = errors.New("mail undeliverable")
 
 type MockMail struct{}
 
@@ -60,7 +60,7 @@ func (m *MockMail) PostMail(ctx context.Context, req MailRequest) error {
 	case "uuid-for-dresden":
 		return nil
 	case "uuid-for-frankfurt":
-		return UndeliverableMailError{Inner: errMailUnderliverable}
+		return UndeliverableMailError{Inner: errMailUndeliverable}
 	}
 	return nil
 }
@@ -96,6 +96,6 @@ func Test_MailDelivery(t *testing.T) {
 
 	// day 4: unmaged project metadata will result in a queue deletion. No recipient could be resolved from the project.
 	s.Clock.StepBy(24 * time.Hour)
-	mustFailT(t, job.ProcessOne(s.Ctx), errMailUnderliverable)
+	mustFailT(t, job.ProcessOne(s.Ctx), errMailUndeliverable)
 	tr.DBChanges().AssertEqualf(`DELETE FROM project_mail_notifications WHERE id = 4;`)
 }


### PR DESCRIPTION
This implementation handles the way of how we deal with projects that don't maintain any metadata.
If no subproject/project or domain delivers any metadata, the queue will be freed of the mail request and a log will be placed.
