### PR TITLE
liquid cinder: Add private volume type matching

### DIFF
--- a/docs/liquids/cinder.md
+++ b/docs/liquids/cinder.md
@@ -49,11 +49,14 @@ The following methods to assign pools to volume types are implemented:
 - Regular Pools are grouped into volume types by matching their `volume_backend_name` against `extra_specs.volume_backend_name` of the volume type.
 - Remaining Pools are grouped into volume types by matching their `storage_protocol` and `quality_type` against the `extra_specs.storage_protocol` and
   `extra_secs.quality_type` of the volume type.
+- Private are grouped into volume types by matching their `storage_protocol` and `vendor_name` against the `extra_specs.storage_protocol` and
+  `extra_secs.vendor_name` of the volume type.
 
-| Matching | Volume Type         | Pools               |
-| -------- | ------------------- | ------------------- |
-| Type 1   | volume_backend_name | volume_backend_name |
-| Type 2   | storage_protocol<br>quality_type    | storage_protocol<br>quality_type    |
+| Matching | Volume Type                      | Pools                            |
+| -------- | -------------------------------- | -------------------------------- |
+| Type 1   | volume_backend_name              | volume_backend_name              |
+| Type 2   | storage_protocol<br>quality_type | storage_protocol<br>quality_type |
+| Type 3   | storage_protocol<br>vendor_name  | storage_protocol<br>vendor_name  |
 
 Pools without a matching volume type are ignored.
 

--- a/internal/liquids/cinder/capacity.go
+++ b/internal/liquids/cinder/capacity.go
@@ -88,6 +88,21 @@ func (l *Logic) ScanCapacity(ctx context.Context, req liquid.ServiceCapacityRequ
 		delete(remainingPools, pool)
 	}
 
+	// match private volume types and pools
+	for pool := range remainingPools {
+		info := VolumeTypeInfo{
+			StorageProtocol: pool.Capabilities.StorageProtocol,
+			VendorName:      pool.Capabilities.VendorName,
+		}
+
+		_, exists := sortedPools[info]
+		if !exists {
+			continue
+		}
+		poolMatches[pool] = info
+		delete(remainingPools, pool)
+	}
+
 	for pool, info := range remainingPools {
 		logg.Info("ScanCapacity: skipping pool %q: no volume type uses pools with %s", pool.Name, info)
 	}
@@ -270,6 +285,7 @@ type StoragePool struct {
 		AllocatedCapacityGB liquids.Float64WithStringErrors `json:"allocated_capacity_gb"`
 		StorageProtocol     string                          `json:"storage_protocol"`
 		QualityType         string                          `json:"quality_type"`
+		VendorName          string                          `json:"vendor_name"`
 
 		// SAP Converged Cloud extension
 		CustomAttributes struct {

--- a/internal/liquids/cinder/liquid.go
+++ b/internal/liquids/cinder/liquid.go
@@ -62,6 +62,7 @@ type VolumeTypeInfo struct {
 	VolumeBackendName string
 	StorageProtocol   string
 	QualityType       string
+	VendorName        string
 }
 
 // String returns a string representation of this VolumeTypeInfo for log messages.
@@ -103,6 +104,7 @@ func (l *Logic) BuildServiceInfo(ctx context.Context) (liquid.ServiceInfo, error
 			VolumeBackendName: vtSpec.ExtraSpecs["volume_backend_name"],
 			StorageProtocol:   vtSpec.ExtraSpecs["storage_protocol"],
 			QualityType:       vtSpec.ExtraSpecs["quality_type"],
+			VendorName:        vtSpec.ExtraSpecs["vendor_name"],
 		}
 
 		if vtIsPrivate {

--- a/vendor/github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumetypes/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumetypes/requests.go
@@ -73,6 +73,7 @@ type ListOptsBuilder interface {
 // ListOpts holds options for listing Volume Types. It is passed to the volumetypes.List
 // function.
 type ListOpts struct {
+	IsPublic string `q:"is_public"`
 	// Comma-separated list of sort keys and optional sort directions in the
 	// form of <key>[:<direction>].
 	Sort string `q:"sort"`

--- a/vendor/github.com/gophercloud/gophercloud/v2/params.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/params.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/sapcc/go-bits/logg"
 )
 
 /*
@@ -416,6 +418,7 @@ func BuildQueryString(opts any) (*url.URL, error) {
 						} else {
 							params[tags[0]] = append(params[tags[0]], values...)
 						}
+						logg.Info("params: %v", params)
 					case reflect.Map:
 						if v.Type().Key().Kind() == reflect.String && v.Type().Elem().Kind() == reflect.String {
 							var s []string


### PR DESCRIPTION
The following changes are included:
- Provide regex patterns as a config option to include private volume types and exclude public volume types.
- check private volume types against their project access list. Not matching entries will receive a forbidden flag.
- Add a capacity matching with volumeTypes and pools.

Checklist:

- [x] If this PR is about a plugin, I tested the plugin against an OpenStack cluster.
- [x] I updated the documentation to describe the semantical or interface changes I introduced.
