### PR TITLE
revert all liquid-cinder changes related to private volume types

### DIFF
--- a/internal/liquids/cinder/capacity.go
+++ b/internal/liquids/cinder/capacity.go
@@ -88,21 +88,6 @@ func (l *Logic) ScanCapacity(ctx context.Context, req liquid.ServiceCapacityRequ
 		delete(remainingPools, pool)
 	}
 
-	// match private volume types and pools
-	for pool := range remainingPools {
-		info := VolumeTypeInfo{
-			StorageProtocol: pool.Capabilities.StorageProtocol,
-			VendorName:      pool.Capabilities.VendorName,
-		}
-
-		_, exists := sortedPools[info]
-		if !exists {
-			continue
-		}
-		poolMatches[pool] = info
-		delete(remainingPools, pool)
-	}
-
 	for pool, info := range remainingPools {
 		logg.Info("ScanCapacity: skipping pool %q: no volume type uses pools with %s", pool.Name, info)
 	}
@@ -285,7 +270,6 @@ type StoragePool struct {
 		AllocatedCapacityGB liquids.Float64WithStringErrors `json:"allocated_capacity_gb"`
 		StorageProtocol     string                          `json:"storage_protocol"`
 		QualityType         string                          `json:"quality_type"`
-		VendorName          string                          `json:"vendor_name"`
 
 		// SAP Converged Cloud extension
 		CustomAttributes struct {

--- a/internal/liquids/cinder/liquid.go
+++ b/internal/liquids/cinder/liquid.go
@@ -13,27 +13,21 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumetypes"
 	"github.com/sapcc/go-api-declarations/liquid"
 	"github.com/sapcc/go-bits/liquidapi"
-	"github.com/sapcc/go-bits/regexpext"
 )
 
 type Logic struct {
 	// configuration
-	WithSubcapacities        bool                    `json:"with_subcapacities"`
-	WithVolumeSubresources   bool                    `json:"with_volume_subresources"`
-	WithSnapshotSubresources bool                    `json:"with_snapshot_subresources"`
-	ManagePrivateVolumeTypes regexpext.BoundedRegexp `json:"manage_private_volume_types"`
-	IgnorePublicVolumeTypes  regexpext.BoundedRegexp `json:"ignore_public_volume_types"`
+	WithSubcapacities        bool `json:"with_subcapacities"`
+	WithVolumeSubresources   bool `json:"with_volume_subresources"`
+	WithSnapshotSubresources bool `json:"with_snapshot_subresources"`
 	// connections
 	CinderV3 *gophercloud.ServiceClient `json:"-"`
 	// state
 	VolumeTypes liquidapi.State[map[VolumeType]VolumeTypeInfo] `json:"-"`
-
-	VolumeTypeAccess liquidapi.State[map[VolumeType]map[ProjectID]struct{}]
 }
 
 // VolumeType is a type with convenience functions for deriving resource names.
 type VolumeType string
-type ProjectID string
 
 func (vt VolumeType) CapacityResourceName() liquid.ResourceName {
 	return liquid.ResourceName("capacity_" + string(vt))
@@ -62,7 +56,6 @@ type VolumeTypeInfo struct {
 	VolumeBackendName string
 	StorageProtocol   string
 	QualityType       string
-	VendorName        string
 }
 
 // String returns a string representation of this VolumeTypeInfo for log messages.
@@ -79,8 +72,8 @@ func (l *Logic) Init(ctx context.Context, provider *gophercloud.ProviderClient, 
 
 // BuildServiceInfo implements the liquidapi.Logic interface.
 func (l *Logic) BuildServiceInfo(ctx context.Context) (liquid.ServiceInfo, error) {
-	// discover volume types. The option 'IsPublic: "None"' retrieves public and private volume types.
-	allPages, err := volumetypes.List(l.CinderV3, ListOpts{IsPublic: VisibilityDefault}).AllPages(ctx)
+	// discover volume types
+	allPages, err := volumetypes.List(l.CinderV3, volumetypes.ListOpts{}).AllPages(ctx)
 	if err != nil {
 		return liquid.ServiceInfo{}, err
 	}
@@ -88,15 +81,9 @@ func (l *Logic) BuildServiceInfo(ctx context.Context) (liquid.ServiceInfo, error
 	if err != nil {
 		return liquid.ServiceInfo{}, err
 	}
-
 	volumeTypes := make(map[VolumeType]VolumeTypeInfo, len(vtSpecs))
-	vtAccess := make(map[VolumeType]map[ProjectID]struct{})
 	for _, vtSpec := range vtSpecs {
-		vtIsPrivate := !vtSpec.IsPublic && !vtSpec.PublicAccess
-		if vtIsPrivate && !l.ManagePrivateVolumeTypes.MatchString(vtSpec.Name) {
-			continue
-		}
-		if !vtIsPrivate && l.IgnorePublicVolumeTypes.MatchString(vtSpec.Name) {
+		if !vtSpec.IsPublic && !vtSpec.PublicAccess {
 			continue
 		}
 
@@ -104,28 +91,9 @@ func (l *Logic) BuildServiceInfo(ctx context.Context) (liquid.ServiceInfo, error
 			VolumeBackendName: vtSpec.ExtraSpecs["volume_backend_name"],
 			StorageProtocol:   vtSpec.ExtraSpecs["storage_protocol"],
 			QualityType:       vtSpec.ExtraSpecs["quality_type"],
-			VendorName:        vtSpec.ExtraSpecs["vendor_name"],
-		}
-
-		if vtIsPrivate {
-			vtAccessPages, err := volumetypes.ListAccesses(l.CinderV3, vtSpec.ID).AllPages(ctx)
-			if err != nil {
-				return liquid.ServiceInfo{}, err
-			}
-			accessResults, err := volumetypes.ExtractAccesses(vtAccessPages)
-			if err != nil {
-				return liquid.ServiceInfo{}, err
-			}
-
-			accessMap := make(map[ProjectID]struct{}, len(accessResults))
-			for _, result := range accessResults {
-				accessMap[ProjectID(result.ProjectID)] = struct{}{}
-			}
-			vtAccess[VolumeType(vtSpec.Name)] = accessMap
 		}
 	}
 	l.VolumeTypes.Set(volumeTypes)
-	l.VolumeTypeAccess.Set(vtAccess)
 
 	// build ResourceInfo set
 	resInfoForCapacity := liquid.ResourceInfo{

--- a/internal/liquids/cinder/usage.go
+++ b/internal/liquids/cinder/usage.go
@@ -28,18 +28,11 @@ func (l *Logic) ScanUsage(ctx context.Context, projectUUID string, req liquid.Se
 		return liquid.ServiceUsageReport{}, err
 	}
 
-	vtAccessMap := l.VolumeTypeAccess.Get()
 	resources := make(map[liquid.ResourceName]*liquid.ResourceUsageReport)
 	for volumeType := range l.VolumeTypes.Get() {
-		isForbidden := false
-		if _, ok := vtAccessMap[volumeType]; ok {
-			// ^ This check ensures that public volume types never set Forbidden (because they do not have an entry in `vtAccessMap`).
-			_, isAllowed := vtAccessMap[volumeType][ProjectID(projectUUID)]
-			isForbidden = !isAllowed
-		}
-		resources[volumeType.CapacityResourceName()] = data.QuotaSet[volumeType.CapacityQuotaName()].ToResourceReport(req.AllAZs, isForbidden)
-		resources[volumeType.SnapshotsResourceName()] = data.QuotaSet[volumeType.SnapshotsQuotaName()].ToResourceReport(req.AllAZs, isForbidden)
-		resources[volumeType.VolumesResourceName()] = data.QuotaSet[volumeType.VolumesQuotaName()].ToResourceReport(req.AllAZs, isForbidden)
+		resources[volumeType.CapacityResourceName()] = data.QuotaSet[volumeType.CapacityQuotaName()].ToResourceReport(req.AllAZs)
+		resources[volumeType.SnapshotsResourceName()] = data.QuotaSet[volumeType.SnapshotsQuotaName()].ToResourceReport(req.AllAZs)
+		resources[volumeType.VolumesResourceName()] = data.QuotaSet[volumeType.VolumesQuotaName()].ToResourceReport(req.AllAZs)
 	}
 
 	// NOTE: We always enumerate volume subresources because we need them for the
@@ -247,10 +240,9 @@ func (f *QuotaSetField) UnmarshalJSON(buf []byte) error {
 	return err
 }
 
-func (f QuotaSetField) ToResourceReport(allAZs []liquid.AvailabilityZone, isForbidden bool) *liquid.ResourceUsageReport {
+func (f QuotaSetField) ToResourceReport(allAZs []liquid.AvailabilityZone) *liquid.ResourceUsageReport {
 	return &liquid.ResourceUsageReport{
-		Quota:     Some(f.Quota),
-		PerAZ:     liquid.AZResourceUsageReport{Usage: f.Usage}.PrepareForBreakdownInto(allAZs),
-		Forbidden: isForbidden,
+		Quota: Some(f.Quota),
+		PerAZ: liquid.AZResourceUsageReport{Usage: f.Usage}.PrepareForBreakdownInto(allAZs),
 	}
 }


### PR DESCRIPTION
The previous hotfix did not help, and I need to get prod back on track.