### PR TITLE
remove cluster_capacitors from DB

### DIFF
--- a/docs/operators/config.md
+++ b/docs/operators/config.md
@@ -104,9 +104,8 @@ services:
   - type: compute
   - type: network
 capacitors:
-  - id: nova
+  - service_type: nova
     params:
-      service_type: compute
       liquid_service_type: liquid-nova
 ```
 
@@ -426,21 +425,20 @@ from the liquid, the `capacitors` accept two additional means of providing capac
 are configured (all 3 can be combined) the whole collection for a service will error if at least one path (liquid, manual, prometheus) fails.
 
 Note that _currently_ capacity for a resource only becomes visible when the corresponding service is enabled in the
-`services[]` list as well.
+`services[]` list as well. Also, the `service_type` of a capacitor must match the `service_type` of the service.
 
 ### `basic configuration of a capacity plugin (liquid)`
 
 ```yaml
 capacitors:
-  - id: nova
+  - service_type: nova
     params:
-      service_type: compute
       liquid_service_type: liquid-nova
 ```
 
 This is a generic integration method for any service that supports [LIQUID](https://pkg.go.dev/github.com/sapcc/go-api-declarations/liquid);
 see documentation over there. The LIQUID endpoint will by located in the Keystone service catalog at service type `liquid-$SERVICE_TYPE`,
-using the value from `params.service_type`, unless this default logic is overridden by `params.liquid_service_type`.
+using the value from `service_type`, unless this default logic is overridden by `params.liquid_service_type`.
 
 Currently, any increase in the ServiceInfo version of the liquid will prompt a fatal error in Limes, thus usually forcing it to restart.
 This is something that we plan on changing into a graceful reload in the future.
@@ -451,9 +449,8 @@ For information on liquids provided by Limes itself, please refer to the [liquid
 
 ```yaml
 capacitors:
-  - id: neutron
+  - service_type: neutron
     params:
-      service_type: network
       fixed_capacity_values:
         values:
           floating_ips: 8192
