### PR TITLE
remove ServiceInfo.ProductName

### DIFF
--- a/internal/collector/fixtures/capacity_data_metrics.prom
+++ b/internal/collector/fixtures/capacity_data_metrics.prom
@@ -1,40 +1,40 @@
 # HELP limes_autogrow_growth_multiplier For resources with quota distribution model "autogrow", reports the configured growth multiplier.
 # TYPE limes_autogrow_growth_multiplier gauge
-limes_autogrow_growth_multiplier{resource="capacity",service="shared",service_name="generic-shared"} 1
-limes_autogrow_growth_multiplier{resource="capacity",service="unshared",service_name="generic-unshared"} 1
-limes_autogrow_growth_multiplier{resource="capacity",service="unshared2",service_name="generic-unshared2"} 1
-limes_autogrow_growth_multiplier{resource="things",service="shared",service_name="generic-shared"} 1
-limes_autogrow_growth_multiplier{resource="things",service="unshared",service_name="generic-unshared"} 1
-limes_autogrow_growth_multiplier{resource="things",service="unshared2",service_name="generic-unshared2"} 1
+limes_autogrow_growth_multiplier{resource="capacity",service="shared",service_name="shared"} 1
+limes_autogrow_growth_multiplier{resource="capacity",service="unshared",service_name="unshared"} 1
+limes_autogrow_growth_multiplier{resource="capacity",service="unshared2",service_name="unshared2"} 1
+limes_autogrow_growth_multiplier{resource="things",service="shared",service_name="shared"} 1
+limes_autogrow_growth_multiplier{resource="things",service="unshared",service_name="unshared"} 1
+limes_autogrow_growth_multiplier{resource="things",service="unshared2",service_name="unshared2"} 1
 # HELP limes_autogrow_quota_overcommit_threshold_percent For resources with quota distribution model "autogrow", reports the allocation percentage above which quota overcommit is disabled.
 # TYPE limes_autogrow_quota_overcommit_threshold_percent gauge
-limes_autogrow_quota_overcommit_threshold_percent{resource="capacity",service="shared",service_name="generic-shared"} 0
-limes_autogrow_quota_overcommit_threshold_percent{resource="capacity",service="unshared",service_name="generic-unshared"} 0
-limes_autogrow_quota_overcommit_threshold_percent{resource="capacity",service="unshared2",service_name="generic-unshared2"} 0
-limes_autogrow_quota_overcommit_threshold_percent{resource="things",service="shared",service_name="generic-shared"} 0
-limes_autogrow_quota_overcommit_threshold_percent{resource="things",service="unshared",service_name="generic-unshared"} 0
-limes_autogrow_quota_overcommit_threshold_percent{resource="things",service="unshared2",service_name="generic-unshared2"} 0
+limes_autogrow_quota_overcommit_threshold_percent{resource="capacity",service="shared",service_name="shared"} 0
+limes_autogrow_quota_overcommit_threshold_percent{resource="capacity",service="unshared",service_name="unshared"} 0
+limes_autogrow_quota_overcommit_threshold_percent{resource="capacity",service="unshared2",service_name="unshared2"} 0
+limes_autogrow_quota_overcommit_threshold_percent{resource="things",service="shared",service_name="shared"} 0
+limes_autogrow_quota_overcommit_threshold_percent{resource="things",service="unshared",service_name="unshared"} 0
+limes_autogrow_quota_overcommit_threshold_percent{resource="things",service="unshared2",service_name="unshared2"} 0
 # HELP limes_cluster_capacity Reported capacity of a Limes resource for an OpenStack cluster.
 # TYPE limes_cluster_capacity gauge
-limes_cluster_capacity{resource="capacity",service="shared",service_name="generic-shared"} 0
-limes_cluster_capacity{resource="capacity",service="unshared",service_name="generic-unshared"} 42
-limes_cluster_capacity{resource="capacity",service="unshared2",service_name="generic-unshared2"} 0
-limes_cluster_capacity{resource="things",service="shared",service_name="generic-shared"} 23
-limes_cluster_capacity{resource="things",service="unshared",service_name="generic-unshared"} 10
-limes_cluster_capacity{resource="things",service="unshared2",service_name="generic-unshared2"} 30
+limes_cluster_capacity{resource="capacity",service="shared",service_name="shared"} 0
+limes_cluster_capacity{resource="capacity",service="unshared",service_name="unshared"} 42
+limes_cluster_capacity{resource="capacity",service="unshared2",service_name="unshared2"} 0
+limes_cluster_capacity{resource="things",service="shared",service_name="shared"} 23
+limes_cluster_capacity{resource="things",service="unshared",service_name="unshared"} 10
+limes_cluster_capacity{resource="things",service="unshared2",service_name="unshared2"} 30
 # HELP limes_cluster_capacity_per_az Reported capacity of a Limes resource for an OpenStack cluster in a specific availability zone.
 # TYPE limes_cluster_capacity_per_az gauge
