### PR TITLE
do not fail project deletion on superseded/expired commitments

### DIFF
--- a/internal/collector/keystone.go
+++ b/internal/collector/keystone.go
@@ -172,9 +172,9 @@ func (c *Collector) ScanProjects(ctx context.Context, domain *db.Domain) (result
 	for _, dbProject := range dbProjects {
 		if !isProjectUUID[dbProject.UUID] {
 			logg.Info("removing deleted Keystone project from our database: %s/%s", domain.Name, dbProject.Name)
-			_, err := c.DB.Delete(dbProject)
+			err = c.deleteProject(dbProject)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("while removing deleted Keystone project %s/%s from our database: %w", domain.Name, dbProject.Name, err)
 			}
 			continue
 		}
@@ -244,6 +244,44 @@ func (c *Collector) initProject(domain *db.Domain, project core.KeystoneProject)
 
 	// add records to `project_services` table
 	err = datamodel.ValidateProjectServices(tx, c.Cluster, *domain, *dbProject, c.MeasureTime())
+	if err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+var deleteCommitmentsInProjectQuery = sqlext.SimplifyWhitespace(`
+	DELETE FROM project_commitments WHERE id IN (
+		SELECT pc.id
+		  FROM projects p
+		  JOIN project_services ps ON ps.project_id = p.id
+		  JOIN project_resources pr ON pr.service_id = ps.id
+		  JOIN project_az_resources par ON par.resource_id = pr.id
+		  JOIN project_commitments pc ON pc.az_resource_id = par.id
+		 WHERE p.id = $1 AND pc.state IN ($2, $3)
+	)
+`)
+
+// Deletes a project from the DB after it was deleted in Keystone.
+// This requires special care because some constraints are "ON DELETE RESTRICT".
+func (c *Collector) deleteProject(project *db.Project) error {
+	// do this in a transaction to avoid commitment deletions going through unless actually necessary
+	tx, err := c.DB.Begin()
+	if err != nil {
+		return err
+	}
+	defer sqlext.RollbackUnlessCommitted(tx)
+
+	// it is fine to delete a project that only has superseded and expired commitments on it
+	// (if there are commitments in any other state, the `DELETE FROM projects` below will fail
+	// and rollback the full transaction)
+	_, err = tx.Exec(deleteCommitmentsInProjectQuery, project.ID, db.CommitmentStateSuperseded, db.CommitmentStateExpired)
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.Delete(project)
 	if err != nil {
 		return err
 	}

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -210,10 +210,10 @@ var sqlMigrations = map[string]string{
 		CREATE TABLE project_mail_notifications (
 			id BIGSERIAL NOT NULL PRIMARY KEY,
 			project_id BIGINT NOT NULL REFERENCES projects ON DELETE CASCADE,
-  			subject TEXT NOT NULL,
-  			body TEXT NOT NULL,
-  			next_submission_at TIMESTAMP NOT NULL DEFAULT NOW(),
-  			failed_submissions BIGINT NOT NULL DEFAULT 0
+			subject TEXT NOT NULL,
+			body TEXT NOT NULL,
+			next_submission_at TIMESTAMP NOT NULL DEFAULT NOW(),
+			failed_submissions BIGINT NOT NULL DEFAULT 0
 		);
 	`,
 	"050_commitment_workflow_context.down.sql": `


### PR DESCRIPTION
With the first wave of commitments expiring in prod, we now often see project deletions failing due to the ON DELETE RESTRICT constraint on project_commitments. This is generally fine; we do not want to delete a project that has active commitments. But if the only existing commitments are in states `superseded` or `expired`, this change will allow the project deletion to proceed without manual intervention.