@@ -471,9 +468,8 @@ allows to track capacity values along with other configuration in a Git reposito
 
 ```yaml
 capacitors:
-  - id: nova
+  - service_type: nova
     params:
-      service_type: compute
       capacity_values_from_prometheus:
         api:
           url: https://prometheus.example.com

--- a/docs/operators/metrics.md
+++ b/docs/operators/metrics.md
@@ -26,8 +26,8 @@ The collector service exposes the following metrics by default:
 | Counter | `limes_failed_domain_discoveries` | none |
 | Counter | `limes_successful_project_discoveries` | `domain`, `domain_id` |
 | Counter | `limes_failed_project_discoveries` | `domain`, `domain_id` |
-| Counter | `limes_successful_capacity_scrapes` | `capacitor` |
-| Counter | `limes_failed_capacity_scrapes` | `capacitor` |
+| Counter | `limes_successful_capacity_scrapes` | `service_type` |
+| Counter | `limes_failed_capacity_scrapes` | `service_type` |
 | Counter | `limes_successful_auditevent_publish` | none |
 | Counter | `limes_failed_auditevent_publish` | none |
 

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -126,8 +126,8 @@ var (
 		 WHERE ps.project_id = $1 AND ps.type = $2 AND pr.name = $3 AND par.az = $4
 	`)
 	forceImmediateCapacityScrapeQuery = sqlext.SimplifyWhitespace(`
-		UPDATE cluster_capacitors SET next_scrape_at = $1 WHERE capacitor_id = (
-			SELECT capacitor_id FROM cluster_services cs JOIN cluster_resources cr ON cs.id = cr.service_id
+		UPDATE cluster_services SET next_scrape_at = $1 WHERE id = (
+			SELECT cs.id FROM cluster_services cs JOIN cluster_resources cr ON cs.id = cr.service_id
 			WHERE cs.type = $2 AND cr.name = $3
 		)
 	`)

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -125,12 +125,6 @@ var (
 		  JOIN project_services ps ON pr.service_id = ps.id
 		 WHERE ps.project_id = $1 AND ps.type = $2 AND pr.name = $3 AND par.az = $4
 	`)
-	forceImmediateCapacityScrapeQuery = sqlext.SimplifyWhitespace(`
-		UPDATE cluster_services SET next_scrape_at = $1 WHERE id = (
-			SELECT cs.id FROM cluster_services cs JOIN cluster_resources cr ON cs.id = cr.service_id
-			WHERE cs.type = $2 AND cr.name = $3
-		)
-	`)
 )
 
 // GetProjectCommitments handles GET /v1/domains/:domain_id/projects/:project_id/commitments.
@@ -453,7 +447,7 @@ func (p *v1Provider) CreateProjectCommitment(w http.ResponseWriter, r *http.Requ
 	// if the commitment is immediately confirmed, trigger a capacity scrape in
 	// order to ApplyComputedProjectQuotas based on the new commitment
 	if dbCommitment.ConfirmedAt.IsSome() {
-		_, err := p.DB.Exec(forceImmediateCapacityScrapeQuery, now, loc.ServiceType, loc.ResourceName)
+		_, err := p.DB.Exec(`UPDATE cluster_services SET next_scrape_at = $1 WHERE type = $2`, now, loc.ServiceType)
 		if respondwith.ErrorText(w, err) {
 			return
 		}

--- a/internal/api/fixtures/start-data-commitments.sql
+++ b/internal/api/fixtures/start-data-commitments.sql
@@ -1,13 +1,11 @@
 CREATE OR REPLACE FUNCTION unix(i integer) RETURNS timestamp AS $$ SELECT TO_TIMESTAMP(i) AT TIME ZONE 'Etc/UTC' $$ LANGUAGE SQL;
 
-INSERT INTO cluster_capacitors (capacitor_id, scraped_at, next_scrape_at) VALUES ('unittest', UNIX(1000), UNIX(2000));
-
-INSERT INTO cluster_services (id, type) VALUES (1, 'first');
-INSERT INTO cluster_services (id, type) VALUES (2, 'second');
+INSERT INTO cluster_services (id, type, scraped_at, next_scrape_at) VALUES (1, 'first', UNIX(1000), UNIX(2000));
+INSERT INTO cluster_services (id, type, scraped_at, next_scrape_at) VALUES (2, 'second', UNIX(1000), UNIX(2000));
 
 -- cluster_resources and cluster_az_resources have entries for the resources where commitments are enabled in the config
-INSERT INTO cluster_resources (id, service_id, name, capacitor_id) VALUES (1, 1, 'capacity', 'unittest');
-INSERT INTO cluster_resources (id, service_id, name, capacitor_id) VALUES (2, 2, 'capacity', 'unittest');
+INSERT INTO cluster_resources (id, service_id, name) VALUES (1, 1, 'capacity');
+INSERT INTO cluster_resources (id, service_id, name) VALUES (2, 2, 'capacity');
 
 INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, subcapacities) VALUES (1, 1, 'az-one', 10, 6, '');
 INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, subcapacities) VALUES (2, 1, 'az-two', 20, 6, '');

--- a/internal/api/fixtures/start-data-small.sql
+++ b/internal/api/fixtures/start-data-small.sql
@@ -3,12 +3,10 @@
 
 CREATE OR REPLACE FUNCTION unix(i integer) RETURNS timestamp AS $$ SELECT TO_TIMESTAMP(i) AT TIME ZONE 'Etc/UTC' $$ LANGUAGE SQL;
 
-INSERT INTO cluster_capacitors (capacitor_id, scraped_at, next_scrape_at) VALUES ('first', UNIX(1000), UNIX(2000));
+INSERT INTO cluster_services (id, type, scraped_at, next_scrape_at) VALUES (1, 'first', UNIX(1000), UNIX(2000));
 
-INSERT INTO cluster_services (id, type) VALUES (1, 'first');
-
-INSERT INTO cluster_resources (id, service_id, name, capacitor_id) VALUES (1, 1, 'things', 'first');
-INSERT INTO cluster_resources (id, service_id, name, capacitor_id) VALUES (2, 1, 'capacity', 'first');
+INSERT INTO cluster_resources (id, service_id, name) VALUES (1, 1, 'things');
+INSERT INTO cluster_resources (id, service_id, name) VALUES (2, 1, 'capacity');
 
 -- "capacity" is modeled as AZ-aware, "things" is not
 INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, subcapacities) VALUES (1, 1, 'any', 0, 0, '');

--- a/internal/api/fixtures/start-data.sql
+++ b/internal/api/fixtures/start-data.sql
@@ -1,17 +1,12 @@
 CREATE OR REPLACE FUNCTION unix(i integer) RETURNS timestamp AS $$ SELECT TO_TIMESTAMP(i) AT TIME ZONE 'Etc/UTC' $$ LANGUAGE SQL;
 
--- two capacitors matching the two services that have capacity values
-INSERT INTO cluster_capacitors (capacitor_id, scraped_at, next_scrape_at) VALUES ('scans-unshared', UNIX(1000), UNIX(2000));
-INSERT INTO cluster_capacitors (capacitor_id, scraped_at, next_scrape_at) VALUES ('scans-shared',   UNIX(1100), UNIX(2100));
-
--- three services
-INSERT INTO cluster_services (id, type) VALUES (1, 'unshared');
-INSERT INTO cluster_services (id, type) VALUES (2, 'shared');
+INSERT INTO cluster_services (id, type, scraped_at, next_scrape_at) VALUES (1, 'unshared', UNIX(1000), UNIX(2000));
+INSERT INTO cluster_services (id, type, scraped_at, next_scrape_at) VALUES (2, 'shared',   UNIX(1100), UNIX(2100));
 
 -- all services have the resources "things" and "capacity"
-INSERT INTO cluster_resources (id, service_id, name, capacitor_id) VALUES (1, 1, 'things', 'scans-unshared');
-INSERT INTO cluster_resources (id, service_id, name, capacitor_id) VALUES (2, 2, 'things', 'scans-shared');
-INSERT INTO cluster_resources (id, service_id, name, capacitor_id) VALUES (3, 2, 'capacity', 'scans-shared');
+INSERT INTO cluster_resources (id, service_id, name) VALUES (1, 1, 'things');
+INSERT INTO cluster_resources (id, service_id, name) VALUES (2, 2, 'things');
+INSERT INTO cluster_resources (id, service_id, name) VALUES (3, 2, 'capacity');
 
 -- "capacity" is modeled as AZ-aware, "things" is not
 INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, subcapacities) VALUES (1, 1, 'any', 139, 45, '[{"smaller_half":46},{"larger_half":93}]');
@@ -121,7 +116,7 @@ INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_big
 -- insert some bullshit data that should be filtered out by the internal/reports/ logic
 -- (cluster "north", service "weird", resource "items" and rate "frobnicate" are not configured)
 INSERT INTO cluster_services (id, type) VALUES (101, 'weird');
-INSERT INTO cluster_resources (id, service_id, name, capacitor_id) VALUES (101, 101, 'things', 'scans-shared');
+INSERT INTO cluster_resources (id, service_id, name) VALUES (101, 101, 'things');
 INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, subcapacities) VALUES (101, 101, 'any', 2, 1, '');
 INSERT INTO project_services (id, project_id, type) VALUES (101, 1, 'weird');
 INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (101, 101, 'things', 2, 2);

--- a/internal/api/liquid.go
+++ b/internal/api/liquid.go
@@ -39,7 +39,7 @@ func (p *v1Provider) GetServiceCapacityRequest(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	serviceType := r.URL.Query().Get("service_type")
+	serviceType := db.ServiceType(r.URL.Query().Get("service_type"))
 	if serviceType == "" {
 		http.Error(w, "missing required parameter: service_type", http.StatusBadRequest)
 		return

--- a/internal/api/liquid_test.go
+++ b/internal/api/liquid_test.go
@@ -44,9 +44,8 @@ const (
 				params:
 					liquid_service_type: %[1]s
 		capacitors:
-		- id: unittest
+		- service_type: unittest
 			params:
-				service_type: unittest
 				liquid_service_type: %[1]s
 		resource_behavior:
 		- { resource: unittest/capacity, overcommit_factor: 1.5 }

--- a/internal/collector/capacity_scrape_test.go
+++ b/internal/collector/capacity_scrape_test.go
@@ -58,13 +58,11 @@ const (
 				params:
 					liquid_service_type: %[2]s
 		capacitors:
-		- id: unittest
+		- service_type: shared
 			params:
-				service_type: shared
 				liquid_service_type: %[1]s
-		- id: unittest2
+		- service_type: unshared
 			params:
-				service_type: unshared
 				liquid_service_type: %[2]s
 	`
 
@@ -79,9 +77,8 @@ const (
 				params:
 					liquid_service_type: %[1]s
 		capacitors:
-		- id: unittest
+		- service_type: shared
 			params:
-				service_type: shared
 				liquid_service_type: %[1]s
 	`
 
@@ -113,13 +110,11 @@ const (
 					liquid_service_type: %[2]s
 				commitment_behavior_per_resource: *commitment-on-capacity
 		capacitors:
-		- id: scans-first
+		- service_type: first
 			params:
-				service_type: first
 				liquid_service_type: %[1]s
-		- id: scans-second
+		- service_type: second
 			params:
-				service_type: second
 				liquid_service_type: %[2]s
 		resource_behavior:
 			# test that overcommit factor is considered when confirming commitments
@@ -170,8 +165,9 @@ func Test_ScanCapacity(t *testing.T) {
 	job := c.CapacityScrapeJob(s.Registry)
 
 	// cluster_services must be created as a baseline (this is usually done by the CheckConsistencyJob)
+	insertTime := s.Clock.Now()
 	for _, serviceType := range s.Cluster.ServiceTypesInAlphabeticalOrder() {
-		err := s.DB.Insert(&db.ClusterService{Type: serviceType})
+		err := s.DB.Insert(&db.ClusterService{Type: serviceType, NextScrapeAt: insertTime})
 		mustT(t, err)
 	}
 
@@ -207,9 +203,9 @@ func Test_ScanCapacity(t *testing.T) {
 	// check baseline
 	tr, tr0 := easypg.NewTracker(t, s.DB.Db)
 	tr0.AssertEqualf(`
-		INSERT INTO cluster_services (id, type) VALUES (1, 'shared');
-		INSERT INTO cluster_services (id, type) VALUES (2, 'unshared');
-	`)
+		INSERT INTO cluster_services (id, type, next_scrape_at) VALUES (1, 'shared', %d);
+		INSERT INTO cluster_services (id, type, next_scrape_at) VALUES (2, 'unshared', %d);
+	`, insertTime.Unix(), insertTime.Unix())
 
 	// check that capacity records are created correctly (and that nonexistent
 	// resources are ignored by the scraper)
@@ -218,17 +214,16 @@ func Test_ScanCapacity(t *testing.T) {
 	tr.DBChanges().AssertEqualf(`
 		INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage) VALUES (1, 1, 'any', 42, 8);
 		INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage) VALUES (2, 2, 'any', 42, 8);
-		INSERT INTO cluster_capacitors (capacitor_id, scraped_at, scrape_duration_secs, serialized_metrics, next_scrape_at) VALUES ('unittest', 5, 5, '{}', 905);
-		INSERT INTO cluster_capacitors (capacitor_id, scraped_at, scrape_duration_secs, serialized_metrics, next_scrape_at) VALUES ('unittest2', 10, 5, '{}', 910);
-		INSERT INTO cluster_resources (id, capacitor_id, service_id, name) VALUES (1, 'unittest', 1, 'things');
-		INSERT INTO cluster_resources (id, capacitor_id, service_id, name) VALUES (2, 'unittest2', 2, 'capacity');
-	`)
+		INSERT INTO cluster_resources (id, service_id, name) VALUES (1, 1, 'things');
+		INSERT INTO cluster_resources (id, service_id, name) VALUES (2, 2, 'capacity');
+    UPDATE cluster_services SET scraped_at = %d, scrape_duration_secs = 5, serialized_metrics = '{}', next_scrape_at = 905 WHERE id = 1 AND type = 'shared';
+		UPDATE cluster_services SET scraped_at = %d, scrape_duration_secs = 5, serialized_metrics = '{}', next_scrape_at = 910 WHERE id = 2 AND type = 'unshared';
+	`, insertTime.Add(5*time.Second).Unix(), insertTime.Add(10*time.Second).Unix())
 
 	// insert some crap records
 	unknownRes := &db.ClusterResource{
-		ServiceID:   2,
-		Name:        "unknown",
-		CapacitorID: "unittest2",
+		ServiceID: 2,
+		Name:      "unknown",
 	}
 	err := s.DB.Insert(unknownRes)
 	if err != nil {
@@ -263,10 +258,10 @@ func Test_ScanCapacity(t *testing.T) {
 	tr.DBChanges().AssertEqualf(`
 		DELETE FROM cluster_az_resources WHERE id = 1 AND resource_id = 1 AND az = 'any';
 		INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage) VALUES (4, 4, 'any', 23, 4);
-		UPDATE cluster_capacitors SET scraped_at = %d, next_scrape_at = %d WHERE capacitor_id = 'unittest';
-		UPDATE cluster_capacitors SET scraped_at = %d, next_scrape_at = %d WHERE capacitor_id = 'unittest2';
 		DELETE FROM cluster_resources WHERE id = 1 AND service_id = 1 AND name = 'things';
-		INSERT INTO cluster_resources (id, capacitor_id, service_id, name) VALUES (4, 'unittest', 1, 'things');
+		INSERT INTO cluster_resources (id, service_id, name) VALUES (4, 1, 'things');
+		UPDATE cluster_services SET scraped_at = %d, next_scrape_at = %d WHERE id = 1 AND type = 'shared';
+		UPDATE cluster_services SET scraped_at = %d, next_scrape_at = %d WHERE id = 2 AND type = 'unshared';
 	`,
 		scrapedAt1.Unix(), scrapedAt1.Add(15*time.Minute).Unix(),
 		scrapedAt2.Unix(), scrapedAt2.Add(15*time.Minute).Unix(),
@@ -306,17 +301,18 @@ func Test_ScanCapacityWithSubcapacities(t *testing.T) {
 	c := getCollector(t, s)
 	job := c.CapacityScrapeJob(s.Registry)
 
-	// cluster_services must be created as a baseline (this is usually done by the CheckConsistencyJob)
+	// cluster_services are be created as a baseline (this is usually done by the CheckConsistencyJob)
+	insertTime := s.Clock.Now()
 	for _, serviceType := range s.Cluster.ServiceTypesInAlphabeticalOrder() {
-		err := s.DB.Insert(&db.ClusterService{Type: serviceType})
+		err := s.DB.Insert(&db.ClusterService{Type: serviceType, NextScrapeAt: insertTime})
 		mustT(t, err)
 	}
 
 	// check baseline
 	tr, tr0 := easypg.NewTracker(t, s.DB.Db)
 	tr0.AssertEqualf(`
-		INSERT INTO cluster_services (id, type) VALUES (1, 'shared');
-	`)
+		INSERT INTO cluster_services (id, type, next_scrape_at) VALUES (1, 'shared', %d);
+	`, insertTime.Unix())
 
 	// check that scraping correctly updates subcapacities on an existing record
 	buf := must.Return(json.Marshal(map[string]any{"az": "az-one"}))
