### PR TITLE
commitments: Add notify on confirm (mail) support

### DIFF
--- a/docs/users/api-spec-resources.md
+++ b/docs/users/api-spec-resources.md
@@ -498,7 +498,8 @@ The following fields can appear in the response body:
 | `commitments[].confirmed_at` | integer | UNIX timestamp when this commitment was confirmed. Only shown after confirmation. |
 | `commitments[].expires_at` | integer | UNIX timestamp when this commitment is set to expire. Note that the duration counts from `confirm_by` (or from `created_at` for immediately-confirmed commitments) and is calculated at creation time, so this is also shown on unconfirmed commitments. |
 | `commitments[].transferable` | boolean | Whether the commitment is marked for transfer to a different project. Transferable commitments do not count towards quota calculation in their project, but still block capacity and still count towards billing. Not shown if false. |
-
+| `commitments[].notify_on_confirm` | boolean | Whether a mail notification should be sent if a created commitment is confirmed. Can only be set if the commitment contains a confirm_by value. |
+ 
 ### POST /v1/domains/:domain\_id/projects/:project\_id/commitments/new
 
 Creates a new commitment within the given project. Requires a project-admin token, and a request body that is a JSON document like:

--- a/docs/users/api-spec-resources.md
+++ b/docs/users/api-spec-resources.md
@@ -498,7 +498,7 @@ The following fields can appear in the response body:
 | `commitments[].confirmed_at` | integer | UNIX timestamp when this commitment was confirmed. Only shown after confirmation. |
 | `commitments[].expires_at` | integer | UNIX timestamp when this commitment is set to expire. Note that the duration counts from `confirm_by` (or from `created_at` for immediately-confirmed commitments) and is calculated at creation time, so this is also shown on unconfirmed commitments. |
 | `commitments[].transferable` | boolean | Whether the commitment is marked for transfer to a different project. Transferable commitments do not count towards quota calculation in their project, but still block capacity and still count towards billing. Not shown if false. |
-| `commitments[].notify_on_confirm` | boolean | Whether a mail notification should be sent if a created commitment is confirmed. Can only be set if the commitment contains a confirm_by value. |
+| `commitments[].notify_on_confirm` | boolean | Whether a mail notification should be sent if a created commitment is confirmed. Can only be set if the commitment contains a `confirm_by` value. |
  
 ### POST /v1/domains/:domain\_id/projects/:project\_id/commitments/new
 

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -400,7 +400,7 @@ func (p *v1Provider) CreateProjectCommitment(w http.ResponseWriter, r *http.Requ
 		CreationContextJSON: json.RawMessage(buf),
 	}
 	if req.NotifyOnConfirm && req.ConfirmBy == nil {
-		http.Error(w, "notification on confirm can't be set for commitments with immediate confirmation", http.StatusConflict)
+		http.Error(w, "notification on confirm cannot be set for commitments with immediate confirmation", http.StatusConflict)
 		return
 	}
 	dbCommitment.NotifyOnConfirm = req.NotifyOnConfirm

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -213,6 +213,7 @@ func (p *v1Provider) convertCommitmentToDisplayForm(c db.ProjectCommitment, loc 
 		ExpiresAt:        limes.UnixEncodedTime{Time: c.ExpiresAt},
 		TransferStatus:   c.TransferStatus,
 		TransferToken:    c.TransferToken,
+		NotifyOnConfirm:  c.NotifyOnConfirm,
 	}
 }
 
@@ -397,6 +398,9 @@ func (p *v1Provider) CreateProjectCommitment(w http.ResponseWriter, r *http.Requ
 		ConfirmedAt:         nil, // may be set below
 		ExpiresAt:           req.Duration.AddTo(unwrapOrDefault(confirmBy, now)),
 		CreationContextJSON: json.RawMessage(buf),
+	}
+	if req.ConfirmBy != nil {
+		dbCommitment.NotifyOnConfirm = req.NotifyOnConfirm
 	}
 	if req.ConfirmBy == nil {
 		// if not planned for confirmation in the future, confirm immediately (or fail)

--- a/internal/api/commitment_test.go
+++ b/internal/api/commitment_test.go
@@ -445,28 +445,12 @@ func TestCommitmentLifecycleWithImmediateConfirmation(t *testing.T) {
 		"duration":          "1 hour",
 		"notify_on_confirm": true,
 	}
-	notificationResp := assert.JSONObject{
-		"id":                2,
-		"service_type":      "first",
-		"resource_name":     "capacity",
-		"availability_zone": "az-one",
-		"amount":            1,
-		"unit":              "B",
-		"duration":          "1 hour",
-		"created_at":        s.Clock.Now().Unix(),
-		"creator_uuid":      "uuid-for-alice",
-		"creator_name":      "alice@Default",
-		"can_be_deleted":    true,
-		"confirmed_at":      s.Clock.Now().Unix(),
-		"expires_at":        s.Clock.Now().Add(1 * time.Hour).Unix(),
-	}
 
 	assert.HTTPRequest{
 		Method:       http.MethodPost,
 		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/new",
 		Body:         assert.JSONObject{"commitment": notificationReq},
-		ExpectBody:   assert.JSONObject{"commitment": notificationResp},
-		ExpectStatus: http.StatusCreated,
+		ExpectStatus: http.StatusConflict,
 	}.Check(t, s.Handler)
 }
 

--- a/vendor/github.com/sapcc/go-api-declarations/limes/resources/commitment.go
+++ b/vendor/github.com/sapcc/go-api-declarations/limes/resources/commitment.go
@@ -56,6 +56,9 @@ type Commitment struct {
 	// TransferStatus and TransferToken are only filled while the commitment is marked for transfer.
 	TransferStatus CommitmentTransferStatus `json:"transfer_status,omitempty"`
 	TransferToken  *string                  `json:"transfer_token,omitempty"`
+	// NotifyOnConfirm can only be set if ConfirmBy is filled.
+	// Used to send a mail notification at commitment confirmation.
+	NotifyOnConfirm bool `json:"notify_on_confirm,omitempty"`
 }
 
 // CommitmentRequest is the API representation of a *new* commitment as requested by a user.
@@ -66,6 +69,7 @@ type CommitmentRequest struct {
 	Amount           uint64                 `json:"amount"`
 	Duration         CommitmentDuration     `json:"duration"`
 	ConfirmBy        *limes.UnixEncodedTime `json:"confirm_by,omitempty"`
+	NotifyOnConfirm  bool                   `json:"notify_on_confirm,omitempty"`
 }
 
 // CommitmentConversionRule is the API representation of how commitments can be converted into a different resource.


### PR DESCRIPTION
If this implementation fits the desired outcome, I will create a PR for go-api-declarations before this gets merged.
