### PR TITLE
add correct version to liquids where missing

### DIFF
--- a/internal/liquids/archer/liquid.go
+++ b/internal/liquids/archer/liquid.go
@@ -5,6 +5,7 @@ package archer
 
 import (
 	"context"
+	"time"
 
 	"github.com/gophercloud/gophercloud/v2"
 	. "github.com/majewsky/gg/option"
@@ -25,7 +26,7 @@ func (l *Logic) Init(ctx context.Context, provider *gophercloud.ProviderClient, 
 // BuildServiceInfo implements the liquidapi.Logic interface.
 func (l *Logic) BuildServiceInfo(ctx context.Context) (liquid.ServiceInfo, error) {
 	return liquid.ServiceInfo{
-		Version: 1,
+		Version: time.Now().Unix(),
 		Resources: map[liquid.ResourceName]liquid.ResourceInfo{
 			"endpoints": {
 				Unit:     liquid.UnitNone,

--- a/internal/liquids/cronus/liquid.go
+++ b/internal/liquids/cronus/liquid.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/gophercloud/gophercloud/v2"
 	. "github.com/majewsky/gg/option"
@@ -29,7 +30,7 @@ func (l *Logic) Init(ctx context.Context, provider *gophercloud.ProviderClient, 
 // BuildServiceInfo implements the liquidapi.Logic interface.
 func (l *Logic) BuildServiceInfo(ctx context.Context) (liquid.ServiceInfo, error) {
 	return liquid.ServiceInfo{
-		Version: 1,
+		Version: time.Now().Unix(),
 		Rates: map[liquid.RateName]liquid.RateInfo{
 			"attachment_size":   {HasUsage: true, Topology: liquid.FlatTopology, Unit: liquid.UnitBytes},
 			"data_transfer_in":  {HasUsage: true, Topology: liquid.FlatTopology, Unit: liquid.UnitBytes},

--- a/internal/liquids/designate/liquid.go
+++ b/internal/liquids/designate/liquid.go
@@ -5,6 +5,7 @@ package designate
 
 import (
 	"context"
+	"time"
 
 	"github.com/gophercloud/gophercloud/v2"
 	. "github.com/majewsky/gg/option"
@@ -25,7 +26,7 @@ func (l *Logic) Init(ctx context.Context, provider *gophercloud.ProviderClient, 
 // BuildServiceInfo implements the liquidapi.Logic interface.
 func (l *Logic) BuildServiceInfo(ctx context.Context) (liquid.ServiceInfo, error) {
 	return liquid.ServiceInfo{
-		Version: 1,
+		Version: time.Now().Unix(),
 		Resources: map[liquid.ResourceName]liquid.ResourceInfo{
 			"zones": {
 				Unit:     liquid.UnitNone,

--- a/internal/liquids/swift/liquid.go
+++ b/internal/liquids/swift/liquid.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack"
@@ -36,7 +37,7 @@ func (l *Logic) Init(ctx context.Context, provider *gophercloud.ProviderClient, 
 // BuildServiceInfo implements the liquidapi.Logic interface.
 func (l *Logic) BuildServiceInfo(ctx context.Context) (liquid.ServiceInfo, error) {
 	return liquid.ServiceInfo{
-		Version: 1,
+		Version: time.Now().Unix(),
 		Resources: map[liquid.ResourceName]liquid.ResourceInfo{
 			"capacity": {
 				Unit:        liquid.UnitBytes,


### PR DESCRIPTION
Checklist:

- [ ] If this PR is about a plugin, I tested the plugin against an OpenStack cluster.
- [ ] I updated the documentation to describe the semantical or interface changes I introduced.

@majewsky Is there any reason, why these liquids did not yet have a correct `Version` in comparison to some of the other liquids, which already have it? I noticed this during local testing, but could not find any background in the code, nor in the respective commit messages. We need this step so that we can take like the next/ upcoming part where we read the `ServiceInfo` from the database. If we don't do this, the code chunk of code will not be fully functional.