@@ -367,8 +363,8 @@ func Test_ScanCapacityWithSubcapacities(t *testing.T) {
 	scrapedAt := s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`
 		INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, subcapacities) VALUES (1, 1, 'any', 42, '[{"name":"smaller_half","capacity":7,"attributes":{"az":"az-one"}},{"name":"larger_half","capacity":14,"attributes":{"az":"az-one"}},{"name":"smaller_half","capacity":7,"attributes":{"az":"az-two"}},{"name":"larger_half","capacity":14,"attributes":{"az":"az-two"}}]');
-		INSERT INTO cluster_capacitors (capacitor_id, scraped_at, scrape_duration_secs, serialized_metrics, next_scrape_at) VALUES ('unittest', %d, 5, '{"limes_unittest_capacity_larger_half":{"lk":null,"m":[{"v":7,"l":null}]},"limes_unittest_capacity_smaller_half":{"lk":null,"m":[{"v":3,"l":null}]}}', %d);
-		INSERT INTO cluster_resources (id, capacitor_id, service_id, name) VALUES (1, 'unittest', 1, 'things');
+		INSERT INTO cluster_resources (id, service_id, name) VALUES (1, 1, 'things');
+		UPDATE cluster_services SET scraped_at = %d, scrape_duration_secs = 5, serialized_metrics = '{"limes_unittest_capacity_larger_half":{"lk":null,"m":[{"v":7,"l":null}]},"limes_unittest_capacity_smaller_half":{"lk":null,"m":[{"v":3,"l":null}]}}', next_scrape_at = %d WHERE id = 1 AND type = 'shared';
 	`,
 		scrapedAt.Unix(), scrapedAt.Add(15*time.Minute).Unix(),
 	)
