### PR TITLE
Save service info in db

### DIFF
--- a/docs/operators/config.md
+++ b/docs/operators/config.md
@@ -187,8 +187,10 @@ liquid. For information on liquids provided by Limes itself, please refer to the
 (a grouping of services, e.g. `network, compute, storage`). The liquid endpoint will be located in the Keystone service catalog at
 service type `liquid-$SERVICE_TYPE`, unless this default is overridden by `liquid_service_type`.
 
-Currently, any increase in the `ServiceInfo` version of the liquid will prompt a fatal error in Limes, thus usually forcing it to restart.
-This is something that we plan on changing into a graceful reload in the future.
+Currently, any increase in the `ServiceInfo` version of the liquid will result in an update of the `LiquidConnection.LiquidServiceInfo`
+during a scrape (capacity, project-usage, project-rates). This change is also replicated to the database, but the data is never read
+from there yet. Soon, we want to use `ServiceInfo` from the database to allow startup of Limes with a temporarily unavailable liquid
+connection.
 
 #### Commitment behavior
 

--- a/internal/api/fixtures/start-data-commitments.sql
+++ b/internal/api/fixtures/start-data-commitments.sql
@@ -1,11 +1,11 @@
 CREATE OR REPLACE FUNCTION unix(i integer) RETURNS timestamp AS $$ SELECT TO_TIMESTAMP(i) AT TIME ZONE 'Etc/UTC' $$ LANGUAGE SQL;
 
-INSERT INTO cluster_services (id, type, scraped_at, next_scrape_at) VALUES (1, 'first', UNIX(1000), UNIX(2000));
-INSERT INTO cluster_services (id, type, scraped_at, next_scrape_at) VALUES (2, 'second', UNIX(1000), UNIX(2000));
+INSERT INTO cluster_services (id, type, scraped_at, next_scrape_at, liquid_version) VALUES (1, 'first', UNIX(1000), UNIX(2000), 1);
+INSERT INTO cluster_services (id, type, scraped_at, next_scrape_at, liquid_version) VALUES (2, 'second', UNIX(1000), UNIX(2000), 1);
 
 -- cluster_resources and cluster_az_resources have entries for the resources where commitments are enabled in the config
-INSERT INTO cluster_resources (id, service_id, name) VALUES (1, 1, 'capacity');
-INSERT INTO cluster_resources (id, service_id, name) VALUES (2, 2, 'capacity');
+INSERT INTO cluster_resources (id, service_id, name, liquid_version) VALUES (1, 1, 'capacity', 1);
+INSERT INTO cluster_resources (id, service_id, name, liquid_version) VALUES (2, 2, 'capacity', 1);
 
 INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, subcapacities) VALUES (1, 1, 'az-one', 10, 6, '');
 INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, subcapacities) VALUES (2, 1, 'az-two', 20, 6, '');

--- a/internal/api/fixtures/start-data-minimal.sql
+++ b/internal/api/fixtures/start-data-minimal.sql
@@ -1,8 +1,8 @@
 CREATE OR REPLACE FUNCTION unix(i integer) RETURNS timestamp AS $$ SELECT TO_TIMESTAMP(i) AT TIME ZONE 'Etc/UTC' $$ LANGUAGE SQL;
 
 -- two services, one shared, one unshared
-INSERT INTO cluster_services (id, type) VALUES (1, 'unshared');
-INSERT INTO cluster_services (id, type) VALUES (2, 'shared');
+INSERT INTO cluster_services (id, type, liquid_version) VALUES (1, 'unshared', 1);
+INSERT INTO cluster_services (id, type, liquid_version) VALUES (2, 'shared', 1);
 
 -- two domains
 INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');

--- a/internal/api/fixtures/start-data-small.sql
+++ b/internal/api/fixtures/start-data-small.sql
@@ -3,10 +3,10 @@
 
 CREATE OR REPLACE FUNCTION unix(i integer) RETURNS timestamp AS $$ SELECT TO_TIMESTAMP(i) AT TIME ZONE 'Etc/UTC' $$ LANGUAGE SQL;
 
-INSERT INTO cluster_services (id, type, scraped_at, next_scrape_at) VALUES (1, 'first', UNIX(1000), UNIX(2000));
+INSERT INTO cluster_services (id, type, scraped_at, next_scrape_at, liquid_version) VALUES (1, 'first', UNIX(1000), UNIX(2000), 1);
 
-INSERT INTO cluster_resources (id, service_id, name) VALUES (1, 1, 'things');
-INSERT INTO cluster_resources (id, service_id, name) VALUES (2, 1, 'capacity');
+INSERT INTO cluster_resources (id, service_id, name, liquid_version) VALUES (1, 1, 'things', 1);
+INSERT INTO cluster_resources (id, service_id, name, liquid_version) VALUES (2, 1, 'capacity', 1);
 
 -- "capacity" is modeled as AZ-aware, "things" is not
 INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, subcapacities) VALUES (1, 1, 'any', 0, 0, '');

--- a/internal/api/fixtures/start-data.sql
+++ b/internal/api/fixtures/start-data.sql
@@ -1,12 +1,12 @@
 CREATE OR REPLACE FUNCTION unix(i integer) RETURNS timestamp AS $$ SELECT TO_TIMESTAMP(i) AT TIME ZONE 'Etc/UTC' $$ LANGUAGE SQL;
 
-INSERT INTO cluster_services (id, type, scraped_at, next_scrape_at) VALUES (1, 'unshared', UNIX(1000), UNIX(2000));
-INSERT INTO cluster_services (id, type, scraped_at, next_scrape_at) VALUES (2, 'shared',   UNIX(1100), UNIX(2100));
+INSERT INTO cluster_services (id, type, scraped_at, next_scrape_at, liquid_version) VALUES (1, 'unshared', UNIX(1000), UNIX(2000), 1);
+INSERT INTO cluster_services (id, type, scraped_at, next_scrape_at, liquid_version) VALUES (2, 'shared',   UNIX(1100), UNIX(2100), 1);
 
 -- all services have the resources "things" and "capacity"
-INSERT INTO cluster_resources (id, service_id, name) VALUES (1, 1, 'things');
-INSERT INTO cluster_resources (id, service_id, name) VALUES (2, 2, 'things');
-INSERT INTO cluster_resources (id, service_id, name) VALUES (3, 2, 'capacity');
+INSERT INTO cluster_resources (id, service_id, name, liquid_version) VALUES (1, 1, 'things', 1);
+INSERT INTO cluster_resources (id, service_id, name, liquid_version) VALUES (2, 2, 'things', 1);
+INSERT INTO cluster_resources (id, service_id, name, liquid_version) VALUES (3, 2, 'capacity', 1);
 
 -- "capacity" is modeled as AZ-aware, "things" is not
 INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, subcapacities) VALUES (1, 1, 'any', 139, 45, '[{"smaller_half":46},{"larger_half":93}]');
@@ -115,8 +115,8 @@ INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_big
 
 -- insert some bullshit data that should be filtered out by the internal/reports/ logic
 -- (cluster "north", service "weird", resource "items" and rate "frobnicate" are not configured)
-INSERT INTO cluster_services (id, type) VALUES (101, 'weird');
-INSERT INTO cluster_resources (id, service_id, name) VALUES (101, 101, 'things');
+INSERT INTO cluster_services (id, type, liquid_version) VALUES (101, 'weird', 1);
+INSERT INTO cluster_resources (id, service_id, name, liquid_version) VALUES (101, 101, 'things', 1);
 INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, subcapacities) VALUES (101, 101, 'any', 2, 1, '');
 INSERT INTO project_services (id, project_id, type) VALUES (101, 1, 'weird');
 INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (101, 101, 'things', 2, 2);

--- a/internal/collector/capacity_scrape.go
+++ b/internal/collector/capacity_scrape.go
@@ -21,7 +21,6 @@ package collector
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"maps"
 	"slices"
@@ -169,50 +168,12 @@ func (c *Collector) processCapacityScrapeTask(ctx context.Context, task capacity
 	}
 	defer sqlext.RollbackUnlessCommitted(tx)
 
+	// a cluster_resources update is not necessary, as it is done within c.scrapeLiquidCapacity if necessary
 	// collect existing cluster_resources
-	var dbResources []db.ClusterResource
-	_, err = tx.Select(&dbResources, `SELECT * FROM cluster_resources`)
+	var dbOwnedResources []db.ClusterResource
+	_, err = tx.Select(&dbOwnedResources, `SELECT cr.* FROM cluster_resources as cr JOIN cluster_services as cs ON cr.service_id = cs.id WHERE cs.type = $1`, service.Type)
 	if err != nil {
 		return fmt.Errorf("cannot inspect existing cluster resources: %w", err)
-	}
-
-	// define the scope of the update
-	var dbOwnedResources []db.ClusterResource
-	for _, res := range dbResources {
-		if res.ServiceID == service.ID {
-			dbOwnedResources = append(dbOwnedResources, res)
-		}
-	}
-
-	var wantedResources []liquid.ResourceName
-
-	for resourceName := range capacityData.Resources {
-		if !c.Cluster.HasResource(service.Type, resourceName) {
-			logg.Info("discarding capacity reported by %s for unknown resource name: %s/%s", service.ID, service.Type, resourceName)
-			continue
-		}
-		wantedResources = append(wantedResources, resourceName)
-	}
-	slices.Sort(wantedResources)
-
-	// create and delete cluster_resources for this cluster_service as needed
-	setUpdate := db.SetUpdate[db.ClusterResource, liquid.ResourceName]{
-		ExistingRecords: dbOwnedResources,
-		WantedKeys:      wantedResources,
-		KeyForRecord: func(resource db.ClusterResource) liquid.ResourceName {
-			return resource.Name
-		},
-		Create: func(resourceName liquid.ResourceName) (db.ClusterResource, error) {
-			return db.ClusterResource{
-				ServiceID: service.ID,
-				Name:      resourceName,
-			}, nil
-		},
-		Update: func(res *db.ClusterResource) (err error) { return nil },
-	}
-	dbOwnedResources, err = setUpdate.Execute(tx)
-	if err != nil {
-		return err
 	}
 
 	// collect cluster_az_resources for the cluster_resources owned by this capacitor
