### PR TITLE
Revert "revert all liquid-cinder changes related to private volume types"

### DIFF
--- a/internal/liquids/cinder/capacity.go
+++ b/internal/liquids/cinder/capacity.go
@@ -88,6 +88,21 @@ func (l *Logic) ScanCapacity(ctx context.Context, req liquid.ServiceCapacityRequ
 		delete(remainingPools, pool)
 	}
 
+	// match private volume types and pools
+	for pool := range remainingPools {
+		info := VolumeTypeInfo{
+			StorageProtocol: pool.Capabilities.StorageProtocol,
+			VendorName:      pool.Capabilities.VendorName,
+		}
+
+		_, exists := sortedPools[info]
+		if !exists {
+			continue
+		}
+		poolMatches[pool] = info
+		delete(remainingPools, pool)
+	}
+
 	for pool, info := range remainingPools {
 		logg.Info("ScanCapacity: skipping pool %q: no volume type uses pools with %s", pool.Name, info)
 	}
@@ -270,6 +285,7 @@ type StoragePool struct {
 		AllocatedCapacityGB liquids.Float64WithStringErrors `json:"allocated_capacity_gb"`
 		StorageProtocol     string                          `json:"storage_protocol"`
 		QualityType         string                          `json:"quality_type"`
+		VendorName          string                          `json:"vendor_name"`
 
 		// SAP Converged Cloud extension
 		CustomAttributes struct {


### PR DESCRIPTION
This reverts commit eeb29406e46883a8ddd8ec9cc507a7b9fd410588.

My saying that the previous fix did not work was incorrect. I hit the promote button in the CI too early and transported the previous version that did not include the fix.

@VoigtS Can you please test this again to see if it's fine?