### PR TITLE
add manila URL replacement

### DIFF
--- a/internal/liquids/manila/liquid.go
+++ b/internal/liquids/manila/liquid.go
@@ -25,6 +25,7 @@ import (
 	"math"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gophercloud/gophercloud/v2"
@@ -77,6 +78,8 @@ func (l *Logic) Init(ctx context.Context, provider *gophercloud.ProviderClient, 
 	if err != nil {
 		return err
 	}
+	// Workaround for gophercloud 2.7.0 which gets the first found OpenStack URL for Manila.
+	l.ManilaV2.Endpoint = strings.Replace(l.ManilaV2.Endpoint, "v1", "v2", 1)
 	microversion, err := l.findMicroversion(ctx, l.ManilaV2)
 	if err != nil {
 		return err


### PR DESCRIPTION
The update to gophercloud 2.7.0 causes the first found Manila URL to be returned, which is the v1 API. This PR is a workaround for this behavior and enforces the use of the v2 API throughout the LIQUID.