-limes_cluster_capacity_per_az{availability_zone="az-one",resource="things",service="unshared2",service_name="generic-unshared2"} 15
-limes_cluster_capacity_per_az{availability_zone="az-two",resource="things",service="unshared2",service_name="generic-unshared2"} 15
+limes_cluster_capacity_per_az{availability_zone="az-one",resource="things",service="unshared2",service_name="unshared2"} 15
+limes_cluster_capacity_per_az{availability_zone="az-two",resource="things",service="unshared2",service_name="unshared2"} 15
 # HELP limes_cluster_usage_per_az Actual usage of a Limes resource for an OpenStack cluster in a specific availability zone.
 # TYPE limes_cluster_usage_per_az gauge
-limes_cluster_usage_per_az{availability_zone="az-one",resource="things",service="unshared2",service_name="generic-unshared2"} 3
-limes_cluster_usage_per_az{availability_zone="az-two",resource="things",service="unshared2",service_name="generic-unshared2"} 3
+limes_cluster_usage_per_az{availability_zone="az-one",resource="things",service="unshared2",service_name="unshared2"} 3
+limes_cluster_usage_per_az{availability_zone="az-two",resource="things",service="unshared2",service_name="unshared2"} 3
 # HELP limes_unit_multiplier Conversion factor that a value of this resource must be multiplied with to obtain the base unit (e.g. bytes). For use with Grafana when only the base unit can be configured because of templating.
 # TYPE limes_unit_multiplier gauge
-limes_unit_multiplier{resource="capacity",service="shared",service_name="generic-shared"} 1
-limes_unit_multiplier{resource="capacity",service="unshared",service_name="generic-unshared"} 1
-limes_unit_multiplier{resource="capacity",service="unshared2",service_name="generic-unshared2"} 1
-limes_unit_multiplier{resource="things",service="shared",service_name="generic-shared"} 1
-limes_unit_multiplier{resource="things",service="unshared",service_name="generic-unshared"} 1
-limes_unit_multiplier{resource="things",service="unshared2",service_name="generic-unshared2"} 1
+limes_unit_multiplier{resource="capacity",service="shared",service_name="shared"} 1
+limes_unit_multiplier{resource="capacity",service="unshared",service_name="unshared"} 1
+limes_unit_multiplier{resource="capacity",service="unshared2",service_name="unshared2"} 1
+limes_unit_multiplier{resource="things",service="shared",service_name="shared"} 1
+limes_unit_multiplier{resource="things",service="unshared",service_name="unshared"} 1
+limes_unit_multiplier{resource="things",service="unshared2",service_name="unshared2"} 1

--- a/internal/collector/fixtures/ratescrape_metrics.prom
+++ b/internal/collector/fixtures/ratescrape_metrics.prom
@@ -1,22 +1,22 @@
 # HELP limes_autogrow_growth_multiplier For resources with quota distribution model "autogrow", reports the configured growth multiplier.
 # TYPE limes_autogrow_growth_multiplier gauge
-limes_autogrow_growth_multiplier{resource="capacity",service="unittest",service_name="generic-unittest"} 1
-limes_autogrow_growth_multiplier{resource="things",service="unittest",service_name="generic-unittest"} 1
+limes_autogrow_growth_multiplier{resource="capacity",service="unittest",service_name="unittest"} 1
+limes_autogrow_growth_multiplier{resource="things",service="unittest",service_name="unittest"} 1
 # HELP limes_autogrow_quota_overcommit_threshold_percent For resources with quota distribution model "autogrow", reports the allocation percentage above which quota overcommit is disabled.
 # TYPE limes_autogrow_quota_overcommit_threshold_percent gauge
-limes_autogrow_quota_overcommit_threshold_percent{resource="capacity",service="unittest",service_name="generic-unittest"} 0
-limes_autogrow_quota_overcommit_threshold_percent{resource="things",service="unittest",service_name="generic-unittest"} 0
+limes_autogrow_quota_overcommit_threshold_percent{resource="capacity",service="unittest",service_name="unittest"} 0
+limes_autogrow_quota_overcommit_threshold_percent{resource="things",service="unittest",service_name="unittest"} 0
 # HELP limes_cluster_capacity Reported capacity of a Limes resource for an OpenStack cluster.
 # TYPE limes_cluster_capacity gauge
-limes_cluster_capacity{resource="capacity",service="unittest",service_name="generic-unittest"} 0
-limes_cluster_capacity{resource="things",service="unittest",service_name="generic-unittest"} 0
+limes_cluster_capacity{resource="capacity",service="unittest",service_name="unittest"} 0
+limes_cluster_capacity{resource="things",service="unittest",service_name="unittest"} 0
 # HELP limes_project_rate_usage Usage of a Limes rate for an OpenStack project. These are counters that never reset.
 # TYPE limes_project_rate_usage gauge
