### PR TITLE
[mail] Fix serviceType and resourceName to their api variants

### DIFF
--- a/internal/collector/capacity_scrape_test.go
+++ b/internal/collector/capacity_scrape_test.go
@@ -132,6 +132,8 @@ const (
 		resource_behavior:
 			# test that overcommit factor is considered when confirming commitments
 			- { resource: first/capacity, overcommit_factor: 10.0 }
+			- resource: second/capacity
+				identity_in_v1_api: service/resource
 		quota_distribution_configs:
 			# test automatic project quota calculation with non-default settings on */capacity resources
 			- { resource: '.*/capacity', model: autogrow, autogrow: { growth_multiplier: 1.0, project_base_quota: 10, usage_data_retention_period: 1m } }
@@ -675,7 +677,7 @@ func TestScanCapacityWithMailNotification(t *testing.T) {
 		UPDATE project_commitments SET confirmed_at = %d, state = 'active', notify_on_confirm = TRUE WHERE id = 1 AND transfer_token = NULL;
 		INSERT INTO project_commitments (id, az_resource_id, amount, duration, created_at, creator_uuid, creator_name, confirm_by, confirmed_at, expires_at, state, notify_on_confirm, creation_context_json) VALUES (11, 27, 1, '2 days', 10, 'dummy', 'dummy', 43210, 86420, 172810, 'active', TRUE, '{}');
 		INSERT INTO project_mail_notifications (id, project_id, subject, body, next_submission_at) VALUES (1, 1, 'Your recent commitment confirmations', 'Domain:germany Project:berlin Creator:dummy Amount:10 Duration:10 days Date:1970-01-02 Service:first Resource:capacity AZ:az-one', %[2]d);
-		INSERT INTO project_mail_notifications (id, project_id, subject, body, next_submission_at) VALUES (2, 2, 'Your recent commitment confirmations', 'Domain:germany Project:dresden Creator:dummy Amount:1 Duration:2 days Date:1970-01-02 Service:second Resource:capacity AZ:az-one', %[3]d);
+		INSERT INTO project_mail_notifications (id, project_id, subject, body, next_submission_at) VALUES (2, 2, 'Your recent commitment confirmations', 'Domain:germany Project:dresden Creator:dummy Amount:1 Duration:2 days Date:1970-01-02 Service:service Resource:resource AZ:az-one', %[3]d);
 		UPDATE project_resources SET quota = 260 WHERE id = 2 AND service_id = 1 AND name = 'capacity';
 	`, timestampUpdates(), scrapedAt1.Unix(), scrapedAt2.Unix())
 
@@ -707,7 +709,7 @@ func TestScanCapacityWithMailNotification(t *testing.T) {
 		INSERT INTO project_commitments (id, az_resource_id, amount, duration, created_at, creator_uuid, creator_name, confirmed_at, expires_at, state, notify_on_confirm, creation_context_json) VALUES (13, 27, 1, '2 days', 86420, 'dummy', 'dummy', 172830, 259220, 'active', TRUE, '{}');
 		UPDATE project_commitments SET confirmed_at = 172825, state = 'active' WHERE id = 2 AND transfer_token = NULL;
 		UPDATE project_commitments SET state = 'pending' WHERE id = 3 AND transfer_token = NULL;
-		INSERT INTO project_mail_notifications (id, project_id, subject, body, next_submission_at) VALUES (3, 2, 'Your recent commitment confirmations', 'Domain:germany Project:dresden Creator:dummy Amount:1 Duration:2 days Date:1970-01-03 Service:second Resource:capacity AZ:az-one Creator:dummy Amount:1 Duration:2 days Date:1970-01-03 Service:second Resource:capacity AZ:az-one', %d);
+		INSERT INTO project_mail_notifications (id, project_id, subject, body, next_submission_at) VALUES (3, 2, 'Your recent commitment confirmations', 'Domain:germany Project:dresden Creator:dummy Amount:1 Duration:2 days Date:1970-01-03 Service:service Resource:resource AZ:az-one Creator:dummy Amount:1 Duration:2 days Date:1970-01-03 Service:service Resource:resource AZ:az-one', %d);
 		UPDATE project_resources SET quota = 360 WHERE id = 2 AND service_id = 1 AND name = 'capacity';
 	`, timestampUpdates(), scrapedAt2.Unix())
 }

--- a/internal/collector/expiring_commitments.go
+++ b/internal/collector/expiring_commitments.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/lib/pq"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sapcc/go-api-declarations/liquid"
 	"github.com/sapcc/go-bits/jobloop"
 	"github.com/sapcc/go-bits/sqlext"
 
@@ -122,6 +123,9 @@ func (c *Collector) processExpiringCommitmentTask(ctx context.Context, commitmen
 			return err
 		}
 
+		apiIdentity := c.Cluster.BehaviorForResource(info.Resource.ServiceType, info.Resource.ResourceName).IdentityInV1API
+		info.Resource.ServiceType = db.ServiceType(apiIdentity.ServiceType)
+		info.Resource.ResourceName = liquid.ResourceName(apiIdentity.Name)
 		info.Commitment = longTermCommitmentsByID[cid]
 		info.DateString = info.Commitment.ExpiresAt.Format(time.DateOnly)
 		notifications[pid] = append(notifications[pid], info)

