### PR TITLE
liquid-neutron: support dynamic quotas

### DIFF
--- a/docs/liquids/neutron.md
+++ b/docs/liquids/neutron.md
@@ -18,8 +18,8 @@ None.
 ## Resources
 
 Some of these resources are provided by optional Neutron extensions.
-Each resource will only be provided if Neutron advertises it in the default quota set and if it is accepted by limes.
-Accepted resources are hardcoded in limes (see list below).
+Each resource will only be provided if Neutron advertises it in the default quota set and if it is accepted by this liquid.
+Accepted resources are hardcoded in the liquid (see list below).
 
 | Resource               | Unit | Capabilities                         |
 | ---------------------- | ---- | ------------------------------------ |
@@ -34,8 +34,6 @@ Accepted resources are hardcoded in limes (see list below).
 | `subnets`              | None | HasCapacity = false, HasQuota = true |
 | `bgpvpns`              | None | HasCapacity = false, HasQuota = true |
 | `trunks`               | None | HasCapacity = false, HasQuota = true |
+| `routers_flavor_$NAME` | None | HasCapacity = false, HasQuota = true (SAP-specific extension) |
 
-In addition we also support dynamically registered Neutron resources.
-These accepted based on a list of prefixes.
-Currently this contains only `routers_flavor_`.
-Note that this is a SAP-specific add-on.
+If there is a `$NAME` placeholder, there will be a resource for any quota that is advertised by Neutron with a matching name.

--- a/docs/liquids/neutron.md
+++ b/docs/liquids/neutron.md
@@ -18,7 +18,8 @@ None.
 ## Resources
 
 Some of these resources are provided by optional Neutron extensions.
-Each resource will only be provided if Neutron advertises it in the default quota set.
+Each resource will only be provided if Neutron advertises it in the default quota set and if it is accepted by limes.
+Accepted resources are hardcoded in limes (see list below).
 
 | Resource               | Unit | Capabilities                         |
 | ---------------------- | ---- | ------------------------------------ |
@@ -33,3 +34,8 @@ Each resource will only be provided if Neutron advertises it in the default quot
 | `subnets`              | None | HasCapacity = false, HasQuota = true |
 | `bgpvpns`              | None | HasCapacity = false, HasQuota = true |
 | `trunks`               | None | HasCapacity = false, HasQuota = true |
+
+In addition we also support dynamically registered Neutron resources.
+These accepted based on a list of prefixes.
+Currently this contains only `routers_flavor_`.
+Note that this is a SAP-specific add-on.