@@ -404,7 +400,7 @@ func Test_ScanCapacityWithSubcapacities(t *testing.T) {
 	scrapedAt = s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`
 		UPDATE cluster_az_resources SET raw_capacity = 10, subcapacities = '[{"name":"smaller_half","capacity":1,"attributes":{"az":"az-one"}},{"name":"larger_half","capacity":4,"attributes":{"az":"az-one"}},{"name":"smaller_half","capacity":1,"attributes":{"az":"az-two"}},{"name":"larger_half","capacity":4,"attributes":{"az":"az-two"}}]' WHERE id = 1 AND resource_id = 1 AND az = 'any';
-		UPDATE cluster_capacitors SET scraped_at = %d, next_scrape_at = %d WHERE capacitor_id = 'unittest';
+		UPDATE cluster_services SET scraped_at = %d, next_scrape_at = %d WHERE id = 1 AND type = 'shared';
 	`,
 		scrapedAt.Unix(), scrapedAt.Add(15*time.Minute).Unix(),
 	)
@@ -452,16 +448,17 @@ func Test_ScanCapacityAZAware(t *testing.T) {
 	job := c.CapacityScrapeJob(s.Registry)
 
 	// cluster_services must be created as a baseline (this is usually done by the CheckConsistencyJob)
+	insertTime := s.Clock.Now()
 	for _, serviceType := range s.Cluster.ServiceTypesInAlphabeticalOrder() {
-		err := s.DB.Insert(&db.ClusterService{Type: serviceType})
+		err := s.DB.Insert(&db.ClusterService{Type: serviceType, NextScrapeAt: insertTime})
 		mustT(t, err)
 	}
 
 	// check baseline
 	tr, tr0 := easypg.NewTracker(t, s.DB.Db)
 	tr0.AssertEqualf(`
-		INSERT INTO cluster_services (id, type) VALUES (1, 'shared');
-	`)
+		INSERT INTO cluster_services (id, type, next_scrape_at) VALUES (1, 'shared', %d);
+	`, insertTime.Unix())
 
 	capacityReport := liquid.ServiceCapacityReport{
 		InfoVersion: 1,
@@ -489,8 +486,8 @@ func Test_ScanCapacityAZAware(t *testing.T) {
 	tr.DBChanges().AssertEqualf(`
 	INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage) VALUES (1, 1, 'az-one', 21, 4);
 	INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage) VALUES (2, 1, 'az-two', 21, 4);
-	INSERT INTO cluster_capacitors (capacitor_id, scraped_at, scrape_duration_secs, serialized_metrics, next_scrape_at) VALUES ('unittest', %d, 5, '{}', %d);
-	INSERT INTO cluster_resources (id, capacitor_id, service_id, name) VALUES (1, 'unittest', 1, 'things');
+	INSERT INTO cluster_resources (id, service_id, name) VALUES (1, 1, 'things');
+	UPDATE cluster_services SET scraped_at = %d, scrape_duration_secs = 5, serialized_metrics = '{}', next_scrape_at = %d WHERE id = 1 AND type = 'shared';
 	`,
 		scrapedAt.Unix(), scrapedAt.Add(15*time.Minute).Unix(),
 	)
@@ -507,7 +504,7 @@ func Test_ScanCapacityAZAware(t *testing.T) {
 	tr.DBChanges().AssertEqualf(`
 		UPDATE cluster_az_resources SET raw_capacity = 15, usage = 3 WHERE id = 1 AND resource_id = 1 AND az = 'az-one';
 		UPDATE cluster_az_resources SET raw_capacity = 15, usage = 3 WHERE id = 2 AND resource_id = 1 AND az = 'az-two';
-		UPDATE cluster_capacitors SET scraped_at = %d, next_scrape_at = %d WHERE capacitor_id = 'unittest';
+		UPDATE cluster_services SET scraped_at = %d, next_scrape_at = %d WHERE id = 1 AND type = 'shared';
 	`,
 		scrapedAt.Unix(), scrapedAt.Add(15*time.Minute).Unix(),
 	)
@@ -521,21 +518,20 @@ func Test_ScanCapacityAZAware(t *testing.T) {
 		ExpectBody:   assert.FixtureFile("fixtures/capacity_data_metrics_azaware.prom"),
 	}.Check(t, dmr)
 
-	// check that removing a capacitor removes its associated resources
+	// check that removing a capacitor does nothing special (will be auto-removed when the quota plugin is also removed)
+	// TODO: this will change when the c.Cluster-Configs are merged
 	delete(s.Cluster.CapacityPlugins, "unittest")
 	setClusterCapacitorsStale(t, s)
-	mustT(t, jobloop.ProcessMany(job, s.Ctx, len(s.Cluster.CapacityPlugins)+1)) //+1 to account for the deleted capacitor
-	tr.DBChanges().AssertEqual(`
-		DELETE FROM cluster_az_resources WHERE id = 1 AND resource_id = 1 AND az = 'az-one';
-		DELETE FROM cluster_az_resources WHERE id = 2 AND resource_id = 1 AND az = 'az-two';
-		DELETE FROM cluster_capacitors WHERE capacitor_id = 'unittest';
-		DELETE FROM cluster_resources WHERE id = 1 AND service_id = 1 AND name = 'things';
-	`)
+	mustT(t, jobloop.ProcessMany(job, s.Ctx, len(s.Cluster.CapacityPlugins)))
+	scrapedAt = s.Clock.Now()
+	tr.DBChanges().AssertEqualf(`
+		UPDATE cluster_services SET scraped_at = %d, next_scrape_at = %d WHERE id = 1 AND type = 'shared';
+	`, scrapedAt.Unix(), scrapedAt.Add(15*time.Minute).Unix())
 }
 
 func setClusterCapacitorsStale(t *testing.T, s test.Setup) {
 	t.Helper()
-	_, err := s.DB.Exec(`UPDATE cluster_capacitors SET next_scrape_at = $1`, s.Clock.Now())
+	_, err := s.DB.Exec(`UPDATE cluster_services SET next_scrape_at = $1`, s.Clock.Now())
 	mustT(t, err)
 }
 
@@ -550,16 +546,17 @@ func Test_ScanCapacityButNoResources(t *testing.T) {
 	job := c.CapacityScrapeJob(s.Registry)
 
 	// cluster_services must be created as a baseline (this is usually done by the CheckConsistencyJob)
+	insertTime := s.Clock.Now()
 	for _, serviceType := range s.Cluster.ServiceTypesInAlphabeticalOrder() {
-		err := s.DB.Insert(&db.ClusterService{Type: serviceType})
+		err := s.DB.Insert(&db.ClusterService{Type: serviceType, NextScrapeAt: insertTime})
 		mustT(t, err)
 	}
 
 	// check baseline
 	tr, tr0 := easypg.NewTracker(t, s.DB.Db)
 	tr0.AssertEqualf(`
-		INSERT INTO cluster_services (id, type) VALUES (1, 'shared');
-	`)
+		INSERT INTO cluster_services (id, type, next_scrape_at) VALUES (1, 'shared', %d);
+	`, insertTime.Unix())
 
 	// adjust the capacity report to not show any resources
 	res := srvInfo.Resources["capacity"]