@@ -234,6 +195,10 @@ func (c *Collector) processCapacityScrapeTask(ctx context.Context, task capacity
 	// for each cluster_resources entry owned by this capacitor, maintain cluster_az_resources
 	for _, res := range dbOwnedResources {
 		resourceData := capacityData.Resources[res.Name]
+		if resourceData == nil {
+			logg.Error("could not find resource %s in capacity data of %s, probably the liquid did not bump the version correctly", res.Name, service.Type)
+			continue
+		}
 
 		setUpdate := db.SetUpdate[db.ClusterAZResource, liquid.AvailabilityZone]{
 			ExistingRecords: dbAZResourcesByResourceID[res.ID],
@@ -251,7 +216,7 @@ func (c *Collector) processCapacityScrapeTask(ctx context.Context, task capacity
 				data := resourceData.PerAZ[azRes.AvailabilityZone]
 				azRes.RawCapacity = data.Capacity
 				azRes.Usage = data.Usage
-				azRes.SubcapacitiesJSON, err = renderListToJSON("subcapacities", data.Subcapacities)
+				azRes.SubcapacitiesJSON, err = util.RenderListToJSON("subcapacities", data.Subcapacities)
 				return err
 			},
 		}
@@ -300,7 +265,7 @@ func (c *Collector) processCapacityScrapeTask(ctx context.Context, task capacity
 }
 
 func (c *Collector) scrapeLiquidCapacity(ctx context.Context, connection *core.LiquidConnection) (liquid.ServiceCapacityReport, []byte, error) {
-	capacityData, err := connection.ScrapeCapacity(ctx, datamodel.NewCapacityScrapeBackchannel(c.Cluster, c.DB), c.Cluster.Config.AvailabilityZones)
+	capacityData, err := connection.ScrapeCapacity(ctx, datamodel.NewCapacityScrapeBackchannel(c.Cluster, c.DB), c.Cluster.Config.AvailabilityZones, c.DB)
 	if err != nil {
 		return liquid.ServiceCapacityReport{}, nil, err
 	}
@@ -350,15 +315,4 @@ func (c *Collector) confirmPendingCommitmentsIfNecessary(serviceType db.ServiceT
 		}
 	}
 	return tx.Commit()
-}
-
-func renderListToJSON[T any](attribute string, entries []T) (string, error) {
-	if len(entries) == 0 {
-		return "", nil
-	}
-	buf, err := json.Marshal(entries)
-	if err != nil {
-		return "", fmt.Errorf("could not convert %s to JSON: %w", attribute, err)
-	}
-	return string(buf), nil
 }

--- a/internal/collector/capacity_scrape_test.go
+++ b/internal/collector/capacity_scrape_test.go
@@ -131,17 +131,13 @@ func Test_ScanCapacity(t *testing.T) {
 	mockLiquidClient2, liquidServiceType2 := test.NewMockLiquidClient(srvInfo2)
 	s := test.NewSetup(t,
 		test.WithConfig(fmt.Sprintf(testScanCapacityConfigYAML, liquidServiceType, liquidServiceType2)),
+		// cluster_services must be created as a baseline
+		test.WithCollectorSetup,
 	)
 
 	c := getCollector(t, s)
 	job := c.CapacityScrapeJob(s.Registry)
-
-	// cluster_services must be created as a baseline (this is usually done by the CheckConsistencyJob)
 	insertTime := s.Clock.Now()
-	for _, serviceType := range s.Cluster.ServiceTypesInAlphabeticalOrder() {
-		err := s.DB.Insert(&db.ClusterService{Type: serviceType, NextScrapeAt: insertTime})
-		mustT(t, err)
-	}
 
 	capacityReport := liquid.ServiceCapacityReport{
 		InfoVersion: 1,
@@ -175,9 +171,11 @@ func Test_ScanCapacity(t *testing.T) {
 	// check baseline
 	tr, tr0 := easypg.NewTracker(t, s.DB.Db)
 	tr0.AssertEqualf(`
-		INSERT INTO cluster_services (id, type, next_scrape_at) VALUES (1, 'shared', %d);
-		INSERT INTO cluster_services (id, type, next_scrape_at) VALUES (2, 'unshared', %d);
-	`, insertTime.Unix(), insertTime.Unix())
+		INSERT INTO cluster_resources (id, service_id, name, liquid_version, topology, has_capacity, has_quota) VALUES (1, 1, 'things', 1, 'flat', TRUE, TRUE);
+		INSERT INTO cluster_resources (id, service_id, name, liquid_version, unit, topology, has_capacity, has_quota) VALUES (2, 2, 'capacity', 1, 'B', 'flat', TRUE, TRUE);
+		INSERT INTO cluster_services (id, type, next_scrape_at, liquid_version) VALUES (1, 'shared', -62135596800, 1);
+		INSERT INTO cluster_services (id, type, next_scrape_at, liquid_version) VALUES (2, 'unshared', -62135596800, 1);
+	`)
 
 	// check that capacity records are created correctly (and that nonexistent
 	// resources are ignored by the scraper)
@@ -186,8 +184,6 @@ func Test_ScanCapacity(t *testing.T) {
 	tr.DBChanges().AssertEqualf(`
 		INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage) VALUES (1, 1, 'any', 42, 8);
 		INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage) VALUES (2, 2, 'any', 42, 8);
-		INSERT INTO cluster_resources (id, service_id, name) VALUES (1, 1, 'things');
-		INSERT INTO cluster_resources (id, service_id, name) VALUES (2, 2, 'capacity');
 		UPDATE cluster_services SET scraped_at = %d, scrape_duration_secs = 5, serialized_metrics = '{}', next_scrape_at = 905 WHERE id = 1 AND type = 'shared';
 		UPDATE cluster_services SET scraped_at = %d, scrape_duration_secs = 5, serialized_metrics = '{}', next_scrape_at = 910 WHERE id = 2 AND type = 'unshared';
 	`, insertTime.Add(5*time.Second).Unix(), insertTime.Add(10*time.Second).Unix())
@@ -217,21 +213,41 @@ func Test_ScanCapacity(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-
-	// next scan should throw out the crap records and recreate the deleted ones;
-	// also change the reported Capacity to see if updates are getting through
 	capacityReport.Resources["things"].PerAZ["any"].Capacity = 23
 	capacityReport.Resources["things"].PerAZ["any"].Usage = Some[uint64](4)
+	tr.DBChanges().Ignore()
+
+	// if we don't bump the version, we will observe that for "things" nothing happens (as it is unknown
+	// to the database) and for "unknown" there is no value
 	setClusterCapacitorsStale(t, s)
 	mustT(t, jobloop.ProcessMany(job, s.Ctx, len(s.Cluster.LiquidConnections)))
 
 	scrapedAt1 := s.Clock.Now().Add(-5 * time.Second)
 	scrapedAt2 := s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`
-		DELETE FROM cluster_az_resources WHERE id = 1 AND resource_id = 1 AND az = 'any';
+		UPDATE cluster_services SET scraped_at = %d, next_scrape_at = %d WHERE id = 1 AND type = 'shared';
+		UPDATE cluster_services SET scraped_at = %d, next_scrape_at = %d WHERE id = 2 AND type = 'unshared';
+	`,
+		scrapedAt1.Unix(), scrapedAt1.Add(15*time.Minute).Unix(),
+		scrapedAt2.Unix(), scrapedAt2.Add(15*time.Minute).Unix(),
+	)
+
+	// now we bump the version, so that the services and resources are reconciled
+	mockLiquidClient.IncrementServiceInfoVersion()
+	mockLiquidClient.IncrementCapacityReportInfoVersion()
+	mockLiquidClient2.IncrementServiceInfoVersion()
+	mockLiquidClient2.IncrementCapacityReportInfoVersion()
+	setClusterCapacitorsStale(t, s)
+	mustT(t, jobloop.ProcessMany(job, s.Ctx, len(s.Cluster.LiquidConnections)))
+
+	scrapedAt1 = s.Clock.Now().Add(-5 * time.Second)
+	scrapedAt2 = s.Clock.Now()
+	tr.DBChanges().AssertEqualf(`
+		DELETE FROM cluster_az_resources WHERE id = 3 AND resource_id = 3 AND az = 'any';
 		INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage) VALUES (4, 4, 'any', 23, 4);
-		DELETE FROM cluster_resources WHERE id = 1 AND service_id = 1 AND name = 'things';
-		INSERT INTO cluster_resources (id, service_id, name) VALUES (4, 1, 'things');
+		UPDATE cluster_resources SET liquid_version = 2 WHERE id = 2 AND service_id = 2 AND name = 'capacity';
+		DELETE FROM cluster_resources WHERE id = 3 AND service_id = 2 AND name = 'unknown';
+		INSERT INTO cluster_resources (id, service_id, name, liquid_version, topology, has_capacity, has_quota) VALUES (4, 1, 'things', 2, 'flat', TRUE, TRUE);
 		UPDATE cluster_services SET scraped_at = %d, next_scrape_at = %d WHERE id = 1 AND type = 'shared';
 		UPDATE cluster_services SET scraped_at = %d, next_scrape_at = %d WHERE id = 2 AND type = 'unshared';
 	`,
@@ -268,23 +284,19 @@ func Test_ScanCapacityWithSubcapacities(t *testing.T) {
 	mockLiquidClient, liquidServiceType := test.NewMockLiquidClient(srvInfo)
 	s := test.NewSetup(t,
 		test.WithConfig(fmt.Sprintf(testScanCapacitySingleLiquidConfigYAML, liquidServiceType)),
+		// cluster_services must be created as a baseline
+		test.WithCollectorSetup,
 	)
 
 	c := getCollector(t, s)
 	job := c.CapacityScrapeJob(s.Registry)
 
-	// cluster_services are created as a baseline (this is usually done by the CheckConsistencyJob)
-	insertTime := s.Clock.Now()
-	for _, serviceType := range s.Cluster.ServiceTypesInAlphabeticalOrder() {
-		err := s.DB.Insert(&db.ClusterService{Type: serviceType, NextScrapeAt: insertTime})
-		mustT(t, err)
-	}
-
 	// check baseline
 	tr, tr0 := easypg.NewTracker(t, s.DB.Db)
-	tr0.AssertEqualf(`
-		INSERT INTO cluster_services (id, type, next_scrape_at) VALUES (1, 'shared', %d);
-	`, insertTime.Unix())
+	tr0.AssertEqual(`
+		INSERT INTO cluster_resources (id, service_id, name, liquid_version, topology, has_capacity, has_quota) VALUES (1, 1, 'things', 1, 'flat', TRUE, TRUE);
+		INSERT INTO cluster_services (id, type, next_scrape_at, liquid_version, capacity_metric_families_json) VALUES (1, 'shared', -62135596800, 1, '{"limes_unittest_capacity_larger_half":{"type":"gauge","help":"","labelKeys":null},"limes_unittest_capacity_smaller_half":{"type":"gauge","help":"","labelKeys":null}}');
+	`)
 
 	// check that scraping correctly updates subcapacities on an existing record
 	buf := must.Return(json.Marshal(map[string]any{"az": "az-one"}))
@@ -335,7 +347,6 @@ func Test_ScanCapacityWithSubcapacities(t *testing.T) {
 	scrapedAt := s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`
 		INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, subcapacities) VALUES (1, 1, 'any', 42, '[{"name":"smaller_half","capacity":7,"attributes":{"az":"az-one"}},{"name":"larger_half","capacity":14,"attributes":{"az":"az-one"}},{"name":"smaller_half","capacity":7,"attributes":{"az":"az-two"}},{"name":"larger_half","capacity":14,"attributes":{"az":"az-two"}}]');