--- a/internal/collector/expiring_commitments_test.go
+++ b/internal/collector/expiring_commitments_test.go
@@ -42,6 +42,9 @@ const (
 			params:
 				capacity: 0
 				resources: []
+		resource_behavior:
+		- resource: first/things
+			identity_in_v1_api: service/resource
 		mail_notifications:
 			templates:
 				expiring_commitments:
@@ -68,8 +71,8 @@ func Test_ExpiringCommitmentNotification(t *testing.T) {
 		UPDATE project_commitments SET notified_for_expiration = TRUE WHERE id = 7 AND transfer_token = NULL;
 		UPDATE project_commitments SET notified_for_expiration = TRUE WHERE id = 8 AND transfer_token = NULL;
 		UPDATE project_commitments SET notified_for_expiration = TRUE WHERE id = 9 AND transfer_token = NULL;
-		INSERT INTO project_mail_notifications (id, project_id, subject, body, next_submission_at) VALUES (1, 1, 'Information about expiring commitments', 'Domain:germany Project:berlin Creator:dummy Amount:5 Duration:1 year Date:1970-01-01 Service:first Resource:things AZ:az-one Creator:dummy Amount:10 Duration:1 year Date:1970-01-01 Service:first Resource:things AZ:az-two', %[1]d);
-		INSERT INTO project_mail_notifications (id, project_id, subject, body, next_submission_at) VALUES (2, 2, 'Information about expiring commitments', 'Domain:germany Project:dresden Creator:dummy Amount:5 Duration:1 year Date:1970-01-27 Service:first Resource:things AZ:az-one Creator:dummy Amount:10 Duration:1 year Date:1970-01-27 Service:first Resource:things AZ:az-two', %[1]d);
+		INSERT INTO project_mail_notifications (id, project_id, subject, body, next_submission_at) VALUES (1, 1, 'Information about expiring commitments', 'Domain:germany Project:berlin Creator:dummy Amount:5 Duration:1 year Date:1970-01-01 Service:service Resource:resource AZ:az-one Creator:dummy Amount:10 Duration:1 year Date:1970-01-01 Service:service Resource:resource AZ:az-two', %[1]d);
+		INSERT INTO project_mail_notifications (id, project_id, subject, body, next_submission_at) VALUES (2, 2, 'Information about expiring commitments', 'Domain:germany Project:dresden Creator:dummy Amount:5 Duration:1 year Date:1970-01-27 Service:service Resource:resource AZ:az-one Creator:dummy Amount:10 Duration:1 year Date:1970-01-27 Service:service Resource:resource AZ:az-two', %[1]d);
 	`, c.MeasureTime().Unix())
 
 	// mail queue with an empty template should fail
@@ -95,6 +98,6 @@ func Test_ExpiringCommitmentNotification(t *testing.T) {
 	mustT(t, job.ProcessOne(s.Ctx))
 	tr.DBChanges().AssertEqualf(`
 		UPDATE project_commitments SET notified_for_expiration = TRUE WHERE id = 99 AND transfer_token = NULL;
-		INSERT INTO project_mail_notifications (id, project_id, subject, body, next_submission_at) VALUES (3, 1, 'Information about expiring commitments', 'Domain:germany Project:berlin Creator:dummy Amount:10 Duration:1 year Date:1970-01-01 Service:first Resource:things AZ:az-one', %d);
+		INSERT INTO project_mail_notifications (id, project_id, subject, body, next_submission_at) VALUES (3, 1, 'Information about expiring commitments', 'Domain:germany Project:berlin Creator:dummy Amount:10 Duration:1 year Date:1970-01-01 Service:service Resource:resource AZ:az-one', %d);
 	`, c.MeasureTime().Unix())
 }

--- a/internal/datamodel/confirm_project_commitments.go
+++ b/internal/datamodel/confirm_project_commitments.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/lib/pq"
+	"github.com/sapcc/go-api-declarations/liquid"
 	"github.com/sapcc/go-bits/logg"
 	"github.com/sapcc/go-bits/sqlext"
 
@@ -153,9 +154,11 @@ func ConfirmPendingCommitments(loc core.AZResourceLocation, cluster *core.Cluste
 
 	// prepare mail notifications (this needs to be done in a separate loop because we collate notifications by project)
 	var mails []db.MailNotification
+	apiIdentity := cluster.BehaviorForResource(loc.ServiceType, loc.ResourceName).IdentityInV1API
+	mailLoc := core.AZResourceLocation{ServiceType: db.ServiceType(apiIdentity.ServiceType), ResourceName: liquid.ResourceName(apiIdentity.Name), AvailabilityZone: loc.AvailabilityZone}
 	if mailConfig, ok := cluster.Config.MailNotifications.Unpack(); ok {
 		for projectID := range confirmedCommitmentIDs {
-			mail, err := prepareConfirmationMail(mailConfig.Templates.ConfirmedCommitments, dbi, loc, projectID, confirmedCommitmentIDs[projectID], now)
+			mail, err := prepareConfirmationMail(mailConfig.Templates.ConfirmedCommitments, dbi, mailLoc, projectID, confirmedCommitmentIDs[projectID], now)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
The implementation was created with the backend goggles on. However, the location stats need to be resolved to their api equivalents as they do in the API's.
