### PR TITLE
ACPQ: do not block base quota overcommit because of empty AZs in buildup

### DIFF
--- a/internal/api/fixtures/start-data-commitments.sql
+++ b/internal/api/fixtures/start-data-commitments.sql
@@ -7,10 +7,10 @@ INSERT INTO cluster_services (id, type, scraped_at, next_scrape_at, liquid_versi
 INSERT INTO cluster_resources (id, service_id, name, liquid_version) VALUES (1, 1, 'capacity', 1);
 INSERT INTO cluster_resources (id, service_id, name, liquid_version) VALUES (2, 2, 'capacity', 1);
 
-INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, subcapacities) VALUES (1, 1, 'az-one', 10, 6, '');
-INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, subcapacities) VALUES (2, 1, 'az-two', 20, 6, '');
-INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, subcapacities) VALUES (3, 2, 'az-one', 30, 6, '');
-INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, subcapacities) VALUES (4, 2, 'az-two', 40, 6, '');
+INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, subcapacities, last_nonzero_raw_capacity) VALUES (1, 1, 'az-one', 10, 6, '', 10);
+INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, subcapacities, last_nonzero_raw_capacity) VALUES (2, 1, 'az-two', 20, 6, '', 20);
+INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, subcapacities, last_nonzero_raw_capacity) VALUES (3, 2, 'az-one', 30, 6, '', 30);
+INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, subcapacities, last_nonzero_raw_capacity) VALUES (4, 2, 'az-two', 40, 6, '', 40);
 
 -- two domains (default setup for StaticDiscoveryPlugin)
 INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');

--- a/internal/api/fixtures/start-data.sql
+++ b/internal/api/fixtures/start-data.sql
@@ -9,10 +9,10 @@ INSERT INTO cluster_resources (id, service_id, name, liquid_version) VALUES (2, 
 INSERT INTO cluster_resources (id, service_id, name, liquid_version) VALUES (3, 2, 'capacity', 1);
 
 -- "capacity" is modeled as AZ-aware, "things" is not
-INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, subcapacities) VALUES (1, 1, 'any', 139, 45, '[{"smaller_half":46},{"larger_half":93}]');
-INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, subcapacities) VALUES (2, 2, 'any', 246, 158, '[{"smaller_half":82},{"larger_half":164}]');
-INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, subcapacities) VALUES (3, 3, 'az-one', 90, 12, '');
-INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, subcapacities) VALUES (4, 3, 'az-two', 95, 15, '');
+INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, subcapacities, last_nonzero_raw_capacity) VALUES (1, 1, 'any', 139, 45, '[{"smaller_half":46},{"larger_half":93}]', 139);
+INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, subcapacities, last_nonzero_raw_capacity) VALUES (2, 2, 'any', 246, 158, '[{"smaller_half":82},{"larger_half":164}]', 246);
+INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, subcapacities, last_nonzero_raw_capacity) VALUES (3, 3, 'az-one', 90, 12, '', 90);
+INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, subcapacities, last_nonzero_raw_capacity) VALUES (4, 3, 'az-two', 95, 15, '', 95);
 
 -- two domains
 INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');