-		INSERT INTO cluster_resources (id, service_id, name) VALUES (1, 1, 'things');
 		UPDATE cluster_services SET scraped_at = %d, scrape_duration_secs = 5, serialized_metrics = '{"limes_unittest_capacity_larger_half":{"lk":null,"m":[{"v":7,"l":null}]},"limes_unittest_capacity_smaller_half":{"lk":null,"m":[{"v":3,"l":null}]}}', next_scrape_at = %d WHERE id = 1 AND type = 'shared';
 	`,
 		scrapedAt.Unix(), scrapedAt.Add(15*time.Minute).Unix(),
@@ -414,23 +425,19 @@ func Test_ScanCapacityAZAware(t *testing.T) {
 	mockLiquidClient, liquidServiceType := test.NewMockLiquidClient(srvInfo)
 	s := test.NewSetup(t,
 		test.WithConfig(fmt.Sprintf(testScanCapacitySingleLiquidConfigYAML, liquidServiceType)),
+		// cluster_services must be created as a baseline
+		test.WithCollectorSetup,
 	)
 
 	c := getCollector(t, s)
 	job := c.CapacityScrapeJob(s.Registry)
 
-	// cluster_services must be created as a baseline (this is usually done by the CheckConsistencyJob)
-	insertTime := s.Clock.Now()
-	for _, serviceType := range s.Cluster.ServiceTypesInAlphabeticalOrder() {
-		err := s.DB.Insert(&db.ClusterService{Type: serviceType, NextScrapeAt: insertTime})
-		mustT(t, err)
-	}
-
 	// check baseline
 	tr, tr0 := easypg.NewTracker(t, s.DB.Db)
-	tr0.AssertEqualf(`
-		INSERT INTO cluster_services (id, type, next_scrape_at) VALUES (1, 'shared', %d);
-	`, insertTime.Unix())
+	tr0.AssertEqual(`
+		INSERT INTO cluster_resources (id, service_id, name, liquid_version, topology, has_capacity, has_quota) VALUES (1, 1, 'things', 1, 'az-aware', TRUE, TRUE);
+		INSERT INTO cluster_services (id, type, next_scrape_at, liquid_version) VALUES (1, 'shared', -62135596800, 1);
+	`)
 
 	capacityReport := liquid.ServiceCapacityReport{
 		InfoVersion: 1,
@@ -458,7 +465,6 @@ func Test_ScanCapacityAZAware(t *testing.T) {
 	tr.DBChanges().AssertEqualf(`
 	INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage) VALUES (1, 1, 'az-one', 21, 4);
 	INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage) VALUES (2, 1, 'az-two', 21, 4);
-	INSERT INTO cluster_resources (id, service_id, name) VALUES (1, 1, 'things');
 	UPDATE cluster_services SET scraped_at = %d, scrape_duration_secs = 5, serialized_metrics = '{}', next_scrape_at = %d WHERE id = 1 AND type = 'shared';
 	`,
 		scrapedAt.Unix(), scrapedAt.Add(15*time.Minute).Unix(),
@@ -511,25 +517,24 @@ func Test_ScanCapacityButNoResources(t *testing.T) {
 	mockLiquidClient, liquidServiceType := test.NewMockLiquidClient(srvInfo)
 	s := test.NewSetup(t,
 		test.WithConfig(fmt.Sprintf(testScanCapacitySingleLiquidConfigYAML, liquidServiceType)),
+		// cluster_services must be created as a baseline
+		test.WithCollectorSetup,
 	)
 
 	c := getCollector(t, s)
 	job := c.CapacityScrapeJob(s.Registry)
 
-	// cluster_services must be created as a baseline (this is usually done by the CheckConsistencyJob)
-	insertTime := s.Clock.Now()
-	for _, serviceType := range s.Cluster.ServiceTypesInAlphabeticalOrder() {
-		err := s.DB.Insert(&db.ClusterService{Type: serviceType, NextScrapeAt: insertTime})
-		mustT(t, err)
-	}
-
 	// check baseline
 	tr, tr0 := easypg.NewTracker(t, s.DB.Db)
-	tr0.AssertEqualf(`
-		INSERT INTO cluster_services (id, type, next_scrape_at) VALUES (1, 'shared', %d);
-	`, insertTime.Unix())
+	//nolint:dupword // false positive on "TRUE, TRUE"
+	tr0.AssertEqual(`
+		INSERT INTO cluster_resources (id, service_id, name, liquid_version, unit, topology, has_capacity, needs_resource_demand, has_quota) VALUES (1, 1, 'capacity', 1, 'B', 'az-aware', TRUE, TRUE, TRUE);
+		INSERT INTO cluster_resources (id, service_id, name, liquid_version, topology, has_quota) VALUES (2, 1, 'things', 1, 'flat', TRUE);
+		INSERT INTO cluster_services (id, type, next_scrape_at, liquid_version) VALUES (1, 'shared', -62135596800, 1);
+	`)
 
 	// adjust the capacity report to not show any resources
+	// this is a state which should not happen in production - it leads to a logged error
 	res := srvInfo.Resources["capacity"]
 	res.HasCapacity = false
 	srvInfo.Resources["capacity"] = res
@@ -558,6 +563,20 @@ func Test_ScanCapacityButNoResources(t *testing.T) {
 	`,
 		s.Clock.Now().Unix(), s.Clock.Now().Add(15*time.Minute).Unix(),
 	)