-limes_project_rate_usage{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",rate="firstrate",service="unittest",service_name="generic-unittest"} 2048
-limes_project_rate_usage{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",rate="secondrate",service="unittest",service_name="generic-unittest"} 4096
-limes_project_rate_usage{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",rate="firstrate",service="unittest",service_name="generic-unittest"} 4096
-limes_project_rate_usage{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",rate="secondrate",service="unittest",service_name="generic-unittest"} 8192
+limes_project_rate_usage{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",rate="firstrate",service="unittest",service_name="unittest"} 2048
+limes_project_rate_usage{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",rate="secondrate",service="unittest",service_name="unittest"} 4096
+limes_project_rate_usage{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",rate="firstrate",service="unittest",service_name="unittest"} 4096
+limes_project_rate_usage{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",rate="secondrate",service="unittest",service_name="unittest"} 8192
 # HELP limes_unit_multiplier Conversion factor that a value of this resource must be multiplied with to obtain the base unit (e.g. bytes). For use with Grafana when only the base unit can be configured because of templating.
 # TYPE limes_unit_multiplier gauge
-limes_unit_multiplier{resource="capacity",service="unittest",service_name="generic-unittest"} 1
-limes_unit_multiplier{resource="things",service="unittest",service_name="generic-unittest"} 1
+limes_unit_multiplier{resource="capacity",service="unittest",service_name="unittest"} 1
+limes_unit_multiplier{resource="things",service="unittest",service_name="unittest"} 1

--- a/internal/collector/fixtures/ratescrape_metrics_skipzero.prom
+++ b/internal/collector/fixtures/ratescrape_metrics_skipzero.prom
@@ -1,22 +1,22 @@
 # HELP limes_autogrow_growth_multiplier For resources with quota distribution model "autogrow", reports the configured growth multiplier.
 # TYPE limes_autogrow_growth_multiplier gauge
-limes_autogrow_growth_multiplier{resource="capacity",service="unittest",service_name="generic-unittest"} 1
-limes_autogrow_growth_multiplier{resource="things",service="unittest",service_name="generic-unittest"} 1
+limes_autogrow_growth_multiplier{resource="capacity",service="unittest",service_name="unittest"} 1
+limes_autogrow_growth_multiplier{resource="things",service="unittest",service_name="unittest"} 1
 # HELP limes_autogrow_quota_overcommit_threshold_percent For resources with quota distribution model "autogrow", reports the allocation percentage above which quota overcommit is disabled.
 # TYPE limes_autogrow_quota_overcommit_threshold_percent gauge
-limes_autogrow_quota_overcommit_threshold_percent{resource="capacity",service="unittest",service_name="generic-unittest"} 0
-limes_autogrow_quota_overcommit_threshold_percent{resource="things",service="unittest",service_name="generic-unittest"} 0
+limes_autogrow_quota_overcommit_threshold_percent{resource="capacity",service="unittest",service_name="unittest"} 0
+limes_autogrow_quota_overcommit_threshold_percent{resource="things",service="unittest",service_name="unittest"} 0
 # HELP limes_cluster_capacity Reported capacity of a Limes resource for an OpenStack cluster.
 # TYPE limes_cluster_capacity gauge
-limes_cluster_capacity{resource="capacity",service="unittest",service_name="generic-unittest"} 0
-limes_cluster_capacity{resource="things",service="unittest",service_name="generic-unittest"} 0
+limes_cluster_capacity{resource="capacity",service="unittest",service_name="unittest"} 0
+limes_cluster_capacity{resource="things",service="unittest",service_name="unittest"} 0
 # HELP limes_project_rate_usage Usage of a Limes rate for an OpenStack project. These are counters that never reset.
 # TYPE limes_project_rate_usage gauge
-limes_project_rate_usage{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",rate="firstrate",service="unittest",service_name="generic-unittest"} 2048
-limes_project_rate_usage{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",rate="secondrate",service="unittest",service_name="generic-unittest"} 4096
-limes_project_rate_usage{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",rate="firstrate",service="unittest",service_name="generic-unittest"} 4096
-limes_project_rate_usage{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",rate="secondrate",service="unittest",service_name="generic-unittest"} 8192
+limes_project_rate_usage{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",rate="firstrate",service="unittest",service_name="unittest"} 2048
+limes_project_rate_usage{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",rate="secondrate",service="unittest",service_name="unittest"} 4096
+limes_project_rate_usage{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",rate="firstrate",service="unittest",service_name="unittest"} 4096
+limes_project_rate_usage{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",rate="secondrate",service="unittest",service_name="unittest"} 8192
 # HELP limes_unit_multiplier Conversion factor that a value of this resource must be multiplied with to obtain the base unit (e.g. bytes). For use with Grafana when only the base unit can be configured because of templating.
 # TYPE limes_unit_multiplier gauge
-limes_unit_multiplier{resource="capacity",service="unittest",service_name="generic-unittest"} 1
-limes_unit_multiplier{resource="things",service="unittest",service_name="generic-unittest"} 1
+limes_unit_multiplier{resource="capacity",service="unittest",service_name="unittest"} 1
+limes_unit_multiplier{resource="things",service="unittest",service_name="unittest"} 1

--- a/internal/collector/fixtures/scrape_data_metrics.prom
+++ b/internal/collector/fixtures/scrape_data_metrics.prom
@@ -1,81 +1,81 @@
 # HELP limes_autogrow_growth_multiplier For resources with quota distribution model "autogrow", reports the configured growth multiplier.
 # TYPE limes_autogrow_growth_multiplier gauge
-limes_autogrow_growth_multiplier{resource="capacity",service="unittest",service_name="generic-unittest"} 1
-limes_autogrow_growth_multiplier{resource="things",service="unittest",service_name="generic-unittest"} 1
+limes_autogrow_growth_multiplier{resource="capacity",service="unittest",service_name="unittest"} 1
+limes_autogrow_growth_multiplier{resource="things",service="unittest",service_name="unittest"} 1
 # HELP limes_autogrow_quota_overcommit_threshold_percent For resources with quota distribution model "autogrow", reports the allocation percentage above which quota overcommit is disabled.
 # TYPE limes_autogrow_quota_overcommit_threshold_percent gauge
-limes_autogrow_quota_overcommit_threshold_percent{resource="capacity",service="unittest",service_name="generic-unittest"} 0
-limes_autogrow_quota_overcommit_threshold_percent{resource="things",service="unittest",service_name="generic-unittest"} 0
+limes_autogrow_quota_overcommit_threshold_percent{resource="capacity",service="unittest",service_name="unittest"} 0
+limes_autogrow_quota_overcommit_threshold_percent{resource="things",service="unittest",service_name="unittest"} 0
 # HELP limes_cluster_capacity Reported capacity of a Limes resource for an OpenStack cluster.
 # TYPE limes_cluster_capacity gauge
-limes_cluster_capacity{resource="capacity",service="unittest",service_name="generic-unittest"} 0
-limes_cluster_capacity{resource="things",service="unittest",service_name="generic-unittest"} 0
+limes_cluster_capacity{resource="capacity",service="unittest",service_name="unittest"} 0
+limes_cluster_capacity{resource="things",service="unittest",service_name="unittest"} 0
 # HELP limes_domain_quota Assigned quota of a Limes resource for an OpenStack domain.
 # TYPE limes_domain_quota gauge
-limes_domain_quota{domain="germany",domain_id="uuid-for-germany",resource="capacity",service="unittest",service_name="generic-unittest"} 40
-limes_domain_quota{domain="germany",domain_id="uuid-for-germany",resource="things",service="unittest",service_name="generic-unittest"} 26
+limes_domain_quota{domain="germany",domain_id="uuid-for-germany",resource="capacity",service="unittest",service_name="unittest"} 40
+limes_domain_quota{domain="germany",domain_id="uuid-for-germany",resource="things",service="unittest",service_name="unittest"} 26
 # HELP limes_project_backendquota Actual quota of a Limes resource for an OpenStack project.
 # TYPE limes_project_backendquota gauge
-limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="generic-unittest"} 20
-limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest",service_name="generic-unittest"} 13
-limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="generic-unittest"} 20
-limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest",service_name="generic-unittest"} 13
+limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="unittest"} 20
+limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest",service_name="unittest"} 13
+limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="unittest"} 20
+limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest",service_name="unittest"} 13
 # HELP limes_project_commitment_min_expires_at Minimum expiredAt timestamp of all commitments for an Openstack project, grouped by resource and service.
 # TYPE limes_project_commitment_min_expires_at gauge
-limes_project_commitment_min_expires_at{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="generic-unittest"} 3.154688e+07
-limes_project_commitment_min_expires_at{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest",service_name="generic-unittest"} 0
-limes_project_commitment_min_expires_at{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="generic-unittest"} 3.154688e+07
-limes_project_commitment_min_expires_at{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest",service_name="generic-unittest"} 0
+limes_project_commitment_min_expires_at{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="unittest"} 3.154688e+07
+limes_project_commitment_min_expires_at{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest",service_name="unittest"} 0
+limes_project_commitment_min_expires_at{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="unittest"} 3.154688e+07
+limes_project_commitment_min_expires_at{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest",service_name="unittest"} 0
 # HELP limes_project_committed_per_az Sum of all active commitments of a Limes resource for an OpenStack project, grouped by availability zone and state.
 # TYPE limes_project_committed_per_az gauge
-limes_project_committed_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="generic-unittest",state="active"} 15
-limes_project_committed_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="generic-unittest",state="active"} 10
-limes_project_committed_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="generic-unittest",state="pending"} 10
+limes_project_committed_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="unittest",state="active"} 15
+limes_project_committed_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="unittest",state="active"} 10
+limes_project_committed_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="unittest",state="pending"} 10
 # HELP limes_project_physical_usage Actual (physical) usage of a Limes resource for an OpenStack project.
 # TYPE limes_project_physical_usage gauge
-limes_project_physical_usage{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="generic-unittest"} 10
-limes_project_physical_usage{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="generic-unittest"} 10
+limes_project_physical_usage{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="unittest"} 10
+limes_project_physical_usage{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="unittest"} 10
 # HELP limes_project_quota Assigned quota of a Limes resource for an OpenStack project.
 # TYPE limes_project_quota gauge
-limes_project_quota{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="generic-unittest"} 20
-limes_project_quota{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest",service_name="generic-unittest"} 13
-limes_project_quota{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="generic-unittest"} 20
-limes_project_quota{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest",service_name="generic-unittest"} 13
+limes_project_quota{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="unittest"} 20
+limes_project_quota{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest",service_name="unittest"} 13
+limes_project_quota{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="unittest"} 20
+limes_project_quota{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest",service_name="unittest"} 13
 # HELP limes_project_usage Actual (logical) usage of a Limes resource for an OpenStack project.
 # TYPE limes_project_usage gauge
-limes_project_usage{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="generic-unittest"} 20
-limes_project_usage{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest",service_name="generic-unittest"} 5
-limes_project_usage{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="generic-unittest"} 20
-limes_project_usage{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest",service_name="generic-unittest"} 5
+limes_project_usage{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="unittest"} 20
+limes_project_usage{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest",service_name="unittest"} 5
+limes_project_usage{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="unittest"} 20
+limes_project_usage{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest",service_name="unittest"} 5
 # HELP limes_project_usage_per_az Actual (logical) usage of a Limes resource for an OpenStack project in a specific availability zone.
 # TYPE limes_project_usage_per_az gauge
-limes_project_usage_per_az{availability_zone="any",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="generic-unittest"} 0
-limes_project_usage_per_az{availability_zone="any",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest",service_name="generic-unittest"} 0
-limes_project_usage_per_az{availability_zone="any",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="generic-unittest"} 0
-limes_project_usage_per_az{availability_zone="any",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest",service_name="generic-unittest"} 0
-limes_project_usage_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="generic-unittest"} 20
-limes_project_usage_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest",service_name="generic-unittest"} 2
-limes_project_usage_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="generic-unittest"} 20
-limes_project_usage_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest",service_name="generic-unittest"} 2
-limes_project_usage_per_az{availability_zone="az-two",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="generic-unittest"} 0
-limes_project_usage_per_az{availability_zone="az-two",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest",service_name="generic-unittest"} 3
-limes_project_usage_per_az{availability_zone="az-two",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="generic-unittest"} 0
-limes_project_usage_per_az{availability_zone="az-two",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest",service_name="generic-unittest"} 3
+limes_project_usage_per_az{availability_zone="any",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="unittest"} 0
+limes_project_usage_per_az{availability_zone="any",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest",service_name="unittest"} 0
+limes_project_usage_per_az{availability_zone="any",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="unittest"} 0
+limes_project_usage_per_az{availability_zone="any",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest",service_name="unittest"} 0
+limes_project_usage_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="unittest"} 20
+limes_project_usage_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest",service_name="unittest"} 2
+limes_project_usage_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="unittest"} 20
+limes_project_usage_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest",service_name="unittest"} 2
+limes_project_usage_per_az{availability_zone="az-two",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="unittest"} 0
+limes_project_usage_per_az{availability_zone="az-two",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest",service_name="unittest"} 3
+limes_project_usage_per_az{availability_zone="az-two",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="unittest"} 0
+limes_project_usage_per_az{availability_zone="az-two",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest",service_name="unittest"} 3
 # HELP limes_project_used_and_or_committed_per_az The maximum of limes_project_usage_per_az and limes_project_committed_per_az{state="active"}.
 # TYPE limes_project_used_and_or_committed_per_az gauge
-limes_project_used_and_or_committed_per_az{availability_zone="any",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="generic-unittest"} 0
-limes_project_used_and_or_committed_per_az{availability_zone="any",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest",service_name="generic-unittest"} 0
-limes_project_used_and_or_committed_per_az{availability_zone="any",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="generic-unittest"} 0
-limes_project_used_and_or_committed_per_az{availability_zone="any",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest",service_name="generic-unittest"} 0
-limes_project_used_and_or_committed_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="generic-unittest"} 20
-limes_project_used_and_or_committed_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest",service_name="generic-unittest"} 2
-limes_project_used_and_or_committed_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="generic-unittest"} 20
-limes_project_used_and_or_committed_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest",service_name="generic-unittest"} 2
-limes_project_used_and_or_committed_per_az{availability_zone="az-two",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="generic-unittest"} 0
-limes_project_used_and_or_committed_per_az{availability_zone="az-two",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest",service_name="generic-unittest"} 3
-limes_project_used_and_or_committed_per_az{availability_zone="az-two",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="generic-unittest"} 0
-limes_project_used_and_or_committed_per_az{availability_zone="az-two",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest",service_name="generic-unittest"} 3
+limes_project_used_and_or_committed_per_az{availability_zone="any",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="unittest"} 0
+limes_project_used_and_or_committed_per_az{availability_zone="any",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest",service_name="unittest"} 0
+limes_project_used_and_or_committed_per_az{availability_zone="any",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="unittest"} 0
+limes_project_used_and_or_committed_per_az{availability_zone="any",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest",service_name="unittest"} 0
+limes_project_used_and_or_committed_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="unittest"} 20
+limes_project_used_and_or_committed_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest",service_name="unittest"} 2
+limes_project_used_and_or_committed_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="unittest"} 20
+limes_project_used_and_or_committed_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest",service_name="unittest"} 2
+limes_project_used_and_or_committed_per_az{availability_zone="az-two",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="unittest"} 0
+limes_project_used_and_or_committed_per_az{availability_zone="az-two",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest",service_name="unittest"} 3
+limes_project_used_and_or_committed_per_az{availability_zone="az-two",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="unittest"} 0
+limes_project_used_and_or_committed_per_az{availability_zone="az-two",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest",service_name="unittest"} 3
 # HELP limes_unit_multiplier Conversion factor that a value of this resource must be multiplied with to obtain the base unit (e.g. bytes). For use with Grafana when only the base unit can be configured because of templating.
 # TYPE limes_unit_multiplier gauge
-limes_unit_multiplier{resource="capacity",service="unittest",service_name="generic-unittest"} 1
-limes_unit_multiplier{resource="things",service="unittest",service_name="generic-unittest"} 1
+limes_unit_multiplier{resource="capacity",service="unittest",service_name="unittest"} 1
+limes_unit_multiplier{resource="things",service="unittest",service_name="unittest"} 1

--- a/internal/collector/fixtures/scrape_data_metrics_skipzero.prom
+++ b/internal/collector/fixtures/scrape_data_metrics_skipzero.prom
@@ -1,67 +1,67 @@
 # HELP limes_autogrow_growth_multiplier For resources with quota distribution model "autogrow", reports the configured growth multiplier.
 # TYPE limes_autogrow_growth_multiplier gauge
-limes_autogrow_growth_multiplier{resource="capacity",service="unittest",service_name="generic-unittest"} 1
-limes_autogrow_growth_multiplier{resource="things",service="unittest",service_name="generic-unittest"} 1
+limes_autogrow_growth_multiplier{resource="capacity",service="unittest",service_name="unittest"} 1
+limes_autogrow_growth_multiplier{resource="things",service="unittest",service_name="unittest"} 1
 # HELP limes_autogrow_quota_overcommit_threshold_percent For resources with quota distribution model "autogrow", reports the allocation percentage above which quota overcommit is disabled.
 # TYPE limes_autogrow_quota_overcommit_threshold_percent gauge
-limes_autogrow_quota_overcommit_threshold_percent{resource="capacity",service="unittest",service_name="generic-unittest"} 0
-limes_autogrow_quota_overcommit_threshold_percent{resource="things",service="unittest",service_name="generic-unittest"} 0
+limes_autogrow_quota_overcommit_threshold_percent{resource="capacity",service="unittest",service_name="unittest"} 0
+limes_autogrow_quota_overcommit_threshold_percent{resource="things",service="unittest",service_name="unittest"} 0
 # HELP limes_cluster_capacity Reported capacity of a Limes resource for an OpenStack cluster.
 # TYPE limes_cluster_capacity gauge
-limes_cluster_capacity{resource="capacity",service="unittest",service_name="generic-unittest"} 0
-limes_cluster_capacity{resource="things",service="unittest",service_name="generic-unittest"} 0
+limes_cluster_capacity{resource="capacity",service="unittest",service_name="unittest"} 0
+limes_cluster_capacity{resource="things",service="unittest",service_name="unittest"} 0
 # HELP limes_domain_quota Assigned quota of a Limes resource for an OpenStack domain.
 # TYPE limes_domain_quota gauge
-limes_domain_quota{domain="germany",domain_id="uuid-for-germany",resource="capacity",service="unittest",service_name="generic-unittest"} 40
-limes_domain_quota{domain="germany",domain_id="uuid-for-germany",resource="things",service="unittest",service_name="generic-unittest"} 26
+limes_domain_quota{domain="germany",domain_id="uuid-for-germany",resource="capacity",service="unittest",service_name="unittest"} 40
+limes_domain_quota{domain="germany",domain_id="uuid-for-germany",resource="things",service="unittest",service_name="unittest"} 26
 # HELP limes_project_backendquota Actual quota of a Limes resource for an OpenStack project.
 # TYPE limes_project_backendquota gauge
-limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="generic-unittest"} 20
-limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest",service_name="generic-unittest"} 13
-limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="generic-unittest"} 20
-limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest",service_name="generic-unittest"} 13
+limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="unittest"} 20
+limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest",service_name="unittest"} 13
+limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="unittest"} 20
+limes_project_backendquota{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest",service_name="unittest"} 13
 # HELP limes_project_commitment_min_expires_at Minimum expiredAt timestamp of all commitments for an Openstack project, grouped by resource and service.
 # TYPE limes_project_commitment_min_expires_at gauge
-limes_project_commitment_min_expires_at{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="generic-unittest"} 3.154688e+07
-limes_project_commitment_min_expires_at{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="generic-unittest"} 3.154688e+07
+limes_project_commitment_min_expires_at{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="unittest"} 3.154688e+07
+limes_project_commitment_min_expires_at{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="unittest"} 3.154688e+07
 # HELP limes_project_committed_per_az Sum of all active commitments of a Limes resource for an OpenStack project, grouped by availability zone and state.
 # TYPE limes_project_committed_per_az gauge
-limes_project_committed_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="generic-unittest",state="active"} 15
-limes_project_committed_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="generic-unittest",state="active"} 10
-limes_project_committed_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="generic-unittest",state="pending"} 10
+limes_project_committed_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="unittest",state="active"} 15
+limes_project_committed_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="unittest",state="active"} 10
+limes_project_committed_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="unittest",state="pending"} 10
 # HELP limes_project_physical_usage Actual (physical) usage of a Limes resource for an OpenStack project.
 # TYPE limes_project_physical_usage gauge
-limes_project_physical_usage{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="generic-unittest"} 10
-limes_project_physical_usage{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="generic-unittest"} 10
+limes_project_physical_usage{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="unittest"} 10
+limes_project_physical_usage{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="unittest"} 10
 # HELP limes_project_quota Assigned quota of a Limes resource for an OpenStack project.
 # TYPE limes_project_quota gauge
-limes_project_quota{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="generic-unittest"} 20
-limes_project_quota{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest",service_name="generic-unittest"} 13
-limes_project_quota{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="generic-unittest"} 20
-limes_project_quota{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest",service_name="generic-unittest"} 13
+limes_project_quota{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="unittest"} 20
+limes_project_quota{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest",service_name="unittest"} 13
+limes_project_quota{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="unittest"} 20
+limes_project_quota{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest",service_name="unittest"} 13
 # HELP limes_project_usage Actual (logical) usage of a Limes resource for an OpenStack project.
 # TYPE limes_project_usage gauge
-limes_project_usage{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="generic-unittest"} 20
-limes_project_usage{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest",service_name="generic-unittest"} 5
-limes_project_usage{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="generic-unittest"} 20
-limes_project_usage{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest",service_name="generic-unittest"} 5
+limes_project_usage{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="unittest"} 20
+limes_project_usage{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest",service_name="unittest"} 5
+limes_project_usage{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="unittest"} 20
+limes_project_usage{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest",service_name="unittest"} 5
 # HELP limes_project_usage_per_az Actual (logical) usage of a Limes resource for an OpenStack project in a specific availability zone.
 # TYPE limes_project_usage_per_az gauge
-limes_project_usage_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="generic-unittest"} 20
-limes_project_usage_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest",service_name="generic-unittest"} 2
-limes_project_usage_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="generic-unittest"} 20
-limes_project_usage_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest",service_name="generic-unittest"} 2
-limes_project_usage_per_az{availability_zone="az-two",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest",service_name="generic-unittest"} 3
-limes_project_usage_per_az{availability_zone="az-two",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest",service_name="generic-unittest"} 3
+limes_project_usage_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="unittest"} 20
+limes_project_usage_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest",service_name="unittest"} 2
+limes_project_usage_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="unittest"} 20
+limes_project_usage_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest",service_name="unittest"} 2
+limes_project_usage_per_az{availability_zone="az-two",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest",service_name="unittest"} 3
+limes_project_usage_per_az{availability_zone="az-two",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest",service_name="unittest"} 3
 # HELP limes_project_used_and_or_committed_per_az The maximum of limes_project_usage_per_az and limes_project_committed_per_az{state="active"}.
 # TYPE limes_project_used_and_or_committed_per_az gauge
-limes_project_used_and_or_committed_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="generic-unittest"} 20
-limes_project_used_and_or_committed_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest",service_name="generic-unittest"} 2
-limes_project_used_and_or_committed_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="generic-unittest"} 20
-limes_project_used_and_or_committed_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest",service_name="generic-unittest"} 2
-limes_project_used_and_or_committed_per_az{availability_zone="az-two",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest",service_name="generic-unittest"} 3
-limes_project_used_and_or_committed_per_az{availability_zone="az-two",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest",service_name="generic-unittest"} 3
+limes_project_used_and_or_committed_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="capacity",service="unittest",service_name="unittest"} 20
+limes_project_used_and_or_committed_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest",service_name="unittest"} 2
+limes_project_used_and_or_committed_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="capacity",service="unittest",service_name="unittest"} 20
+limes_project_used_and_or_committed_per_az{availability_zone="az-one",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest",service_name="unittest"} 2
+limes_project_used_and_or_committed_per_az{availability_zone="az-two",domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",resource="things",service="unittest",service_name="unittest"} 3
+limes_project_used_and_or_committed_per_az{availability_zone="az-two",domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",resource="things",service="unittest",service_name="unittest"} 3
 # HELP limes_unit_multiplier Conversion factor that a value of this resource must be multiplied with to obtain the base unit (e.g. bytes). For use with Grafana when only the base unit can be configured because of templating.
 # TYPE limes_unit_multiplier gauge
-limes_unit_multiplier{resource="capacity",service="unittest",service_name="generic-unittest"} 1
-limes_unit_multiplier{resource="things",service="unittest",service_name="generic-unittest"} 1
+limes_unit_multiplier{resource="capacity",service="unittest",service_name="unittest"} 1
+limes_unit_multiplier{resource="things",service="unittest",service_name="unittest"} 1

--- a/internal/collector/fixtures/scrape_metrics.prom
+++ b/internal/collector/fixtures/scrape_metrics.prom
@@ -1,13 +1,13 @@
 # HELP limes_newest_scraped_at Newest (i.e. largest) scraped_at timestamp for any project given a certain service in a certain OpenStack cluster.
 # TYPE limes_newest_scraped_at gauge
-limes_newest_scraped_at{service="unittest",service_name="generic-unittest"} 10880
+limes_newest_scraped_at{service="unittest",service_name="unittest"} 10880
 # HELP limes_oldest_scraped_at Oldest (i.e. smallest) scraped_at timestamp for any project given a certain service in a certain OpenStack cluster.
 # TYPE limes_oldest_scraped_at gauge
-limes_oldest_scraped_at{service="unittest",service_name="generic-unittest"} 10875
+limes_oldest_scraped_at{service="unittest",service_name="unittest"} 10875
 # HELP limes_plugin_metrics_ok Whether quota plugin metrics were rendered successfully for a particular project service. Only present when the project service emits metrics.
 # TYPE limes_plugin_metrics_ok gauge
-limes_plugin_metrics_ok{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",service="unittest",service_name="generic-unittest"} 1
-limes_plugin_metrics_ok{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",service="unittest",service_name="generic-unittest"} 1
+limes_plugin_metrics_ok{domain="germany",domain_id="uuid-for-germany",project="berlin",project_id="uuid-for-berlin",service="unittest",service_name="unittest"} 1
+limes_plugin_metrics_ok{domain="germany",domain_id="uuid-for-germany",project="dresden",project_id="uuid-for-dresden",service="unittest",service_name="unittest"} 1
 # HELP limes_unittest_capacity_usage 
 # TYPE limes_unittest_capacity_usage gauge
 limes_unittest_capacity_usage{domain_id="uuid-for-germany",project_id="uuid-for-berlin"} 20

--- a/internal/collector/scrape.go
+++ b/internal/collector/scrape.go
@@ -127,7 +127,7 @@ func (c *Collector) discoverScrapeTask(labels prometheus.Labels, query string) (
 	if !c.Cluster.HasService(serviceType) {
 		return projectScrapeTask{}, fmt.Errorf("no such service type: %q", serviceType)
 	}
-	labels["service_name"] = c.Cluster.InfoForService(serviceType).ProductName
+	labels["service_name"] = labels["service_type"] // for backwards compatibility only (TODO: remove usage from alert definitions, then remove this label)
 
 	task.Timing.StartedAt = c.MeasureTime()
 	err = c.DB.SelectOne(&task.Service, query, serviceType, task.Timing.StartedAt)

--- a/internal/collector/sync_quota_to_backend.go
+++ b/internal/collector/sync_quota_to_backend.go
@@ -71,11 +71,9 @@ func (c *Collector) discoverQuotaSyncTask(ctx context.Context, labels prometheus
 	if !c.Cluster.HasService(serviceType) {
 		return db.ProjectService{}, fmt.Errorf("no such service type: %q", serviceType)
 	}
+	labels["service_name"] = labels["service_type"] // for backwards compatibility only (TODO: remove usage from alert definitions, then remove this label)
 
 	err = c.DB.SelectOne(&srv, quotaSyncDiscoverQuery, serviceType)
-	if err == nil {
-		labels["service_name"] = c.Cluster.InfoForService(srv.Type).ProductName
-	}
 	return
 }
 

--- a/internal/core/plugin.go
+++ b/internal/core/plugin.go
@@ -184,17 +184,15 @@ type QuotaPlugin interface {
 // ServiceInfo is a reduced version of type limes.ServiceInfo, suitable for
 // being returned from func QuotaPlugin.ServiceInfo().
 type ServiceInfo struct {
-	ProductName string
-	Area        string
+	Area string
 }
 
 // ForAPI inflates the given core.ServiceInfo into a limes.ServiceInfo.
 // The given ServiceType should be the one that we want to appear in the API.
 func (s ServiceInfo) ForAPI(serviceType limes.ServiceType) limes.ServiceInfo {
 	return limes.ServiceInfo{
-		Type:        serviceType,
-		ProductName: s.ProductName,
-		Area:        s.Area,
+		Type: serviceType,
+		Area: s.Area,
 	}
 }
 

--- a/internal/plugins/liquid.go
+++ b/internal/plugins/liquid.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"strings"
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/prometheus/client_golang/prometheus"
@@ -88,10 +87,7 @@ func (p *LiquidQuotaPlugin) Init(ctx context.Context, client *gophercloud.Provid
 
 // ServiceInfo implements the core.QuotaPlugin interface.
 func (p *LiquidQuotaPlugin) ServiceInfo() core.ServiceInfo {
-	return core.ServiceInfo{
-		ProductName: strings.TrimPrefix(p.LiquidServiceType, "liquid-"),
-		Area:        p.Area,
-	}
+	return core.ServiceInfo{Area: p.Area}
 }
 
 // Resources implements the core.QuotaPlugin interface.


### PR DESCRIPTION
When the internal service types were "compute", "network" etc., we had ProductName in order to have "nova", "neutron" etc. on metrics to aid in alert routing to the respective service channels. Since the DB service types are now changed to already be "nova", "neutron" etc., we can get rid of this.