--- a/internal/collector/capacity_scrape.go
+++ b/internal/collector/capacity_scrape.go
@@ -199,6 +199,9 @@ func (c *Collector) processCapacityScrapeTask(ctx context.Context, task capacity
 			Update: func(azRes *db.ClusterAZResource) (err error) {
 				data := resourceData.PerAZ[azRes.AvailabilityZone]
 				azRes.RawCapacity = data.Capacity
+				if data.Capacity > 0 {
+					azRes.LastNonzeroRawCapacity = Some(data.Capacity)
+				}
 				azRes.Usage = data.Usage
 				azRes.SubcapacitiesJSON, err = util.RenderListToJSON("subcapacities", data.Subcapacities)
 				return err

--- a/internal/collector/fixtures/capacity_scrape_with_commitments.sql
+++ b/internal/collector/fixtures/capacity_scrape_with_commitments.sql
@@ -13,14 +13,14 @@ INSERT INTO cluster_resources (id, service_id, name) VALUES (2, 1, 'capacity');
 INSERT INTO cluster_resources (id, service_id, name) VALUES (3, 2, 'things');
 INSERT INTO cluster_resources (id, service_id, name) VALUES (4, 2, 'capacity');
 
-INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage) VALUES (1, 1, 'az-one', 42, 8);
-INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage) VALUES (2, 1, 'az-two', 42, 8);
-INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage) VALUES (3, 2, 'az-one', 42, 8);
-INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage) VALUES (4, 2, 'az-two', 42, 8);
-INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage) VALUES (5, 3, 'az-one', 23, 4);
-INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage) VALUES (6, 3, 'az-two', 23, 4);
-INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage) VALUES (7, 4, 'az-one', 23, 4);
-INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage) VALUES (8, 4, 'az-two', 23, 4);
+INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, last_nonzero_raw_capacity) VALUES (1, 1, 'az-one', 42, 8, 42);
+INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, last_nonzero_raw_capacity) VALUES (2, 1, 'az-two', 42, 8, 42);
+INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, last_nonzero_raw_capacity) VALUES (3, 2, 'az-one', 42, 8, 42);
+INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, last_nonzero_raw_capacity) VALUES (4, 2, 'az-two', 42, 8, 42);
+INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, last_nonzero_raw_capacity) VALUES (5, 3, 'az-one', 23, 4, 23);
+INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, last_nonzero_raw_capacity) VALUES (6, 3, 'az-two', 23, 4, 23);
+INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, last_nonzero_raw_capacity) VALUES (7, 4, 'az-one', 23, 4, 23);
+INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity, usage, last_nonzero_raw_capacity) VALUES (8, 4, 'az-two', 23, 4, 23);
 
 -- one domain
 INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -334,11 +334,11 @@ var sqlMigrations = map[string]string{
 		ALTER TABLE project_resources
 			ADD COLUMN min_quota_from_backend BIGINT DEFAULT NULL,
 			ADD COLUMN max_quota_from_backend BIGINT DEFAULT NULL;
-			
+
 		UPDATE project_resources
 			SET max_quota_from_backend = 0
 			WHERE forbidden = TRUE;
-		
+
 		ALTER TABLE project_resources
 			DROP COLUMN forbidden;
 	`,
@@ -353,7 +353,6 @@ var sqlMigrations = map[string]string{
 		ALTER TABLE project_resources
 			DROP COLUMN min_quota_from_backend,
 			DROP COLUMN max_quota_from_backend;
-
 	`,
 	"054_persist_service_info.down.sql": `
 		DROP TABLE cluster_rates;
@@ -379,7 +378,7 @@ var sqlMigrations = map[string]string{
 			name            TEXT       NOT NULL,
 			liquid_version  BIGINT     NOT NULL DEFAULT 0,
 			unit            TEXT       NOT NULL DEFAULT '',
-			topology 		TEXT 	   NOT NULL DEFAULT '',
+			topology        TEXT       NOT NULL DEFAULT '',
 			has_usage       BOOLEAN    NOT NULL DEFAULT FALSE,
 			UNIQUE (service_id, name)
 		);
@@ -397,5 +396,13 @@ var sqlMigrations = map[string]string{
 			ADD COLUMN usage_metric_families_json             TEXT     NOT NULL DEFAULT '',
 			ADD COLUMN usage_report_needs_project_metadata    BOOLEAN  NOT NULL DEFAULT FALSE,
 			ADD COLUMN quota_update_needs_project_metadata    BOOLEAN  NOT NULL DEFAULT FALSE;
-		`,
+	`,
+	"055_add_cluster_az_resources_last_nonzero_raw_capacity.down.sql": `
+		ALTER TABLE cluster_az_resources
+			DROP COLUMN last_nonzero_raw_capacity;
+	`,
+	"055_add_cluster_az_resources_last_nonzero_raw_capacity.up.sql": `
+		ALTER TABLE cluster_az_resources
+			ADD COLUMN last_nonzero_raw_capacity BIGINT DEFAULT NULL;
+	`,
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -60,6 +60,11 @@ type ClusterAZResource struct {
 	RawCapacity       uint64                 `db:"raw_capacity"`
 	Usage             Option[uint64]         `db:"usage"`
 	SubcapacitiesJSON string                 `db:"subcapacities"`
+
+	// LastNonzeroRawCapacity is None initially, and gets filled whenever capacity scrape sees a non-zero capacity value.
+	// We use this as a signal for ACPQ to distinguish new AZs in buildup that should be ignored for the purposes of base quota overcommit,
+	// from existing AZs with faulty capacity recording that should block base quota overcommit.
+	LastNonzeroRawCapacity Option[uint64] `db:"last_nonzero_raw_capacity"`
 }
 
 // ClusterRate contains a record from the `cluster_rates` table.


### PR DESCRIPTION
The addition of the second AZ in Tokyo to our config is causing problems. There is no compute capacity, but because customers have seen the new AZ, they tried poking it and creating instances there. These instances will inevitably fail to spawn because there are no matching hypervisors to place them on, but the instances are still around in status `ERROR`. When ACPQ runs, it sees usage in the AZ, but no capacity to go with it, and so base quota overcommit is blocked.

This is an undesirable behavior, but we don't see a good way to prevent this situation from arising. Instances in status `ERROR` need to be reported (because they count towards the quota) and need to be in the correct AZ (because billing needs to associate them with commitments to apply the correct price).

We have an existing special case to disregard AZs with zero capacity and also zero usage for the base quota overcommit (which covers the decom case), so this gets extended to also include AZs that _never_ had non-zero capacity (which covers the buildup case).