+
+	// now we bump the version, so that the services and resources are reconciled
+	mockLiquidClient.IncrementServiceInfoVersion()
+	mockLiquidClient.IncrementCapacityReportInfoVersion()
+	setClusterCapacitorsStale(t, s)
+	mustT(t, job.ProcessOne(s.Ctx))
+
+	tr.DBChanges().AssertEqualf(`
+        UPDATE cluster_resources SET liquid_version = 2, has_capacity = FALSE WHERE id = 1 AND service_id = 1 AND name = 'capacity';
+		UPDATE cluster_resources SET liquid_version = 2 WHERE id = 2 AND service_id = 1 AND name = 'things';
+		UPDATE cluster_services SET scraped_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND type = 'shared';
+	`,
+		s.Clock.Now().Unix(), s.Clock.Now().Add(15*time.Minute).Unix(),
+	)
 }
 
 func Test_ScanManualCapacity(t *testing.T) {
@@ -568,25 +587,23 @@ func Test_ScanManualCapacity(t *testing.T) {
 	mockLiquidClient, liquidServiceType := test.NewMockLiquidClient(srvInfo)
 	s := test.NewSetup(t,
 		test.WithConfig(fmt.Sprintf(testScanCapacityManualConfigYAML, liquidServiceType)),
+		test.WithCollectorSetup,
 	)
 
 	c := getCollector(t, s)
 	job := c.CapacityScrapeJob(s.Registry)
 
-	// cluster_services must be created as a baseline (this is usually done by the CheckConsistencyJob)
-	insertTime := s.Clock.Now()
-	for _, serviceType := range s.Cluster.ServiceTypesInAlphabeticalOrder() {
-		err := s.DB.Insert(&db.ClusterService{Type: serviceType, NextScrapeAt: insertTime})
-		mustT(t, err)
-	}
-
 	// check baseline
 	tr, tr0 := easypg.NewTracker(t, s.DB.Db)
-	tr0.AssertEqualf(`
-		INSERT INTO cluster_services (id, type, next_scrape_at) VALUES (1, 'shared', %d);
-	`, insertTime.Unix())
+	//nolint:dupword // false positive on "TRUE, TRUE"
+	tr0.AssertEqual(`
+		INSERT INTO cluster_resources (id, service_id, name, liquid_version, unit, topology, has_capacity, needs_resource_demand, has_quota) VALUES (1, 1, 'capacity', 1, 'B', 'az-aware', TRUE, TRUE, TRUE);
+		INSERT INTO cluster_resources (id, service_id, name, liquid_version, topology, has_quota) VALUES (2, 1, 'things', 1, 'flat', TRUE);
+		INSERT INTO cluster_services (id, type, next_scrape_at, liquid_version) VALUES (1, 'shared', -62135596800, 1);
+	`)
 
 	// adjust the capacity report to not show any capacity
+	// this is a state which should not happen in production - it leads to a logged error
 	res := srvInfo.Resources["capacity"]
 	res.HasCapacity = false
 	srvInfo.Resources["capacity"] = res
@@ -599,9 +616,22 @@ func Test_ScanManualCapacity(t *testing.T) {
 	mustT(t, job.ProcessOne(s.Ctx))
 
 	tr.DBChanges().AssertEqualf(`
-		INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity) VALUES (1, 1, 'any', 1000000);
-		INSERT INTO cluster_resources (id, service_id, name) VALUES (1, 1, 'things');
+		INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity) VALUES (1, 2, 'any', 1000000);
 		UPDATE cluster_services SET scraped_at = %d, scrape_duration_secs = 5, serialized_metrics = '{}', next_scrape_at = %d WHERE id = 1 AND type = 'shared';
+	`,
+		s.Clock.Now().Unix(), s.Clock.Now().Add(15*time.Minute).Unix(),
+	)
+
+	// now we bump the version, so that the services and resources are reconciled
+	mockLiquidClient.IncrementServiceInfoVersion()
+	mockLiquidClient.IncrementCapacityReportInfoVersion()
+	setClusterCapacitorsStale(t, s)
+	mustT(t, job.ProcessOne(s.Ctx))
+
+	tr.DBChanges().AssertEqualf(`
+        UPDATE cluster_resources SET liquid_version = 2, has_capacity = FALSE WHERE id = 1 AND service_id = 1 AND name = 'capacity';
+		UPDATE cluster_resources SET liquid_version = 2 WHERE id = 2 AND service_id = 1 AND name = 'things';
+		UPDATE cluster_services SET scraped_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND type = 'shared';
 	`,
 		s.Clock.Now().Unix(), s.Clock.Now().Add(15*time.Minute).Unix(),
 	)
@@ -647,6 +677,7 @@ func CommonScanCapacityWithCommitmentsSetup(t *testing.T) (s test.Setup, scrapeJ
 	s = test.NewSetup(t,
 		test.WithConfig(fmt.Sprintf(testScanCapacityWithCommitmentsConfigYAML, liquidServiceType, liquidServiceType2)),
 		test.WithDBFixtureFile("fixtures/capacity_scrape_with_commitments.sql"),
+		test.WithCollectorSetup,
 	)
 	c := getCollector(t, s)
 	scrapeJob = c.CapacityScrapeJob(s.Registry)

--- a/internal/collector/consistency.go
+++ b/internal/collector/consistency.go
@@ -34,59 +34,27 @@ import (
 func (c *Collector) CheckConsistencyJob(registerer prometheus.Registerer) jobloop.Job {
 	return (&jobloop.CronJob{
 		Metadata: jobloop.JobMetadata{
-			ReadableName: "ensure that all active domains and projects in this cluster have a service entry for this liquid's service type",
+			ReadableName: "ensure that all active domains and projects in this cluster have a service entry for the liquid's service types",
 			CounterOpts: prometheus.CounterOpts{
 				Name: "limes_cron_consistency_runs",
 				Help: "Counter for consistency checks runs",
 			},
 		},
 		Interval: 1 * time.Hour,
-		// When new services or resources are added, we need this job to create the respective DB entries immediately upon deployment.
+		// When new services or resources are added, we need this job to populate the project level services densely.
+		// It does not take care of cluster level services, resources, or rates - they are added on demand from
+		// LiquidConnection.ReconcileLiquidConnection() or whenever the collect job is started. Project level resources
+		// and az_resources are created by the scraping job, which picks up the created project_services.
 		InitialDelay: 10 * time.Second,
-		Task:         c.checkConsistencyCluster,
+		Task:         c.CheckConsistencyAllDomains,
 	}).Setup(registerer)
 }
 
-func (c *Collector) checkConsistencyCluster(_ context.Context, _ prometheus.Labels) error {
-	// check cluster_services entries
-	var services []db.ClusterService
-	_, err := c.DB.Select(&services, `SELECT * FROM cluster_services`)
-	if err != nil {
-		return err
-	}
-	logg.Info("checking consistency for %d cluster services...", len(services))
-
-	// cleanup entries for services that have been disabled
-	seen := make(map[db.ServiceType]bool)
-	for _, service := range services {
-		seen[service.Type] = true
-
-		if !c.Cluster.HasService(service.Type) {
-			logg.Info("cleaning up %s cluster service entry", service.Type)
-			_, err := c.DB.Delete(&service)
-			if err != nil {
-				c.LogError(err.Error())
-			}
-		}
-	}
-
-	// create missing service entries
-	for _, serviceType := range c.Cluster.ServiceTypesInAlphabeticalOrder() {
-		if seen[serviceType] {
-			continue
-		}
-
-		logg.Info("creating missing %s cluster service entry", serviceType)
-		err := c.DB.Insert(&db.ClusterService{Type: serviceType, NextScrapeAt: c.MeasureTime()})
-		if err != nil {
-			c.LogError(err.Error())
-		}
-	}
-
+func (c *Collector) CheckConsistencyAllDomains(_ context.Context, _ prometheus.Labels) error {
 	// recurse into domains (with deterministic ordering for the unit test's sake;
 	// the DESC ordering is because I was too lazy to change the fixtures)
 	var domains []db.Domain
-	_, err = c.DB.Select(&domains, `SELECT * FROM domains ORDER BY name DESC`)
+	_, err := c.DB.Select(&domains, `SELECT * FROM domains ORDER BY name DESC`)
 	if err != nil {
 		return err
 	}

--- a/internal/collector/consistency_test.go
+++ b/internal/collector/consistency_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/sapcc/go-bits/easypg"
 
+	"github.com/sapcc/limes/internal/core"
 	"github.com/sapcc/limes/internal/db"
 )
 
@@ -77,12 +78,22 @@ func Test_Consistency(t *testing.T) {
 	easypg.AssertDBContent(t, s.DB.Db, "fixtures/checkconsistency1.sql")
 
 	// check that CheckConsistency() brings everything back into a nice state
-	//
-	// Also, for all domain services that are created here, all domain resources are added.
+	// the "whatever" service will remain but is ignored by the consistency service,
+	// as that one is using the c.Cluster configuration.
 	s.Clock.StepBy(time.Hour)
 	err = consistencyJob.ProcessOne(s.Ctx)
 	if err != nil {
 		t.Error(err)
 	}
 	easypg.AssertDBContent(t, s.DB.Db, "fixtures/checkconsistency2.sql")
+
+	// now we add the "whatever" service to the configuration, which will change the state of
+	// the DB after running the job again
+	s.Cluster.LiquidConnections["whatever"] = &core.LiquidConnection{}
+	s.Clock.StepBy(time.Hour)
+	err = consistencyJob.ProcessOne(s.Ctx)
+	if err != nil {
+		t.Error(err)
+	}
+	easypg.AssertDBContent(t, s.DB.Db, "fixtures/checkconsistency3.sql")
 }

--- a/internal/collector/fixtures/checkconsistency0.sql
+++ b/internal/collector/fixtures/checkconsistency0.sql
@@ -1,6 +1,3 @@
-INSERT INTO cluster_services (id, type, next_scrape_at) VALUES (1, 'shared', 3600);
-INSERT INTO cluster_services (id, type, next_scrape_at) VALUES (2, 'unshared', 3600);
-
 INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
 INSERT INTO domains (id, name, uuid) VALUES (2, 'france', 'uuid-for-france');
 

--- a/internal/collector/fixtures/checkconsistency1.sql
+++ b/internal/collector/fixtures/checkconsistency1.sql
@@ -1,5 +1,4 @@
-INSERT INTO cluster_services (id, type, next_scrape_at) VALUES (2, 'unshared', 3600);
-INSERT INTO cluster_services (id, type, next_scrape_at) VALUES (3, 'whatever', 3600);
+INSERT INTO cluster_services (id, type, next_scrape_at) VALUES (1, 'whatever', 3600);
 
 INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
 INSERT INTO domains (id, name, uuid) VALUES (2, 'france', 'uuid-for-france');

--- a/internal/collector/fixtures/checkconsistency3.sql
+++ b/internal/collector/fixtures/checkconsistency3.sql
@@ -4,6 +4,9 @@ INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
 INSERT INTO domains (id, name, uuid) VALUES (2, 'france', 'uuid-for-france');
 
 INSERT INTO project_services (id, project_id, type, stale, rates_stale, next_scrape_at, rates_next_scrape_at) VALUES (10, 3, 'shared', TRUE, TRUE, 7200, 7200);
+INSERT INTO project_services (id, project_id, type, stale, rates_stale, next_scrape_at, rates_next_scrape_at) VALUES (11, 1, 'whatever', TRUE, TRUE, 10800, 10800);
+INSERT INTO project_services (id, project_id, type, stale, rates_stale, next_scrape_at, rates_next_scrape_at) VALUES (12, 2, 'whatever', TRUE, TRUE, 10800, 10800);
+INSERT INTO project_services (id, project_id, type, stale, rates_stale, next_scrape_at, rates_next_scrape_at) VALUES (13, 3, 'whatever', TRUE, TRUE, 10800, 10800);
 INSERT INTO project_services (id, project_id, type, stale, rates_stale, next_scrape_at, rates_next_scrape_at) VALUES (2, 1, 'unshared', TRUE, TRUE, 0, 0);
 INSERT INTO project_services (id, project_id, type, stale, rates_stale, next_scrape_at, rates_next_scrape_at) VALUES (4, 2, 'unshared', TRUE, TRUE, 0, 0);
 INSERT INTO project_services (id, project_id, type, stale, rates_stale, next_scrape_at, rates_next_scrape_at) VALUES (6, 3, 'unshared', TRUE, TRUE, 0, 0);

--- a/internal/collector/fixtures/scrape0.sql
+++ b/internal/collector/fixtures/scrape0.sql
@@ -1,3 +1,8 @@
+INSERT INTO cluster_resources (id, service_id, name, liquid_version, unit, topology, has_capacity, needs_resource_demand, has_quota) VALUES (1, 1, 'capacity', 1, 'B', 'az-aware', TRUE, TRUE, TRUE);
+INSERT INTO cluster_resources (id, service_id, name, liquid_version, topology, has_quota) VALUES (2, 1, 'things', 1, 'az-aware', TRUE);
+
+INSERT INTO cluster_services (id, type, next_scrape_at, liquid_version, usage_metric_families_json) VALUES (1, 'unittest', -62135596800, 1, '{"limes_unittest_capacity_usage":{"type":"gauge","help":"","labelKeys":null},"limes_unittest_things_usage":{"type":"gauge","help":"","labelKeys":null}}');
+
 INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
 
 INSERT INTO project_services (id, project_id, type, stale, rates_stale, next_scrape_at, rates_next_scrape_at) VALUES (1, 1, 'unittest', TRUE, TRUE, 0, 0);

--- a/internal/collector/ratescrape.go
+++ b/internal/collector/ratescrape.go
@@ -106,7 +106,7 @@ func (c *Collector) processRateScrapeTask(ctx context.Context, task projectScrap
 	logg.Debug("scraping %s rates for %s/%s", srv.Type, project.Domain.Name, project.Name)
 
 	// perform rate scrape
-	rateData, ratesScrapeState, err := connection.ScrapeRates(ctx, project, c.Cluster.Config.AvailabilityZones, srv.RatesScrapeState)
+	rateData, ratesScrapeState, err := connection.ScrapeRates(ctx, project, c.Cluster.Config.AvailabilityZones, srv.RatesScrapeState, c.DB)
 	if err != nil {
 		task.Err = util.UnpackError(err)
 	}

--- a/internal/collector/ratescrape_test.go
+++ b/internal/collector/ratescrape_test.go
@@ -100,6 +100,7 @@ func commonRateScrapeTestSetup(t *testing.T) (s test.Setup, job jobloop.Job, wit
 	mockLiquidClient, liquidServiceType := test.NewMockLiquidClient(srvInfo)
 	s = test.NewSetup(t,
 		test.WithConfig(fmt.Sprintf(testRateScrapeBasicConfigYAML, liquidServiceType)),
+		test.WithCollectorSetup,
 	)
 	s.Cluster.Config.QuotaDistributionConfigs = []core.QuotaDistributionConfiguration{
 		{
@@ -176,6 +177,11 @@ func Test_RateScrapeSuccess(t *testing.T) {
 	tr, tr0 := easypg.NewTracker(t, s.DB.Db)
 	//nolint:dupword // false positive on "TRUE, TRUE"
 	tr0.AssertEqualf(`
+		INSERT INTO cluster_rates (id, service_id, name, liquid_version, has_usage) VALUES (1, 1, 'firstrate', 1, TRUE);
+		INSERT INTO cluster_rates (id, service_id, name, liquid_version, unit, has_usage) VALUES (2, 1, 'secondrate', 1, 'KiB', TRUE);
+		INSERT INTO cluster_resources (id, service_id, name, liquid_version, topology) VALUES (1, 1, 'capacity', 1, 'az-aware');
+		INSERT INTO cluster_resources (id, service_id, name, liquid_version, topology) VALUES (2, 1, 'things', 1, 'az-aware');
+		INSERT INTO cluster_services (id, type, next_scrape_at, liquid_version) VALUES (1, 'unittest', -62135596800, 1);
 		INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
 		INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_bigint) VALUES (1, 'otherrate', 42, 120000000000, '');
 		INSERT INTO project_rates (service_id, name, rate_limit, window_ns, usage_as_bigint) VALUES (1, 'secondrate', 10, 1000000000, '');
@@ -279,7 +285,24 @@ func Test_RateScrapeFailure(t *testing.T) {
 
 	// check that ScanDomains created the domain, project and their services
 	tr, tr0 := easypg.NewTracker(t, s.DB.Db)
-	tr0.AssertEqualToFile("fixtures/scrape0.sql")
+	//nolint:dupword // false positive on "TRUE, TRUE"
+	tr0.AssertEqual(`
+		INSERT INTO cluster_rates (id, service_id, name, liquid_version, has_usage) VALUES (1, 1, 'firstrate', 1, TRUE);
+		INSERT INTO cluster_rates (id, service_id, name, liquid_version, unit, has_usage) VALUES (2, 1, 'secondrate', 1, 'KiB', TRUE);
+		
+		INSERT INTO cluster_resources (id, service_id, name, liquid_version, topology) VALUES (1, 1, 'capacity', 1, 'az-aware');
+		INSERT INTO cluster_resources (id, service_id, name, liquid_version, topology) VALUES (2, 1, 'things', 1, 'az-aware');
+		
+		INSERT INTO cluster_services (id, type, next_scrape_at, liquid_version) VALUES (1, 'unittest', -62135596800, 1);
+		
+		INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
+		
+		INSERT INTO project_services (id, project_id, type, stale, rates_stale, next_scrape_at, rates_next_scrape_at) VALUES (1, 1, 'unittest', TRUE, TRUE, 0, 0);
+		INSERT INTO project_services (id, project_id, type, stale, rates_stale, next_scrape_at, rates_next_scrape_at) VALUES (2, 2, 'unittest', TRUE, TRUE, 0, 0);
+		
+		INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany');
+		INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (2, 1, 'dresden', 'uuid-for-dresden', 'uuid-for-berlin');
+    `)
 
 	// ScrapeRates should not touch the DB when scraping fails
 	mockLiquidClient.SetUsageReportError(errors.New("GetUsageReport failed as requested"))

--- a/internal/collector/scrape.go
+++ b/internal/collector/scrape.go
@@ -207,7 +207,7 @@ func (c *Collector) processResourceScrapeTask(ctx context.Context, task projectS
 }
 
 func (c *Collector) scrapeLiquid(ctx context.Context, connection *core.LiquidConnection, project core.KeystoneProject) (liquid.ServiceUsageReport, []byte, error) {
-	resourceData, err := connection.Scrape(ctx, project, c.Cluster.Config.AvailabilityZones)
+	resourceData, err := connection.Scrape(ctx, project, c.Cluster.Config.AvailabilityZones, c.DB)
 	if err != nil {
 		return liquid.ServiceUsageReport{}, nil, err
 	}
@@ -346,7 +346,7 @@ func (c *Collector) writeResourceScrapeResult(dbDomain db.Domain, dbProject db.P
 					)
 				}
 
-				azRes.SubresourcesJSON, err = renderListToJSON("subresources", data.Subresources)
+				azRes.SubresourcesJSON, err = util.RenderListToJSON("subresources", data.Subresources)
 				if err != nil {
 					return err
 				}

--- a/internal/collector/scrape_test.go
+++ b/internal/collector/scrape_test.go
@@ -125,6 +125,7 @@ func commonComplexScrapeTestSetup(t *testing.T) (s test.Setup, scrapeJob jobloop
 	mockLiquidClient, liquidServiceType := test.NewMockLiquidClient(srvInfo)
 	s = test.NewSetup(t,
 		test.WithConfig(fmt.Sprintf(testScrapeBasicConfigYAML, liquidServiceType)),
+		test.WithCollectorSetup,
 	)
 	prepareDomainsAndProjectsForScrape(t, s)
 
@@ -600,6 +601,7 @@ func Test_ScrapeButNoResources(t *testing.T) {
 	mockLiquidClient, liquidServiceType := test.NewMockLiquidClient(srvInfo)
 	s := test.NewSetup(t,
 		test.WithConfig(fmt.Sprintf(testNoopConfigYAML, liquidServiceType)),
+		test.WithCollectorSetup,
 	)
 	prepareDomainsAndProjectsForScrape(t, s)
 
@@ -618,6 +620,7 @@ func Test_ScrapeButNoResources(t *testing.T) {
 	scrapedAt := s.Clock.Now()
 	_, tr0 := easypg.NewTracker(t, s.DB.Db)
 	tr0.AssertEqualf(`
+        INSERT INTO cluster_services (id, type, next_scrape_at, liquid_version) VALUES (1, 'noop', -62135596800, 1);
 		INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
 		INSERT INTO project_services (id, project_id, type, scraped_at, scrape_duration_secs, rates_stale, serialized_metrics, checked_at, next_scrape_at, rates_next_scrape_at) VALUES (1, 1, 'noop', %[1]d, 5, TRUE, '{}', %[1]d, %[2]d, 0);
 		INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany');
@@ -639,6 +642,7 @@ func Test_ScrapeReturnsNoUsageData(t *testing.T) {
 	mockLiquidClient, liquidServiceType := test.NewMockLiquidClient(srvInfo)
 	s := test.NewSetup(t,
 		test.WithConfig(fmt.Sprintf(testNoopConfigYAML, liquidServiceType)),
+		test.WithCollectorSetup,
 	)
 	prepareDomainsAndProjectsForScrape(t, s)
 
@@ -657,6 +661,8 @@ func Test_ScrapeReturnsNoUsageData(t *testing.T) {
 	scrapedAt := s.Clock.Now()
 	_, tr0 := easypg.NewTracker(t, s.DB.Db)
 	tr0.AssertEqualf(`
+		INSERT INTO cluster_resources (id, service_id, name, liquid_version, topology, has_quota) VALUES (1, 1, 'things', 1, 'az-aware', TRUE);
+		INSERT INTO cluster_services (id, type, next_scrape_at, liquid_version) VALUES (1, 'noop', -62135596800, 1);
 		INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
 		INSERT INTO project_az_resources (id, resource_id, az, usage) VALUES (1, 1, 'any', 0);
 		INSERT INTO project_resources (id, service_id, name, quota, backend_quota) VALUES (1, 1, 'things', 0, -1);
@@ -668,7 +674,7 @@ func Test_ScrapeReturnsNoUsageData(t *testing.T) {
 }
 
 func Test_TopologyScrapes(t *testing.T) {
-	s, job, withLabel, syncJob, srvInfo, serviceUsageReport, _ := commonComplexScrapeTestSetup(t)
+	s, job, withLabel, syncJob, srvInfo, serviceUsageReport, mockLiquidClient := commonComplexScrapeTestSetup(t)
 
 	// use AZSeperated topology and adjust quota reporting accordingly
 	resInfoCap := srvInfo.Resources["capacity"]
@@ -758,6 +764,9 @@ func Test_TopologyScrapes(t *testing.T) {
 	resThings.Quota = Some[int64](42)
 	resThings.PerAZ["az-one"].Quota = None[int64]()
 	resThings.PerAZ["az-two"].Quota = None[int64]()
+	// in reality, this would be an update of the liquid, so we bump the version that the liquid and the report return
+	mockLiquidClient.IncrementServiceInfoVersion()
+	mockLiquidClient.IncrementUsageReportInfoVersion()
 
 	mustT(t, job.ProcessOne(s.Ctx, withLabel))
 	mustT(t, job.ProcessOne(s.Ctx, withLabel))
@@ -765,6 +774,9 @@ func Test_TopologyScrapes(t *testing.T) {
 	checkedAt1 := s.Clock.Now().Add(-5 * time.Second)
 	checkedAt2 := s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`
+		UPDATE cluster_resources SET liquid_version = 2, topology = 'az-separated' WHERE id = 1 AND service_id = 1 AND name = 'capacity';
+		UPDATE cluster_resources SET liquid_version = 2 WHERE id = 2 AND service_id = 1 AND name = 'things';
+		UPDATE cluster_services SET liquid_version = 2 WHERE id = 1 AND type = 'unittest';
 		UPDATE project_az_resources SET backend_quota = 50 WHERE id = 1 AND resource_id = 1 AND az = 'az-one';
 		INSERT INTO project_az_resources (id, resource_id, az, usage, historical_usage) VALUES (10, 4, 'any', 0, '{"t":[1830],"v":[0]}');
 		UPDATE project_az_resources SET backend_quota = 50 WHERE id = 2 AND resource_id = 1 AND az = 'az-two';
@@ -788,6 +800,10 @@ func Test_TopologyScrapes(t *testing.T) {
 	// negative: service info validation should fail with invalid AZs
 	resInfoCap.Topology = "invalidAZ1"
 	srvInfo.Resources["capacity"] = resInfoCap
+	// in reality, this would be an update of the liquid, so we bump the version that the liquid and the report returns
+	mockLiquidClient.IncrementServiceInfoVersion()
+	mockLiquidClient.IncrementUsageReportInfoVersion()
+
 	mustFailT(t, job.ProcessOne(s.Ctx, withLabel), errors.New("during resource scrape of project germany/berlin: received ServiceInfo is invalid: .Resources[\"capacity\"] has invalid topology \"invalidAZ1\""))
 
 	s.Clock.StepBy(scrapeInterval)

--- a/internal/core/cluster.go
+++ b/internal/core/cluster.go
@@ -21,9 +21,12 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"slices"
+	"sort"
 	"time"
 
+	"github.com/go-gorp/gorp/v3"
 	"github.com/gophercloud/gophercloud/v2"
 	. "github.com/majewsky/gg/option"
 	"github.com/sapcc/go-api-declarations/limes"
@@ -109,6 +112,50 @@ func (c *Cluster) Connect(ctx context.Context, provider *gophercloud.ProviderCli
 	}
 
 	return errs
+}
+
+// ReconcileLiquidConnections should be called once on startup of the limes-collect task, so that
+// the database tables are in a consistent state with the configured LiquidConnections. For this,
+// each individual LiquidConnection is reconciled and leftover entries are deleted. This means resources
+// and rates can change without restarting the limes-collect task, but a change in of LiquidConnections
+// needs restart.
+func (c *Cluster) ReconcileLiquidConnections(dbm *gorp.DbMap) (err error) {
+	// sort for testing purposes
+	serviceTypes := make([]db.ServiceType, len(c.LiquidConnections))
+	i := 0
+	for serviceType := range c.LiquidConnections {
+		serviceTypes[i] = serviceType
+		i++
+	}
+	slices.Sort(serviceTypes)
+
+	for _, serviceType := range serviceTypes {
+		err := c.LiquidConnections[serviceType].ReconcileLiquidConnection(dbm)
+		if err != nil {
+			return err
+		}
+	}
+
+	// delete all orphaned cluster_services
+	// respective cluster_resources, cluster_az_resources and cluster_rates are handled by delete-cascade
+	var dbServices []db.ClusterService
+	_, err = dbm.Select(&dbServices, `SELECT * FROM cluster_services`)
+	if err != nil {
+		return fmt.Errorf("cannot inspect existing cluster_service: %w", err)
+	}
+	// sort for testing purposes
+	sort.SliceStable(dbServices, func(i, j int) bool {
+		return dbServices[i].Type < dbServices[j].Type || dbServices[i].Type > dbServices[j].Type
+	})
+	for _, dbService := range dbServices {
+		if c.LiquidConnections[dbService.Type] == nil {
+			_, err = dbm.Exec(`DELETE FROM cluster_services WHERE type = $1`, dbService.Type)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // ServiceTypesInAlphabeticalOrder can be used when service types need to be

--- a/internal/core/liquid.go
+++ b/internal/core/liquid.go
@@ -27,6 +27,7 @@ import (
 	"math/big"
 	"slices"
 
+	"github.com/go-gorp/gorp/v3"
 	"github.com/gophercloud/gophercloud/v2"
 	. "github.com/majewsky/gg/option"
 	"github.com/prometheus/common/model"
@@ -36,13 +37,15 @@ import (
 	"github.com/sapcc/go-bits/liquidapi"
 	"github.com/sapcc/go-bits/logg"
 	"github.com/sapcc/go-bits/promquery"
+	"github.com/sapcc/go-bits/sqlext"
 
 	"github.com/sapcc/limes/internal/db"
+	"github.com/sapcc/limes/internal/util"
 )
 
-// LiquidConnection holds all the necessary information which is necessary to interact with the LiquidClient.
-// In future, the state information of the LiquidConnection should be persisted in the database to avoid
-// reloading in case of configuration changes.
+// LiquidConnection holds all the information which is necessary to interact with the LiquidClient.
+// The state information of the LiquidConnection is persisted in the database to avoid reloading
+// in case of configuration changes.
 type LiquidConnection struct {
 	// configuration
 	LiquidServiceType               string
@@ -76,12 +79,190 @@ func (l *LiquidConnection) Init(ctx context.Context, client *gophercloud.Provide
 		return err
 	}
 
+	return l.updateServiceInfo(ctx)
+}
+
+// compareServiceInfoVersions compares a report version of the ServiceInfo with the saved version
+// and triggers the update and persisting if necessary.
+func (l *LiquidConnection) compareServiceInfoVersions(ctx context.Context, infoVersion int64, dbm *gorp.DbMap) (err error) {
+	if infoVersion != l.LiquidServiceInfo.Version {
+		logg.Info("ServiceInfo version for %s changed from %d to %d; reloading and persisting ServiceInfo.", l.LiquidServiceType, l.LiquidServiceInfo.Version, infoVersion)
+		err = l.updateServiceInfo(ctx)
+		if err != nil {
+			return err
+		}
+		err = l.ReconcileLiquidConnection(dbm)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// updateServiceInfo queries the backend service for the latest ServiceInfo and validates it.
+func (l *LiquidConnection) updateServiceInfo(ctx context.Context) (err error) {
 	l.LiquidServiceInfo, err = l.LiquidClient.GetInfo(ctx)
 	if err != nil {
 		return err
 	}
 	err = liquid.ValidateServiceInfo(l.LiquidServiceInfo)
 	return err
+}
+
+// ReconcileLiquidConnection ensures consistency of tables cluster_services, cluster_resources and cluster_rates
+// with the latest ServiceInfo of this LiquidConnection. It is called whenever the LiquidVersion changes
+// during Scrape or ScrapeCapacity. On startup of the collect task, this function is called from the Cluster
+// where additionally, orphaned entries are removed.
+func (l *LiquidConnection) ReconcileLiquidConnection(dbm *gorp.DbMap) (err error) {
+	// do the whole consistency check for one connection in a transaction to avoid inconsistent dbm state
+	tx, err := dbm.Begin()
+	if err != nil {
+		return err
+	}
+	defer sqlext.RollbackUnlessCommitted(tx)
+
+	// collect existing cluster_service and the wanted cluster_service
+	var dbServices []db.ClusterService
+	_, err = tx.Select(&dbServices, `SELECT * FROM cluster_services WHERE type = $1`, l.ServiceType)
+	if err != nil {
+		return fmt.Errorf("cannot inspect existing cluster_service %s: %w", l.ServiceType, err)
+	}
+	var wantedServices = []db.ServiceType{l.ServiceType}
+
+	// do update for cluster_service (as set update, for convenience)
+	cmf, err := util.RenderMapToJSON("capacity_metric_families", l.LiquidServiceInfo.CapacityMetricFamilies)
+	if err != nil {
+		return fmt.Errorf("cannot serialize CapacityMetricFamilies for %s: %w", l.ServiceType, err)
+	}
+	umf, err := util.RenderMapToJSON("usage_metric_families", l.LiquidServiceInfo.UsageMetricFamilies)
+	if err != nil {
+		return fmt.Errorf("cannot serialize UsageMetricFamilies for %s: %w", l.ServiceType, err)
+	}
+	serviceUpdate := db.SetUpdate[db.ClusterService, db.ServiceType]{
+		ExistingRecords: dbServices,
+		WantedKeys:      wantedServices,
+		KeyForRecord: func(service db.ClusterService) db.ServiceType {
+			return service.Type
+		},
+		Create: func(serviceType db.ServiceType) (db.ClusterService, error) {
+			return db.ClusterService{
+				Type:                       l.ServiceType,
+				LiquidVersion:              l.LiquidServiceInfo.Version,
+				CapacityMetricFamiliesJSON: cmf,
+				UsageMetricFamiliesJSON:    umf,
+			}, nil
+		},
+		Update: func(service *db.ClusterService) (err error) {
+			service.LiquidVersion = l.LiquidServiceInfo.Version
+			service.CapacityMetricFamiliesJSON = cmf
+			service.UsageMetricFamiliesJSON = umf
+			return nil
+		},
+	}
+	dbServices, err = serviceUpdate.Execute(tx)
+	if err != nil {
+		return fmt.Errorf("update cluster_services failed for %s: %w", l.ServiceType, err)
+	}
+
+	// collect existing cluster_resources and the wanted cluster_resources
+	var dbResources []db.ClusterResource
+	_, err = tx.Select(&dbResources, `SELECT * FROM cluster_resources WHERE service_id = $1`, dbServices[0].ID)
+	if err != nil {
+		return fmt.Errorf("cannot inspect existing cluster resources for %s: %w", l.ServiceType, err)
+	}
+	wantedResources := make([]liquid.ResourceName, len(l.LiquidServiceInfo.Resources))
+	i := 0
+	for resourceName := range l.LiquidServiceInfo.Resources {
+		wantedResources[i] = resourceName
+		i++
+	}
+	// sort for testing purposes
+	slices.Sort(wantedResources)
+
+	// do update for cluster_resources
+	resourceUpdate := db.SetUpdate[db.ClusterResource, liquid.ResourceName]{
+		ExistingRecords: dbResources,
+		WantedKeys:      wantedResources,
+		KeyForRecord: func(resource db.ClusterResource) liquid.ResourceName {
+			return resource.Name
+		},
+		Create: func(resourceName liquid.ResourceName) (db.ClusterResource, error) {
+			return db.ClusterResource{
+				ServiceID:           dbServices[0].ID,
+				Name:                resourceName,
+				LiquidVersion:       l.LiquidServiceInfo.Version,
+				Unit:                l.LiquidServiceInfo.Resources[resourceName].Unit,
+				Topology:            l.LiquidServiceInfo.Resources[resourceName].Topology,
+				HasCapacity:         l.LiquidServiceInfo.Resources[resourceName].HasCapacity,
+				NeedsResourceDemand: l.LiquidServiceInfo.Resources[resourceName].NeedsResourceDemand,
+				HasQuota:            l.LiquidServiceInfo.Resources[resourceName].HasQuota,
+				AttributesJSON:      string(l.LiquidServiceInfo.Resources[resourceName].Attributes),
+			}, nil
+		},
+		Update: func(res *db.ClusterResource) (err error) {
+			res.LiquidVersion = l.LiquidServiceInfo.Version
+			res.Unit = l.LiquidServiceInfo.Resources[res.Name].Unit
+			res.Topology = l.LiquidServiceInfo.Resources[res.Name].Topology
+			res.HasCapacity = l.LiquidServiceInfo.Resources[res.Name].HasCapacity
+			res.NeedsResourceDemand = l.LiquidServiceInfo.Resources[res.Name].NeedsResourceDemand
+			res.HasQuota = l.LiquidServiceInfo.Resources[res.Name].HasQuota
+			res.AttributesJSON = string(l.LiquidServiceInfo.Resources[res.Name].Attributes)
+			return nil
+		},
+	}
+	_, err = resourceUpdate.Execute(tx)
+	if err != nil {
+		return err
+	}
+
+	// collect existing cluster_rates and the wanted cluster_rates
+	var dbRates []db.ClusterRate
+	_, err = tx.Select(&dbRates, `SELECT * FROM cluster_rates WHERE service_id = $1`, dbServices[0].ID)
+	if err != nil {
+		return fmt.Errorf("cannot inspect existing cluster rates for %s: %w", l.ServiceType, err)
+	}
+	wantedRates := make([]liquid.RateName, len(l.LiquidServiceInfo.Rates))
+	i = 0
+	for rateName := range l.LiquidServiceInfo.Rates {
+		wantedRates[i] = rateName
+		i++
+	}
+	// sort for testing purposes
+	slices.Sort(wantedRates)
+
+	// do update for cluster_resources
+	rateUpdate := db.SetUpdate[db.ClusterRate, liquid.RateName]{
+		ExistingRecords: dbRates,
+		WantedKeys:      wantedRates,
+		KeyForRecord: func(rate db.ClusterRate) liquid.RateName {
+			return rate.Name
+		},
+		Create: func(rateName liquid.RateName) (db.ClusterRate, error) {
+			return db.ClusterRate{
+				ServiceID:     dbServices[0].ID,
+				Name:          rateName,
+				LiquidVersion: l.LiquidServiceInfo.Version,
+				Unit:          l.LiquidServiceInfo.Rates[rateName].Unit,
+				HasUsage:      l.LiquidServiceInfo.Rates[rateName].HasUsage,
+			}, nil
+		},
+		Update: func(rate *db.ClusterRate) (err error) {
+			rate.LiquidVersion = l.LiquidServiceInfo.Version
+			rate.Unit = l.LiquidServiceInfo.Rates[rate.Name].Unit
+			rate.HasUsage = l.LiquidServiceInfo.Rates[rate.Name].HasUsage
+			return nil
+		},
+	}
+	_, err = rateUpdate.Execute(tx)
+	if err != nil {
+		return err
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // ServiceInfo returns metadata for this liquid.
@@ -97,7 +278,7 @@ func (l *LiquidConnection) ServiceInfo() liquid.ServiceInfo {
 // building AZ-aware usage data, to ensure that each AZ-aware resource reports
 // usage in all available AZs, even when the project in question does not have
 // usage in every AZ.
-func (l *LiquidConnection) Scrape(ctx context.Context, project KeystoneProject, allAZs []limes.AvailabilityZone) (result liquid.ServiceUsageReport, err error) {
+func (l *LiquidConnection) Scrape(ctx context.Context, project KeystoneProject, allAZs []limes.AvailabilityZone, dbm *gorp.DbMap) (result liquid.ServiceUsageReport, err error) {
 	// shortcut for liquids that only have rates and no resources
 	if len(l.LiquidServiceInfo.Resources) == 0 && len(l.LiquidServiceInfo.UsageMetricFamilies) == 0 {
 		return liquid.ServiceUsageReport{}, nil
@@ -112,14 +293,12 @@ func (l *LiquidConnection) Scrape(ctx context.Context, project KeystoneProject, 
 	if err != nil {
 		return liquid.ServiceUsageReport{}, err
 	}
-	if result.InfoVersion != l.LiquidServiceInfo.Version {
-		logg.Fatal("ServiceInfo version for %s changed from %d to %d; restarting now to reload ServiceInfo...",
-			l.LiquidServiceType, l.LiquidServiceInfo.Version, result.InfoVersion)
-	}
-	err = liquid.ValidateServiceInfo(l.LiquidServiceInfo)
+
+	err = l.compareServiceInfoVersions(ctx, result.InfoVersion, dbm)
 	if err != nil {
 		return liquid.ServiceUsageReport{}, err
 	}
+
 	err = liquid.ValidateUsageReport(result, req, l.LiquidServiceInfo)
 	if err != nil {
 		return liquid.ServiceUsageReport{}, err
@@ -132,7 +311,7 @@ func (l *LiquidConnection) Scrape(ctx context.Context, project KeystoneProject, 
 // that this LiquidConnection is concerned with. The result is a two-dimensional map,
 // with the first key being the service type, and the second key being the
 // resource name.
-func (l *LiquidConnection) ScrapeCapacity(ctx context.Context, backchannel CapacityScrapeBackchannel, allAZs []limes.AvailabilityZone) (result liquid.ServiceCapacityReport, err error) {
+func (l *LiquidConnection) ScrapeCapacity(ctx context.Context, backchannel CapacityScrapeBackchannel, allAZs []limes.AvailabilityZone, dbm *gorp.DbMap) (result liquid.ServiceCapacityReport, err error) {
 	req, err := l.BuildServiceCapacityRequest(backchannel, allAZs)
 	if err != nil {
 		return liquid.ServiceCapacityReport{}, err
@@ -142,14 +321,12 @@ func (l *LiquidConnection) ScrapeCapacity(ctx context.Context, backchannel Capac
 	if err != nil {
 		return liquid.ServiceCapacityReport{}, err
 	}
-	if result.InfoVersion != l.LiquidServiceInfo.Version {
-		logg.Fatal("ServiceInfo version for %s changed from %d to %d; restarting now to reload ServiceInfo...",
-			l.LiquidServiceType, l.LiquidServiceInfo.Version, result.InfoVersion)
-	}
-	err = liquid.ValidateServiceInfo(l.LiquidServiceInfo)
+
+	err = l.compareServiceInfoVersions(ctx, result.InfoVersion, dbm)
 	if err != nil {
 		return liquid.ServiceCapacityReport{}, err
 	}
+
 	err = liquid.ValidateCapacityReport(result, req, l.LiquidServiceInfo)
 	if err != nil {
 		return liquid.ServiceCapacityReport{}, err
@@ -308,7 +485,7 @@ func (l *LiquidConnection) SetQuota(ctx context.Context, project KeystoneProject
 // by the core application in any way. The LiquidConnection can use this
 // field to carry state between ScrapeRates() calls, esp. to detect and handle
 // counter resets in the backend.
-func (l *LiquidConnection) ScrapeRates(ctx context.Context, project KeystoneProject, allAZs []limes.AvailabilityZone, prevSerializedState string) (result map[liquid.RateName]*big.Int, serializedState string, err error) {
+func (l *LiquidConnection) ScrapeRates(ctx context.Context, project KeystoneProject, allAZs []limes.AvailabilityZone, prevSerializedState string, dbm *gorp.DbMap) (result map[liquid.RateName]*big.Int, serializedState string, err error) {
 	// shortcut for liquids that do not have rates
 	if len(l.LiquidServiceInfo.Rates) == 0 {
 		return nil, "", nil
@@ -326,9 +503,10 @@ func (l *LiquidConnection) ScrapeRates(ctx context.Context, project KeystoneProj
 	if err != nil {
 		return nil, "", err
 	}
-	if resp.InfoVersion != l.LiquidServiceInfo.Version {
-		logg.Fatal("ServiceInfo version for %s changed from %d to %d; restarting now to reload ServiceInfo...",
-			l.LiquidServiceType, l.LiquidServiceInfo.Version, resp.InfoVersion)
+
+	err = l.compareServiceInfoVersions(ctx, resp.InfoVersion, dbm)
+	if err != nil {
+		return nil, "", err
 	}
 
 	result = make(map[liquid.RateName]*big.Int)

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -371,4 +371,42 @@ var sqlMigrations = map[string]string{
 			DROP COLUMN max_quota_from_backend;
 
 	`,
+	"054_persist_service_info.down.sql": `
+        DROP TABLE cluster_rates;
+        ALTER TABLE cluster_resources
+          DROP COLUMN liquid_version,
+		  DROP COLUMN unit,
+		  DROP COLUMN topology,
+		  DROP COLUMN has_capacity,
+		  DROP COLUMN needs_resource_demand,
+		  DROP COLUMN has_quota,
+		  DROP COLUMN attributes_json;
+	    ALTER TABLE cluster_services
+	      DROP COLUMN liquid_version,
+	      DROP COLUMN capacity_metric_families_json,
+	      DROP COLUMN usage_metric_families_json;
+    `,
+	"054_persist_service_info.up.sql": `
+        CREATE TABLE cluster_rates (
+			id               BIGSERIAL  NOT NULL PRIMARY KEY,
+			service_id       BIGINT     NOT NULL REFERENCES cluster_services ON DELETE CASCADE,
+			name             TEXT       NOT NULL,
+			liquid_version   BIGINT     NOT NULL DEFAULT 0,
+			unit  		     TEXT       NOT NULL DEFAULT '',
+			has_usage        BOOLEAN    NOT NULL DEFAULT FALSE,
+			UNIQUE (service_id, name)
+		);
+        ALTER TABLE cluster_resources
+          ADD COLUMN liquid_version BIGINT NOT NULL DEFAULT 0,
+          ADD COLUMN unit TEXT NOT NULL DEFAULT '',
+          ADD COLUMN topology TEXT NOT NULL DEFAULT '',
+          ADD COLUMN has_capacity BOOLEAN NOT NULL DEFAULT FALSE,
+          ADD COLUMN needs_resource_demand BOOLEAN NOT NULL DEFAULT FALSE,
+          ADD COLUMN has_quota BOOLEAN NOT NULL DEFAULT FALSE,
+          ADD COLUMN attributes_json text NOT NULL DEFAULT '';
+		ALTER TABLE cluster_services
+		  ADD COLUMN liquid_version BIGINT NOT NULL DEFAULT 0,
+		  ADD COLUMN capacity_metric_families_json text NOT NULL DEFAULT '',
+		  ADD COLUMN usage_metric_families_json text NOT NULL DEFAULT '';
+    `,
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -40,6 +40,10 @@ type ClusterService struct {
 	SerializedMetrics  string            `db:"serialized_metrics"`
 	NextScrapeAt       time.Time         `db:"next_scrape_at"`
 	ScrapeErrorMessage string            `db:"scrape_error_message"`
+	// following fields get filled from liquid.ServiceInfo
+	LiquidVersion              int64  `db:"liquid_version"`
+	CapacityMetricFamiliesJSON string `db:"capacity_metric_families_json"`
+	UsageMetricFamiliesJSON    string `db:"usage_metric_families_json"`
 }
 
 // ClusterResource contains a record from the `cluster_resources` table.
@@ -47,6 +51,14 @@ type ClusterResource struct {
 	ID        ClusterResourceID   `db:"id"`
 	ServiceID ClusterServiceID    `db:"service_id"`
 	Name      liquid.ResourceName `db:"name"`
+	// following fields get filled from liquid.ServiceInfo
+	LiquidVersion       int64           `db:"liquid_version"`
+	Unit                liquid.Unit     `db:"unit"`
+	Topology            liquid.Topology `db:"topology"`
+	HasCapacity         bool            `db:"has_capacity"`
+	NeedsResourceDemand bool            `db:"needs_resource_demand"`
+	HasQuota            bool            `db:"has_quota"`
+	AttributesJSON      string          `db:"attributes_json"`
 }
 
 // Ref returns the ResourceRef for this resource.
@@ -62,6 +74,17 @@ type ClusterAZResource struct {
 	RawCapacity       uint64                 `db:"raw_capacity"`
 	Usage             Option[uint64]         `db:"usage"`
 	SubcapacitiesJSON string                 `db:"subcapacities"`
+}
+
+// ClusterRate contains a record from the `cluster_rates` table.
+type ClusterRate struct {
+	ID        ClusterRateID    `db:"id"`
+	ServiceID ClusterServiceID `db:"service_id"`
+	Name      liquid.RateName  `db:"name"`
+	// following fields get filled from liquid.ServiceInfo
+	LiquidVersion int64       `db:"liquid_version"`
+	Unit          liquid.Unit `db:"unit"`
+	HasUsage      bool        `db:"has_usage"`
 }
 
 // Domain contains a record from the `domains` table.
@@ -242,6 +265,7 @@ type MailNotification struct {
 func initGorp(db *gorp.DbMap) {
 	db.AddTableWithName(ClusterService{}, "cluster_services").SetKeys(true, "id")
 	db.AddTableWithName(ClusterResource{}, "cluster_resources").SetKeys(true, "id")
+	db.AddTableWithName(ClusterRate{}, "cluster_rates").SetKeys(true, "id")
 	db.AddTableWithName(ClusterAZResource{}, "cluster_az_resources").SetKeys(true, "id")
 	db.AddTableWithName(Domain{}, "domains").SetKeys(true, "id")
 	db.AddTableWithName(Project{}, "projects").SetKeys(true, "id")

--- a/internal/db/refs.go
+++ b/internal/db/refs.go
@@ -44,6 +44,10 @@ type ClusterResourceID int64
 // used to distinguish these IDs from IDs of other tables or raw int64 values.
 type ClusterAZResourceID int64
 
+// ClusterRateID is an ID into the cluster_rates table. This typedef is
+// used to distinguish these IDs from IDs of other tables or raw int64 values.
+type ClusterRateID int64
+
 // DomainID is an ID into the domains table. This typedef is
 // used to distinguish these IDs from IDs of other tables or raw int64 values.
 type DomainID int64

--- a/internal/test/mock_liquid_client.go
+++ b/internal/test/mock_liquid_client.go
@@ -109,6 +109,10 @@ func (l *MockLiquidClient) SetServiceInfo(info liquid.ServiceInfo) {
 	l.serviceInfo = info
 }
 
+func (l *MockLiquidClient) IncrementServiceInfoVersion() {
+	l.serviceInfo.Version++
+}
+
 func (l *MockLiquidClient) SetCapacityReportError(err error) {
 	l.capacityReportError = err
 }
@@ -124,6 +128,10 @@ func (l *MockLiquidClient) SetCapacityReport(capacityReport liquid.ServiceCapaci
 	l.serviceCapacityReport = capacityReport
 }
 
+func (l *MockLiquidClient) IncrementCapacityReportInfoVersion() {
+	l.serviceCapacityReport.InfoVersion++
+}
+
 func (l *MockLiquidClient) SetUsageReportError(err error) {
 	l.usageReportError = err
 }
@@ -137,6 +145,10 @@ func (l *MockLiquidClient) GetUsageReport(ctx context.Context, projectUUID strin
 
 func (l *MockLiquidClient) SetUsageReport(usageReport liquid.ServiceUsageReport) {
 	l.serviceUsageReport = usageReport
+}
+
+func (l *MockLiquidClient) IncrementUsageReportInfoVersion() {
+	l.serviceUsageReport.InfoVersion++
 }
 
 func (l *MockLiquidClient) SetQuotaError(err error) {

--- a/internal/test/setup.go
+++ b/internal/test/setup.go
@@ -54,6 +54,7 @@ type setupParams struct {
 	APIMiddlewares           []httpapi.API
 	Projects                 []*core.KeystoneProject
 	WithEmptyRecordsAsNeeded bool
+	WithCollectorSetup       bool
 }
 
 // SetupOption is an option that can be given to NewSetup().
@@ -93,6 +94,13 @@ func WithProject(p core.KeystoneProject) SetupOption {
 	return func(params *setupParams) {
 		params.Projects = append(params.Projects, &p)
 	}
+}
+
+// WithCollectorSetup is a SetupOption that sets up the Cluster the same ways
+// as the limes-collect would do. Namely, this reconciles the LiquidConnections
+// on startup.
+func WithCollectorSetup(params *setupParams) {
+	params.WithCollectorSetup = true
 }
 
 // WithEmptyRecordsAsNeeded is a SetupOption that populates the DB with empty
@@ -144,6 +152,12 @@ func NewSetup(t *testing.T, opts ...SetupOption) Setup {
 	s.DB = initDatabase(t, params.DBSetupOptions)
 	s.Cluster = initCluster(t, s.Ctx, params.ConfigYAML)
 	s.Clock = mock.NewClock()
+	if params.WithCollectorSetup {
+		err := s.Cluster.ReconcileLiquidConnections(s.DB)
+		if err != nil {
+			logg.Fatal("failed to reconcile liquid connections: %w", err)
+		}
+	}
 	s.Registry = prometheus.NewPedanticRegistry()
 
 	// load mock policy (where everything is allowed)
@@ -266,7 +280,7 @@ func initDatabase(t *testing.T, extraOpts []easypg.TestSetupOption) *gorp.DbMap 
 	opts := append(slices.Clone(extraOpts),
 		easypg.ClearTables("project_commitments", "cluster_services", "domains"),
 		easypg.ResetPrimaryKeys(
-			"cluster_services", "cluster_resources", "cluster_az_resources",
+			"cluster_services", "cluster_resources", "cluster_rates", "cluster_az_resources",
 			"domains", "projects", "project_commitments", "project_mail_notifications",
 			"project_services", "project_resources", "project_az_resources",
 		),

--- a/internal/util/tojson.go
+++ b/internal/util/tojson.go
@@ -1,0 +1,47 @@
+/*******************************************************************************
+*
+* Copyright 2025 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func RenderListToJSON[T any](attribute string, entries []T) (string, error) {
+	if len(entries) == 0 {
+		return "", nil
+	}
+	buf, err := json.Marshal(entries)
+	if err != nil {
+		return "", fmt.Errorf("could not convert %s to JSON: %w", attribute, err)
+	}
+	return string(buf), nil
+}
+
+func RenderMapToJSON[T ~string, U any](attribute string, entries map[T]U) (string, error) {
+	if len(entries) == 0 {
+		return "", nil
+	}
+	buf, err := json.Marshal(entries)
+	if err != nil {
+		return "", fmt.Errorf("could not convert %s to JSON: %w", attribute, err)
+	}
+	return string(buf), nil
+}

--- a/main.go
+++ b/main.go
@@ -191,6 +191,12 @@ func taskCollect(ctx context.Context, cluster *core.Cluster, args []string, prov
 		mailClient = Some(must.Return(collector.NewMailClient(provider, mailConfig.Endpoint)))
 	}
 
+	// bring liquidConnections into sync with the database
+	err := cluster.ReconcileLiquidConnections(dbm)
+	if err != nil {
+		logg.Fatal("reconciling liquid connections on startup failed: %w", err)
+	}
+
 	// start scraping threads (NOTE: Many people use a pair of sync.WaitGroup and
 	// stop channel to shutdown threads in a controlled manner. I decided against
 	// that for now, and instead construct worker threads in such a way that they


### PR DESCRIPTION
Checklist:

- [X] If this PR is about a plugin, I tested the plugin against an OpenStack cluster.
- [X] I updated the documentation to describe the semantical or interface changes I introduced.

Outline:
* the `liquid.ServiceInfo` is distributed to the 3 tables `cluster_services, cluster_resources, cluster_rates` and persisted there on startup
* additionally, a graceful reload of the ServiceInfo on change of a liquid version is implemented (`ReconcileLiquidConnection` - I am open for better naming suggestions?)
* cluster_services and cluster_resources are not written by the consistency checks or the scrape itself, instead by the reconciliation

next steps:
* make sure that all liquids emit version numbers correctly (currently not done)
* use the data from the database on startup in case of unavailability of a liquid