### PR TITLE
[mail] do not include superseded commitments

### DIFF
--- a/internal/collector/expiring_commitments.go
+++ b/internal/collector/expiring_commitments.go
@@ -56,8 +56,7 @@ func (c *Collector) ExpiringCommitmentNotificationJob(registerer prometheus.Regi
 }
 
 var (
-	// TODO: do not notify if already renewed
-	discoverExpiringCommitmentsQuery = `SELECT * FROM project_commitments WHERE expires_at <= $1 AND renew_context_json IS NULL AND NOT notified_for_expiration`
+	discoverExpiringCommitmentsQuery = `SELECT * FROM project_commitments WHERE expires_at <= $1 AND state != 'superseded' AND renew_context_json IS NULL AND NOT notified_for_expiration`
 	locateExpiringCommitmentsQuery   = sqlext.SimplifyWhitespace(`
 		SELECT ps.project_id, ps.type, pr.name, par.az, pc.id
 		  FROM project_services ps

--- a/internal/collector/fixtures/mail_expiring_commitments.sql
+++ b/internal/collector/fixtures/mail_expiring_commitments.sql
@@ -31,3 +31,6 @@ INSERT INTO project_commitments (id, az_resource_id, amount, created_at, creator
 -- expiring short-term commitments should not be queued and be marked as notified
 INSERT INTO project_commitments (id, az_resource_id, amount, created_at, creator_uuid, creator_name, confirm_by, duration, expires_at, state, creation_context_json) VALUES (8, 1, 10, UNIX(0), 'dummy', 'dummy', UNIX(86400), '10 days', UNIX(950400), 'planned', '{}'::jsonb);
 INSERT INTO project_commitments (id, az_resource_id, amount, created_at, creator_uuid, creator_name, confirmed_at, duration, expires_at, state, creation_context_json) VALUES (9, 1, 10, UNIX(0), 'dummy', 'dummy', UNIX(0), '10 days', UNIX(777600), 'active', '{}'::jsonb);
+
+-- superseded commitments should not be queued for notifications
+INSERT INTO project_commitments (id, az_resource_id, amount, created_at, creator_uuid, creator_name, duration, expires_at, state, creation_context_json) VALUES (10, 4, 1, UNIX(0), 'dummy', 'dummy', '1 year', UNIX(2246400), 'superseded', '{}'::jsonb);

--- a/main.go
+++ b/main.go
@@ -238,8 +238,7 @@ func taskCollect(ctx context.Context, cluster *core.Cluster, args []string, prov
 	// start mail processing if requested
 	if mc, ok := mailClient.Unpack(); ok {
 		if !osext.GetenvBool("LIMES_BLOCK_EXPIRY_NOTIFICATIONS") {
-			// ^ This is a hidden flag to block expiry notifications from being sent
-			//   until we have the "Renew" functionality available on the UI.
+			// ^ This is a hidden flag to block expiry notifications from being sent if necessary.
 			go c.ExpiringCommitmentNotificationJob(nil).Run(ctx)
 		}
 		go c.MailDeliveryJob(nil, mc).Run(ctx)


### PR DESCRIPTION
During a checkup I noticed that superseded commitments are currently processed by the expiration mailer.
This PR fixes this.