@@ -576,7 +573,7 @@ func Test_ScanCapacityButNoResources(t *testing.T) {
 	mustT(t, job.ProcessOne(s.Ctx))
 
 	tr.DBChanges().AssertEqualf(`
-		INSERT INTO cluster_capacitors (capacitor_id, scraped_at, scrape_duration_secs, serialized_metrics, next_scrape_at) VALUES ('unittest', %[1]d, 5, '{}', %[2]d);
+		UPDATE cluster_services SET scraped_at = %d, scrape_duration_secs = 5, serialized_metrics = '{}', next_scrape_at = %d WHERE id = 1 AND type = 'shared';
 	`,
 		s.Clock.Now().Unix(), s.Clock.Now().Add(15*time.Minute).Unix(),
 	)
@@ -586,7 +583,7 @@ func Test_ScanCapacityButNoResources(t *testing.T) {
 	mustT(t, job.ProcessOne(s.Ctx))
 
 	tr.DBChanges().AssertEqualf(`
-		UPDATE cluster_capacitors SET scraped_at = %[1]d, next_scrape_at = %[2]d WHERE capacitor_id = 'unittest';
+		UPDATE cluster_services SET scraped_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND type = 'shared';
 	`,
 		s.Clock.Now().Unix(), s.Clock.Now().Add(15*time.Minute).Unix(),
 	)
@@ -607,16 +604,17 @@ func Test_ScanManualCapacity(t *testing.T) {
 	job := c.CapacityScrapeJob(s.Registry)
 
 	// cluster_services must be created as a baseline (this is usually done by the CheckConsistencyJob)
+	insertTime := s.Clock.Now()
 	for _, serviceType := range s.Cluster.ServiceTypesInAlphabeticalOrder() {
-		err := s.DB.Insert(&db.ClusterService{Type: serviceType})
+		err := s.DB.Insert(&db.ClusterService{Type: serviceType, NextScrapeAt: insertTime})
 		mustT(t, err)
 	}
 
 	// check baseline
 	tr, tr0 := easypg.NewTracker(t, s.DB.Db)
 	tr0.AssertEqualf(`
-		INSERT INTO cluster_services (id, type) VALUES (1, 'shared');
-	`)
+		INSERT INTO cluster_services (id, type, next_scrape_at) VALUES (1, 'shared', %d);
+	`, insertTime.Unix())
 
 	// adjust the capacity report to not show any capacity
 	res := srvInfo.Resources["capacity"]
@@ -632,8 +630,8 @@ func Test_ScanManualCapacity(t *testing.T) {
 
 	tr.DBChanges().AssertEqualf(`
 		INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity) VALUES (1, 1, 'any', 1000000);
-		INSERT INTO cluster_capacitors (capacitor_id, scraped_at, scrape_duration_secs, serialized_metrics, next_scrape_at) VALUES ('unittest', %[1]d, 5, '{}', %[2]d);
-		INSERT INTO cluster_resources (id, capacitor_id, service_id, name) VALUES (1, 'unittest', 1, 'things');
+		INSERT INTO cluster_resources (id, service_id, name) VALUES (1, 1, 'things');
+		UPDATE cluster_services SET scraped_at = %d, scrape_duration_secs = 5, serialized_metrics = '{}', next_scrape_at = %d WHERE id = 1 AND type = 'shared';
 	`,
 		s.Clock.Now().Unix(), s.Clock.Now().Add(15*time.Minute).Unix(),
 	)
@@ -753,22 +751,22 @@ func Test_ScanCapacityWithCommitments(t *testing.T) {
 	tr, tr0 := easypg.NewTracker(t, s.DB.Db)
 	tr0.Ignore()
 
-	// in each of the test steps below, the timestamp updates on cluster_capacitors will always be the same
+	// in each of the test steps below, the timestamp updates on cluster_services will always be the same
 	timestampUpdates := func(initMetrics bool) string {
 		scrapedAt1 := s.Clock.Now().Add(-5 * time.Second)
 		scrapedAt2 := s.Clock.Now()
 		if !initMetrics {
 			return strings.TrimSpace(fmt.Sprintf(`
-				UPDATE cluster_capacitors SET scraped_at = %d, next_scrape_at = %d WHERE capacitor_id = 'scans-first';
-				UPDATE cluster_capacitors SET scraped_at = %d, next_scrape_at = %d WHERE capacitor_id = 'scans-second';
+				UPDATE cluster_services SET scraped_at = %d, next_scrape_at = %d WHERE id = 1 AND type = 'first';
+				UPDATE cluster_services SET scraped_at = %d, next_scrape_at = %d WHERE id = 2 AND type = 'second';
 			`,
 				scrapedAt1.Unix(), scrapedAt1.Add(15*time.Minute).Unix(),
 				scrapedAt2.Unix(), scrapedAt2.Add(15*time.Minute).Unix(),
 			))
 		}
 		return strings.TrimSpace(fmt.Sprintf(`
-				UPDATE cluster_capacitors SET scraped_at = %d, serialized_metrics = '{}', next_scrape_at = %d WHERE capacitor_id = 'scans-first';
-				UPDATE cluster_capacitors SET scraped_at = %d, serialized_metrics = '{}', next_scrape_at = %d WHERE capacitor_id = 'scans-second';
+				UPDATE cluster_services SET scraped_at = %d, serialized_metrics = '{}', next_scrape_at = %d WHERE id = 1 AND type = 'first';
+				UPDATE cluster_services SET scraped_at = %d, serialized_metrics = '{}', next_scrape_at = %d WHERE id = 2 AND type = 'second';
 			`,
 			scrapedAt1.Unix(), scrapedAt1.Add(15*time.Minute).Unix(),
 			scrapedAt2.Unix(), scrapedAt2.Add(15*time.Minute).Unix(),
@@ -956,13 +954,13 @@ func TestScanCapacityWithMailNotification(t *testing.T) {
 
 	mustT(t, jobloop.ProcessMany(job, s.Ctx, len(s.Cluster.CapacityPlugins)))
 
-	// in each of the test steps below, the timestamp updates on cluster_capacitors will always be the same
+	// in each of the test steps below, the timestamp updates on cluster_services will always be the same
 	timestampUpdates := func() string {
 		scrapedAt1 := s.Clock.Now().Add(-5 * time.Second)
 		scrapedAt2 := s.Clock.Now()
 		return strings.TrimSpace(fmt.Sprintf(`
-					UPDATE cluster_capacitors SET scraped_at = %d, next_scrape_at = %d WHERE capacitor_id = 'scans-first';
-					UPDATE cluster_capacitors SET scraped_at = %d, next_scrape_at = %d WHERE capacitor_id = 'scans-second';
+					UPDATE cluster_services SET scraped_at = %d, next_scrape_at = %d WHERE id = 1 AND type = 'first';
+					UPDATE cluster_services SET scraped_at = %d, next_scrape_at = %d WHERE id = 2 AND type = 'second';
 				`,
 			scrapedAt1.Unix(), scrapedAt1.Add(15*time.Minute).Unix(),
 			scrapedAt2.Unix(), scrapedAt2.Add(15*time.Minute).Unix(),

--- a/internal/collector/capacity_scrape_test.go
+++ b/internal/collector/capacity_scrape_test.go
@@ -216,7 +216,7 @@ func Test_ScanCapacity(t *testing.T) {
 		INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage) VALUES (2, 2, 'any', 42, 8);
 		INSERT INTO cluster_resources (id, service_id, name) VALUES (1, 1, 'things');
 		INSERT INTO cluster_resources (id, service_id, name) VALUES (2, 2, 'capacity');
-    UPDATE cluster_services SET scraped_at = %d, scrape_duration_secs = 5, serialized_metrics = '{}', next_scrape_at = 905 WHERE id = 1 AND type = 'shared';
+		UPDATE cluster_services SET scraped_at = %d, scrape_duration_secs = 5, serialized_metrics = '{}', next_scrape_at = 905 WHERE id = 1 AND type = 'shared';
 		UPDATE cluster_services SET scraped_at = %d, scrape_duration_secs = 5, serialized_metrics = '{}', next_scrape_at = 910 WHERE id = 2 AND type = 'unshared';
 	`, insertTime.Add(5*time.Second).Unix(), insertTime.Add(10*time.Second).Unix())
 
@@ -301,7 +301,7 @@ func Test_ScanCapacityWithSubcapacities(t *testing.T) {
 	c := getCollector(t, s)
 	job := c.CapacityScrapeJob(s.Registry)
 
-	// cluster_services are be created as a baseline (this is usually done by the CheckConsistencyJob)
+	// cluster_services are created as a baseline (this is usually done by the CheckConsistencyJob)
 	insertTime := s.Clock.Now()
 	for _, serviceType := range s.Cluster.ServiceTypesInAlphabeticalOrder() {
 		err := s.DB.Insert(&db.ClusterService{Type: serviceType, NextScrapeAt: insertTime})

--- a/internal/collector/consistency.go
+++ b/internal/collector/consistency.go
@@ -77,7 +77,7 @@ func (c *Collector) checkConsistencyCluster(_ context.Context, _ prometheus.Labe
 		}
 
 		logg.Info("creating missing %s cluster service entry", serviceType)
-		err := c.DB.Insert(&db.ClusterService{Type: serviceType})
+		err := c.DB.Insert(&db.ClusterService{Type: serviceType, NextScrapeAt: c.MeasureTime()})
 		if err != nil {
 			c.LogError(err.Error())
 		}

--- a/internal/collector/consistency_test.go
+++ b/internal/collector/consistency_test.go
@@ -61,7 +61,7 @@ func Test_Consistency(t *testing.T) {
 		t.Error(err)
 	}
 	// add some useless *_services entries
-	err = s.DB.Insert(&db.ClusterService{Type: "whatever"})
+	err = s.DB.Insert(&db.ClusterService{Type: "whatever", NextScrapeAt: s.Clock.Now()})
 	if err != nil {
 		t.Error(err)
 	}

--- a/internal/collector/expiring_commitments_test.go
+++ b/internal/collector/expiring_commitments_test.go
@@ -41,9 +41,8 @@ const (
 				params:
 					liquid_service_type: %[1]s
 		capacitors:
-		- id: noop
+		- service_type: noop
 			params:
-				service_type: noop
 				liquid_service_type: %[1]s
 		resource_behavior:
 		- resource: first/things

--- a/internal/collector/fixtures/capacity_metrics.prom
+++ b/internal/collector/fixtures/capacity_metrics.prom
@@ -1,6 +1,6 @@
 # HELP limes_capacity_plugin_metrics_ok Whether capacity plugin metrics were rendered successfully for a particular capacitor. Only present when the capacitor emits metrics.
 # TYPE limes_capacity_plugin_metrics_ok gauge
-limes_capacity_plugin_metrics_ok{capacitor="unittest"} 1
+limes_capacity_plugin_metrics_ok{capacitor="shared"} 1
 # HELP limes_unittest_capacity_larger_half 
 # TYPE limes_unittest_capacity_larger_half gauge
 limes_unittest_capacity_larger_half 7

--- a/internal/collector/fixtures/capacity_metrics.prom
+++ b/internal/collector/fixtures/capacity_metrics.prom
@@ -1,6 +1,6 @@
-# HELP limes_capacity_plugin_metrics_ok Whether capacity plugin metrics were rendered successfully for a particular capacitor. Only present when the capacitor emits metrics.
+# HELP limes_capacity_plugin_metrics_ok Whether capacity plugin metrics were rendered successfully for a particular service_type. Only present when the service_type emits metrics.
 # TYPE limes_capacity_plugin_metrics_ok gauge
-limes_capacity_plugin_metrics_ok{capacitor="shared"} 1
+limes_capacity_plugin_metrics_ok{service_type="shared"} 1
 # HELP limes_unittest_capacity_larger_half 
 # TYPE limes_unittest_capacity_larger_half gauge
 limes_unittest_capacity_larger_half 7

--- a/internal/collector/fixtures/capacity_scrape_with_commitments.sql
+++ b/internal/collector/fixtures/capacity_scrape_with_commitments.sql
@@ -3,18 +3,15 @@
 CREATE OR REPLACE FUNCTION unix(i integer) RETURNS timestamp AS $$ SELECT TO_TIMESTAMP(i) AT TIME ZONE 'Etc/UTC' $$ LANGUAGE SQL;
 
 -- capacity scrape needs these as a baseline (these are usually created by the CheckConsistencyJob)
-INSERT INTO cluster_services (id, type) VALUES (1, 'first');
-INSERT INTO cluster_services (id, type) VALUES (2, 'second');
+INSERT INTO cluster_services (id, type, next_scrape_at, scrape_duration_secs) VALUES (1, 'first',  UNIX(0), 5);
+INSERT INTO cluster_services (id, type, next_scrape_at, scrape_duration_secs) VALUES (2, 'second', UNIX(0), 5);
 
--- capacity scrape would fill cluster_capacitors, cluster_resources and cluster_az_resources
+-- capacity scrape would fill cluster_resources and cluster_az_resources
 -- on its own, but we do it here to minimize the inline diffs in the test code
-INSERT INTO cluster_capacitors (capacitor_id, next_scrape_at, scrape_duration_secs) VALUES ('scans-first',  UNIX(0), 5);
-INSERT INTO cluster_capacitors (capacitor_id, next_scrape_at, scrape_duration_secs) VALUES ('scans-second', UNIX(0), 5);
-
-INSERT INTO cluster_resources (id, capacitor_id, service_id, name) VALUES (1, 'scans-first',  1, 'things');
-INSERT INTO cluster_resources (id, capacitor_id, service_id, name) VALUES (2, 'scans-first',  1, 'capacity');
-INSERT INTO cluster_resources (id, capacitor_id, service_id, name) VALUES (3, 'scans-second', 2, 'things');
-INSERT INTO cluster_resources (id, capacitor_id, service_id, name) VALUES (4, 'scans-second', 2, 'capacity');
+INSERT INTO cluster_resources (id, service_id, name) VALUES (1, 1, 'things');
+INSERT INTO cluster_resources (id, service_id, name) VALUES (2, 1, 'capacity');
+INSERT INTO cluster_resources (id, service_id, name) VALUES (3, 2, 'things');
+INSERT INTO cluster_resources (id, service_id, name) VALUES (4, 2, 'capacity');
 
 INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage) VALUES (1, 1, 'az-one', 42, 8);
 INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage) VALUES (2, 1, 'az-two', 42, 8);

--- a/internal/collector/fixtures/checkconsistency0.sql
+++ b/internal/collector/fixtures/checkconsistency0.sql
@@ -1,5 +1,5 @@
-INSERT INTO cluster_services (id, type) VALUES (1, 'shared');
-INSERT INTO cluster_services (id, type) VALUES (2, 'unshared');
+INSERT INTO cluster_services (id, type, next_scrape_at) VALUES (1, 'shared', 3600);
+INSERT INTO cluster_services (id, type, next_scrape_at) VALUES (2, 'unshared', 3600);
 
 INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
 INSERT INTO domains (id, name, uuid) VALUES (2, 'france', 'uuid-for-france');

--- a/internal/collector/fixtures/checkconsistency1.sql
+++ b/internal/collector/fixtures/checkconsistency1.sql
@@ -1,5 +1,5 @@
-INSERT INTO cluster_services (id, type) VALUES (2, 'unshared');
-INSERT INTO cluster_services (id, type) VALUES (3, 'whatever');
+INSERT INTO cluster_services (id, type, next_scrape_at) VALUES (2, 'unshared', 3600);
+INSERT INTO cluster_services (id, type, next_scrape_at) VALUES (3, 'whatever', 3600);
 
 INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
 INSERT INTO domains (id, name, uuid) VALUES (2, 'france', 'uuid-for-france');

--- a/internal/collector/fixtures/checkconsistency2.sql
+++ b/internal/collector/fixtures/checkconsistency2.sql
@@ -1,5 +1,5 @@
-INSERT INTO cluster_services (id, type) VALUES (2, 'unshared');
-INSERT INTO cluster_services (id, type) VALUES (4, 'shared');
+INSERT INTO cluster_services (id, type, next_scrape_at) VALUES (2, 'unshared', 3600);
+INSERT INTO cluster_services (id, type, next_scrape_at) VALUES (4, 'shared', 7200);
 
 INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
 INSERT INTO domains (id, name, uuid) VALUES (2, 'france', 'uuid-for-france');

--- a/internal/collector/mail_delivery_test.go
+++ b/internal/collector/mail_delivery_test.go
@@ -44,9 +44,8 @@ const (
 				params:
 					liquid_service_type: %[1]s
 		capacitors:
-		- id: noop
+		- service_type: noop
 			params:
-				service_type: noop
 				liquid_service_type: %[1]s
 `
 )

--- a/internal/collector/metrics.go
+++ b/internal/collector/metrics.go
@@ -180,9 +180,9 @@ func timeAsUnixOrZero(t *time.Time) float64 {
 var capacityPluginMetricsOkGauge = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{
 		Name: "limes_capacity_plugin_metrics_ok",
-		Help: "Whether capacity plugin metrics were rendered successfully for a particular capacitor. Only present when the capacitor emits metrics.",
+		Help: "Whether capacity plugin metrics were rendered successfully for a particular service_type. Only present when the service_type emits metrics.",
 	},
-	[]string{"capacitor"},
+	[]string{"service_type"},
 )
 
 // CapacityPluginMetricsCollector is a prometheus.Collector that submits metrics
@@ -253,7 +253,7 @@ func (c *CapacityPluginMetricsCollector) collectOneCapacitor(ch chan<- prometheu
 		successAsFloat = 0.0
 		// errors in plugin.LiquidCollectMetrics() are not fatal: we record a failure in
 		// the metrics and keep going with the other project services
-		logg.Error("while collecting capacity metrics for capacitor %s: %s",
+		logg.Error("while collecting capacity metrics for service_type %s: %s",
 			instance.ServiceType, err.Error())
 	}
 	ch <- prometheus.MustNewConstMetric(

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -131,8 +131,8 @@ type RateLimitConfiguration struct {
 // CapacitorConfiguration describes a capacity plugin that is enabled for a
 // certain cluster.
 type CapacitorConfiguration struct {
-	ID         string              `yaml:"id"`
-	Parameters util.YamlRawMessage `yaml:"params"`
+	ServiceType db.ServiceType      `yaml:"service_type"`
+	Parameters  util.YamlRawMessage `yaml:"params"`
 }
 
 // QuotaDistributionConfiguration contains configuration options for specifying
@@ -218,8 +218,8 @@ func (cluster ClusterConfiguration) validateConfig() (errs errext.ErrorSet) {
 		}
 	}
 	for idx, capa := range cluster.Capacitors {
-		if capa.ID == "" {
-			missing(fmt.Sprintf("capacitors[%d].id", idx))
+		if capa.ServiceType == "" {
+			missing(fmt.Sprintf("capacitors[%d].service_type", idx))
 		}
 	}
 

--- a/internal/core/plugin.go
+++ b/internal/core/plugin.go
@@ -186,7 +186,7 @@ type CapacityPlugin interface {
 	//
 	// Before Init is called, the `capacitors[].params` provided in the config
 	// file will be yaml.Unmarshal()ed into the plugin object itself.
-	Init(ctx context.Context, client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) error
+	Init(ctx context.Context, client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, serviceType db.ServiceType) error
 	// ServiceInfo returns metadata for this service.
 	// This includes metadata for all the resources and rates that this plugin scrapes.
 	ServiceInfo() liquid.ServiceInfo

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -318,13 +318,13 @@ var sqlMigrations = map[string]string{
 			ADD COLUMN renew_context_json JSONB;
 	`,
 	"052_capacitors_removal.down.sql": `
-    ALTER TABLE cluster_services
-      DROP COLUMN scraped_at,
+		ALTER TABLE cluster_services
+			DROP COLUMN scraped_at,
 			DROP COLUMN scrape_duration_secs,
 			DROP COLUMN serialized_metrics,
 			DROP COLUMN next_scrape_at,
 			DROP COLUMN scrape_error_message;
-    CREATE TABLE cluster_capacitors (
+		CREATE TABLE cluster_capacitors (
 			capacitor_id text NOT NULL,
 			scraped_at timestamp without time zone,
 			scrape_duration_secs real DEFAULT 0 NOT NULL,
@@ -332,15 +332,15 @@ var sqlMigrations = map[string]string{
 			next_scrape_at timestamp without time zone DEFAULT now() NOT NULL,
 			scrape_error_message text DEFAULT ''::text NOT NULL
 		);
-    ALTER TABLE cluster_resources
-		  ADD COLUMN capacitor_id TEXT NOT NULL;
+		ALTER TABLE cluster_resources
+			ADD COLUMN capacitor_id TEXT NOT NULL;
   `,
 	"052_capacitors_removal.up.sql": `
-    ALTER TABLE cluster_resources
-      DROP COLUMN capacitor_id;
-    DROP TABLE cluster_capacitors;
-    ALTER TABLE cluster_services
-      ADD COLUMN scraped_at timestamp without time zone,
+		ALTER TABLE cluster_resources
+			DROP COLUMN capacitor_id;
+		DROP TABLE cluster_capacitors;
+		ALTER TABLE cluster_services
+			ADD COLUMN scraped_at timestamp without time zone,
 			ADD COLUMN scrape_duration_secs real DEFAULT 0 NOT NULL,
 			ADD COLUMN serialized_metrics text DEFAULT ''::text NOT NULL,
 			ADD COLUMN next_scrape_at timestamp without time zone DEFAULT now() NOT NULL,

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -31,9 +31,10 @@ import (
 	"github.com/sapcc/go-api-declarations/liquid"
 )
 
-// ClusterCapacitor contains a record from the `cluster_capacitors` table.
-type ClusterCapacitor struct {
-	CapacitorID        string            `db:"capacitor_id"`
+// ClusterService contains a record from the `cluster_services` table.
+type ClusterService struct {
+	ID                 ClusterServiceID  `db:"id"`
+	Type               ServiceType       `db:"type"`
 	ScrapedAt          Option[time.Time] `db:"scraped_at"` // None if never scraped so far
 	ScrapeDurationSecs float64           `db:"scrape_duration_secs"`
 	SerializedMetrics  string            `db:"serialized_metrics"`
@@ -41,18 +42,11 @@ type ClusterCapacitor struct {
 	ScrapeErrorMessage string            `db:"scrape_error_message"`
 }
 
-// ClusterService contains a record from the `cluster_services` table.
-type ClusterService struct {
-	ID   ClusterServiceID `db:"id"`
-	Type ServiceType      `db:"type"`
-}
-
 // ClusterResource contains a record from the `cluster_resources` table.
 type ClusterResource struct {
-	ID          ClusterResourceID   `db:"id"`
-	CapacitorID string              `db:"capacitor_id"`
-	ServiceID   ClusterServiceID    `db:"service_id"`
-	Name        liquid.ResourceName `db:"name"`
+	ID        ClusterResourceID   `db:"id"`
+	ServiceID ClusterServiceID    `db:"service_id"`
+	Name      liquid.ResourceName `db:"name"`
 }
 
 // Ref returns the ResourceRef for this resource.
@@ -247,7 +241,6 @@ type MailNotification struct {
 
 // initGorp is used by Init() to setup the ORM part of the database connection.
 func initGorp(db *gorp.DbMap) {
-	db.AddTableWithName(ClusterCapacitor{}, "cluster_capacitors").SetKeys(false, "capacitor_id")
 	db.AddTableWithName(ClusterService{}, "cluster_services").SetKeys(true, "id")
 	db.AddTableWithName(ClusterResource{}, "cluster_resources").SetKeys(true, "id")
 	db.AddTableWithName(ClusterAZResource{}, "cluster_az_resources").SetKeys(true, "id")

--- a/internal/plugins/capacity_liquid.go
+++ b/internal/plugins/capacity_liquid.go
@@ -50,12 +50,12 @@ type fixedCapacityConfiguration struct {
 
 type LiquidCapacityPlugin struct {
 	// configuration
-	ServiceType                     db.ServiceType                          `yaml:"service_type"`
 	LiquidServiceType               string                                  `yaml:"liquid_service_type"`
 	FixedCapacityConfiguration      Option[fixedCapacityConfiguration]      `yaml:"fixed_capacity_values"`
 	PrometheusCapacityConfiguration Option[prometheusCapacityConfiguration] `yaml:"capacity_values_from_prometheus"`
 
 	// state
+	ServiceType       db.ServiceType     `yaml:"-"`
 	LiquidServiceInfo liquid.ServiceInfo `yaml:"-"`
 	LiquidClient      core.LiquidClient  `yaml:"-"`
 }
@@ -70,10 +70,8 @@ func (p *LiquidCapacityPlugin) PluginTypeID() string {
 }
 
 // Init implements the core.CapacityPlugin interface.
-func (p *LiquidCapacityPlugin) Init(ctx context.Context, client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (err error) {
-	if p.ServiceType == "" {
-		return errors.New("missing required value: params.service_type")
-	}
+func (p *LiquidCapacityPlugin) Init(ctx context.Context, client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, serviceType db.ServiceType) (err error) {
+	p.ServiceType = serviceType
 	if p.LiquidServiceType == "" {
 		p.LiquidServiceType = "liquid-" + string(p.ServiceType)
 	}

--- a/internal/reports/cluster.go
+++ b/internal/reports/cluster.go
@@ -65,11 +65,10 @@ var clusterReportQuery2 = sqlext.SimplifyWhitespace(`
 `)
 
 var clusterReportQuery3 = sqlext.SimplifyWhitespace(`
-	SELECT cs.type, cr.name, car.az, car.raw_capacity, car.usage, car.subcapacities, cc.scraped_at
+	SELECT cs.type, cr.name, car.az, car.raw_capacity, car.usage, car.subcapacities, cs.scraped_at
 	  FROM cluster_services cs
 	  JOIN cluster_resources cr ON cr.service_id = cs.id {{AND cr.name = $resource_name}}
 	  LEFT OUTER JOIN cluster_az_resources car ON car.resource_id = cr.id
-	  LEFT OUTER JOIN cluster_capacitors cc ON cc.capacitor_id = cr.capacitor_id
 	 WHERE TRUE {{AND cs.type = $service_type}}
 	 ORDER BY car.az
 `)

--- a/internal/test/setup.go
+++ b/internal/test/setup.go
@@ -131,7 +131,7 @@ func GenerateDummyToken() string {
 	return "dummyToken"
 }
 
-// NewSetup prepares most or all pieces of Keppel for a test.
+// NewSetup prepares most or all pieces of Limes for a test.
 func NewSetup(t *testing.T, opts ...SetupOption) Setup {
 	logg.ShowDebug = osext.GetenvBool("LIMES_DEBUG")
 	var params setupParams
@@ -264,7 +264,7 @@ func mustDo(t *testing.T, err error) {
 
 func initDatabase(t *testing.T, extraOpts []easypg.TestSetupOption) *gorp.DbMap {
 	opts := append(slices.Clone(extraOpts),
-		easypg.ClearTables("project_commitments", "cluster_capacitors", "cluster_services", "domains"),
+		easypg.ClearTables("project_commitments", "cluster_services", "domains"),
 		easypg.ResetPrimaryKeys(
 			"cluster_services", "cluster_resources", "cluster_az_resources",
 			"domains", "projects", "project_commitments", "project_mail_notifications",


### PR DESCRIPTION
Checklist:

- [X] If this PR is about a plugin, I tested the plugin against an OpenStack cluster.
- [X] I updated the documentation to describe the semantical or interface changes I introduced.

This PR has the next level of changes towards a common configuration for `services[]` and `capacitors`:
* we remove the `cluster_capacitors` table and shift the columns to the `cluster_services`
* we move around the `service_type` to be on the same level as for `services[]` already
* we shift some of the wording - the capacitors only really exist on app layer/ configuration after this change
* as a result, we assume that the `service_type` of a `service` and `capacitor` are the same if they belong together

naturally, this needs a companion PR for the deployment. I tested again locally and all the results in the DB looked the same.