--- a/internal/liquids/neutron/liquid.go
+++ b/internal/liquids/neutron/liquid.go
@@ -70,14 +70,14 @@ func getResourceNameIfQuotaRelevant(neutronName string) Option[liquid.ResourceNa
 	// check for static quota name
 	for resName, v := range neutronNameForResource {
 		if v == neutronName {
-			return Some[liquid.ResourceName](resName)
+			return Some(resName)
 		}
 	}
 
 	// check for dynamic quota names
 	for _, prefix := range dynamicQuotaPrefixes {
 		if strings.HasPrefix(neutronName, prefix) {
-			return Some[liquid.ResourceName](liquid.ResourceName(neutronName))
+			return Some(liquid.ResourceName(neutronName))
 		}
 	}
 	return None[liquid.ResourceName]()
@@ -100,7 +100,7 @@ func (l *Logic) BuildServiceInfo(ctx context.Context) (liquid.ServiceInfo, error
 	// we support all resources that Neutron supports and that we also know about
 	resources := make(map[liquid.ResourceName]liquid.ResourceInfo, len(neutronNameForResource))
 	for neutronName := range data.Quota {
-		var resName, isRelevantQuota = getResourceNameIfQuotaRelevant(neutronName).Unpack()
+		resName, isRelevantQuota := getResourceNameIfQuotaRelevant(neutronName).Unpack()
 
 		if isRelevantQuota {
 			resources[resName] = liquid.ResourceInfo{

--- a/internal/liquids/neutron/liquid.go
+++ b/internal/liquids/neutron/liquid.go
@@ -6,6 +6,7 @@ package neutron
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/gophercloud/gophercloud/v2"
@@ -39,6 +40,19 @@ var neutronNameForResource = map[liquid.ResourceName]string{
 	"trunks":  "trunk",
 }
 
+func getNeutronNameForResource(resourceName liquid.ResourceName) string {
+	val, exists := neutronNameForResource[resourceName]
+	if exists {
+		return val
+	} else {
+		return string(resourceName)
+	}
+}
+
+var dynamicQuotaPrefixes = []string{
+	"routers_flavor_",
+}
+
 // Init implements the liquidapi.Logic interface.
 func (l *Logic) Init(ctx context.Context, provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (err error) {
 	l.NeutronV2, err = openstack.NewNetworkV2(provider, eo)
@@ -50,6 +64,23 @@ func (l *Logic) Init(ctx context.Context, provider *gophercloud.ProviderClient, 
 		return fmt.Errorf("cannot find project scope of own token: %w", err)
 	}
 	return nil
+}
+
+func getResourceNameIfQuotaRelevant(neutronName string) Option[liquid.ResourceName] {
+	// check for static quota name
+	for resName, v := range neutronNameForResource {
+		if v == neutronName {
+			return Some[liquid.ResourceName](resName)
+		}
+	}
+
+	// check for dynamic quota names
+	for _, prefix := range dynamicQuotaPrefixes {
+		if strings.HasPrefix(neutronName, prefix) {
+			return Some[liquid.ResourceName](liquid.ResourceName(neutronName))
+		}
+	}
+	return None[liquid.ResourceName]()
 }
 
 // BuildServiceInfo implements the liquidapi.Logic interface.
@@ -68,9 +99,10 @@ func (l *Logic) BuildServiceInfo(ctx context.Context) (liquid.ServiceInfo, error
 
 	// we support all resources that Neutron supports and that we also know about
 	resources := make(map[liquid.ResourceName]liquid.ResourceInfo, len(neutronNameForResource))
-	for resName, neutronName := range neutronNameForResource {
-		_, exists := data.Quota[neutronName]
-		if exists {
+	for neutronName := range data.Quota {
+		var resName, isRelevantQuota = getResourceNameIfQuotaRelevant(neutronName).Unpack()
+
+		if isRelevantQuota {
 			resources[resName] = liquid.ResourceInfo{
 				Unit:        liquid.UnitNone,
 				Topology:    liquid.FlatTopology,
@@ -107,7 +139,7 @@ func (l *Logic) ScanUsage(ctx context.Context, projectUUID string, req liquid.Se
 
 	resourceReports := make(map[liquid.ResourceName]*liquid.ResourceUsageReport, len(serviceInfo.Resources))
 	for resName := range serviceInfo.Resources {
-		resData := data.Resources[neutronNameForResource[resName]]
+		resData := data.Resources[getNeutronNameForResource(resName)]
 		resourceReports[resName] = &liquid.ResourceUsageReport{
 			Quota: Some(resData.Quota),
 			PerAZ: liquid.InAnyAZ(liquid.AZResourceUsageReport{Usage: resData.Usage}),
@@ -124,7 +156,7 @@ func (l *Logic) ScanUsage(ctx context.Context, projectUUID string, req liquid.Se
 func (l *Logic) SetQuota(ctx context.Context, projectUUID string, req liquid.ServiceQuotaRequest, serviceInfo liquid.ServiceInfo) error {
 	neutronQuotas := make(quotaSet, len(serviceInfo.Resources))
 	for resName := range serviceInfo.Resources {
-		neutronQuotas[neutronNameForResource[resName]] = req.Resources[resName].Quota
+		neutronQuotas[getNeutronNameForResource(resName)] = req.Resources[resName].Quota
 	}
 	_, err := quotas.Update(ctx, l.NeutronV2, projectUUID, neutronQuotas).Extract()
 	return err


### PR DESCRIPTION
We now support dynamically registered quotas for Neutron, where we only know a prefix of the quota and not the full name. This is done so Neutron can expose network flavors as quotas, but might be used for other objects in the future. To expose these dynamic quotas we're now checking if the quota name has a prefix from a list of predefined prefixes (in addition to the lookup in the liquids already existing hardcoded list).

Checklist:

- [x] If this PR is about a plugin, I tested the plugin against an OpenStack cluster.
- [x] I updated the documentation to describe the semantical or interface changes I introduced.
