### PR TITLE
Neutron liquid support vpnaas fwaas

### DIFF
--- a/docs/liquids/neutron.md
+++ b/docs/liquids/neutron.md
@@ -39,6 +39,9 @@ Accepted resources are hardcoded in the liquid (see list below).
 | `ipsec_site_connections` | None | HasCapacity = false, HasQuota = true |
 | `ipsecpolicies`          | None | HasCapacity = false, HasQuota = true |
 | `vpnservices`            | None | HasCapacity = false, HasQuota = true |
+| `firewall_groups`        | None | HasCapacity = false, HasQuota = true |
+| `firewall_policies`      | None | HasCapacity = false, HasQuota = true |
+| `firewall_rules`         | None | HasCapacity = false, HasQuota = true |
 | `routers_flavor_$NAME`   | None | HasCapacity = false, HasQuota = true (SAP-specific extension) |
 
 If there is a `$NAME` placeholder, there will be a resource for any quota that is advertised by Neutron with a matching name.

--- a/internal/liquids/neutron/liquid.go
+++ b/internal/liquids/neutron/liquid.go
@@ -44,6 +44,10 @@ var neutronNameForResource = map[liquid.ResourceName]string{
 	"ipsec_site_connections": "ipsec_site_connection",
 	"ipsecpolicies":          "ipsecpolicy",
 	"vpnservices":            "vpnservice",
+	// FWaaS
+	"firewall_groups":   "firewall_group",
+	"firewall_policies": "firewall_policy",
+	"firewall_rules":    "firewall_rule",
 }
 
 func getNeutronNameForResource(resourceName liquid.ResourceName) string {


### PR DESCRIPTION
Checklist:

- [x] If this PR is about a plugin, I tested the plugin against an OpenStack cluster.
- [x] I updated the documentation to describe the semantical or interface changes I introduced.

FWaaS qa-de-1:
```
./limesctl liquid service-info neutron --compare --endpoint http://localhost:8080/
  liquid.ServiceInfo{
  	Version: 0,
  	Resources: map[liquid.ResourceName]liquid.ResourceInfo{
  		"bgpvpns":           {Topology: "flat", HasQuota: true},
+ 		"firewall_groups":   {Topology: "flat", HasQuota: true},
+ 		"firewall_policies": {Topology: "flat", HasQuota: true},
+ 		"firewall_rules":    {Topology: "flat", HasQuota: true},
  		"floating_ips":      {Topology: "flat", HasQuota: true},
  		"networks":          {Topology: "flat", HasQuota: true},
  		... // 8 identical entries
  	},
  	Rates:                  nil,
  	CapacityMetricFamilies: nil,
  	... // 3 identical fields
  }
```

VPNaaS qa-de-2:
```
./limesctl liquid service-info neutron --compare --endpoint http://localhost:8080/
  liquid.ServiceInfo{
  	Version: 0,
  	Resources: map[liquid.ResourceName]liquid.ResourceInfo{
  		"bgpvpns":                {Topology: "flat", HasQuota: true},
+ 		"endpoint_groups":        {Topology: "flat", HasQuota: true},
  		"floating_ips":           {Topology: "flat", HasQuota: true},
+ 		"ikepolicies":            {Topology: "flat", HasQuota: true},
+ 		"ipsec_site_connections": {Topology: "flat", HasQuota: true},
+ 		"ipsecpolicies":          {Topology: "flat", HasQuota: true},
  		"networks":               {Topology: "flat", HasQuota: true},
  		"ports":                  {Topology: "flat", HasQuota: true},
  		... // 6 identical entries
  		"subnets":     {Topology: "flat", HasQuota: true},
  		"trunks":      {Topology: "flat", HasQuota: true},
+ 		"vpnservices": {Topology: "flat", HasQuota: true},
  	},
  	Rates:                  nil,
  	CapacityMetricFamilies: nil,
  	... // 3 identical fields
  }
```