### PR TITLE
remove v2 tag from project tables

### DIFF
--- a/internal/api/fixtures/start-data-az-separated.sql
+++ b/internal/api/fixtures/start-data-az-separated.sql
@@ -11,10 +11,10 @@ INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
 
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany');
 
-INSERT INTO project_services_v2 (id, project_id, service_id, scraped_at, checked_at) VALUES (1, 1, 1,   UNIX(22), UNIX(22));
+INSERT INTO project_services (id, project_id, service_id, scraped_at, checked_at) VALUES (1, 1, 1,   UNIX(22), UNIX(22));
 
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (1,  1, 1, NULL, NULL);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (1,  1, 1, NULL, NULL);
 
 -- AZ separated resource does not include any az.
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, backend_quota, quota, usage, physical_usage, subresources) VALUES (1,  1, 1, 5, 5,    1, NULL, '');
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, backend_quota, quota, usage, physical_usage, subresources) VALUES (2,  1, 2, 5, 5,    1, NULL, '');
+INSERT INTO project_az_resources (id, project_id, az_resource_id, backend_quota, quota, usage, physical_usage, subresources) VALUES (1,  1, 1, 5, 5,    1, NULL, '');
+INSERT INTO project_az_resources (id, project_id, az_resource_id, backend_quota, quota, usage, physical_usage, subresources) VALUES (2,  1, 2, 5, 5,    1, NULL, '');

--- a/internal/api/fixtures/start-data-commitments.sql
+++ b/internal/api/fixtures/start-data-commitments.sql
@@ -48,80 +48,80 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (2, 1, 'dre
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (3, 2, 'paris', 'uuid-for-paris', 'uuid-for-france');
 
 -- project_services is fully populated (as ensured by the collector's consistency check)
-INSERT INTO project_services_v2 (id, project_id, service_id, scraped_at, checked_at) VALUES (1, 1, 1,  UNIX(11), UNIX(11));
-INSERT INTO project_services_v2 (id, project_id, service_id, scraped_at, checked_at) VALUES (2, 1, 2, UNIX(22), UNIX(22));
-INSERT INTO project_services_v2 (id, project_id, service_id, scraped_at, checked_at) VALUES (3, 2, 1,  UNIX(33), UNIX(33));
-INSERT INTO project_services_v2 (id, project_id, service_id, scraped_at, checked_at) VALUES (4, 2, 2, UNIX(44), UNIX(44));
-INSERT INTO project_services_v2 (id, project_id, service_id, scraped_at, checked_at) VALUES (5, 3, 1,  UNIX(55), UNIX(55));
-INSERT INTO project_services_v2 (id, project_id, service_id, scraped_at, checked_at) VALUES (6, 3, 2, UNIX(66), UNIX(66));
+INSERT INTO project_services (id, project_id, service_id, scraped_at, checked_at) VALUES (1, 1, 1,  UNIX(11), UNIX(11));
+INSERT INTO project_services (id, project_id, service_id, scraped_at, checked_at) VALUES (2, 1, 2, UNIX(22), UNIX(22));
+INSERT INTO project_services (id, project_id, service_id, scraped_at, checked_at) VALUES (3, 2, 1,  UNIX(33), UNIX(33));
+INSERT INTO project_services (id, project_id, service_id, scraped_at, checked_at) VALUES (4, 2, 2, UNIX(44), UNIX(44));
+INSERT INTO project_services (id, project_id, service_id, scraped_at, checked_at) VALUES (5, 3, 1,  UNIX(55), UNIX(55));
+INSERT INTO project_services (id, project_id, service_id, scraped_at, checked_at) VALUES (6, 3, 2, UNIX(66), UNIX(66));
 
 -- project_resources contains only boring placeholder values
 -- berlin
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (1,  1, 3,   10, 10);
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (2,  1, 1, 10, 10);
-INSERT INTO project_resources_v2 (id, project_id, resource_id) VALUES (3,  1, 11);
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (4,  1, 4,   10, 10);
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (5,  1, 2, 10, 10);
-INSERT INTO project_resources_v2 (id, project_id, resource_id) VALUES (6,  1, 10);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (1,  1, 3,   10, 10);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (2,  1, 1, 10, 10);
+INSERT INTO project_resources (id, project_id, resource_id) VALUES (3,  1, 11);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (4,  1, 4,   10, 10);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (5,  1, 2, 10, 10);
+INSERT INTO project_resources (id, project_id, resource_id) VALUES (6,  1, 10);
 -- dresden
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (7,  2, 3,   10, 10);
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (8,  2, 1, 10, 10);
-INSERT INTO project_resources_v2 (id, project_id, resource_id) VALUES (9,  2, 11);
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (10,  2, 4,   10, 10);
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (11,  2, 2, 10, 10);
-INSERT INTO project_resources_v2 (id, project_id, resource_id) VALUES (12,  2, 10);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (7,  2, 3,   10, 10);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (8,  2, 1, 10, 10);
+INSERT INTO project_resources (id, project_id, resource_id) VALUES (9,  2, 11);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (10,  2, 4,   10, 10);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (11,  2, 2, 10, 10);
+INSERT INTO project_resources (id, project_id, resource_id) VALUES (12,  2, 10);
 -- paris
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (13,  3, 3,   10, 10);
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (14,  3, 1, 10, 10);
-INSERT INTO project_resources_v2 (id, project_id, resource_id) VALUES (15,  3, 11);
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (16,  3, 4,   10, 10);
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (17,  3, 2, 10, 10);
-INSERT INTO project_resources_v2 (id, project_id, resource_id) VALUES (18,  3, 10);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (13,  3, 3,   10, 10);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (14,  3, 1, 10, 10);
+INSERT INTO project_resources (id, project_id, resource_id) VALUES (15,  3, 11);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (16,  3, 4,   10, 10);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (17,  3, 2, 10, 10);
+INSERT INTO project_resources (id, project_id, resource_id) VALUES (18,  3, 10);
 
 -- project_az_resources has "things" as non-AZ-aware and "capacity" as AZ-aware with an even split
 -- NOTE: AZ-aware resources also have an entry for AZ "any" with 0 usage
 --       (this is consistent with what Scrape does, and reporting should ignore those entries)
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (1,  1,  7,   4);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (2,  1,  1,   0);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (3,  1,  2,   2);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (4,  1,  3,   2);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (5,  1,  17,  0);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (6,  1,  18,  1);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (7,  1,  19,  1);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (8,  1,  8,   4);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (9,  1,  4,   0);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (10, 1,  5,   2);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (11, 1,  6,   2);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (12, 1,  14,  0);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (13, 1,  15,  1);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (14, 1,  16,  1);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (15, 2,  7,   4);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (16, 2,  1,   0);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (17, 2,  2,   2);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (18, 2,  3,   2);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (19, 2,  17,  0);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (20, 2,  18,  1);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (21, 2,  19,  1);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (22, 2,  8,   4);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (23, 2,  4,   0);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (24, 2,  5,   2);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (25, 2,  6,   2);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (26, 2,  14,  0);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (27, 2,  15,  1);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (28, 2,  16,  1);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (29, 3,  7,   4);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (30, 3,  1,   0);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (31, 3,  2,   2);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (32, 3,  3,   2);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (33, 3,  17,  0);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (34, 3,  18,  1);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (35, 3,  19,  1);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (36, 3,  8,   4);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (37, 3,  4,   0);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (38, 3,  5,   2);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (39, 3,  6,   2);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (40, 3,  14,  0);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (41, 3,  15,  1);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (42, 3,  16,  1);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (1,  1,  7,   4);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (2,  1,  1,   0);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (3,  1,  2,   2);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (4,  1,  3,   2);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (5,  1,  17,  0);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (6,  1,  18,  1);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (7,  1,  19,  1);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (8,  1,  8,   4);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (9,  1,  4,   0);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (10, 1,  5,   2);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (11, 1,  6,   2);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (12, 1,  14,  0);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (13, 1,  15,  1);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (14, 1,  16,  1);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (15, 2,  7,   4);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (16, 2,  1,   0);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (17, 2,  2,   2);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (18, 2,  3,   2);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (19, 2,  17,  0);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (20, 2,  18,  1);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (21, 2,  19,  1);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (22, 2,  8,   4);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (23, 2,  4,   0);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (24, 2,  5,   2);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (25, 2,  6,   2);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (26, 2,  14,  0);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (27, 2,  15,  1);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (28, 2,  16,  1);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (29, 3,  7,   4);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (30, 3,  1,   0);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (31, 3,  2,   2);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (32, 3,  3,   2);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (33, 3,  17,  0);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (34, 3,  18,  1);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (35, 3,  19,  1);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (36, 3,  8,   4);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (37, 3,  4,   0);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (38, 3,  5,   2);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (39, 3,  6,   2);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (40, 3,  14,  0);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (41, 3,  15,  1);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (42, 3,  16,  1);
 
 -- project_rates is empty: no rates configured

--- a/internal/api/fixtures/start-data-inconsistencies.sql
+++ b/internal/api/fixtures/start-data-inconsistencies.sql
@@ -25,31 +25,31 @@ INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity) VALUES (2, 
 INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity) VALUES (3, 3, 'any', 0);
 
 -- project_services is fully populated (as ensured by the collector's consistency check)
-INSERT INTO project_services_v2 (id, project_id, service_id, scraped_at, checked_at) VALUES (1, 1, 1, '2018-06-13 15:06:37', '2018-06-13 15:06:37');
-INSERT INTO project_services_v2 (id, project_id, service_id, scraped_at, checked_at) VALUES (2, 1, 2, '2018-06-13 15:06:37', '2018-06-13 15:06:37');
-INSERT INTO project_services_v2 (id, project_id, service_id, scraped_at, checked_at) VALUES (3, 2, 1, '2018-06-13 15:06:37', '2018-06-13 15:06:37');
-INSERT INTO project_services_v2 (id, project_id, service_id, scraped_at, checked_at) VALUES (4, 2, 2, '2018-06-13 15:06:37', '2018-06-13 15:06:37');
-INSERT INTO project_services_v2 (id, project_id, service_id, scraped_at, checked_at) VALUES (5, 3, 1, '2018-06-13 15:06:37', '2018-06-13 15:06:37');
-INSERT INTO project_services_v2 (id, project_id, service_id, scraped_at, checked_at) VALUES (6, 3, 2, '2018-06-13 15:06:37', '2018-06-13 15:06:37');
+INSERT INTO project_services (id, project_id, service_id, scraped_at, checked_at) VALUES (1, 1, 1, '2018-06-13 15:06:37', '2018-06-13 15:06:37');
+INSERT INTO project_services (id, project_id, service_id, scraped_at, checked_at) VALUES (2, 1, 2, '2018-06-13 15:06:37', '2018-06-13 15:06:37');
+INSERT INTO project_services (id, project_id, service_id, scraped_at, checked_at) VALUES (3, 2, 1, '2018-06-13 15:06:37', '2018-06-13 15:06:37');
+INSERT INTO project_services (id, project_id, service_id, scraped_at, checked_at) VALUES (4, 2, 2, '2018-06-13 15:06:37', '2018-06-13 15:06:37');
+INSERT INTO project_services (id, project_id, service_id, scraped_at, checked_at) VALUES (5, 3, 1, '2018-06-13 15:06:37', '2018-06-13 15:06:37');
+INSERT INTO project_services (id, project_id, service_id, scraped_at, checked_at) VALUES (6, 3, 2, '2018-06-13 15:06:37', '2018-06-13 15:06:37');
 
 -- project_resources contains some pathological cases
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (1, 1, 1, 30,  10);
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (2, 1, 2, 100, 100);
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (3, 1, 3, 10,  10);
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (4, 2, 1, 14,  14);
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (5, 2, 2, 60,  60);
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (6, 2, 3, 5,   5);
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (7, 3, 1, 30,  30);
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (8, 3, 2, 62,  62);
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (9, 3, 3, 10,  10);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (1, 1, 1, 30,  10);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (2, 1, 2, 100, 100);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (3, 1, 3, 10,  10);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (4, 2, 1, 14,  14);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (5, 2, 2, 60,  60);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (6, 2, 3, 5,   5);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (7, 3, 1, 30,  30);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (8, 3, 2, 62,  62);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (9, 3, 3, 10,  10);
 
 -- project_az_resources has everything as non-AZ-aware (the consistency checks do not really care about AZs)
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, physical_usage) VALUES (1, 1, 1, 14, NULL);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, physical_usage) VALUES (2, 1, 2, 88, 92);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, physical_usage) VALUES (3, 1, 3, 5,  NULL);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, physical_usage) VALUES (4, 2, 1, 18, NULL);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, physical_usage) VALUES (5, 2, 2, 45, 40);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, physical_usage) VALUES (6, 2, 3, 2,  NULL);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, physical_usage) VALUES (7, 3, 1, 20, NULL);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, physical_usage) VALUES (8, 3, 2, 48, 43);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, physical_usage) VALUES (9, 3, 3, 4,  NULL);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, physical_usage) VALUES (1, 1, 1, 14, NULL);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, physical_usage) VALUES (2, 1, 2, 88, 92);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, physical_usage) VALUES (3, 1, 3, 5,  NULL);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, physical_usage) VALUES (4, 2, 1, 18, NULL);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, physical_usage) VALUES (5, 2, 2, 45, 40);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, physical_usage) VALUES (6, 2, 3, 2,  NULL);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, physical_usage) VALUES (7, 3, 1, 20, NULL);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, physical_usage) VALUES (8, 3, 2, 48, 43);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, physical_usage) VALUES (9, 3, 3, 4,  NULL);

--- a/internal/api/fixtures/start-data-small.sql
+++ b/internal/api/fixtures/start-data-small.sql
@@ -20,13 +20,13 @@ INSERT INTO domains (id, name, uuid) VALUES (1, 'domainone', 'uuid-for-domainone
 
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (1, 1, 'projectone', 'uuid-for-projectone', 'uuid-for-domainone');
 
-INSERT INTO project_services_v2 (id, project_id, service_id, scraped_at, checked_at) VALUES (1, 1, 1, UNIX(11), UNIX(11));
+INSERT INTO project_services (id, project_id, service_id, scraped_at, checked_at) VALUES (1, 1, 1, UNIX(11), UNIX(11));
 
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (1,  1, 1,   0, 0);
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (2,  1, 2, 0, 0);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (1,  1, 1,   0, 0);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (2,  1, 2, 0, 0);
 
 -- "capacity" is modeled as AZ-aware, "things" is not
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (1,  1,  1, 0,    0, NULL, '');
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (2,  1,  2, 0,    0, NULL, '');
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (3,  1,  3, 0,    0, NULL, '');
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (4,  1,  4, 0,    0, NULL, '');
+INSERT INTO project_az_resources (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (1,  1,  1, 0,    0, NULL, '');
+INSERT INTO project_az_resources (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (2,  1,  2, 0,    0, NULL, '');
+INSERT INTO project_az_resources (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (3,  1,  3, 0,    0, NULL, '');
+INSERT INTO project_az_resources (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (4,  1,  4, 0,    0, NULL, '');

--- a/internal/api/fixtures/start-data.sql
+++ b/internal/api/fixtures/start-data.sql
@@ -40,29 +40,29 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (2, 1, 'dre
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (3, 2, 'paris', 'uuid-for-paris', 'uuid-for-france');
 
 -- project_services is fully populated (as ensured by the collector's consistency check)
-INSERT INTO project_services_v2 (id, project_id, service_id, scraped_at, checked_at) VALUES (1, 1, 1, UNIX(11), UNIX(11));
-INSERT INTO project_services_v2 (id, project_id, service_id, scraped_at, checked_at) VALUES (2, 1, 2,   UNIX(22), UNIX(22));
-INSERT INTO project_services_v2 (id, project_id, service_id, scraped_at, checked_at) VALUES (3, 2, 1, UNIX(33), UNIX(33));
-INSERT INTO project_services_v2 (id, project_id, service_id, scraped_at, checked_at) VALUES (4, 2, 2,   UNIX(44), UNIX(44));
-INSERT INTO project_services_v2 (id, project_id, service_id, scraped_at, checked_at) VALUES (5, 3, 1, UNIX(55), UNIX(55));
-INSERT INTO project_services_v2 (id, project_id, service_id, scraped_at, checked_at) VALUES (6, 3, 2,   UNIX(66), UNIX(66));
+INSERT INTO project_services (id, project_id, service_id, scraped_at, checked_at) VALUES (1, 1, 1, UNIX(11), UNIX(11));
+INSERT INTO project_services (id, project_id, service_id, scraped_at, checked_at) VALUES (2, 1, 2,   UNIX(22), UNIX(22));
+INSERT INTO project_services (id, project_id, service_id, scraped_at, checked_at) VALUES (3, 2, 1, UNIX(33), UNIX(33));
+INSERT INTO project_services (id, project_id, service_id, scraped_at, checked_at) VALUES (4, 2, 2,   UNIX(44), UNIX(44));
+INSERT INTO project_services (id, project_id, service_id, scraped_at, checked_at) VALUES (5, 3, 1, UNIX(55), UNIX(55));
+INSERT INTO project_services (id, project_id, service_id, scraped_at, checked_at) VALUES (6, 3, 2,   UNIX(66), UNIX(66));
 
 -- project_resources contains some pathological cases
 -- berlin (also used for test cases concerning subresources)
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (1,  1, 1,   10, 10);
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (2,  1, 2, 10, 10);
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (3,  1, 3,   10, 10);
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (4,  1, 4, 10, 10);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (1,  1, 1,   10, 10);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (2,  1, 2, 10, 10);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (3,  1, 3,   10, 10);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (4,  1, 4, 10, 10);
 -- dresden (backend quota for shared/capacity mismatches approved quota and exceeds domain quota)
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (5, 2,  1,   10, 10);
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (6, 2,  2, 10, 10);
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (7, 2, 3,   10, 10);
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (8, 2, 4, 10, 100);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (5, 2,  1,   10, 10);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (6, 2,  2, 10, 10);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (7, 2, 3,   10, 10);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (8, 2, 4, 10, 100);
 -- paris (infinite backend quota for unshared/things; non-null physical_usage for */capacity, all other project resources should report physical_usage = usage in aggregations)
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (9, 3, 1,   10, -1);
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (10, 3, 2, 10, 10);
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (11, 3, 3,   10, 10);
-INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota, max_quota_from_outside_admin) VALUES (12, 3, 4, 10, 10, 200);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (9, 3, 1,   10, -1);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (10, 3, 2, 10, 10);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (11, 3, 3,   10, 10);
+INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota, max_quota_from_outside_admin) VALUES (12, 3, 4, 10, 10, 200);
 
 -- "capacity" is modeled as AZ-aware, "things" is not
 -- NOTE: AZ-aware resources also have an entry for AZ "any" with 0 usage
@@ -71,61 +71,61 @@ INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_qu
 --       (TODO: migrate the latter to AZ-aware quota once we remove HQD)
 --
 -- berlin (also used for test cases concerning subresources)
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (1, 1, 1, 10,   2, NULL, '[{"id":"firstthing","value":23},{"id":"secondthing","value":42}]');
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (2, 1, 2, 0,    0, NULL, '');
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (3, 1, 3, 5,    1, NULL, '');
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (4, 1, 4, 5,    1, NULL, '');
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (5, 1, 5, 10,   2, NULL, '[{"id":"thirdthing","value":5},{"id":"fourththing","value":123}]');
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (6, 1, 6, 0,    0, NULL, '');
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (7, 1, 7, 5,    1, NULL, '');
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (8, 1, 8, 5,    1, NULL, '');
+INSERT INTO project_az_resources (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (1, 1, 1, 10,   2, NULL, '[{"id":"firstthing","value":23},{"id":"secondthing","value":42}]');
+INSERT INTO project_az_resources (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (2, 1, 2, 0,    0, NULL, '');
+INSERT INTO project_az_resources (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (3, 1, 3, 5,    1, NULL, '');
+INSERT INTO project_az_resources (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (4, 1, 4, 5,    1, NULL, '');
+INSERT INTO project_az_resources (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (5, 1, 5, 10,   2, NULL, '[{"id":"thirdthing","value":5},{"id":"fourththing","value":123}]');
+INSERT INTO project_az_resources (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (6, 1, 6, 0,    0, NULL, '');
+INSERT INTO project_az_resources (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (7, 1, 7, 5,    1, NULL, '');
+INSERT INTO project_az_resources (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (8, 1, 8, 5,    1, NULL, '');
 -- dresden
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (9, 2, 1, 10,   2, NULL, '');
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (10, 2,  2, 4,    0, NULL, '');
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (11, 2,  3, 3,    1, NULL, '');
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (12, 2,  4, 3,    1, NULL, '');
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (13, 2,  5, 10,   2, NULL, '');
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (14, 2,  6, 4,    0, NULL, '');
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (15, 2,  7, 3,    1, NULL, '');
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (16, 2,  8, 3,    1, NULL, '');
+INSERT INTO project_az_resources (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (9, 2, 1, 10,   2, NULL, '');
+INSERT INTO project_az_resources (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (10, 2,  2, 4,    0, NULL, '');
+INSERT INTO project_az_resources (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (11, 2,  3, 3,    1, NULL, '');
+INSERT INTO project_az_resources (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (12, 2,  4, 3,    1, NULL, '');
+INSERT INTO project_az_resources (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (13, 2,  5, 10,   2, NULL, '');
+INSERT INTO project_az_resources (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (14, 2,  6, 4,    0, NULL, '');
+INSERT INTO project_az_resources (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (15, 2,  7, 3,    1, NULL, '');
+INSERT INTO project_az_resources (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (16, 2,  8, 3,    1, NULL, '');
 -- paris (non-null physical_usage for */capacity, all other project resources should report physical_usage = usage in aggregations)
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (17, 3, 1, NULL, 2, NULL, '');
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (18, 3, 2, NULL, 0, NULL, '');
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (19, 3, 3, NULL, 1, 0, '');
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (20, 3, 4, NULL, 1, 1, '');
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (21, 3, 5, NULL, 2, NULL, '');
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (22, 3, 6, NULL, 0, NULL, '');
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (23, 3, 7, NULL, 1, 0, '');
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (24, 3, 8, NULL, 1, 1, '');
+INSERT INTO project_az_resources (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (17, 3, 1, NULL, 2, NULL, '');
+INSERT INTO project_az_resources (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (18, 3, 2, NULL, 0, NULL, '');
+INSERT INTO project_az_resources (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (19, 3, 3, NULL, 1, 0, '');
+INSERT INTO project_az_resources (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (20, 3, 4, NULL, 1, 1, '');
+INSERT INTO project_az_resources (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (21, 3, 5, NULL, 2, NULL, '');
+INSERT INTO project_az_resources (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (22, 3, 6, NULL, 0, NULL, '');
+INSERT INTO project_az_resources (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (23, 3, 7, NULL, 1, 0, '');
+INSERT INTO project_az_resources (id, project_id, az_resource_id, quota, usage, physical_usage, subresources) VALUES (24, 3, 8, NULL, 1, 1, '');
 
 -- project_commitments has several entries for project dresden
 -- on "unshared/capacity": regular active commitments with different durations
-INSERT INTO project_commitments_v2 (id, uuid, project_id, az_resource_id, amount, duration, created_at, creator_uuid, creator_name, confirm_by, confirmed_at, expires_at, state, creation_context_json) VALUES (1, '00000000-0000-0000-0000-000000000001', 2, 3, 1,   '2 years',    UNIX(1), 'uuid-for-alice', 'alice@Default', UNIX(1),       UNIX(1), UNIX(100000001), 'active',  '{}'::jsonb);
-INSERT INTO project_commitments_v2 (id, uuid, project_id, az_resource_id, amount, duration, created_at, creator_uuid, creator_name, confirm_by, confirmed_at, expires_at, state, creation_context_json) VALUES (2, '00000000-0000-0000-0000-000000000002', 2, 3, 1,   '1 year',     UNIX(2), 'uuid-for-alice', 'alice@Default', UNIX(2),       UNIX(2), UNIX(100000002), 'active',  '{}'::jsonb);
-INSERT INTO project_commitments_v2 (id, uuid, project_id, az_resource_id, amount, duration, created_at, creator_uuid, creator_name, confirm_by, confirmed_at, expires_at, state, creation_context_json) VALUES (3, '00000000-0000-0000-0000-000000000003', 2, 3, 1,   '1 year',     UNIX(3), 'uuid-for-alice', 'alice@Default', UNIX(3),       UNIX(3), UNIX(100000003), 'active',  '{}'::jsonb);
-INSERT INTO project_commitments_v2 (id, uuid, project_id, az_resource_id, amount, duration, created_at, creator_uuid, creator_name, confirm_by, confirmed_at, expires_at, state, creation_context_json) VALUES (4, '00000000-0000-0000-0000-000000000004', 2, 4, 2,   '1 year',     UNIX(4), 'uuid-for-alice', 'alice@Default', UNIX(4),       UNIX(4), UNIX(100000004), 'active',  '{}'::jsonb);
+INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, amount, duration, created_at, creator_uuid, creator_name, confirm_by, confirmed_at, expires_at, state, creation_context_json) VALUES (1, '00000000-0000-0000-0000-000000000001', 2, 3, 1,   '2 years',    UNIX(1), 'uuid-for-alice', 'alice@Default', UNIX(1),       UNIX(1), UNIX(100000001), 'active',  '{}'::jsonb);
+INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, amount, duration, created_at, creator_uuid, creator_name, confirm_by, confirmed_at, expires_at, state, creation_context_json) VALUES (2, '00000000-0000-0000-0000-000000000002', 2, 3, 1,   '1 year',     UNIX(2), 'uuid-for-alice', 'alice@Default', UNIX(2),       UNIX(2), UNIX(100000002), 'active',  '{}'::jsonb);
+INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, amount, duration, created_at, creator_uuid, creator_name, confirm_by, confirmed_at, expires_at, state, creation_context_json) VALUES (3, '00000000-0000-0000-0000-000000000003', 2, 3, 1,   '1 year',     UNIX(3), 'uuid-for-alice', 'alice@Default', UNIX(3),       UNIX(3), UNIX(100000003), 'active',  '{}'::jsonb);
+INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, amount, duration, created_at, creator_uuid, creator_name, confirm_by, confirmed_at, expires_at, state, creation_context_json) VALUES (4, '00000000-0000-0000-0000-000000000004', 2, 4, 2,   '1 year',     UNIX(4), 'uuid-for-alice', 'alice@Default', UNIX(4),       UNIX(4), UNIX(100000004), 'active',  '{}'::jsonb);
 -- on "unshared/capacity": unconfirmed commitments should be reported as "pending"
-INSERT INTO project_commitments_v2 (id, uuid, project_id, az_resource_id, amount, duration, created_at, creator_uuid, creator_name, confirm_by, confirmed_at, expires_at, state, creation_context_json) VALUES (5, '00000000-0000-0000-0000-000000000005', 2, 4, 100, '2 years',    UNIX(5), 'uuid-for-alice', 'alice@Default', UNIX(5),       NULL,    UNIX(100000005), 'pending', '{}'::jsonb);
+INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, amount, duration, created_at, creator_uuid, creator_name, confirm_by, confirmed_at, expires_at, state, creation_context_json) VALUES (5, '00000000-0000-0000-0000-000000000005', 2, 4, 100, '2 years',    UNIX(5), 'uuid-for-alice', 'alice@Default', UNIX(5),       NULL,    UNIX(100000005), 'pending', '{}'::jsonb);
 -- on "unshared/capacity": expired commitments should not be reported (NOTE: the test's clock stands at UNIX timestamp 3600)
-INSERT INTO project_commitments_v2 (id, uuid, project_id, az_resource_id, amount, duration, created_at, creator_uuid, creator_name, confirm_by, confirmed_at, expires_at, state, creation_context_json) VALUES (6, '00000000-0000-0000-0000-000000000006', 2, 3, 5,   '10 minutes', UNIX(6), 'uuid-for-alice', 'alice@Default', UNIX(6),       UNIX(6), UNIX(606),       'expired', '{}'::jsonb);
+INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, amount, duration, created_at, creator_uuid, creator_name, confirm_by, confirmed_at, expires_at, state, creation_context_json) VALUES (6, '00000000-0000-0000-0000-000000000006', 2, 3, 5,   '10 minutes', UNIX(6), 'uuid-for-alice', 'alice@Default', UNIX(6),       UNIX(6), UNIX(606),       'expired', '{}'::jsonb);
 -- on "shared/capacity": only an unconfirmed commitment that should be reported as "planned", this tests that the "committed" structure is absent in the JSON for that resource
-INSERT INTO project_commitments_v2 (id, uuid, project_id, az_resource_id, amount, duration, created_at, creator_uuid, creator_name, confirm_by, confirmed_at, expires_at, state, creation_context_json) VALUES (7, '00000000-0000-0000-0000-000000000007', 2, 7, 100, '2 years',    UNIX(7), 'uuid-for-alice', 'alice@Default', UNIX(1000007), NULL,    UNIX(100000007), 'planned', '{}'::jsonb);
+INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, amount, duration, created_at, creator_uuid, creator_name, confirm_by, confirmed_at, expires_at, state, creation_context_json) VALUES (7, '00000000-0000-0000-0000-000000000007', 2, 7, 100, '2 years',    UNIX(7), 'uuid-for-alice', 'alice@Default', UNIX(1000007), NULL,    UNIX(100000007), 'planned', '{}'::jsonb);
 -- on "unshared/things": an active commitment on AZ "any"
-INSERT INTO project_commitments_v2 (id, uuid, project_id, az_resource_id, amount, duration, created_at, creator_uuid, creator_name, confirm_by, confirmed_at, expires_at, state, creation_context_json) VALUES (8, '00000000-0000-0000-0000-000000000008', 2, 1, 1,   '2 years',    UNIX(8), 'uuid-for-alice', 'alice@Default', UNIX(8),       UNIX(8), UNIX(100000008), 'active',  '{}'::jsonb);
+INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, amount, duration, created_at, creator_uuid, creator_name, confirm_by, confirmed_at, expires_at, state, creation_context_json) VALUES (8, '00000000-0000-0000-0000-000000000008', 2, 1, 1,   '2 years',    UNIX(8), 'uuid-for-alice', 'alice@Default', UNIX(8),       UNIX(8), UNIX(100000008), 'active',  '{}'::jsonb);
 
 -- project_rates also has multiple different setups to test different cases
 -- berlin has custom rate limits
-INSERT INTO project_rates_v2 (id, project_id, rate_id, rate_limit, window_ns, usage_as_bigint) VALUES (1, 1, 1, 5, 60000000000, '');
-INSERT INTO project_rates_v2 (id, project_id, rate_id, rate_limit, window_ns, usage_as_bigint) VALUES (2, 1, 2, 2, 60000000000, '12345');
-INSERT INTO project_rates_v2 (id, project_id, rate_id, rate_limit, window_ns, usage_as_bigint) VALUES (3, 1, 3, 2, 60000000000, '');
-INSERT INTO project_rates_v2 (id, project_id, rate_id, rate_limit, window_ns, usage_as_bigint) VALUES (4, 1, 4, 5, 60000000000, '');
-INSERT INTO project_rates_v2 (id, project_id, rate_id, rate_limit, window_ns, usage_as_bigint) VALUES (5, 1, 5, 2, 60000000000, '23456');
-INSERT INTO project_rates_v2 (id, project_id, rate_id, rate_limit, window_ns, usage_as_bigint) VALUES (6, 1, 6, 2, 60000000000, '');
+INSERT INTO project_rates (id, project_id, rate_id, rate_limit, window_ns, usage_as_bigint) VALUES (1, 1, 1, 5, 60000000000, '');
+INSERT INTO project_rates (id, project_id, rate_id, rate_limit, window_ns, usage_as_bigint) VALUES (2, 1, 2, 2, 60000000000, '12345');
+INSERT INTO project_rates (id, project_id, rate_id, rate_limit, window_ns, usage_as_bigint) VALUES (3, 1, 3, 2, 60000000000, '');
+INSERT INTO project_rates (id, project_id, rate_id, rate_limit, window_ns, usage_as_bigint) VALUES (4, 1, 4, 5, 60000000000, '');
+INSERT INTO project_rates (id, project_id, rate_id, rate_limit, window_ns, usage_as_bigint) VALUES (5, 1, 5, 2, 60000000000, '23456');
+INSERT INTO project_rates (id, project_id, rate_id, rate_limit, window_ns, usage_as_bigint) VALUES (6, 1, 6, 2, 60000000000, '');
 -- dresden only has usage values, and it also shows usage for a rate that does not have rate limits
 -- also, dresden has some zero-valued usage values, which is different from empty string (empty string means "usage unknown", 0 means "no usage yet")
-INSERT INTO project_rates_v2 (id, project_id, rate_id, rate_limit, window_ns, usage_as_bigint) VALUES (7, 2, 2, NULL, NULL, '0');
-INSERT INTO project_rates_v2 (id, project_id, rate_id, rate_limit, window_ns, usage_as_bigint) VALUES (8, 2, 5, NULL, NULL, '0');
-INSERT INTO project_rates_v2 (id, project_id, rate_id, rate_limit, window_ns, usage_as_bigint) VALUES (9, 2, 7, NULL, NULL, '1048576');
+INSERT INTO project_rates (id, project_id, rate_id, rate_limit, window_ns, usage_as_bigint) VALUES (7, 2, 2, NULL, NULL, '0');
+INSERT INTO project_rates (id, project_id, rate_id, rate_limit, window_ns, usage_as_bigint) VALUES (8, 2, 5, NULL, NULL, '0');
+INSERT INTO project_rates (id, project_id, rate_id, rate_limit, window_ns, usage_as_bigint) VALUES (9, 2, 7, NULL, NULL, '1048576');
 -- not pictured: paris has no records at all, so the API will only display the default rate limits
 
 -- insert some bullshit data that should be filtered out by the internal/reports/ logic

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -151,7 +151,7 @@ func (p *v1Provider) doSyncProject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// mark all project services as stale to force limes-collect to sync ASAP
-	_, err := p.DB.Exec(`UPDATE project_services_v2 SET stale = '1' WHERE project_id = $1`, dbProject.ID)
+	_, err := p.DB.Exec(`UPDATE project_services SET stale = '1' WHERE project_id = $1`, dbProject.ID)
 	if respondwith.ErrorText(w, err) {
 		return
 	}
@@ -266,7 +266,7 @@ func (p *v1Provider) PutProjectMaxQuota(w http.ResponseWriter, r *http.Request) 
 
 	var services []db.ClusterService
 	_, err = tx.Select(&services,
-		`SELECT cs.* FROM cluster_services cs JOIN project_services_v2 ps ON ps.service_id = cs.id and ps.project_id = $1 ORDER BY cs.type`, dbProject.ID)
+		`SELECT cs.* FROM cluster_services cs JOIN project_services ps ON ps.service_id = cs.id and ps.project_id = $1 ORDER BY cs.type`, dbProject.ID)
 	if respondwith.ErrorText(w, err) {
 		return
 	}
@@ -278,7 +278,7 @@ func (p *v1Provider) PutProjectMaxQuota(w http.ResponseWriter, r *http.Request) 
 		}
 
 		_, err := datamodel.ProjectResourceUpdate{
-			UpdateResource: func(res *db.ProjectResourceV2, resName liquid.ResourceName) error {
+			UpdateResource: func(res *db.ProjectResource, resName liquid.ResourceName) error {
 				requestedChange := requestedInService[resName]
 				if requestedChange != nil && domainAccess {
 					requestedChange.OldValue = res.MaxQuotaFromOutsideAdmin // remember for audit event

--- a/internal/api/rates.go
+++ b/internal/api/rates.go
@@ -193,9 +193,9 @@ func (p *v1Provider) putOrSimulatePutProjectRates(w http.ResponseWriter, r *http
 	}
 
 	// get all project_rates and make them accessible quickly by ID
-	var projectRates []db.ProjectRateV2
-	_, err = tx.Select(&projectRates, `SELECT * FROM project_rates_v2 WHERE project_id = $1`, updater.Project.ID)
-	projectRateByClusterRateID := make(map[db.ClusterRateID]db.ProjectRateV2)
+	var projectRates []db.ProjectRate
+	_, err = tx.Select(&projectRates, `SELECT * FROM project_rates WHERE project_id = $1`, updater.Project.ID)
+	projectRateByClusterRateID := make(map[db.ClusterRateID]db.ProjectRate)
 	if respondwith.ErrorText(w, err) {
 		return
 	}
@@ -261,7 +261,7 @@ func (p *v1Provider) putOrSimulatePutProjectRates(w http.ResponseWriter, r *http
 	}
 	// update the DB with the new rate limits
 	mergeStr := sqlext.SimplifyWhitespace(`
-		MERGE INTO project_rates_v2 pr 
+		MERGE INTO project_rates pr 
 		USING json_to_recordset($1::json) src (project_id BIGINT, rate_id BIGINT, rate_limit BIGINT, window_ns BIGINT)
 		ON src.project_id = pr.project_id AND src.rate_id = pr.rate_id
 		WHEN MATCHED THEN UPDATE SET rate_limit = src.rate_limit, window_ns = src.window_ns

--- a/internal/api/translation_test.go
+++ b/internal/api/translation_test.go
@@ -515,7 +515,7 @@ func testSubresourceTranslation(t *testing.T, ruleID, liquidServiceType string, 
 		TranslationRuleInV1API: must.Return(core.NewTranslationRule(ruleID)),
 	}}
 
-	_, err := s.DB.Exec(`UPDATE project_az_resources_v2 SET subresources = $1 WHERE id = 3`,
+	_, err := s.DB.Exec(`UPDATE project_az_resources SET subresources = $1 WHERE id = 3`,
 		string(must.Return(json.Marshal(subresourcesInLiquidFormat))),
 	)
 	if err != nil {

--- a/internal/collector/capacity_scrape.go
+++ b/internal/collector/capacity_scrape.go
@@ -73,7 +73,7 @@ var (
 	// project_commitments to replace lengthy and time-dependent conditions with
 	// simple checks on the enum value in `state`.
 	updateProjectCommitmentStatesForResourceQuery = sqlext.SimplifyWhitespace(`
-		UPDATE project_commitments_v2
+		UPDATE project_commitments
 		   SET state = CASE WHEN superseded_at IS NOT NULL THEN 'superseded'
 		                    WHEN expires_at <= $3          THEN 'expired'
 		                    WHEN confirm_by > $3           THEN 'planned'

--- a/internal/collector/capacity_scrape_test.go
+++ b/internal/collector/capacity_scrape_test.go
@@ -917,34 +917,34 @@ func Test_ScanCapacityWithCommitments(t *testing.T) {
 	desyncedAt1 := s.Clock.Now().Add(-5 * time.Second)
 	desyncedAt2 := s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`%s
-		UPDATE project_az_resources_v2 SET quota = 0 WHERE id = 1 AND project_id = 1 AND az_resource_id = 1;
-		UPDATE project_az_resources_v2 SET quota = 1 WHERE id = 10 AND project_id = 1 AND az_resource_id = 12;
-		UPDATE project_az_resources_v2 SET quota = 8 WHERE id = 11 AND project_id = 2 AND az_resource_id = 4;
-		UPDATE project_az_resources_v2 SET quota = 1 WHERE id = 12 AND project_id = 2 AND az_resource_id = 5;
-		UPDATE project_az_resources_v2 SET quota = 1 WHERE id = 13 AND project_id = 2 AND az_resource_id = 6;
-		UPDATE project_az_resources_v2 SET quota = 8 WHERE id = 14 AND project_id = 2 AND az_resource_id = 10;
-		UPDATE project_az_resources_v2 SET quota = 1 WHERE id = 15 AND project_id = 2 AND az_resource_id = 11;
-		UPDATE project_az_resources_v2 SET quota = 1 WHERE id = 16 AND project_id = 2 AND az_resource_id = 12;
-		UPDATE project_az_resources_v2 SET quota = 0 WHERE id = 2 AND project_id = 1 AND az_resource_id = 7;
-		UPDATE project_az_resources_v2 SET quota = 0 WHERE id = 3 AND project_id = 2 AND az_resource_id = 1;
-		UPDATE project_az_resources_v2 SET quota = 0 WHERE id = 4 AND project_id = 2 AND az_resource_id = 7;
-		UPDATE project_az_resources_v2 SET quota = 0 WHERE id = 5 AND project_id = 1 AND az_resource_id = 4;
-		UPDATE project_az_resources_v2 SET quota = 1 WHERE id = 6 AND project_id = 1 AND az_resource_id = 5;
-		UPDATE project_az_resources_v2 SET quota = 250 WHERE id = 7 AND project_id = 1 AND az_resource_id = 6;
-		UPDATE project_az_resources_v2 SET quota = 8 WHERE id = 8 AND project_id = 1 AND az_resource_id = 10;
-		UPDATE project_az_resources_v2 SET quota = 1 WHERE id = 9 AND project_id = 1 AND az_resource_id = 11;
-		UPDATE project_resources_v2 SET quota = 0 WHERE id = 1 AND project_id = 1 AND resource_id = 1;
-		UPDATE project_resources_v2 SET quota = 251 WHERE id = 2 AND project_id = 1 AND resource_id = 2;
-		UPDATE project_resources_v2 SET quota = 0 WHERE id = 3 AND project_id = 1 AND resource_id = 3;
-		UPDATE project_resources_v2 SET quota = 10 WHERE id = 4 AND project_id = 1 AND resource_id = 4;
-		UPDATE project_resources_v2 SET quota = 0 WHERE id = 5 AND project_id = 2 AND resource_id = 1;
-		UPDATE project_resources_v2 SET quota = 10 WHERE id = 6 AND project_id = 2 AND resource_id = 2;
-		UPDATE project_resources_v2 SET quota = 0 WHERE id = 7 AND project_id = 2 AND resource_id = 3;
-		UPDATE project_resources_v2 SET quota = 10 WHERE id = 8 AND project_id = 2 AND resource_id = 4;
-		UPDATE project_services_v2 SET quota_desynced_at = %[2]d WHERE id = 1 AND project_id = 1 AND service_id = 1;
-		UPDATE project_services_v2 SET quota_desynced_at = %[3]d WHERE id = 2 AND project_id = 1 AND service_id = 2;
-		UPDATE project_services_v2 SET quota_desynced_at = %[2]d WHERE id = 3 AND project_id = 2 AND service_id = 1;
-		UPDATE project_services_v2 SET quota_desynced_at = %[3]d WHERE id = 4 AND project_id = 2 AND service_id = 2;
+		UPDATE project_az_resources SET quota = 0 WHERE id = 1 AND project_id = 1 AND az_resource_id = 1;
+		UPDATE project_az_resources SET quota = 1 WHERE id = 10 AND project_id = 1 AND az_resource_id = 12;
+		UPDATE project_az_resources SET quota = 8 WHERE id = 11 AND project_id = 2 AND az_resource_id = 4;
+		UPDATE project_az_resources SET quota = 1 WHERE id = 12 AND project_id = 2 AND az_resource_id = 5;
+		UPDATE project_az_resources SET quota = 1 WHERE id = 13 AND project_id = 2 AND az_resource_id = 6;
+		UPDATE project_az_resources SET quota = 8 WHERE id = 14 AND project_id = 2 AND az_resource_id = 10;
+		UPDATE project_az_resources SET quota = 1 WHERE id = 15 AND project_id = 2 AND az_resource_id = 11;
+		UPDATE project_az_resources SET quota = 1 WHERE id = 16 AND project_id = 2 AND az_resource_id = 12;
+		UPDATE project_az_resources SET quota = 0 WHERE id = 2 AND project_id = 1 AND az_resource_id = 7;
+		UPDATE project_az_resources SET quota = 0 WHERE id = 3 AND project_id = 2 AND az_resource_id = 1;
+		UPDATE project_az_resources SET quota = 0 WHERE id = 4 AND project_id = 2 AND az_resource_id = 7;
+		UPDATE project_az_resources SET quota = 0 WHERE id = 5 AND project_id = 1 AND az_resource_id = 4;
+		UPDATE project_az_resources SET quota = 1 WHERE id = 6 AND project_id = 1 AND az_resource_id = 5;
+		UPDATE project_az_resources SET quota = 250 WHERE id = 7 AND project_id = 1 AND az_resource_id = 6;
+		UPDATE project_az_resources SET quota = 8 WHERE id = 8 AND project_id = 1 AND az_resource_id = 10;
+		UPDATE project_az_resources SET quota = 1 WHERE id = 9 AND project_id = 1 AND az_resource_id = 11;
+		UPDATE project_resources SET quota = 0 WHERE id = 1 AND project_id = 1 AND resource_id = 1;
+		UPDATE project_resources SET quota = 251 WHERE id = 2 AND project_id = 1 AND resource_id = 2;
+		UPDATE project_resources SET quota = 0 WHERE id = 3 AND project_id = 1 AND resource_id = 3;
+		UPDATE project_resources SET quota = 10 WHERE id = 4 AND project_id = 1 AND resource_id = 4;
+		UPDATE project_resources SET quota = 0 WHERE id = 5 AND project_id = 2 AND resource_id = 1;
+		UPDATE project_resources SET quota = 10 WHERE id = 6 AND project_id = 2 AND resource_id = 2;
+		UPDATE project_resources SET quota = 0 WHERE id = 7 AND project_id = 2 AND resource_id = 3;
+		UPDATE project_resources SET quota = 10 WHERE id = 8 AND project_id = 2 AND resource_id = 4;
+		UPDATE project_services SET quota_desynced_at = %[2]d WHERE id = 1 AND project_id = 1 AND service_id = 1;
+		UPDATE project_services SET quota_desynced_at = %[3]d WHERE id = 2 AND project_id = 1 AND service_id = 2;
+		UPDATE project_services SET quota_desynced_at = %[2]d WHERE id = 3 AND project_id = 2 AND service_id = 1;
+		UPDATE project_services SET quota_desynced_at = %[3]d WHERE id = 4 AND project_id = 2 AND service_id = 2;
 	`, timestampUpdates(true), desyncedAt1.Unix(), desyncedAt2.Unix())
 
 	// day 1: test that confirmation works at all
@@ -955,9 +955,9 @@ func Test_ScanCapacityWithCommitments(t *testing.T) {
 
 	scrapedAt1 := s.Clock.Now().Add(-5 * time.Second)
 	tr.DBChanges().AssertEqualf(`%s
-		UPDATE project_az_resources_v2 SET quota = 10 WHERE id = 6 AND project_id = 1 AND az_resource_id = 5;
-		UPDATE project_commitments_v2 SET state = 'active', confirmed_at = %d WHERE id = 1 AND uuid = '00000000-0000-0000-0000-000000000001' AND transfer_token = NULL;
-		UPDATE project_resources_v2 SET quota = 260 WHERE id = 2 AND project_id = 1 AND resource_id = 2;
+		UPDATE project_az_resources SET quota = 10 WHERE id = 6 AND project_id = 1 AND az_resource_id = 5;
+		UPDATE project_commitments SET state = 'active', confirmed_at = %d WHERE id = 1 AND uuid = '00000000-0000-0000-0000-000000000001' AND transfer_token = NULL;
+		UPDATE project_resources SET quota = 260 WHERE id = 2 AND project_id = 1 AND resource_id = 2;
 	`, timestampUpdates(false), scrapedAt1.Unix())
 
 	// day 2: test that confirmation considers the resource's capacity overcommit factor
@@ -969,10 +969,10 @@ func Test_ScanCapacityWithCommitments(t *testing.T) {
 
 	scrapedAt1 = s.Clock.Now().Add(-5 * time.Second)
 	tr.DBChanges().AssertEqualf(`%s
-		UPDATE project_az_resources_v2 SET quota = 110 WHERE id = 6 AND project_id = 1 AND az_resource_id = 5;
-		UPDATE project_commitments_v2 SET state = 'active', confirmed_at = %d WHERE id = 2 AND uuid = '00000000-0000-0000-0000-000000000002' AND transfer_token = NULL;
-		UPDATE project_commitments_v2 SET state = 'pending' WHERE id = 3 AND uuid = '00000000-0000-0000-0000-000000000003' AND transfer_token = NULL;
-		UPDATE project_resources_v2 SET quota = 360 WHERE id = 2 AND project_id = 1 AND resource_id = 2;
+		UPDATE project_az_resources SET quota = 110 WHERE id = 6 AND project_id = 1 AND az_resource_id = 5;
+		UPDATE project_commitments SET state = 'active', confirmed_at = %d WHERE id = 2 AND uuid = '00000000-0000-0000-0000-000000000002' AND transfer_token = NULL;
+		UPDATE project_commitments SET state = 'pending' WHERE id = 3 AND uuid = '00000000-0000-0000-0000-000000000003' AND transfer_token = NULL;
+		UPDATE project_resources SET quota = 360 WHERE id = 2 AND project_id = 1 AND resource_id = 2;
 	`, timestampUpdates(false), scrapedAt1.Unix())
 
 	// day 3: test confirmation order with several commitments, on second/capacity in az-one
@@ -986,12 +986,12 @@ func Test_ScanCapacityWithCommitments(t *testing.T) {
 
 	scrapedAt2 := s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`%s
-		UPDATE project_az_resources_v2 SET quota = 0 WHERE id = 14 AND project_id = 2 AND az_resource_id = 10;
-		UPDATE project_az_resources_v2 SET quota = 20 WHERE id = 15 AND project_id = 2 AND az_resource_id = 11;
-		UPDATE project_commitments_v2 SET state = 'active', confirmed_at = %d WHERE id = 4 AND uuid = '00000000-0000-0000-0000-000000000004' AND transfer_token = NULL;
-		UPDATE project_commitments_v2 SET state = 'active', confirmed_at = %d WHERE id = 5 AND uuid = '00000000-0000-0000-0000-000000000005' AND transfer_token = NULL;
-		UPDATE project_commitments_v2 SET state = 'pending' WHERE id = 6 AND uuid = '00000000-0000-0000-0000-000000000006' AND transfer_token = NULL;
-		UPDATE project_resources_v2 SET quota = 21 WHERE id = 8 AND project_id = 2 AND resource_id = 4;
+		UPDATE project_az_resources SET quota = 0 WHERE id = 14 AND project_id = 2 AND az_resource_id = 10;
+		UPDATE project_az_resources SET quota = 20 WHERE id = 15 AND project_id = 2 AND az_resource_id = 11;
+		UPDATE project_commitments SET state = 'active', confirmed_at = %d WHERE id = 4 AND uuid = '00000000-0000-0000-0000-000000000004' AND transfer_token = NULL;
+		UPDATE project_commitments SET state = 'active', confirmed_at = %d WHERE id = 5 AND uuid = '00000000-0000-0000-0000-000000000005' AND transfer_token = NULL;
+		UPDATE project_commitments SET state = 'pending' WHERE id = 6 AND uuid = '00000000-0000-0000-0000-000000000006' AND transfer_token = NULL;
+		UPDATE project_resources SET quota = 21 WHERE id = 8 AND project_id = 2 AND resource_id = 4;
 	`, timestampUpdates(false), scrapedAt2.Unix(), scrapedAt2.Unix())
 
 	// day 4: test how confirmation interacts with existing usage, on first/capacity in az-two
@@ -1003,10 +1003,10 @@ func Test_ScanCapacityWithCommitments(t *testing.T) {
 
 	scrapedAt1 = s.Clock.Now().Add(-5 * time.Second)
 	tr.DBChanges().AssertEqualf(`%s
-		UPDATE project_az_resources_v2 SET quota = 300 WHERE id = 7 AND project_id = 1 AND az_resource_id = 6;
-		UPDATE project_commitments_v2 SET state = 'pending' WHERE id = 7 AND uuid = '00000000-0000-0000-0000-000000000007' AND transfer_token = NULL;
-		UPDATE project_commitments_v2 SET state = 'active', confirmed_at = %d WHERE id = 8 AND uuid = '00000000-0000-0000-0000-000000000008' AND transfer_token = NULL;
-		UPDATE project_resources_v2 SET quota = 410 WHERE id = 2 AND project_id = 1 AND resource_id = 2;
+		UPDATE project_az_resources SET quota = 300 WHERE id = 7 AND project_id = 1 AND az_resource_id = 6;
+		UPDATE project_commitments SET state = 'pending' WHERE id = 7 AND uuid = '00000000-0000-0000-0000-000000000007' AND transfer_token = NULL;
+		UPDATE project_commitments SET state = 'active', confirmed_at = %d WHERE id = 8 AND uuid = '00000000-0000-0000-0000-000000000008' AND transfer_token = NULL;
+		UPDATE project_resources SET quota = 410 WHERE id = 2 AND project_id = 1 AND resource_id = 2;
 	`, timestampUpdates(false), scrapedAt1.Unix())
 
 	// day 5: test commitments that cannot be confirmed until the previous commitment expires, on second/capacity in az-one
@@ -1019,11 +1019,11 @@ func Test_ScanCapacityWithCommitments(t *testing.T) {
 
 	scrapedAt2 = s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`%s
-		UPDATE project_az_resources_v2 SET quota = 22 WHERE id = 10 AND project_id = 1 AND az_resource_id = 12;
-		UPDATE project_az_resources_v2 SET quota = 0 WHERE id = 8 AND project_id = 1 AND az_resource_id = 10;
-		UPDATE project_commitments_v2 SET state = 'pending' WHERE id = 10 AND uuid = '00000000-0000-0000-0000-000000000010' AND transfer_token = NULL;
-		UPDATE project_commitments_v2 SET state = 'active', confirmed_at = %d WHERE id = 9 AND uuid = '00000000-0000-0000-0000-000000000009' AND transfer_token = NULL;
-		UPDATE project_resources_v2 SET quota = 23 WHERE id = 4 AND project_id = 1 AND resource_id = 4;
+		UPDATE project_az_resources SET quota = 22 WHERE id = 10 AND project_id = 1 AND az_resource_id = 12;
+		UPDATE project_az_resources SET quota = 0 WHERE id = 8 AND project_id = 1 AND az_resource_id = 10;
+		UPDATE project_commitments SET state = 'pending' WHERE id = 10 AND uuid = '00000000-0000-0000-0000-000000000010' AND transfer_token = NULL;
+		UPDATE project_commitments SET state = 'active', confirmed_at = %d WHERE id = 9 AND uuid = '00000000-0000-0000-0000-000000000009' AND transfer_token = NULL;
+		UPDATE project_resources SET quota = 23 WHERE id = 4 AND project_id = 1 AND resource_id = 4;
 	`, timestampUpdates(false), scrapedAt2.Unix())
 
 	// ...Once ID=9 expires an hour later, ID=10 can be confirmed.
@@ -1032,13 +1032,13 @@ func Test_ScanCapacityWithCommitments(t *testing.T) {
 
 	scrapedAt2 = s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`%s
-		UPDATE project_az_resources_v2 SET quota = 1 WHERE id = 10 AND project_id = 1 AND az_resource_id = 12;
-		UPDATE project_az_resources_v2 SET quota = 2 WHERE id = 16 AND project_id = 2 AND az_resource_id = 12;
-		UPDATE project_az_resources_v2 SET quota = 8 WHERE id = 8 AND project_id = 1 AND az_resource_id = 10;
-		UPDATE project_commitments_v2 SET state = 'active', confirmed_at = %d WHERE id = 10 AND uuid = '00000000-0000-0000-0000-000000000010' AND transfer_token = NULL;
-		UPDATE project_commitments_v2 SET state = 'expired' WHERE id = 9 AND uuid = '00000000-0000-0000-0000-000000000009' AND transfer_token = NULL;
-		UPDATE project_resources_v2 SET quota = 10 WHERE id = 4 AND project_id = 1 AND resource_id = 4;
-		UPDATE project_resources_v2 SET quota = 22 WHERE id = 8 AND project_id = 2 AND resource_id = 4;
+		UPDATE project_az_resources SET quota = 1 WHERE id = 10 AND project_id = 1 AND az_resource_id = 12;
+		UPDATE project_az_resources SET quota = 2 WHERE id = 16 AND project_id = 2 AND az_resource_id = 12;
+		UPDATE project_az_resources SET quota = 8 WHERE id = 8 AND project_id = 1 AND az_resource_id = 10;
+		UPDATE project_commitments SET state = 'active', confirmed_at = %d WHERE id = 10 AND uuid = '00000000-0000-0000-0000-000000000010' AND transfer_token = NULL;
+		UPDATE project_commitments SET state = 'expired' WHERE id = 9 AND uuid = '00000000-0000-0000-0000-000000000009' AND transfer_token = NULL;
+		UPDATE project_resources SET quota = 10 WHERE id = 4 AND project_id = 1 AND resource_id = 4;
+		UPDATE project_resources SET quota = 22 WHERE id = 8 AND project_id = 2 AND resource_id = 4;
 	`, timestampUpdates(false), scrapedAt2.Unix())
 
 	// test GetGlobalResourceDemand (this is not used by any of our mock liquids,
@@ -1080,20 +1080,20 @@ func Test_ScanCapacityWithCommitments(t *testing.T) {
 	s.Clock.StepBy(9 * 24 * time.Hour)
 	mustT(t, jobloop.ProcessMany(job, s.Ctx, len(s.Cluster.LiquidConnections)))
 	tr.DBChanges().AssertEqualf(`%s
-		UPDATE project_az_resources_v2 SET quota = 7 WHERE id = 14 AND project_id = 2 AND az_resource_id = 10;
-		UPDATE project_az_resources_v2 SET quota = 1 WHERE id = 15 AND project_id = 2 AND az_resource_id = 11;
-		UPDATE project_az_resources_v2 SET quota = 1 WHERE id = 6 AND project_id = 1 AND az_resource_id = 5;
-		UPDATE project_az_resources_v2 SET quota = 250 WHERE id = 7 AND project_id = 1 AND az_resource_id = 6;
-		UPDATE project_commitments_v2 SET state = 'expired' WHERE id = 1 AND uuid = '00000000-0000-0000-0000-000000000001' AND transfer_token = NULL;
-		UPDATE project_commitments_v2 SET state = 'expired' WHERE id = 2 AND uuid = '00000000-0000-0000-0000-000000000002' AND transfer_token = NULL;
-		UPDATE project_commitments_v2 SET state = 'expired' WHERE id = 3 AND uuid = '00000000-0000-0000-0000-000000000003' AND transfer_token = NULL;
-		UPDATE project_commitments_v2 SET state = 'expired' WHERE id = 4 AND uuid = '00000000-0000-0000-0000-000000000004' AND transfer_token = NULL;
-		UPDATE project_commitments_v2 SET state = 'expired' WHERE id = 5 AND uuid = '00000000-0000-0000-0000-000000000005' AND transfer_token = NULL;
-		UPDATE project_commitments_v2 SET state = 'expired' WHERE id = 6 AND uuid = '00000000-0000-0000-0000-000000000006' AND transfer_token = NULL;
-		UPDATE project_commitments_v2 SET state = 'expired' WHERE id = 7 AND uuid = '00000000-0000-0000-0000-000000000007' AND transfer_token = NULL;
-		UPDATE project_commitments_v2 SET state = 'expired' WHERE id = 8 AND uuid = '00000000-0000-0000-0000-000000000008' AND transfer_token = NULL;
-		UPDATE project_resources_v2 SET quota = 251 WHERE id = 2 AND project_id = 1 AND resource_id = 2;
-		UPDATE project_resources_v2 SET quota = 10 WHERE id = 8 AND project_id = 2 AND resource_id = 4;
+		UPDATE project_az_resources SET quota = 7 WHERE id = 14 AND project_id = 2 AND az_resource_id = 10;
+		UPDATE project_az_resources SET quota = 1 WHERE id = 15 AND project_id = 2 AND az_resource_id = 11;
+		UPDATE project_az_resources SET quota = 1 WHERE id = 6 AND project_id = 1 AND az_resource_id = 5;
+		UPDATE project_az_resources SET quota = 250 WHERE id = 7 AND project_id = 1 AND az_resource_id = 6;
+		UPDATE project_commitments SET state = 'expired' WHERE id = 1 AND uuid = '00000000-0000-0000-0000-000000000001' AND transfer_token = NULL;
+		UPDATE project_commitments SET state = 'expired' WHERE id = 2 AND uuid = '00000000-0000-0000-0000-000000000002' AND transfer_token = NULL;
+		UPDATE project_commitments SET state = 'expired' WHERE id = 3 AND uuid = '00000000-0000-0000-0000-000000000003' AND transfer_token = NULL;
+		UPDATE project_commitments SET state = 'expired' WHERE id = 4 AND uuid = '00000000-0000-0000-0000-000000000004' AND transfer_token = NULL;
+		UPDATE project_commitments SET state = 'expired' WHERE id = 5 AND uuid = '00000000-0000-0000-0000-000000000005' AND transfer_token = NULL;
+		UPDATE project_commitments SET state = 'expired' WHERE id = 6 AND uuid = '00000000-0000-0000-0000-000000000006' AND transfer_token = NULL;
+		UPDATE project_commitments SET state = 'expired' WHERE id = 7 AND uuid = '00000000-0000-0000-0000-000000000007' AND transfer_token = NULL;
+		UPDATE project_commitments SET state = 'expired' WHERE id = 8 AND uuid = '00000000-0000-0000-0000-000000000008' AND transfer_token = NULL;
+		UPDATE project_resources SET quota = 251 WHERE id = 2 AND project_id = 1 AND resource_id = 2;
+		UPDATE project_resources SET quota = 10 WHERE id = 8 AND project_id = 2 AND resource_id = 4;
 	`, timestampUpdates(false))
 
 	// we remove first/capacity, which does not have any active commitments. The trigger removes the expired commitments.
@@ -1116,18 +1116,18 @@ func Test_ScanCapacityWithCommitments(t *testing.T) {
 		DELETE FROM cluster_services WHERE id = 1 AND type = 'first' AND liquid_version = 1;
 		INSERT INTO cluster_services (id, type, scraped_at, scrape_duration_secs, serialized_metrics, next_scrape_at, liquid_version) VALUES (1, 'first', 1216885, 5, '{}', 1217785, 2);
 		UPDATE cluster_services SET scraped_at = 1216890, next_scrape_at = 1217790 WHERE id = 2 AND type = 'second' AND liquid_version = 1;
-		DELETE FROM project_az_resources_v2 WHERE id = 11 AND project_id = 2 AND az_resource_id = 4;
-		DELETE FROM project_az_resources_v2 WHERE id = 12 AND project_id = 2 AND az_resource_id = 5;
-		DELETE FROM project_az_resources_v2 WHERE id = 13 AND project_id = 2 AND az_resource_id = 6;
-		DELETE FROM project_az_resources_v2 WHERE id = 5 AND project_id = 1 AND az_resource_id = 4;
-		DELETE FROM project_az_resources_v2 WHERE id = 6 AND project_id = 1 AND az_resource_id = 5;
-		DELETE FROM project_az_resources_v2 WHERE id = 7 AND project_id = 1 AND az_resource_id = 6;
-		DELETE FROM project_commitments_v2 WHERE id = 1 AND uuid = '00000000-0000-0000-0000-000000000001' AND transfer_token = NULL;
-		DELETE FROM project_commitments_v2 WHERE id = 2 AND uuid = '00000000-0000-0000-0000-000000000002' AND transfer_token = NULL;
-		DELETE FROM project_commitments_v2 WHERE id = 7 AND uuid = '00000000-0000-0000-0000-000000000007' AND transfer_token = NULL;
-		DELETE FROM project_commitments_v2 WHERE id = 8 AND uuid = '00000000-0000-0000-0000-000000000008' AND transfer_token = NULL;
-		DELETE FROM project_resources_v2 WHERE id = 2 AND project_id = 1 AND resource_id = 2;
-		DELETE FROM project_resources_v2 WHERE id = 6 AND project_id = 2 AND resource_id = 2;
+		DELETE FROM project_az_resources WHERE id = 11 AND project_id = 2 AND az_resource_id = 4;
+		DELETE FROM project_az_resources WHERE id = 12 AND project_id = 2 AND az_resource_id = 5;
+		DELETE FROM project_az_resources WHERE id = 13 AND project_id = 2 AND az_resource_id = 6;
+		DELETE FROM project_az_resources WHERE id = 5 AND project_id = 1 AND az_resource_id = 4;
+		DELETE FROM project_az_resources WHERE id = 6 AND project_id = 1 AND az_resource_id = 5;
+		DELETE FROM project_az_resources WHERE id = 7 AND project_id = 1 AND az_resource_id = 6;
+		DELETE FROM project_commitments WHERE id = 1 AND uuid = '00000000-0000-0000-0000-000000000001' AND transfer_token = NULL;
+		DELETE FROM project_commitments WHERE id = 2 AND uuid = '00000000-0000-0000-0000-000000000002' AND transfer_token = NULL;
+		DELETE FROM project_commitments WHERE id = 7 AND uuid = '00000000-0000-0000-0000-000000000007' AND transfer_token = NULL;
+		DELETE FROM project_commitments WHERE id = 8 AND uuid = '00000000-0000-0000-0000-000000000008' AND transfer_token = NULL;
+		DELETE FROM project_resources WHERE id = 2 AND project_id = 1 AND resource_id = 2;
+		DELETE FROM project_resources WHERE id = 6 AND project_id = 2 AND resource_id = 2;
 	`)
 
 	// now we try to remove second/capacity, which has an active commitment. Hence, it will fail on SaveServiceInfoToDB
@@ -1141,7 +1141,7 @@ func Test_ScanCapacityWithCommitments(t *testing.T) {
 	s.Clock.StepBy(1 * time.Hour)
 	mustFailT(t, jobloop.ProcessMany(job, s.Ctx, len(s.Cluster.LiquidConnections)), errors.New(sqlext.SimplifyWhitespace(
 		`failed in iteration 2: while scraping clusterService 2: could not delete db.ClusterResource record with key capacity:
-		pq: update or delete on table "cluster_az_resources" violates foreign key constraint "project_commitments_v2_az_resource_id_fkey" on table "project_commitments_v2"
+		pq: update or delete on table "cluster_az_resources" violates foreign key constraint "project_commitments_az_resource_id_fkey" on table "project_commitments"
 		(additional error while updating DB: pq: update or delete on table "cluster_services" violates foreign key constraint "cluster_resources_service_id_liquid_version_fkey" on table "cluster_resources"`)))
 }
 
@@ -1170,13 +1170,13 @@ func TestScanCapacityWithMailNotification(t *testing.T) {
 
 	// day 1: schedule two mails for different projects
 	// (Commitment ID: 1) Confirmed commitment for first/capacity in berlin az-one (amount = 10).
-	_, err := s.DB.Exec("UPDATE project_commitments_v2 SET notify_on_confirm=true WHERE id=1;")
+	_, err := s.DB.Exec("UPDATE project_commitments SET notify_on_confirm=true WHERE id=1;")
 	if err != nil {
 		t.Fatal(err)
 	}
 	// (Commitment ID: 11) Confirmed commitment for second/capacity in dresden az-one (amount = 1).
 	_, err = s.DB.Exec(`
-			INSERT INTO project_commitments_v2
+			INSERT INTO project_commitments
 			(id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, confirm_by, duration, expires_at, state, notify_on_confirm, creation_context_json)
 			VALUES(11, '00000000-0000-0000-0000-000000000011', 2, 11, 1, $1, 'dummy', 'dummy', $2, '2 days', $3, 'planned', true, '{}'::jsonb)`, s.Clock.Now(), s.Clock.Now().Add(12*time.Hour), s.Clock.Now().Add(48*time.Hour))
 	if err != nil {
@@ -1189,25 +1189,25 @@ func TestScanCapacityWithMailNotification(t *testing.T) {
 	scrapedAt1 := s.Clock.Now().Add(-5 * time.Second)
 	scrapedAt2 := s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`%s
-		UPDATE project_az_resources_v2 SET quota = 10 WHERE id = 6 AND project_id = 1 AND az_resource_id = 5;
-		UPDATE project_commitments_v2 SET state = 'active', confirmed_at = 86415, notify_on_confirm = TRUE WHERE id = 1 AND uuid = '00000000-0000-0000-0000-000000000001' AND transfer_token = NULL;
-		INSERT INTO project_commitments_v2 (id, uuid, project_id, az_resource_id, state, amount, duration, created_at, creator_uuid, creator_name, confirm_by, confirmed_at, expires_at, notify_on_confirm, creation_context_json) VALUES (11, '00000000-0000-0000-0000-000000000011', 2, 11, 'active', 1, '2 days', 10, 'dummy', 'dummy', 43210, 86420, 172810, TRUE, '{}');
+		UPDATE project_az_resources SET quota = 10 WHERE id = 6 AND project_id = 1 AND az_resource_id = 5;
+		UPDATE project_commitments SET state = 'active', confirmed_at = 86415, notify_on_confirm = TRUE WHERE id = 1 AND uuid = '00000000-0000-0000-0000-000000000001' AND transfer_token = NULL;
+		INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, state, amount, duration, created_at, creator_uuid, creator_name, confirm_by, confirmed_at, expires_at, notify_on_confirm, creation_context_json) VALUES (11, '00000000-0000-0000-0000-000000000011', 2, 11, 'active', 1, '2 days', 10, 'dummy', 'dummy', 43210, 86420, 172810, TRUE, '{}');
 		INSERT INTO project_mail_notifications (id, project_id, subject, body, next_submission_at) VALUES (1, 1, 'Your recent commitment confirmations', 'Domain:germany Project:berlin Creator:dummy Amount:10 Duration:10 days Date:1970-01-02 Service:first Resource:capacity AZ:az-one', %[2]d);
 		INSERT INTO project_mail_notifications (id, project_id, subject, body, next_submission_at) VALUES (2, 2, 'Your recent commitment confirmations', 'Domain:germany Project:dresden Creator:dummy Amount:1 Duration:2 days Date:1970-01-02 Service:service Resource:resource AZ:az-one', %[3]d);
-		UPDATE project_resources_v2 SET quota = 260 WHERE id = 2 AND project_id = 1 AND resource_id = 2;
+		UPDATE project_resources SET quota = 260 WHERE id = 2 AND project_id = 1 AND resource_id = 2;
 	`, timestampUpdates(), scrapedAt1.Unix(), scrapedAt2.Unix())
 
 	// day 2: schedule one mail with two commitments for the same project.
 	// (Commitment IDs: 12, 13) Confirmed commitment for second/capacity in dresden az-one (amount = 1).
 	_, err = s.DB.Exec(`
-			INSERT INTO project_commitments_v2
+			INSERT INTO project_commitments
 			(id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, duration, expires_at, state, notify_on_confirm, creation_context_json)
 			VALUES(12, '00000000-0000-0000-0000-000000000012', 2, 11, 1, $1, 'dummy', 'dummy', '2 days', $2, 'pending', true, '{}'::jsonb)`, s.Clock.Now(), s.Clock.Now().Add(48*time.Hour))
 	if err != nil {
 		t.Fatal(err)
 	}
 	_, err = s.DB.Exec(`
-			INSERT INTO project_commitments_v2
+			INSERT INTO project_commitments
 			(id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, duration, expires_at, state, notify_on_confirm, creation_context_json)
 			VALUES(13, '00000000-0000-0000-0000-000000000013', 2, 11, 1, $1, 'dummy', 'dummy', '2 days', $2, 'pending', true, '{}'::jsonb)`, s.Clock.Now(), s.Clock.Now().Add(48*time.Hour))
 	if err != nil {
@@ -1217,15 +1217,15 @@ func TestScanCapacityWithMailNotification(t *testing.T) {
 	mustT(t, jobloop.ProcessMany(job, s.Ctx, len(s.Cluster.LiquidConnections)))
 	scrapedAt2 = s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`%s
-		UPDATE project_az_resources_v2 SET quota = 7 WHERE id = 14 AND project_id = 2 AND az_resource_id = 10;
-		UPDATE project_az_resources_v2 SET quota = 2 WHERE id = 15 AND project_id = 2 AND az_resource_id = 11;
-		UPDATE project_az_resources_v2 SET quota = 110 WHERE id = 6 AND project_id = 1 AND az_resource_id = 5;
-		UPDATE project_commitments_v2 SET state = 'expired' WHERE id = 11 AND uuid = '00000000-0000-0000-0000-000000000011' AND transfer_token = NULL;
-		INSERT INTO project_commitments_v2 (id, uuid, project_id, az_resource_id, state, amount, duration, created_at, creator_uuid, creator_name, confirmed_at, expires_at, notify_on_confirm, creation_context_json) VALUES (12, '00000000-0000-0000-0000-000000000012', 2, 11, 'active', 1, '2 days', 86420, 'dummy', 'dummy', 172830, 259220, TRUE, '{}');
-		INSERT INTO project_commitments_v2 (id, uuid, project_id, az_resource_id, state, amount, duration, created_at, creator_uuid, creator_name, confirmed_at, expires_at, notify_on_confirm, creation_context_json) VALUES (13, '00000000-0000-0000-0000-000000000013', 2, 11, 'active', 1, '2 days', 86420, 'dummy', 'dummy', 172830, 259220, TRUE, '{}');
-		UPDATE project_commitments_v2 SET state = 'active', confirmed_at = 172825 WHERE id = 2 AND uuid = '00000000-0000-0000-0000-000000000002' AND transfer_token = NULL;
-		UPDATE project_commitments_v2 SET state = 'pending' WHERE id = 3 AND uuid = '00000000-0000-0000-0000-000000000003' AND transfer_token = NULL;
+		UPDATE project_az_resources SET quota = 7 WHERE id = 14 AND project_id = 2 AND az_resource_id = 10;
+		UPDATE project_az_resources SET quota = 2 WHERE id = 15 AND project_id = 2 AND az_resource_id = 11;
+		UPDATE project_az_resources SET quota = 110 WHERE id = 6 AND project_id = 1 AND az_resource_id = 5;
+		UPDATE project_commitments SET state = 'expired' WHERE id = 11 AND uuid = '00000000-0000-0000-0000-000000000011' AND transfer_token = NULL;
+		INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, state, amount, duration, created_at, creator_uuid, creator_name, confirmed_at, expires_at, notify_on_confirm, creation_context_json) VALUES (12, '00000000-0000-0000-0000-000000000012', 2, 11, 'active', 1, '2 days', 86420, 'dummy', 'dummy', 172830, 259220, TRUE, '{}');
+		INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, state, amount, duration, created_at, creator_uuid, creator_name, confirmed_at, expires_at, notify_on_confirm, creation_context_json) VALUES (13, '00000000-0000-0000-0000-000000000013', 2, 11, 'active', 1, '2 days', 86420, 'dummy', 'dummy', 172830, 259220, TRUE, '{}');
+		UPDATE project_commitments SET state = 'active', confirmed_at = 172825 WHERE id = 2 AND uuid = '00000000-0000-0000-0000-000000000002' AND transfer_token = NULL;
+		UPDATE project_commitments SET state = 'pending' WHERE id = 3 AND uuid = '00000000-0000-0000-0000-000000000003' AND transfer_token = NULL;
 		INSERT INTO project_mail_notifications (id, project_id, subject, body, next_submission_at) VALUES (3, 2, 'Your recent commitment confirmations', 'Domain:germany Project:dresden Creator:dummy Amount:1 Duration:2 days Date:1970-01-03 Service:service Resource:resource AZ:az-one Creator:dummy Amount:1 Duration:2 days Date:1970-01-03 Service:service Resource:resource AZ:az-one', %d);
-		UPDATE project_resources_v2 SET quota = 360 WHERE id = 2 AND project_id = 1 AND resource_id = 2;
+		UPDATE project_resources SET quota = 360 WHERE id = 2 AND project_id = 1 AND resource_id = 2;
 	`, timestampUpdates(), scrapedAt2.Unix())
 }

--- a/internal/collector/commitment_cleanup.go
+++ b/internal/collector/commitment_cleanup.go
@@ -38,7 +38,7 @@ func (c *Collector) cleanupOldCommitments(_ context.Context, _ prometheus.Labels
 
 	// step 1: move commitments to state "expired" if expires_at <= NOW()
 	query := fmt.Sprintf(
-		`UPDATE project_commitments_v2 SET state = '%s' WHERE state != '%s' AND expires_at <= $1`,
+		`UPDATE project_commitments SET state = '%s' WHERE state != '%s' AND expires_at <= $1`,
 		db.CommitmentStateExpired, db.CommitmentStateSuperseded)
 	_, err := c.DB.Exec(query, now)
 	if err != nil {
@@ -54,7 +54,7 @@ func (c *Collector) cleanupOldCommitments(_ context.Context, _ prometheus.Labels
 	// potentially help in investigations when customers complain about
 	// commitments expiring unexpectedly.
 	query = sqlext.SimplifyWhitespace(`
-		DELETE FROM project_commitments_v2 pc WHERE expires_at + interval '1 month' <= $1
+		DELETE FROM project_commitments pc WHERE expires_at + interval '1 month' <= $1
 	`)
 	_, err = c.DB.Exec(query, now)
 	if err != nil {

--- a/internal/collector/consistency.go
+++ b/internal/collector/consistency.go
@@ -47,11 +47,11 @@ var (
 
 	// See `initProjectServicesQuery` for rationale regarding `next_scrape_at = NOW(), stale = TRUE`.
 	insertMissingProjectServicesQuery = sqlext.SimplifyWhitespace(`
-		INSERT INTO project_services_v2 (project_id, service_id, next_scrape_at, stale)
+		INSERT INTO project_services (project_id, service_id, next_scrape_at, stale)
 		SELECT p.id, cs.id, $1::TIMESTAMPTZ, TRUE
 		  FROM cluster_services cs
 		  JOIN projects p ON TRUE -- this is intentionally a full cross join between "cs" and "p"
-		  LEFT OUTER JOIN project_services_v2 ps ON ps.project_id = p.id AND ps.service_id = cs.id
+		  LEFT OUTER JOIN project_services ps ON ps.project_id = p.id AND ps.service_id = cs.id
 		 WHERE ps.id IS NULL
 		RETURNING project_id, service_id
 	`)

--- a/internal/collector/consistency_test.go
+++ b/internal/collector/consistency_test.go
@@ -37,7 +37,7 @@ func Test_Consistency(t *testing.T) {
 	tr.DBChanges().AssertEmpty()
 
 	// remove some project_services entries
-	_, err = s.DB.Exec(`DELETE FROM project_services_v2 WHERE id = $1`, 2)
+	_, err = s.DB.Exec(`DELETE FROM project_services WHERE id = $1`, 2)
 	if err != nil {
 		t.Error(err)
 	}
@@ -46,7 +46,7 @@ func Test_Consistency(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	err = s.DB.Insert(&db.ProjectServiceV2{
+	err = s.DB.Insert(&db.ProjectService{
 		ProjectID:    1,
 		ServiceID:    3,
 		NextScrapeAt: time.Unix(0, 0).UTC(),
@@ -64,8 +64,8 @@ func Test_Consistency(t *testing.T) {
 	}
 	tr.DBChanges().AssertEqualf(`
 		DELETE FROM cluster_services WHERE id = 3 AND type = 'whatever' AND liquid_version = 0;
-		DELETE FROM project_services_v2 WHERE id = 7 AND project_id = 1 AND service_id = 3;
-		INSERT INTO project_services_v2 (id, project_id, service_id, stale, next_scrape_at) VALUES (8, 1, 2, TRUE, %d);
+		DELETE FROM project_services WHERE id = 7 AND project_id = 1 AND service_id = 3;
+		INSERT INTO project_services (id, project_id, service_id, stale, next_scrape_at) VALUES (8, 1, 2, TRUE, %d);
 	`,
 		s.Clock.Now().Unix(),
 	)

--- a/internal/collector/expiring_commitments.go
+++ b/internal/collector/expiring_commitments.go
@@ -28,7 +28,7 @@ const (
 // For all applicable commitments within a project the mail content to inform customers will be prepared and added to a queue.
 // Long-term commitments will be queued while short-term commitments will only be marked as notified.
 func (c *Collector) ExpiringCommitmentNotificationJob(registerer prometheus.Registerer) jobloop.Job {
-	return (&jobloop.ProducerConsumerJob[[]db.ProjectCommitmentV2]{
+	return (&jobloop.ProducerConsumerJob[[]db.ProjectCommitment]{
 		Metadata: jobloop.JobMetadata{
 			ReadableName: "add expiring commitments to mail queue",
 			CounterOpts: prometheus.CounterOpts{
@@ -42,20 +42,20 @@ func (c *Collector) ExpiringCommitmentNotificationJob(registerer prometheus.Regi
 }
 
 var (
-	discoverExpiringCommitmentsQuery = `SELECT * FROM project_commitments_v2 WHERE expires_at <= $1 AND state = 'active' AND renew_context_json IS NULL AND NOT notified_for_expiration`
+	discoverExpiringCommitmentsQuery = `SELECT * FROM project_commitments WHERE expires_at <= $1 AND state = 'active' AND renew_context_json IS NULL AND NOT notified_for_expiration`
 	locateExpiringCommitmentsQuery   = sqlext.SimplifyWhitespace(`
 		SELECT pc.project_id, cs.type, cr.name, cazr.az, pc.id
 		  FROM cluster_services cs
 		  JOIN cluster_resources cr ON cr.service_id = cs.id
 		  JOIN cluster_az_resources cazr ON cazr.resource_id = cr.id
-		  JOIN project_commitments_v2 pc ON pc.az_resource_id = cazr.id
+		  JOIN project_commitments pc ON pc.az_resource_id = cazr.id
 		WHERE pc.id = ANY($1)
 		ORDER BY cs.type, cr.name, cazr.az ASC, pc.amount DESC
 	`)
-	updateCommitmentAsNotifiedQuery = `UPDATE project_commitments_v2 SET notified_for_expiration = true WHERE id = ANY($1)`
+	updateCommitmentAsNotifiedQuery = `UPDATE project_commitments SET notified_for_expiration = true WHERE id = ANY($1)`
 )
 
-func (c *Collector) discoverExpiringCommitments(_ context.Context, _ prometheus.Labels) (result []db.ProjectCommitmentV2, err error) {
+func (c *Collector) discoverExpiringCommitments(_ context.Context, _ prometheus.Labels) (result []db.ProjectCommitment, err error) {
 	now := c.MeasureTime()
 	cutoff := now.Add(expiringCommitmentsNoticePeriod)
 	_, err = c.DB.Select(&result, discoverExpiringCommitmentsQuery, cutoff)
@@ -69,7 +69,7 @@ func (c *Collector) discoverExpiringCommitments(_ context.Context, _ prometheus.
 	}
 }
 
-func (c *Collector) processExpiringCommitmentTask(ctx context.Context, commitments []db.ProjectCommitmentV2, _ prometheus.Labels) error {
+func (c *Collector) processExpiringCommitmentTask(ctx context.Context, commitments []db.ProjectCommitment, _ prometheus.Labels) error {
 	now := c.MeasureTime()
 	cutoff := now.Add(expiringCommitmentsNoticePeriod)
 	tx, err := c.DB.Begin()
@@ -79,7 +79,7 @@ func (c *Collector) processExpiringCommitmentTask(ctx context.Context, commitmen
 	defer sqlext.RollbackUnlessCommitted(tx)
 
 	// find which commitments need a notification
-	longTermCommitmentsByID := make(map[db.ProjectCommitmentID]db.ProjectCommitmentV2)
+	longTermCommitmentsByID := make(map[db.ProjectCommitmentID]db.ProjectCommitment)
 	var shortTermCommitmentIDs []db.ProjectCommitmentID
 	for _, c := range commitments {
 		if c.Duration.AddTo(now).Before(cutoff) {

--- a/internal/collector/expiring_commitments_test.go
+++ b/internal/collector/expiring_commitments_test.go
@@ -58,12 +58,12 @@ func Test_ExpiringCommitmentNotification(t *testing.T) {
 	// successfully queue two projects with 2 commitments each. Ignore short-term commitments and mark them as notified.
 	mustT(t, job.ProcessOne(s.Ctx))
 	tr.DBChanges().AssertEqualf(`
-		UPDATE project_commitments_v2 SET notified_for_expiration = TRUE WHERE id = 4 AND uuid = '00000000-0000-0000-0000-000000000004' AND transfer_token = NULL;
-		UPDATE project_commitments_v2 SET notified_for_expiration = TRUE WHERE id = 5 AND uuid = '00000000-0000-0000-0000-000000000005' AND transfer_token = NULL;
-		UPDATE project_commitments_v2 SET notified_for_expiration = TRUE WHERE id = 6 AND uuid = '00000000-0000-0000-0000-000000000006' AND transfer_token = NULL;
-		UPDATE project_commitments_v2 SET notified_for_expiration = TRUE WHERE id = 7 AND uuid = '00000000-0000-0000-0000-000000000007' AND transfer_token = NULL;
-		UPDATE project_commitments_v2 SET notified_for_expiration = TRUE WHERE id = 8 AND uuid = '00000000-0000-0000-0000-000000000008' AND transfer_token = NULL;
-		UPDATE project_commitments_v2 SET notified_for_expiration = TRUE WHERE id = 9 AND uuid = '00000000-0000-0000-0000-000000000009' AND transfer_token = NULL;
+		UPDATE project_commitments SET notified_for_expiration = TRUE WHERE id = 4 AND uuid = '00000000-0000-0000-0000-000000000004' AND transfer_token = NULL;
+		UPDATE project_commitments SET notified_for_expiration = TRUE WHERE id = 5 AND uuid = '00000000-0000-0000-0000-000000000005' AND transfer_token = NULL;
+		UPDATE project_commitments SET notified_for_expiration = TRUE WHERE id = 6 AND uuid = '00000000-0000-0000-0000-000000000006' AND transfer_token = NULL;
+		UPDATE project_commitments SET notified_for_expiration = TRUE WHERE id = 7 AND uuid = '00000000-0000-0000-0000-000000000007' AND transfer_token = NULL;
+		UPDATE project_commitments SET notified_for_expiration = TRUE WHERE id = 8 AND uuid = '00000000-0000-0000-0000-000000000008' AND transfer_token = NULL;
+		UPDATE project_commitments SET notified_for_expiration = TRUE WHERE id = 9 AND uuid = '00000000-0000-0000-0000-000000000009' AND transfer_token = NULL;
 		INSERT INTO project_mail_notifications (id, project_id, subject, body, next_submission_at) VALUES (1, 1, 'Information about expiring commitments', 'Domain:germany Project:berlin Creator:dummy Amount:5 Duration:1 year Date:1970-01-01 Service:service Resource:resource AZ:az-one Creator:dummy Amount:10 Duration:1 year Date:1970-01-01 Service:service Resource:resource AZ:az-two', %[1]d);
 		INSERT INTO project_mail_notifications (id, project_id, subject, body, next_submission_at) VALUES (2, 2, 'Information about expiring commitments', 'Domain:germany Project:dresden Creator:dummy Amount:5 Duration:1 year Date:1970-01-27 Service:service Resource:resource AZ:az-one Creator:dummy Amount:10 Duration:1 year Date:1970-01-27 Service:service Resource:resource AZ:az-two', %[1]d);
 	`, c.MeasureTime().Unix())
@@ -73,7 +73,7 @@ func Test_ExpiringCommitmentNotification(t *testing.T) {
 	originalMailTemplates := mailConfig.Templates
 	mailConfig.Templates = core.MailTemplateConfiguration{ExpiringCommitments: core.MailTemplate{Compiled: template.New("")}}
 	// commitments that are already sent out for a notification are not visible in the result set anymore - a new one gets created.
-	_, err := s.DB.Exec("INSERT INTO project_commitments_v2 (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, duration, expires_at, state, creation_context_json) VALUES (99, '00000000-0000-0000-0000-000000000099', 1, 1, 10, UNIX(0), 'dummy', 'dummy', '1 year', UNIX(0), 'active', '{}'::jsonb);")
+	_, err := s.DB.Exec("INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, duration, expires_at, state, creation_context_json) VALUES (99, '00000000-0000-0000-0000-000000000099', 1, 1, 10, UNIX(0), 'dummy', 'dummy', '1 year', UNIX(0), 'active', '{}'::jsonb);")
 	tr.DBChanges().Ignore()
 	mustT(t, err)
 	err = (job.ProcessOne(s.Ctx))
@@ -90,7 +90,7 @@ func Test_ExpiringCommitmentNotification(t *testing.T) {
 	mailConfig.Templates = originalMailTemplates
 	mustT(t, job.ProcessOne(s.Ctx))
 	tr.DBChanges().AssertEqualf(`
-		UPDATE project_commitments_v2 SET notified_for_expiration = TRUE WHERE id = 99 AND uuid = '00000000-0000-0000-0000-000000000099' AND transfer_token = NULL;
+		UPDATE project_commitments SET notified_for_expiration = TRUE WHERE id = 99 AND uuid = '00000000-0000-0000-0000-000000000099' AND transfer_token = NULL;
 		INSERT INTO project_mail_notifications (id, project_id, subject, body, next_submission_at) VALUES (3, 1, 'Information about expiring commitments', 'Domain:germany Project:berlin Creator:dummy Amount:10 Duration:1 year Date:1970-01-01 Service:service Resource:resource AZ:az-one', %d);
 	`, c.MeasureTime().Unix())
 }

--- a/internal/collector/fixtures/capacity_scrape_with_commitments.sql
+++ b/internal/collector/fixtures/capacity_scrape_with_commitments.sql
@@ -40,65 +40,65 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (1, 1, 'ber
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (2, 1, 'dresden', 'uuid-for-dresden', 'uuid-for-berlin');
 
 -- project_services is fully populated (as ensured by the collector's consistency check)
-INSERT INTO project_services_v2 (id, project_id, service_id) VALUES (1, 1, 1);
-INSERT INTO project_services_v2 (id, project_id, service_id) VALUES (2, 1, 2);
-INSERT INTO project_services_v2 (id, project_id, service_id) VALUES (3, 2, 1);
-INSERT INTO project_services_v2 (id, project_id, service_id) VALUES (4, 2, 2);
+INSERT INTO project_services (id, project_id, service_id) VALUES (1, 1, 1);
+INSERT INTO project_services (id, project_id, service_id) VALUES (2, 1, 2);
+INSERT INTO project_services (id, project_id, service_id) VALUES (3, 2, 1);
+INSERT INTO project_services (id, project_id, service_id) VALUES (4, 2, 2);
 
 -- no quota set here because commitment confirmation does not care about quota
-INSERT INTO project_resources_v2 (id, project_id, resource_id) VALUES (1,  1, 1);
-INSERT INTO project_resources_v2 (id, project_id, resource_id) VALUES (2,  1, 2);
-INSERT INTO project_resources_v2 (id, project_id, resource_id) VALUES (3,  1, 3);
-INSERT INTO project_resources_v2 (id, project_id, resource_id) VALUES (4,  1, 4);
-INSERT INTO project_resources_v2 (id, project_id, resource_id) VALUES (5,  2, 1);
-INSERT INTO project_resources_v2 (id, project_id, resource_id) VALUES (6,  2, 2);
-INSERT INTO project_resources_v2 (id, project_id, resource_id) VALUES (7, 2, 3);
-INSERT INTO project_resources_v2 (id, project_id, resource_id) VALUES (8, 2, 4);
+INSERT INTO project_resources (id, project_id, resource_id) VALUES (1,  1, 1);
+INSERT INTO project_resources (id, project_id, resource_id) VALUES (2,  1, 2);
+INSERT INTO project_resources (id, project_id, resource_id) VALUES (3,  1, 3);
+INSERT INTO project_resources (id, project_id, resource_id) VALUES (4,  1, 4);
+INSERT INTO project_resources (id, project_id, resource_id) VALUES (5,  2, 1);
+INSERT INTO project_resources (id, project_id, resource_id) VALUES (6,  2, 2);
+INSERT INTO project_resources (id, project_id, resource_id) VALUES (7, 2, 3);
+INSERT INTO project_resources (id, project_id, resource_id) VALUES (8, 2, 4);
 
 -- */things resources do not have commitments, so they are boring and we don't need to care
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (1, 1,  1,    0);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (2, 1,  7,    0);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (3, 2,  1,    0);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (4, 2, 7,    0);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (1, 1,  1,    0);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (2, 1,  7,    0);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (3, 2,  1,    0);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (4, 2, 7,    0);
 
 -- part 2: */capacity resources can have commitments, so we have some large
 -- usage values here to see that these block commitments on other projects, but
 -- not on the project itself
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (5, 1, 4, 0);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (6, 1, 5, 1);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (7, 1, 6, 250);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (8, 1,  10,    0);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (9, 1,  11, 1);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (10, 1, 12, 1);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (11, 2, 4,    0);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (12, 2, 5, 1);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (13, 2, 6, 1);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (14, 2, 10,    0);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (15, 2, 11, 1);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (16, 2, 12, 1);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (5, 1, 4, 0);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (6, 1, 5, 1);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (7, 1, 6, 250);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (8, 1,  10,    0);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (9, 1,  11, 1);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (10, 1, 12, 1);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (11, 2, 4,    0);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (12, 2, 5, 1);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (13, 2, 6, 1);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (14, 2, 10,    0);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (15, 2, 11, 1);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (16, 2, 12, 1);
 
 -- project_commitments has multiple testcases that invoke in the test by skipping to the respective confirm_by time
 -- (the confirm_by and expires_at timestamps are all aligned on day boundaries, i.e. T = 86400 * N for some integer N)
 
 -- day 1: just a boring commitment that easily fits in the available capacity
-INSERT INTO project_commitments_v2 (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, confirm_by, duration, expires_at, state, creation_context_json) VALUES (1, '00000000-0000-0000-0000-000000000001', 1, 5, 10, UNIX(0), 'dummy', 'dummy', UNIX(86400), '10 days', UNIX(950400), 'planned', '{}'::jsonb);
+INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, confirm_by, duration, expires_at, state, creation_context_json) VALUES (1, '00000000-0000-0000-0000-000000000001', 1, 5, 10, UNIX(0), 'dummy', 'dummy', UNIX(86400), '10 days', UNIX(950400), 'planned', '{}'::jsonb);
 
 -- day 2: very large commitments that exceed the raw capacity; only the one on "first" works because that service has a large overcommit factor
-INSERT INTO project_commitments_v2 (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, confirm_by, duration, expires_at, state, creation_context_json) VALUES (2, '00000000-0000-0000-0000-000000000002', 1, 5, 100, UNIX(0), 'dummy', 'dummy', UNIX(172800), '10 days', UNIX(1036800), 'planned', '{}'::jsonb);
-INSERT INTO project_commitments_v2 (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, confirm_by, duration, expires_at, state, creation_context_json) VALUES (3, '00000000-0000-0000-0000-000000000003', 1, 11, 100, UNIX(0), 'dummy', 'dummy', UNIX(172800), '10 days', UNIX(1036800), 'planned', '{}'::jsonb);
+INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, confirm_by, duration, expires_at, state, creation_context_json) VALUES (2, '00000000-0000-0000-0000-000000000002', 1, 5, 100, UNIX(0), 'dummy', 'dummy', UNIX(172800), '10 days', UNIX(1036800), 'planned', '{}'::jsonb);
+INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, confirm_by, duration, expires_at, state, creation_context_json) VALUES (3, '00000000-0000-0000-0000-000000000003', 1, 11, 100, UNIX(0), 'dummy', 'dummy', UNIX(172800), '10 days', UNIX(1036800), 'planned', '{}'::jsonb);
 
 -- day 3: a bunch of small commitments with different timestamps, to test confirmation order in two ways:
 --
 -- 1. ID=3 does not block these commitments even though it is on the same resource and AZ
 -- 2. we cannot confirm all of these; which ones are confirmed demonstrates the order of consideration
-INSERT INTO project_commitments_v2 (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, confirm_by, duration, expires_at, state, creation_context_json) VALUES (4, '00000000-0000-0000-0000-000000000004', 2, 11, 10, UNIX(1), 'dummy', 'dummy', UNIX(259202), '10 days', UNIX(1123200), 'planned', '{}'::jsonb);
-INSERT INTO project_commitments_v2 (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, confirm_by, duration, expires_at, state, creation_context_json) VALUES (5, '00000000-0000-0000-0000-000000000005', 2, 11, 10, UNIX(2), 'dummy', 'dummy', UNIX(259201), '10 days', UNIX(1123200), 'planned', '{}'::jsonb);
-INSERT INTO project_commitments_v2 (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, confirm_by, duration, expires_at, state, creation_context_json) VALUES (6, '00000000-0000-0000-0000-000000000006', 2, 11, 10, UNIX(3), 'dummy', 'dummy', UNIX(259200), '10 days', UNIX(1123200), 'planned', '{}'::jsonb);
+INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, confirm_by, duration, expires_at, state, creation_context_json) VALUES (4, '00000000-0000-0000-0000-000000000004', 2, 11, 10, UNIX(1), 'dummy', 'dummy', UNIX(259202), '10 days', UNIX(1123200), 'planned', '{}'::jsonb);
+INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, confirm_by, duration, expires_at, state, creation_context_json) VALUES (5, '00000000-0000-0000-0000-000000000005', 2, 11, 10, UNIX(2), 'dummy', 'dummy', UNIX(259201), '10 days', UNIX(1123200), 'planned', '{}'::jsonb);
+INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, confirm_by, duration, expires_at, state, creation_context_json) VALUES (6, '00000000-0000-0000-0000-000000000006', 2, 11, 10, UNIX(3), 'dummy', 'dummy', UNIX(259200), '10 days', UNIX(1123200), 'planned', '{}'::jsonb);
 
 -- day 4: test confirmation that is (or is not) blocked by existing usage in other projects (on a capacity of 420, there is already 250 usage in berlin, so only berlin can confirm a commitment for amount = 300, even though dresden asked first)
-INSERT INTO project_commitments_v2 (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, confirm_by, duration, expires_at, state, creation_context_json) VALUES (7, '00000000-0000-0000-0000-000000000007', 2, 6, 300, UNIX(1), 'dummy', 'dummy', UNIX(345600), '10 days', UNIX(1209600), 'planned', '{}'::jsonb);
-INSERT INTO project_commitments_v2 (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, confirm_by, duration, expires_at, state, creation_context_json) VALUES (8, '00000000-0000-0000-0000-000000000008', 1, 6, 300, UNIX(2), 'dummy', 'dummy', UNIX(345600), '10 days', UNIX(1209600), 'planned', '{}'::jsonb);
+INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, confirm_by, duration, expires_at, state, creation_context_json) VALUES (7, '00000000-0000-0000-0000-000000000007', 2, 6, 300, UNIX(1), 'dummy', 'dummy', UNIX(345600), '10 days', UNIX(1209600), 'planned', '{}'::jsonb);
+INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, confirm_by, duration, expires_at, state, creation_context_json) VALUES (8, '00000000-0000-0000-0000-000000000008', 1, 6, 300, UNIX(2), 'dummy', 'dummy', UNIX(345600), '10 days', UNIX(1209600), 'planned', '{}'::jsonb);
 
 -- day 5: test commitments that cannot be confirmed until the previous commitment expires (ID=9 is confirmed, and then ID=10 cannot be confirmed until ID=9 expires because ID=9 blocks absolutely all available capacity in that resource and AZ)
-INSERT INTO project_commitments_v2 (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, confirm_by, duration, expires_at, state, creation_context_json) VALUES (9, '00000000-0000-0000-0000-000000000009',  1, 12,  22, UNIX(1), 'dummy', 'dummy', UNIX(432000), '1 hour', UNIX(435600),  'planned', '{}'::jsonb);
-INSERT INTO project_commitments_v2 (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, confirm_by, duration, expires_at, state, creation_context_json) VALUES (10, '00000000-0000-0000-0000-000000000010', 2, 12, 2, UNIX(2), 'dummy', 'dummy', UNIX(432000), '10 days', UNIX(1296000), 'planned', '{}'::jsonb);
+INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, confirm_by, duration, expires_at, state, creation_context_json) VALUES (9, '00000000-0000-0000-0000-000000000009',  1, 12,  22, UNIX(1), 'dummy', 'dummy', UNIX(432000), '1 hour', UNIX(435600),  'planned', '{}'::jsonb);
+INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, confirm_by, duration, expires_at, state, creation_context_json) VALUES (10, '00000000-0000-0000-0000-000000000010', 2, 12, 2, UNIX(2), 'dummy', 'dummy', UNIX(432000), '10 days', UNIX(1296000), 'planned', '{}'::jsonb);

--- a/internal/collector/fixtures/checkconsistency0.sql
+++ b/internal/collector/fixtures/checkconsistency0.sql
@@ -20,12 +20,12 @@ INSERT INTO cluster_services (id, type, next_scrape_at, liquid_version) VALUES (
 INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
 INSERT INTO domains (id, name, uuid) VALUES (2, 'france', 'uuid-for-france');
 
-INSERT INTO project_services_v2 (id, project_id, service_id, stale, next_scrape_at) VALUES (1, 1, 1, TRUE, 0);
-INSERT INTO project_services_v2 (id, project_id, service_id, stale, next_scrape_at) VALUES (2, 1, 2, TRUE, 0);
-INSERT INTO project_services_v2 (id, project_id, service_id, stale, next_scrape_at) VALUES (3, 2, 1, TRUE, 0);
-INSERT INTO project_services_v2 (id, project_id, service_id, stale, next_scrape_at) VALUES (4, 2, 2, TRUE, 0);
-INSERT INTO project_services_v2 (id, project_id, service_id, stale, next_scrape_at) VALUES (5, 3, 1, TRUE, 0);
-INSERT INTO project_services_v2 (id, project_id, service_id, stale, next_scrape_at) VALUES (6, 3, 2, TRUE, 0);
+INSERT INTO project_services (id, project_id, service_id, stale, next_scrape_at) VALUES (1, 1, 1, TRUE, 0);
+INSERT INTO project_services (id, project_id, service_id, stale, next_scrape_at) VALUES (2, 1, 2, TRUE, 0);
+INSERT INTO project_services (id, project_id, service_id, stale, next_scrape_at) VALUES (3, 2, 1, TRUE, 0);
+INSERT INTO project_services (id, project_id, service_id, stale, next_scrape_at) VALUES (4, 2, 2, TRUE, 0);
+INSERT INTO project_services (id, project_id, service_id, stale, next_scrape_at) VALUES (5, 3, 1, TRUE, 0);
+INSERT INTO project_services (id, project_id, service_id, stale, next_scrape_at) VALUES (6, 3, 2, TRUE, 0);
 
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany');
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (2, 1, 'dresden', 'uuid-for-dresden', 'uuid-for-berlin');

--- a/internal/collector/fixtures/mail_expiring_commitments.sql
+++ b/internal/collector/fixtures/mail_expiring_commitments.sql
@@ -7,37 +7,37 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (2, 1, 'dre
 
 INSERT INTO cluster_services (id, type) VALUES (1, 'first');
 
-INSERT INTO project_services_v2 (id, project_id, service_id) VALUES (1, 1, 1);
-INSERT INTO project_services_v2 (id, project_id, service_id) VALUES (2, 2, 1);
+INSERT INTO project_services (id, project_id, service_id) VALUES (1, 1, 1);
+INSERT INTO project_services (id, project_id, service_id) VALUES (2, 2, 1);
 
 INSERT INTO cluster_resources (id, service_id, name) VALUES (1, 1, 'things');
 
-INSERT INTO project_resources_v2 (id, project_id, resource_id) VALUES (1,  1, 1);
-INSERT INTO project_resources_v2 (id, project_id, resource_id) VALUES (2,  2, 1);
+INSERT INTO project_resources (id, project_id, resource_id) VALUES (1,  1, 1);
+INSERT INTO project_resources (id, project_id, resource_id) VALUES (2,  2, 1);
 
 INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity) VALUES (1, 1,  'az-one', 0);
 INSERT INTO cluster_az_resources (id, resource_id, az, raw_capacity) VALUES (2, 1,  'az-two', 0);
 
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (1, 1,  1, 0);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (2, 1,  2, 0);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (3, 2,  1, 0);
-INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (4, 2,  2, 0);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (1, 1,  1, 0);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (2, 1,  2, 0);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (3, 2,  1, 0);
+INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (4, 2,  2, 0);
 
 -- active/planned commitments should be ignored
-INSERT INTO project_commitments_v2 (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, confirm_by, duration, expires_at, state, creation_context_json) VALUES (1, '00000000-0000-0000-0000-000000000001', 1, 1, 10, UNIX(0), 'dummy', 'dummy', UNIX(86400), '1 year', UNIX(31536000), 'planned', '{}'::jsonb);
-INSERT INTO project_commitments_v2 (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, duration, expires_at, state, creation_context_json) VALUES (2, '00000000-0000-0000-0000-000000000002', 1, 1, 10, UNIX(0), 'dummy', 'dummy', '1 year', UNIX(31536000), 'active', '{}'::jsonb);
-INSERT INTO project_commitments_v2 (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, confirm_by, duration, expires_at, state, creation_context_json) VALUES (3, '00000000-0000-0000-0000-000000000003', 1, 1, 10, UNIX(0), 'dummy', 'dummy', UNIX(5097600), '10 days', UNIX(5875200), 'planned', '{}'::jsonb);
+INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, confirm_by, duration, expires_at, state, creation_context_json) VALUES (1, '00000000-0000-0000-0000-000000000001', 1, 1, 10, UNIX(0), 'dummy', 'dummy', UNIX(86400), '1 year', UNIX(31536000), 'planned', '{}'::jsonb);
+INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, duration, expires_at, state, creation_context_json) VALUES (2, '00000000-0000-0000-0000-000000000002', 1, 1, 10, UNIX(0), 'dummy', 'dummy', '1 year', UNIX(31536000), 'active', '{}'::jsonb);
+INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, confirm_by, duration, expires_at, state, creation_context_json) VALUES (3, '00000000-0000-0000-0000-000000000003', 1, 1, 10, UNIX(0), 'dummy', 'dummy', UNIX(5097600), '10 days', UNIX(5875200), 'planned', '{}'::jsonb);
 
 -- expiring commitments for each project
-INSERT INTO project_commitments_v2 (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, duration, expires_at, state, creation_context_json) VALUES (4, '00000000-0000-0000-0000-000000000004', 1, 1, 5, UNIX(0), 'dummy', 'dummy', '1 year', UNIX(0), 'active', '{}'::jsonb);
-INSERT INTO project_commitments_v2 (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, duration, expires_at, state, creation_context_json) VALUES (5, '00000000-0000-0000-0000-000000000005', 1, 2, 10, UNIX(0), 'dummy', 'dummy', '1 year', UNIX(0), 'active', '{}'::jsonb);
+INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, duration, expires_at, state, creation_context_json) VALUES (4, '00000000-0000-0000-0000-000000000004', 1, 1, 5, UNIX(0), 'dummy', 'dummy', '1 year', UNIX(0), 'active', '{}'::jsonb);
+INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, duration, expires_at, state, creation_context_json) VALUES (5, '00000000-0000-0000-0000-000000000005', 1, 2, 10, UNIX(0), 'dummy', 'dummy', '1 year', UNIX(0), 'active', '{}'::jsonb);
 -- expiring commitments, marked as one year to make them pass the short-term commitment check, but they will expire within the scrape timeframe.
-INSERT INTO project_commitments_v2 (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, duration, expires_at, state, creation_context_json) VALUES (6, '00000000-0000-0000-0000-000000000006', 2, 1, 5, UNIX(0), 'dummy', 'dummy', '1 year', UNIX(2246400), 'active', '{}'::jsonb);
-INSERT INTO project_commitments_v2 (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, duration, expires_at, state, creation_context_json) VALUES (7, '00000000-0000-0000-0000-000000000007', 2, 2, 10, UNIX(0), 'dummy', 'dummy', '1 year', UNIX(2246400), 'active', '{}'::jsonb);
+INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, duration, expires_at, state, creation_context_json) VALUES (6, '00000000-0000-0000-0000-000000000006', 2, 1, 5, UNIX(0), 'dummy', 'dummy', '1 year', UNIX(2246400), 'active', '{}'::jsonb);
+INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, duration, expires_at, state, creation_context_json) VALUES (7, '00000000-0000-0000-0000-000000000007', 2, 2, 10, UNIX(0), 'dummy', 'dummy', '1 year', UNIX(2246400), 'active', '{}'::jsonb);
 
 -- expiring short-term commitments should not be queued and be marked as notified
-INSERT INTO project_commitments_v2 (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, confirm_by, duration, expires_at, state, creation_context_json) VALUES (8, '00000000-0000-0000-0000-000000000008', 1, 1, 10, UNIX(0), 'dummy', 'dummy', UNIX(86400), '10 days', UNIX(950400), 'active', '{}'::jsonb);
-INSERT INTO project_commitments_v2 (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, confirmed_at, duration, expires_at, state, creation_context_json) VALUES (9, '00000000-0000-0000-0000-000000000009', 1, 1, 10, UNIX(0), 'dummy', 'dummy', UNIX(0), '10 days', UNIX(777600), 'active', '{}'::jsonb);
+INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, confirm_by, duration, expires_at, state, creation_context_json) VALUES (8, '00000000-0000-0000-0000-000000000008', 1, 1, 10, UNIX(0), 'dummy', 'dummy', UNIX(86400), '10 days', UNIX(950400), 'active', '{}'::jsonb);
+INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, confirmed_at, duration, expires_at, state, creation_context_json) VALUES (9, '00000000-0000-0000-0000-000000000009', 1, 1, 10, UNIX(0), 'dummy', 'dummy', UNIX(0), '10 days', UNIX(777600), 'active', '{}'::jsonb);
 
 -- superseded commitments should not be queued for notifications
-INSERT INTO project_commitments_v2 (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, duration, expires_at, state, creation_context_json) VALUES (10, '00000000-0000-0000-0000-000000000010', 2, 2, 1, UNIX(0), 'dummy', 'dummy', '1 year', UNIX(2246400), 'superseded', '{}'::jsonb);
+INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, amount, created_at, creator_uuid, creator_name, duration, expires_at, state, creation_context_json) VALUES (10, '00000000-0000-0000-0000-000000000010', 2, 2, 1, UNIX(0), 'dummy', 'dummy', '1 year', UNIX(2246400), 'superseded', '{}'::jsonb);

--- a/internal/collector/fixtures/scandomains1.sql
+++ b/internal/collector/fixtures/scandomains1.sql
@@ -20,12 +20,12 @@ INSERT INTO cluster_services (id, type, next_scrape_at, liquid_version) VALUES (
 INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
 INSERT INTO domains (id, name, uuid) VALUES (2, 'france', 'uuid-for-france');
 
-INSERT INTO project_services_v2 (id, project_id, service_id, stale, next_scrape_at) VALUES (1, 1, 1, TRUE, 0);
-INSERT INTO project_services_v2 (id, project_id, service_id, stale, next_scrape_at) VALUES (2, 1, 2, TRUE, 0);
-INSERT INTO project_services_v2 (id, project_id, service_id, stale, next_scrape_at) VALUES (3, 2, 1, TRUE, 0);
-INSERT INTO project_services_v2 (id, project_id, service_id, stale, next_scrape_at) VALUES (4, 2, 2, TRUE, 0);
-INSERT INTO project_services_v2 (id, project_id, service_id, stale, next_scrape_at) VALUES (5, 3, 1, TRUE, 0);
-INSERT INTO project_services_v2 (id, project_id, service_id, stale, next_scrape_at) VALUES (6, 3, 2, TRUE, 0);
+INSERT INTO project_services (id, project_id, service_id, stale, next_scrape_at) VALUES (1, 1, 1, TRUE, 0);
+INSERT INTO project_services (id, project_id, service_id, stale, next_scrape_at) VALUES (2, 1, 2, TRUE, 0);
+INSERT INTO project_services (id, project_id, service_id, stale, next_scrape_at) VALUES (3, 2, 1, TRUE, 0);
+INSERT INTO project_services (id, project_id, service_id, stale, next_scrape_at) VALUES (4, 2, 2, TRUE, 0);
+INSERT INTO project_services (id, project_id, service_id, stale, next_scrape_at) VALUES (5, 3, 1, TRUE, 0);
+INSERT INTO project_services (id, project_id, service_id, stale, next_scrape_at) VALUES (6, 3, 2, TRUE, 0);
 
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany');
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (2, 1, 'dresden', 'uuid-for-dresden', 'uuid-for-berlin');

--- a/internal/collector/fixtures/scrape0.sql
+++ b/internal/collector/fixtures/scrape0.sql
@@ -19,11 +19,11 @@ INSERT INTO cluster_services (id, type, next_scrape_at, liquid_version, usage_me
 
 INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
 
-INSERT INTO project_rates_v2 (id, project_id, rate_id, rate_limit, window_ns, usage_as_bigint) VALUES (1, 2, 3, 10, 1000000000, '');
-INSERT INTO project_rates_v2 (id, project_id, rate_id, rate_limit, window_ns, usage_as_bigint) VALUES (2, 1, 4, 42, 120000000000, '');
+INSERT INTO project_rates (id, project_id, rate_id, rate_limit, window_ns, usage_as_bigint) VALUES (1, 2, 3, 10, 1000000000, '');
+INSERT INTO project_rates (id, project_id, rate_id, rate_limit, window_ns, usage_as_bigint) VALUES (2, 1, 4, 42, 120000000000, '');
 
-INSERT INTO project_services_v2 (id, project_id, service_id, stale, next_scrape_at) VALUES (1, 1, 1, TRUE, 0);
-INSERT INTO project_services_v2 (id, project_id, service_id, stale, next_scrape_at) VALUES (2, 2, 1, TRUE, 0);
+INSERT INTO project_services (id, project_id, service_id, stale, next_scrape_at) VALUES (1, 1, 1, TRUE, 0);
+INSERT INTO project_services (id, project_id, service_id, stale, next_scrape_at) VALUES (2, 2, 1, TRUE, 0);
 
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany');
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (2, 1, 'dresden', 'uuid-for-dresden', 'uuid-for-berlin');

--- a/internal/collector/metrics.go
+++ b/internal/collector/metrics.go
@@ -61,7 +61,7 @@ func (c *AggregateMetricsCollector) Describe(ch chan<- *prometheus.Desc) {
 
 var scrapedAtAggregateQuery = sqlext.SimplifyWhitespace(`
 	SELECT cs.type, MIN(ps.scraped_at), MAX(ps.scraped_at), MIN(ps.scraped_at), MAX(ps.scraped_at)
-	  FROM project_services_v2 ps
+	  FROM project_services ps
 	  JOIN cluster_services cs ON cs.id = ps.service_id
 	 WHERE ps.scraped_at IS NOT NULL
 	 GROUP BY cs.type
@@ -251,7 +251,7 @@ var quotaSerializedMetricsGetQuery = sqlext.SimplifyWhitespace(`
 	  FROM cluster_services cs
 	  CROSS JOIN domains d
 	  JOIN projects p ON p.domain_id = d.id
-	  JOIN project_services_v2 ps ON ps.service_id = cs.id AND ps.project_id = p.id
+	  JOIN project_services ps ON ps.service_id = cs.id AND ps.project_id = p.id
 	 WHERE ps.serialized_metrics != '' AND ps.serialized_metrics != '{}'
 `)
 
@@ -418,8 +418,8 @@ var domainMetricsQuery = sqlext.SimplifyWhitespace(`
 	  JOIN cluster_resources cr ON cr.service_id = cs.id
 	  CROSS JOIN domains d
 	  JOIN projects p ON p.domain_id = d.id
-	  JOIN project_services_v2 ps ON ps.project_id = p.id AND ps.service_id = cs.id
-	  JOIN project_resources_v2 pr ON pr.project_id = p.id AND pr.resource_id = cr.id
+	  JOIN project_services ps ON ps.project_id = p.id AND ps.service_id = cs.id
+	  JOIN project_resources pr ON pr.project_id = p.id AND pr.resource_id = cr.id
 	 GROUP BY d.name, d.uuid, cs.type, cr.name
 `)
 
@@ -429,7 +429,7 @@ var projectMetricsQuery = sqlext.SimplifyWhitespace(`
 	         SUM(pazr.usage) AS usage,
 	         SUM(COALESCE(pazr.physical_usage, pazr.usage)) AS physical_usage,
 	         COUNT(pazr.physical_usage) > 0 AS has_physical_usage
-	    FROM project_az_resources_v2 pazr
+	    FROM project_az_resources pazr
 	    JOIN cluster_az_resources cazr ON cazr.id = pazr.az_resource_id
 	   GROUP BY cazr.resource_id, pazr.project_id
 	),
@@ -438,7 +438,7 @@ var projectMetricsQuery = sqlext.SimplifyWhitespace(`
 		FROM cluster_services cs
 		JOIN cluster_resources cr ON cr.service_id = cs.id
 		JOIN cluster_az_resources cazr ON cazr.resource_id = cr.id
-		JOIN project_commitments_v2 pc ON pc.az_resource_id = cazr.id AND pc.state = 'active'
+		JOIN project_commitments pc ON pc.az_resource_id = cazr.id AND pc.state = 'active'
 		JOIN projects p ON p.id = pc.project_id
 		GROUP BY p.domain_id, p.id, cs.type, cr.name
 	)
@@ -450,7 +450,7 @@ var projectMetricsQuery = sqlext.SimplifyWhitespace(`
 	  JOIN cluster_resources cr ON cr.service_id = cs.id
 	  CROSS JOIN domains d
 	  JOIN projects p ON p.domain_id = d.id
-	  JOIN project_resources_v2 pr ON pr.resource_id = cr.id AND pr.project_id = p.id
+	  JOIN project_resources pr ON pr.resource_id = cr.id AND pr.project_id = p.id
 	  JOIN project_sums psums ON psums.resource_id = cr.id AND psums.project_id = p.id
 	  LEFT JOIN project_commitment_minExpiresAt pcmea ON d.id = pcmea.domain_id AND p.id = pcmea.project_id AND cs.type= pcmea.TYPE AND cr.name = pcmea.name
 `)
@@ -458,7 +458,7 @@ var projectMetricsQuery = sqlext.SimplifyWhitespace(`
 var projectAZMetricsQuery = sqlext.SimplifyWhitespace(`
 	WITH project_commitment_sums_by_state AS (
 	  SELECT az_resource_id, project_id, state, SUM(amount) AS amount
-	    FROM project_commitments_v2
+	    FROM project_commitments
 	   WHERE state NOT IN ('superseded', 'expired')
 	   GROUP BY az_resource_id, project_id, state
 	), project_commitment_sums AS (
@@ -472,7 +472,7 @@ var projectAZMetricsQuery = sqlext.SimplifyWhitespace(`
 	  JOIN cluster_az_resources cazr ON cazr.resource_id = cr.id
 	  CROSS JOIN domains d
 	  JOIN projects p ON p.domain_id = d.id
-	  JOIN project_az_resources_v2 pazr ON pazr.az_resource_id = cazr.id AND pazr.project_id = p.id
+	  JOIN project_az_resources pazr ON pazr.az_resource_id = cazr.id AND pazr.project_id = p.id
 	  LEFT OUTER JOIN project_commitment_sums pcs ON pcs.az_resource_id = cazr.id AND pcs.project_id = p.id
 `)
 
@@ -482,7 +482,7 @@ var projectRateMetricsQuery = sqlext.SimplifyWhitespace(`
 	  JOIN cluster_rates cra ON cra.service_id = cs.id
 	  CROSS JOIN domains d
 	  JOIN projects p ON p.domain_id = d.id
-	  JOIN project_rates_v2 pra ON pra.rate_id = cra.id AND pra.project_id = p.id
+	  JOIN project_rates pra ON pra.rate_id = cra.id AND pra.project_id = p.id
 	 WHERE pra.usage_as_bigint != ''
 `)
 

--- a/internal/collector/quota_overrides.go
+++ b/internal/collector/quota_overrides.go
@@ -90,15 +90,15 @@ var (
 		SELECT ps.id
 		  FROM domains d
 		  JOIN projects p ON p.domain_id = d.id
-		  JOIN project_services_v2 ps ON ps.project_id = p.id
+		  JOIN project_services ps ON ps.project_id = p.id
 		  JOIN cluster_services cs ON cs.id = ps.service_id
 		 WHERE d.name = $1 AND p.name = $2 AND cs.type = $3
 	`)
 	aqoUpdateOverrideQuery = sqlext.SimplifyWhitespace(`
-		UPDATE project_resources_v2 pr
+		UPDATE project_resources pr
 		   SET override_quota_from_config = $1
 		 FROM cluster_resources cr
-		 JOIN project_services_v2 ps ON ps.service_id = cr.service_id
+		 JOIN project_services ps ON ps.service_id = cr.service_id
 		 WHERE cr.id = pr.resource_id AND ps.project_id = pr.project_id
 		 AND ps.id = $2 AND cr.name = $3
 	`)
@@ -106,13 +106,13 @@ var (
 		SELECT pr.id, d.name, p.name, cs.type, cr.name
 		  FROM domains d
 		  JOIN projects p ON p.domain_id = d.id
-		  JOIN project_resources_v2 pr ON pr.project_id = p.id
+		  JOIN project_resources pr ON pr.project_id = p.id
 		  JOIN cluster_resources cr ON cr.id = pr.resource_id
 		  JOIN cluster_services cs ON cs.id = cr.service_id
 		 WHERE pr.override_quota_from_config IS NOT NULL
 	`)
 	aqoClearOverrideQuery = sqlext.SimplifyWhitespace(`
-		UPDATE project_resources_v2
+		UPDATE project_resources
 		   SET override_quota_from_config = NULL
 		 WHERE id = $1
 	`)

--- a/internal/collector/quota_overrides_test.go
+++ b/internal/collector/quota_overrides_test.go
@@ -70,8 +70,8 @@ func TestApplyQuotaOverrides(t *testing.T) {
 	mustT(t, os.WriteFile(configPath, []byte(buf), 0666))
 	mustT(t, job.ProcessOne(s.Ctx))
 	tr.DBChanges().AssertEqualf(`
-		UPDATE project_resources_v2 SET override_quota_from_config = 10 WHERE id = 1 AND project_id = 1 AND resource_id = 1;
-		UPDATE project_resources_v2 SET override_quota_from_config = 1000 WHERE id = 2 AND project_id = 1 AND resource_id = 2;
+		UPDATE project_resources SET override_quota_from_config = 10 WHERE id = 1 AND project_id = 1 AND resource_id = 1;
+		UPDATE project_resources SET override_quota_from_config = 1000 WHERE id = 2 AND project_id = 1 AND resource_id = 2;
 	`)
 
 	// test changing and removing quota overrides
@@ -84,9 +84,9 @@ func TestApplyQuotaOverrides(t *testing.T) {
 	mustT(t, os.WriteFile(configPath, []byte(buf), 0666))
 	mustT(t, job.ProcessOne(s.Ctx))
 	tr.DBChanges().AssertEqualf(`
-		UPDATE project_resources_v2 SET override_quota_from_config = 15 WHERE id = 1 AND project_id = 1 AND resource_id = 1;
-		UPDATE project_resources_v2 SET override_quota_from_config = NULL WHERE id = 2 AND project_id = 1 AND resource_id = 2;
-		UPDATE project_resources_v2 SET override_quota_from_config = 20 WHERE id = 3 AND project_id = 2 AND resource_id = 1;
+		UPDATE project_resources SET override_quota_from_config = 15 WHERE id = 1 AND project_id = 1 AND resource_id = 1;
+		UPDATE project_resources SET override_quota_from_config = NULL WHERE id = 2 AND project_id = 1 AND resource_id = 2;
+		UPDATE project_resources SET override_quota_from_config = 20 WHERE id = 3 AND project_id = 2 AND resource_id = 1;
 	`)
 
 	// test quota overrides referring to nonexistent domains and projects (should be ignored without error)

--- a/internal/collector/scrape_test.go
+++ b/internal/collector/scrape_test.go
@@ -142,7 +142,7 @@ func commonComplexScrapeTestSetup(t *testing.T) (s test.Setup, scrapeJob jobloop
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = s.DB.Insert(&db.ProjectRateV2{
+	err = s.DB.Insert(&db.ProjectRate{
 		ProjectID: 2,
 		RateID:    3,
 		Limit:     Some[uint64](10),
@@ -151,7 +151,7 @@ func commonComplexScrapeTestSetup(t *testing.T) (s test.Setup, scrapeJob jobloop
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = s.DB.Insert(&db.ProjectRateV2{
+	err = s.DB.Insert(&db.ProjectRate{
 		ProjectID: 1,
 		RateID:    4,
 		Limit:     Some[uint64](42),
@@ -253,28 +253,28 @@ func Test_ScrapeSuccess(t *testing.T) {
 	scrapedAt1 := s.Clock.Now().Add(-5 * time.Second)
 	scrapedAt2 := s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, historical_usage) VALUES (1, 1, 1, 0, '{"t":[%[1]d],"v":[0]}');
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, historical_usage) VALUES (10, 2, 5, 0, '{"t":[%[3]d],"v":[0]}');
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, subresources, historical_usage) VALUES (11, 2, 6, 2, '[{"name":"index","usage":0},{"name":"index","usage":1}]', '{"t":[%[3]d],"v":[2]}');
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, subresources, historical_usage) VALUES (12, 2, 7, 2, '[{"name":"index","usage":2},{"name":"index","usage":3}]', '{"t":[%[3]d],"v":[2]}');
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, physical_usage, historical_usage) VALUES (2, 1, 2, 0, 0, '{"t":[%[1]d],"v":[0]}');
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, physical_usage, historical_usage) VALUES (3, 1, 3, 0, 0, '{"t":[%[1]d],"v":[0]}');
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, historical_usage) VALUES (4, 1, 5, 0, '{"t":[%[1]d],"v":[0]}');
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, subresources, historical_usage) VALUES (5, 1, 6, 2, '[{"name":"index","usage":0},{"name":"index","usage":1}]', '{"t":[%[1]d],"v":[2]}');
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, subresources, historical_usage) VALUES (6, 1, 7, 2, '[{"name":"index","usage":2},{"name":"index","usage":3}]', '{"t":[%[1]d],"v":[2]}');
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, historical_usage) VALUES (7, 2, 1, 0, '{"t":[%[3]d],"v":[0]}');
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, physical_usage, historical_usage) VALUES (8, 2, 2, 0, 0, '{"t":[%[3]d],"v":[0]}');
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, physical_usage, historical_usage) VALUES (9, 2, 3, 0, 0, '{"t":[%[3]d],"v":[0]}');
-		INSERT INTO project_rates_v2 (id, project_id, rate_id, usage_as_bigint) VALUES (3, 1, 1, '1024');
-		INSERT INTO project_rates_v2 (id, project_id, rate_id, usage_as_bigint) VALUES (4, 1, 2, '2048');
-		INSERT INTO project_rates_v2 (id, project_id, rate_id, usage_as_bigint) VALUES (5, 2, 1, '1024');
-		INSERT INTO project_rates_v2 (id, project_id, rate_id, usage_as_bigint) VALUES (6, 2, 2, '2048');
-		INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (1, 1, 1, 0, 100);
-		INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (2, 1, 2, 0, 42);
-		INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (3, 2, 1, 0, 100);
-		INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (4, 2, 2, 0, 42);
-		UPDATE project_services_v2 SET scraped_at = %[1]d, stale = FALSE, scrape_duration_secs = 5, serialized_scrape_state = '{"firstrate":1024,"secondrate":2048}', serialized_metrics = '{"limes_unittest_capacity_usage":{"lk":null,"m":[{"v":0,"l":null}]},"limes_unittest_things_usage":{"lk":null,"m":[{"v":4,"l":null}]}}', checked_at = %[1]d, next_scrape_at = %[2]d, quota_desynced_at = %[1]d WHERE id = 1 AND project_id = 1 AND service_id = 1;
-		UPDATE project_services_v2 SET scraped_at = %[3]d, stale = FALSE, scrape_duration_secs = 5, serialized_scrape_state = '{"firstrate":1024,"secondrate":2048}', serialized_metrics = '{"limes_unittest_capacity_usage":{"lk":null,"m":[{"v":0,"l":null}]},"limes_unittest_things_usage":{"lk":null,"m":[{"v":4,"l":null}]}}', checked_at = %[3]d, next_scrape_at = %[4]d, quota_desynced_at = %[3]d WHERE id = 2 AND project_id = 2 AND service_id = 1;
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, historical_usage) VALUES (1, 1, 1, 0, '{"t":[%[1]d],"v":[0]}');
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, historical_usage) VALUES (10, 2, 5, 0, '{"t":[%[3]d],"v":[0]}');
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, subresources, historical_usage) VALUES (11, 2, 6, 2, '[{"name":"index","usage":0},{"name":"index","usage":1}]', '{"t":[%[3]d],"v":[2]}');
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, subresources, historical_usage) VALUES (12, 2, 7, 2, '[{"name":"index","usage":2},{"name":"index","usage":3}]', '{"t":[%[3]d],"v":[2]}');
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, physical_usage, historical_usage) VALUES (2, 1, 2, 0, 0, '{"t":[%[1]d],"v":[0]}');
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, physical_usage, historical_usage) VALUES (3, 1, 3, 0, 0, '{"t":[%[1]d],"v":[0]}');
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, historical_usage) VALUES (4, 1, 5, 0, '{"t":[%[1]d],"v":[0]}');
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, subresources, historical_usage) VALUES (5, 1, 6, 2, '[{"name":"index","usage":0},{"name":"index","usage":1}]', '{"t":[%[1]d],"v":[2]}');
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, subresources, historical_usage) VALUES (6, 1, 7, 2, '[{"name":"index","usage":2},{"name":"index","usage":3}]', '{"t":[%[1]d],"v":[2]}');
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, historical_usage) VALUES (7, 2, 1, 0, '{"t":[%[3]d],"v":[0]}');
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, physical_usage, historical_usage) VALUES (8, 2, 2, 0, 0, '{"t":[%[3]d],"v":[0]}');
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, physical_usage, historical_usage) VALUES (9, 2, 3, 0, 0, '{"t":[%[3]d],"v":[0]}');
+		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (3, 1, 1, '1024');
+		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (4, 1, 2, '2048');
+		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (5, 2, 1, '1024');
+		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (6, 2, 2, '2048');
+		INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (1, 1, 1, 0, 100);
+		INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (2, 1, 2, 0, 42);
+		INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (3, 2, 1, 0, 100);
+		INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (4, 2, 2, 0, 42);
+		UPDATE project_services SET scraped_at = %[1]d, stale = FALSE, scrape_duration_secs = 5, serialized_scrape_state = '{"firstrate":1024,"secondrate":2048}', serialized_metrics = '{"limes_unittest_capacity_usage":{"lk":null,"m":[{"v":0,"l":null}]},"limes_unittest_things_usage":{"lk":null,"m":[{"v":4,"l":null}]}}', checked_at = %[1]d, next_scrape_at = %[2]d, quota_desynced_at = %[1]d WHERE id = 1 AND project_id = 1 AND service_id = 1;
+		UPDATE project_services SET scraped_at = %[3]d, stale = FALSE, scrape_duration_secs = 5, serialized_scrape_state = '{"firstrate":1024,"secondrate":2048}', serialized_metrics = '{"limes_unittest_capacity_usage":{"lk":null,"m":[{"v":0,"l":null}]},"limes_unittest_things_usage":{"lk":null,"m":[{"v":4,"l":null}]}}', checked_at = %[3]d, next_scrape_at = %[4]d, quota_desynced_at = %[3]d WHERE id = 2 AND project_id = 2 AND service_id = 1;
 	`,
 		scrapedAt1.Unix(), scrapedAt1.Add(scrapeInterval).Unix(),
 		scrapedAt2.Unix(), scrapedAt2.Add(scrapeInterval).Unix(),
@@ -301,12 +301,12 @@ func Test_ScrapeSuccess(t *testing.T) {
 	scrapedAt1 = s.Clock.Now().Add(-5 * time.Second)
 	scrapedAt2 = s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`
-		UPDATE project_az_resources_v2 SET usage = 3, subresources = '[{"name":"index","usage":2},{"name":"index","usage":3},{"name":"index","usage":4}]', historical_usage = '{"t":[%[6]d,%[3]d],"v":[2,3]}' WHERE id = 12 AND project_id = 2 AND az_resource_id = 7;
-		UPDATE project_az_resources_v2 SET usage = 3, subresources = '[{"name":"index","usage":2},{"name":"index","usage":3},{"name":"index","usage":4}]', historical_usage = '{"t":[%[5]d,%[1]d],"v":[2,3]}' WHERE id = 6 AND project_id = 1 AND az_resource_id = 7;
-		UPDATE project_resources_v2 SET backend_quota = 110 WHERE id = 1 AND project_id = 1 AND resource_id = 1;
-		UPDATE project_resources_v2 SET backend_quota = 110 WHERE id = 3 AND project_id = 2 AND resource_id = 1;
-		UPDATE project_services_v2 SET scraped_at = %[1]d, serialized_metrics = '{"limes_unittest_capacity_usage":{"lk":null,"m":[{"v":0,"l":null}]},"limes_unittest_things_usage":{"lk":null,"m":[{"v":3,"l":null}]}}', checked_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND service_id = 1;
-		UPDATE project_services_v2 SET scraped_at = %[3]d, serialized_metrics = '{"limes_unittest_capacity_usage":{"lk":null,"m":[{"v":0,"l":null}]},"limes_unittest_things_usage":{"lk":null,"m":[{"v":3,"l":null}]}}', checked_at = %[3]d, next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND service_id = 1;
+		UPDATE project_az_resources SET usage = 3, subresources = '[{"name":"index","usage":2},{"name":"index","usage":3},{"name":"index","usage":4}]', historical_usage = '{"t":[%[6]d,%[3]d],"v":[2,3]}' WHERE id = 12 AND project_id = 2 AND az_resource_id = 7;
+		UPDATE project_az_resources SET usage = 3, subresources = '[{"name":"index","usage":2},{"name":"index","usage":3},{"name":"index","usage":4}]', historical_usage = '{"t":[%[5]d,%[1]d],"v":[2,3]}' WHERE id = 6 AND project_id = 1 AND az_resource_id = 7;
+		UPDATE project_resources SET backend_quota = 110 WHERE id = 1 AND project_id = 1 AND resource_id = 1;
+		UPDATE project_resources SET backend_quota = 110 WHERE id = 3 AND project_id = 2 AND resource_id = 1;
+		UPDATE project_services SET scraped_at = %[1]d, serialized_metrics = '{"limes_unittest_capacity_usage":{"lk":null,"m":[{"v":0,"l":null}]},"limes_unittest_things_usage":{"lk":null,"m":[{"v":3,"l":null}]}}', checked_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND service_id = 1;
+		UPDATE project_services SET scraped_at = %[3]d, serialized_metrics = '{"limes_unittest_capacity_usage":{"lk":null,"m":[{"v":0,"l":null}]},"limes_unittest_things_usage":{"lk":null,"m":[{"v":3,"l":null}]}}', checked_at = %[3]d, next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND service_id = 1;
 	`,
 		scrapedAt1.Unix(), scrapedAt1.Add(scrapeInterval).Unix(),
 		scrapedAt2.Unix(), scrapedAt2.Add(scrapeInterval).Unix(),
@@ -322,10 +322,10 @@ func Test_ScrapeSuccess(t *testing.T) {
 	scrapedAt1 = s.Clock.Now().Add(-5 * time.Second)
 	scrapedAt2 = s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`
-			UPDATE project_resources_v2 SET forbidden = TRUE WHERE id = 1 AND project_id = 1 AND resource_id = 1;
-			UPDATE project_resources_v2 SET forbidden = TRUE WHERE id = 3 AND project_id = 2 AND resource_id = 1;
-			UPDATE project_services_v2 SET scraped_at = %[1]d, checked_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND service_id = 1;
-			UPDATE project_services_v2 SET scraped_at = %[3]d, checked_at = %[3]d, next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND service_id = 1;
+			UPDATE project_resources SET forbidden = TRUE WHERE id = 1 AND project_id = 1 AND resource_id = 1;
+			UPDATE project_resources SET forbidden = TRUE WHERE id = 3 AND project_id = 2 AND resource_id = 1;
+			UPDATE project_services SET scraped_at = %[1]d, checked_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND service_id = 1;
+			UPDATE project_services SET scraped_at = %[3]d, checked_at = %[3]d, next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND service_id = 1;
 		`,
 		scrapedAt1.Unix(), scrapedAt1.Add(scrapeInterval).Unix(),
 		scrapedAt2.Unix(), scrapedAt2.Add(scrapeInterval).Unix(),
@@ -339,10 +339,10 @@ func Test_ScrapeSuccess(t *testing.T) {
 	scrapedAt1 = s.Clock.Now().Add(-5 * time.Second)
 	scrapedAt2 = s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`
-			UPDATE project_resources_v2 SET forbidden = FALSE WHERE id = 1 AND project_id = 1 AND resource_id = 1;
-			UPDATE project_resources_v2 SET forbidden = FALSE WHERE id = 3 AND project_id = 2 AND resource_id = 1;
-			UPDATE project_services_v2 SET scraped_at = %[1]d, checked_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND service_id = 1;
-			UPDATE project_services_v2 SET scraped_at = %[3]d, checked_at = %[3]d, next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND service_id = 1;
+			UPDATE project_resources SET forbidden = FALSE WHERE id = 1 AND project_id = 1 AND resource_id = 1;
+			UPDATE project_resources SET forbidden = FALSE WHERE id = 3 AND project_id = 2 AND resource_id = 1;
+			UPDATE project_services SET scraped_at = %[1]d, checked_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND service_id = 1;
+			UPDATE project_services SET scraped_at = %[3]d, checked_at = %[3]d, next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND service_id = 1;
 		`,
 		scrapedAt1.Unix(), scrapedAt1.Add(scrapeInterval).Unix(),
 		scrapedAt2.Unix(), scrapedAt2.Add(scrapeInterval).Unix(),
@@ -351,11 +351,11 @@ func Test_ScrapeSuccess(t *testing.T) {
 	// set some new quota values and align the report values with it, so nothing changes when next Scrape happens
 	serviceUsageReport.Resources["capacity"].Quota = Some[int64](20)
 	serviceUsageReport.Resources["things"].Quota = Some[int64](13)
-	_, err := s.DB.Exec(`UPDATE project_resources_v2 ps SET quota = $1 FROM cluster_resources cs WHERE ps.resource_id = cs.id AND cs.name = $2`, 20, "capacity")
+	_, err := s.DB.Exec(`UPDATE project_resources ps SET quota = $1 FROM cluster_resources cs WHERE ps.resource_id = cs.id AND cs.name = $2`, 20, "capacity")
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = s.DB.Exec(`UPDATE project_resources_v2 ps SET quota = $1 FROM cluster_resources cs WHERE ps.resource_id = cs.id AND cs.name = $2`, 13, "things")
+	_, err = s.DB.Exec(`UPDATE project_resources ps SET quota = $1 FROM cluster_resources cs WHERE ps.resource_id = cs.id AND cs.name = $2`, 13, "things")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -371,8 +371,8 @@ func Test_ScrapeSuccess(t *testing.T) {
 	failedAt1 := s.Clock.Now().Add(-5 * time.Second)
 	failedAt2 := s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`
-		UPDATE project_services_v2 SET quota_desynced_at = %[1]d, quota_sync_duration_secs = 5 WHERE id = 1 AND project_id = 1 AND service_id = 1;
-		UPDATE project_services_v2 SET quota_desynced_at = %[2]d, quota_sync_duration_secs = 5 WHERE id = 2 AND project_id = 2 AND service_id = 1;
+		UPDATE project_services SET quota_desynced_at = %[1]d, quota_sync_duration_secs = 5 WHERE id = 1 AND project_id = 1 AND service_id = 1;
+		UPDATE project_services SET quota_desynced_at = %[2]d, quota_sync_duration_secs = 5 WHERE id = 2 AND project_id = 2 AND service_id = 1;
 	`,
 		failedAt1.Add(30*time.Second).Unix(),
 		failedAt2.Add(30*time.Second).Unix(),
@@ -383,12 +383,12 @@ func Test_ScrapeSuccess(t *testing.T) {
 	mustT(t, syncJob.ProcessOne(s.Ctx, withLabel))
 	mustT(t, syncJob.ProcessOne(s.Ctx, withLabel))
 	tr.DBChanges().AssertEqualf(`
-		UPDATE project_resources_v2 SET backend_quota = 20 WHERE id = 1 AND project_id = 1 AND resource_id = 1;
-		UPDATE project_resources_v2 SET backend_quota = 13 WHERE id = 2 AND project_id = 1 AND resource_id = 2;
-		UPDATE project_resources_v2 SET backend_quota = 20 WHERE id = 3 AND project_id = 2 AND resource_id = 1;
-		UPDATE project_resources_v2 SET backend_quota = 13 WHERE id = 4 AND project_id = 2 AND resource_id = 2;
-		UPDATE project_services_v2 SET quota_desynced_at = NULL WHERE id = 1 AND project_id = 1 AND service_id = 1;
-		UPDATE project_services_v2 SET quota_desynced_at = NULL WHERE id = 2 AND project_id = 2 AND service_id = 1;
+		UPDATE project_resources SET backend_quota = 20 WHERE id = 1 AND project_id = 1 AND resource_id = 1;
+		UPDATE project_resources SET backend_quota = 13 WHERE id = 2 AND project_id = 1 AND resource_id = 2;
+		UPDATE project_resources SET backend_quota = 20 WHERE id = 3 AND project_id = 2 AND resource_id = 1;
+		UPDATE project_resources SET backend_quota = 13 WHERE id = 4 AND project_id = 2 AND resource_id = 2;
+		UPDATE project_services SET quota_desynced_at = NULL WHERE id = 1 AND project_id = 1 AND service_id = 1;
+		UPDATE project_services SET quota_desynced_at = NULL WHERE id = 2 AND project_id = 2 AND service_id = 1;
 	`)
 
 	// test SyncQuotaToBackendJob not having anything to do
@@ -403,8 +403,8 @@ func Test_ScrapeSuccess(t *testing.T) {
 	scrapedAt1 = s.Clock.Now().Add(-5 * time.Second)
 	scrapedAt2 = s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`
-		UPDATE project_services_v2 SET scraped_at = %[1]d, checked_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND service_id = 1;
-		UPDATE project_services_v2 SET scraped_at = %[3]d, checked_at = %[3]d, next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND service_id = 1;
+		UPDATE project_services SET scraped_at = %[1]d, checked_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND service_id = 1;
+		UPDATE project_services SET scraped_at = %[3]d, checked_at = %[3]d, next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND service_id = 1;
 	`,
 		scrapedAt1.Unix(), scrapedAt1.Add(scrapeInterval).Unix(),
 		scrapedAt2.Unix(), scrapedAt2.Add(scrapeInterval).Unix(),
@@ -423,10 +423,10 @@ func Test_ScrapeSuccess(t *testing.T) {
 	scrapedAt1 = s.Clock.Now().Add(-5 * time.Second)
 	scrapedAt2 = s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`
-		UPDATE project_az_resources_v2 SET usage = 20, physical_usage = 10, historical_usage = '{"t":[%[5]d,%[1]d],"v":[0,20]}' WHERE id = 2 AND project_id = 1 AND az_resource_id = 2;
-		UPDATE project_az_resources_v2 SET usage = 20, physical_usage = 10, historical_usage = '{"t":[%[6]d,%[3]d],"v":[0,20]}' WHERE id = 8 AND project_id = 2 AND az_resource_id = 2;
-		UPDATE project_services_v2 SET scraped_at = %[1]d, serialized_metrics = '{"limes_unittest_capacity_usage":{"lk":null,"m":[{"v":20,"l":null}]},"limes_unittest_things_usage":{"lk":null,"m":[{"v":3,"l":null}]}}', checked_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND service_id = 1;
-		UPDATE project_services_v2 SET scraped_at = %[3]d, serialized_metrics = '{"limes_unittest_capacity_usage":{"lk":null,"m":[{"v":20,"l":null}]},"limes_unittest_things_usage":{"lk":null,"m":[{"v":3,"l":null}]}}', checked_at = %[3]d, next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND service_id = 1;
+		UPDATE project_az_resources SET usage = 20, physical_usage = 10, historical_usage = '{"t":[%[5]d,%[1]d],"v":[0,20]}' WHERE id = 2 AND project_id = 1 AND az_resource_id = 2;
+		UPDATE project_az_resources SET usage = 20, physical_usage = 10, historical_usage = '{"t":[%[6]d,%[3]d],"v":[0,20]}' WHERE id = 8 AND project_id = 2 AND az_resource_id = 2;
+		UPDATE project_services SET scraped_at = %[1]d, serialized_metrics = '{"limes_unittest_capacity_usage":{"lk":null,"m":[{"v":20,"l":null}]},"limes_unittest_things_usage":{"lk":null,"m":[{"v":3,"l":null}]}}', checked_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND service_id = 1;
+		UPDATE project_services SET scraped_at = %[3]d, serialized_metrics = '{"limes_unittest_capacity_usage":{"lk":null,"m":[{"v":20,"l":null}]},"limes_unittest_things_usage":{"lk":null,"m":[{"v":3,"l":null}]}}', checked_at = %[3]d, next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND service_id = 1;
 	`,
 		scrapedAt1.Unix(), scrapedAt1.Add(scrapeInterval).Unix(),
 		scrapedAt2.Unix(), scrapedAt2.Add(scrapeInterval).Unix(),
@@ -443,7 +443,7 @@ func Test_ScrapeSuccess(t *testing.T) {
 	buf, err := json.Marshal(creationContext)
 	mustT(t, err)
 	for idx, amount := range []uint64{7, 8} {
-		mustT(t, s.DB.Insert(&db.ProjectCommitmentV2{
+		mustT(t, s.DB.Insert(&db.ProjectCommitment{
 			UUID:                db.ProjectCommitmentUUID(fmt.Sprintf("00000000-0000-0000-0000-%012d", idx+1)),
 			ProjectID:           1,
 			AZResourceID:        2,
@@ -459,7 +459,7 @@ func Test_ScrapeSuccess(t *testing.T) {
 		}))
 	}
 	// AZResourceID = 8 has two commitments in different states to test aggregation over different states
-	mustT(t, s.DB.Insert(&db.ProjectCommitmentV2{
+	mustT(t, s.DB.Insert(&db.ProjectCommitment{
 		UUID:                "00000000-0000-0000-0000-000000000003",
 		ProjectID:           2,
 		AZResourceID:        2,
@@ -473,7 +473,7 @@ func Test_ScrapeSuccess(t *testing.T) {
 		State:               db.CommitmentStateActive,
 		CreationContextJSON: buf,
 	}))
-	mustT(t, s.DB.Insert(&db.ProjectCommitmentV2{
+	mustT(t, s.DB.Insert(&db.ProjectCommitment{
 		UUID:                "00000000-0000-0000-0000-000000000004",
 		ProjectID:           2,
 		AZResourceID:        2,
@@ -508,12 +508,12 @@ func Test_ScrapeSuccess(t *testing.T) {
 	scrapedAt1 = s.Clock.Now().Add(-5 * time.Second)
 	scrapedAt2 = s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`
-		UPDATE project_rates_v2 SET usage_as_bigint = '2048' WHERE id = 3 AND project_id = 1 AND rate_id = 1;
-		UPDATE project_rates_v2 SET usage_as_bigint = '4096' WHERE id = 4 AND project_id = 1 AND rate_id = 2;
-		UPDATE project_rates_v2 SET usage_as_bigint = '4096' WHERE id = 5 AND project_id = 2 AND rate_id = 1;
-		UPDATE project_rates_v2 SET usage_as_bigint = '8192' WHERE id = 6 AND project_id = 2 AND rate_id = 2;
-		UPDATE project_services_v2 SET scraped_at = %[1]d, serialized_scrape_state = '{"firstrate":2048,"secondrate":4096}', checked_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND service_id = 1;
-		UPDATE project_services_v2 SET scraped_at = %[3]d, serialized_scrape_state = '{"firstrate":4096,"secondrate":8192}', checked_at = %[3]d, next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND service_id = 1;
+		UPDATE project_rates SET usage_as_bigint = '2048' WHERE id = 3 AND project_id = 1 AND rate_id = 1;
+		UPDATE project_rates SET usage_as_bigint = '4096' WHERE id = 4 AND project_id = 1 AND rate_id = 2;
+		UPDATE project_rates SET usage_as_bigint = '4096' WHERE id = 5 AND project_id = 2 AND rate_id = 1;
+		UPDATE project_rates SET usage_as_bigint = '8192' WHERE id = 6 AND project_id = 2 AND rate_id = 2;
+		UPDATE project_services SET scraped_at = %[1]d, serialized_scrape_state = '{"firstrate":2048,"secondrate":4096}', checked_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND service_id = 1;
+		UPDATE project_services SET scraped_at = %[3]d, serialized_scrape_state = '{"firstrate":4096,"secondrate":8192}', checked_at = %[3]d, next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND service_id = 1;
 	`,
 		scrapedAt1.Unix(), scrapedAt1.Add(scrapeInterval).Unix(),
 		scrapedAt2.Unix(), scrapedAt2.Add(scrapeInterval).Unix(),
@@ -580,16 +580,16 @@ func Test_ScrapeFailure(t *testing.T) {
 	checkedAt1 := s.Clock.Now().Add(-5 * time.Second)
 	checkedAt2 := s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (1, 1, 1, 0);
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (2, 1, 5, 0);
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (3, 2, 1, 0);
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (4, 2, 5, 0);
-		INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (1, 1, 1, 0, -1);
-		INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (2, 1, 2, 0, -1);
-		INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (3, 2, 1, 0, -1);
-		INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (4, 2, 2, 0, -1);
-		UPDATE project_services_v2 SET scraped_at = 0, stale = FALSE, checked_at = %[1]d, scrape_error_message = 'GetUsageReport failed as requested', next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND service_id = 1;
-		UPDATE project_services_v2 SET scraped_at = 0, stale = FALSE, checked_at = %[3]d, scrape_error_message = 'GetUsageReport failed as requested', next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND service_id = 1;
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (1, 1, 1, 0);
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (2, 1, 5, 0);
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (3, 2, 1, 0);
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (4, 2, 5, 0);
+		INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (1, 1, 1, 0, -1);
+		INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (2, 1, 2, 0, -1);
+		INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (3, 2, 1, 0, -1);
+		INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (4, 2, 2, 0, -1);
+		UPDATE project_services SET scraped_at = 0, stale = FALSE, checked_at = %[1]d, scrape_error_message = 'GetUsageReport failed as requested', next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND service_id = 1;
+		UPDATE project_services SET scraped_at = 0, stale = FALSE, checked_at = %[3]d, scrape_error_message = 'GetUsageReport failed as requested', next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND service_id = 1;
 	`,
 		checkedAt1.Unix(), checkedAt1.Add(recheckInterval).Unix(),
 		checkedAt2.Unix(), checkedAt2.Add(recheckInterval).Unix(),
@@ -603,8 +603,8 @@ func Test_ScrapeFailure(t *testing.T) {
 	checkedAt1 = s.Clock.Now().Add(-5 * time.Second)
 	checkedAt2 = s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`
-		UPDATE project_services_v2 SET checked_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND service_id = 1;
-		UPDATE project_services_v2 SET checked_at = %[3]d, next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND service_id = 1;
+		UPDATE project_services SET checked_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND service_id = 1;
+		UPDATE project_services SET checked_at = %[3]d, next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND service_id = 1;
 	`,
 		checkedAt1.Unix(), checkedAt1.Add(recheckInterval).Unix(),
 		checkedAt2.Unix(), checkedAt2.Add(recheckInterval).Unix(),
@@ -622,28 +622,28 @@ func Test_ScrapeFailure(t *testing.T) {
 	scrapedAt1 := s.Clock.Now().Add(-5 * time.Second)
 	scrapedAt2 := s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`
-		UPDATE project_az_resources_v2 SET historical_usage = '{"t":[%[1]d],"v":[0]}' WHERE id = 1 AND project_id = 1 AND az_resource_id = 1;
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, physical_usage, historical_usage) VALUES (10, 2, 3, 0, 0, '{"t":[%[3]d],"v":[0]}');
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, subresources, historical_usage) VALUES (11, 2, 6, 2, '[{"name":"index","usage":0},{"name":"index","usage":1}]', '{"t":[%[3]d],"v":[2]}');
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, subresources, historical_usage) VALUES (12, 2, 7, 2, '[{"name":"index","usage":2},{"name":"index","usage":3}]', '{"t":[%[3]d],"v":[2]}');
-		UPDATE project_az_resources_v2 SET historical_usage = '{"t":[%[1]d],"v":[0]}' WHERE id = 2 AND project_id = 1 AND az_resource_id = 5;
-		UPDATE project_az_resources_v2 SET historical_usage = '{"t":[%[3]d],"v":[0]}' WHERE id = 3 AND project_id = 2 AND az_resource_id = 1;
-		UPDATE project_az_resources_v2 SET historical_usage = '{"t":[%[3]d],"v":[0]}' WHERE id = 4 AND project_id = 2 AND az_resource_id = 5;
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, physical_usage, historical_usage) VALUES (5, 1, 2, 0, 0, '{"t":[%[1]d],"v":[0]}');
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, physical_usage, historical_usage) VALUES (6, 1, 3, 0, 0, '{"t":[%[1]d],"v":[0]}');
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, subresources, historical_usage) VALUES (7, 1, 6, 2, '[{"name":"index","usage":0},{"name":"index","usage":1}]', '{"t":[%[1]d],"v":[2]}');
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, subresources, historical_usage) VALUES (8, 1, 7, 2, '[{"name":"index","usage":2},{"name":"index","usage":3}]', '{"t":[%[1]d],"v":[2]}');
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, physical_usage, historical_usage) VALUES (9, 2, 2, 0, 0, '{"t":[%[3]d],"v":[0]}');
-		INSERT INTO project_rates_v2 (id, project_id, rate_id, usage_as_bigint) VALUES (3, 1, 1, '1024');
-		INSERT INTO project_rates_v2 (id, project_id, rate_id, usage_as_bigint) VALUES (4, 1, 2, '2048');
-		INSERT INTO project_rates_v2 (id, project_id, rate_id, usage_as_bigint) VALUES (5, 2, 1, '1024');
-		INSERT INTO project_rates_v2 (id, project_id, rate_id, usage_as_bigint) VALUES (6, 2, 2, '2048');
-		UPDATE project_resources_v2 SET backend_quota = 100 WHERE id = 1 AND project_id = 1 AND resource_id = 1;
-		UPDATE project_resources_v2 SET backend_quota = 42 WHERE id = 2 AND project_id = 1 AND resource_id = 2;
-		UPDATE project_resources_v2 SET backend_quota = 100 WHERE id = 3 AND project_id = 2 AND resource_id = 1;
-		UPDATE project_resources_v2 SET backend_quota = 42 WHERE id = 4 AND project_id = 2 AND resource_id = 2;
-		UPDATE project_services_v2 SET scraped_at = %[1]d, scrape_duration_secs = 5, serialized_scrape_state = '{"firstrate":1024,"secondrate":2048}', serialized_metrics = '{"limes_unittest_capacity_usage":{"lk":null,"m":[{"v":0,"l":null}]},"limes_unittest_things_usage":{"lk":null,"m":[{"v":4,"l":null}]}}', checked_at = %[1]d, scrape_error_message = '', next_scrape_at = %[2]d, quota_desynced_at = %[1]d WHERE id = 1 AND project_id = 1 AND service_id = 1;
-		UPDATE project_services_v2 SET scraped_at = %[3]d, scrape_duration_secs = 5, serialized_scrape_state = '{"firstrate":1024,"secondrate":2048}', serialized_metrics = '{"limes_unittest_capacity_usage":{"lk":null,"m":[{"v":0,"l":null}]},"limes_unittest_things_usage":{"lk":null,"m":[{"v":4,"l":null}]}}', checked_at = %[3]d, scrape_error_message = '', next_scrape_at = %[4]d, quota_desynced_at = %[3]d WHERE id = 2 AND project_id = 2 AND service_id = 1;
+		UPDATE project_az_resources SET historical_usage = '{"t":[%[1]d],"v":[0]}' WHERE id = 1 AND project_id = 1 AND az_resource_id = 1;
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, physical_usage, historical_usage) VALUES (10, 2, 3, 0, 0, '{"t":[%[3]d],"v":[0]}');
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, subresources, historical_usage) VALUES (11, 2, 6, 2, '[{"name":"index","usage":0},{"name":"index","usage":1}]', '{"t":[%[3]d],"v":[2]}');
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, subresources, historical_usage) VALUES (12, 2, 7, 2, '[{"name":"index","usage":2},{"name":"index","usage":3}]', '{"t":[%[3]d],"v":[2]}');
+		UPDATE project_az_resources SET historical_usage = '{"t":[%[1]d],"v":[0]}' WHERE id = 2 AND project_id = 1 AND az_resource_id = 5;
+		UPDATE project_az_resources SET historical_usage = '{"t":[%[3]d],"v":[0]}' WHERE id = 3 AND project_id = 2 AND az_resource_id = 1;
+		UPDATE project_az_resources SET historical_usage = '{"t":[%[3]d],"v":[0]}' WHERE id = 4 AND project_id = 2 AND az_resource_id = 5;
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, physical_usage, historical_usage) VALUES (5, 1, 2, 0, 0, '{"t":[%[1]d],"v":[0]}');
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, physical_usage, historical_usage) VALUES (6, 1, 3, 0, 0, '{"t":[%[1]d],"v":[0]}');
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, subresources, historical_usage) VALUES (7, 1, 6, 2, '[{"name":"index","usage":0},{"name":"index","usage":1}]', '{"t":[%[1]d],"v":[2]}');
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, subresources, historical_usage) VALUES (8, 1, 7, 2, '[{"name":"index","usage":2},{"name":"index","usage":3}]', '{"t":[%[1]d],"v":[2]}');
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, physical_usage, historical_usage) VALUES (9, 2, 2, 0, 0, '{"t":[%[3]d],"v":[0]}');
+		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (3, 1, 1, '1024');
+		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (4, 1, 2, '2048');
+		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (5, 2, 1, '1024');
+		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (6, 2, 2, '2048');
+		UPDATE project_resources SET backend_quota = 100 WHERE id = 1 AND project_id = 1 AND resource_id = 1;
+		UPDATE project_resources SET backend_quota = 42 WHERE id = 2 AND project_id = 1 AND resource_id = 2;
+		UPDATE project_resources SET backend_quota = 100 WHERE id = 3 AND project_id = 2 AND resource_id = 1;
+		UPDATE project_resources SET backend_quota = 42 WHERE id = 4 AND project_id = 2 AND resource_id = 2;
+		UPDATE project_services SET scraped_at = %[1]d, scrape_duration_secs = 5, serialized_scrape_state = '{"firstrate":1024,"secondrate":2048}', serialized_metrics = '{"limes_unittest_capacity_usage":{"lk":null,"m":[{"v":0,"l":null}]},"limes_unittest_things_usage":{"lk":null,"m":[{"v":4,"l":null}]}}', checked_at = %[1]d, scrape_error_message = '', next_scrape_at = %[2]d, quota_desynced_at = %[1]d WHERE id = 1 AND project_id = 1 AND service_id = 1;
+		UPDATE project_services SET scraped_at = %[3]d, scrape_duration_secs = 5, serialized_scrape_state = '{"firstrate":1024,"secondrate":2048}', serialized_metrics = '{"limes_unittest_capacity_usage":{"lk":null,"m":[{"v":0,"l":null}]},"limes_unittest_things_usage":{"lk":null,"m":[{"v":4,"l":null}]}}', checked_at = %[3]d, scrape_error_message = '', next_scrape_at = %[4]d, quota_desynced_at = %[3]d WHERE id = 2 AND project_id = 2 AND service_id = 1;
 	`,
 		scrapedAt1.Unix(), scrapedAt1.Add(scrapeInterval).Unix(),
 		scrapedAt2.Unix(), scrapedAt2.Add(scrapeInterval).Unix(),
@@ -660,8 +660,8 @@ func Test_ScrapeFailure(t *testing.T) {
 	checkedAt1 = s.Clock.Now().Add(-5 * time.Second)
 	checkedAt2 = s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`
-		UPDATE project_services_v2 SET checked_at = %[1]d, scrape_error_message = 'GetUsageReport failed as requested', next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND service_id = 1;
-		UPDATE project_services_v2 SET checked_at = %[3]d, scrape_error_message = 'GetUsageReport failed as requested', next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND service_id = 1;
+		UPDATE project_services SET checked_at = %[1]d, scrape_error_message = 'GetUsageReport failed as requested', next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND service_id = 1;
+		UPDATE project_services SET checked_at = %[3]d, scrape_error_message = 'GetUsageReport failed as requested', next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND service_id = 1;
 	`,
 		checkedAt1.Unix(), checkedAt1.Add(recheckInterval).Unix(),
 		checkedAt2.Unix(), checkedAt2.Add(recheckInterval).Unix(),
@@ -716,7 +716,7 @@ func Test_ScrapeButNoResources(t *testing.T) {
 	tr0.AssertEqualf(`
 		INSERT INTO cluster_services (id, type, next_scrape_at, liquid_version) VALUES (1, 'noop', %[1]d, 1);
 		INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
-		INSERT INTO project_services_v2 (id, project_id, service_id, scraped_at, scrape_duration_secs, serialized_metrics, checked_at, next_scrape_at) VALUES (1, 1, 1, %[2]d, 5, '{}', %[2]d, %[3]d);
+		INSERT INTO project_services (id, project_id, service_id, scraped_at, scrape_duration_secs, serialized_metrics, checked_at, next_scrape_at) VALUES (1, 1, 1, %[2]d, 5, '{}', %[2]d, %[3]d);
 		INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany');
 	`,
 		initialTime.Unix(), scrapedAt.Unix(), scrapedAt.Add(scrapeInterval).Unix(),
@@ -763,9 +763,9 @@ func Test_ScrapeReturnsNoUsageData(t *testing.T) {
 		INSERT INTO cluster_resources (id, service_id, name, liquid_version, topology, has_quota) VALUES (1, 1, 'things', 1, 'az-aware', TRUE);
 		INSERT INTO cluster_services (id, type, next_scrape_at, liquid_version) VALUES (1, 'noop', %[1]d, 1);
 		INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage) VALUES (1, 1, 1, 0);
-		INSERT INTO project_resources_v2 (id, project_id, resource_id, quota, backend_quota) VALUES (1, 1, 1, 0, -1);
-		INSERT INTO project_services_v2 (id, project_id, service_id, scraped_at, checked_at, scrape_error_message, next_scrape_at) VALUES (1, 1, 1, 0, %[2]d, 'received ServiceUsageReport is invalid: missing value for .Resources["things"]', %[3]d);
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage) VALUES (1, 1, 1, 0);
+		INSERT INTO project_resources (id, project_id, resource_id, quota, backend_quota) VALUES (1, 1, 1, 0, -1);
+		INSERT INTO project_services (id, project_id, service_id, scraped_at, checked_at, scrape_error_message, next_scrape_at) VALUES (1, 1, 1, 0, %[2]d, 'received ServiceUsageReport is invalid: missing value for .Resources["things"]', %[3]d);
 		INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany');
 	`,
 		initialTime.Unix(), scrapedAt.Unix(), scrapedAt.Add(recheckInterval).Unix(),
@@ -805,39 +805,39 @@ func Test_TopologyScrapes(t *testing.T) {
 	scrapedAt1 := s.Clock.Now().Add(-5 * time.Second)
 	scrapedAt2 := s.Clock.Now()
 	tr.DBChanges().AssertEqualf(`
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, physical_usage, historical_usage, backend_quota) VALUES (1, 1, 2, 0, 0, '{"t":[%[1]d],"v":[0]}', 50);
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, physical_usage, historical_usage, backend_quota) VALUES (2, 1, 3, 0, 0, '{"t":[%[1]d],"v":[0]}', 50);
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, subresources, historical_usage, backend_quota) VALUES (3, 1, 6, 2, '[{"name":"index","usage":0},{"name":"index","usage":1}]', '{"t":[%[1]d],"v":[2]}', 21);
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, subresources, historical_usage, backend_quota) VALUES (4, 1, 7, 2, '[{"name":"index","usage":2},{"name":"index","usage":3}]', '{"t":[%[1]d],"v":[2]}', 21);
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, physical_usage, historical_usage, backend_quota) VALUES (5, 2, 2, 0, 0, '{"t":[%[3]d],"v":[0]}', 50);
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, physical_usage, historical_usage, backend_quota) VALUES (6, 2, 3, 0, 0, '{"t":[%[3]d],"v":[0]}', 50);
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, subresources, historical_usage, backend_quota) VALUES (7, 2, 6, 2, '[{"name":"index","usage":0},{"name":"index","usage":1}]', '{"t":[%[3]d],"v":[2]}', 21);
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, subresources, historical_usage, backend_quota) VALUES (8, 2, 7, 2, '[{"name":"index","usage":2},{"name":"index","usage":3}]', '{"t":[%[3]d],"v":[2]}', 21);
-		INSERT INTO project_rates_v2 (id, project_id, rate_id, usage_as_bigint) VALUES (3, 1, 1, '1024');
-		INSERT INTO project_rates_v2 (id, project_id, rate_id, usage_as_bigint) VALUES (4, 1, 2, '2048');
-		INSERT INTO project_rates_v2 (id, project_id, rate_id, usage_as_bigint) VALUES (5, 2, 1, '1024');
-		INSERT INTO project_rates_v2 (id, project_id, rate_id, usage_as_bigint) VALUES (6, 2, 2, '2048');
-		INSERT INTO project_resources_v2 (id, project_id, resource_id) VALUES (1, 1, 1);
-		INSERT INTO project_resources_v2 (id, project_id, resource_id) VALUES (2, 1, 2);
-		INSERT INTO project_resources_v2 (id, project_id, resource_id) VALUES (3, 2, 1);
-		INSERT INTO project_resources_v2 (id, project_id, resource_id) VALUES (4, 2, 2);
-		UPDATE project_services_v2 SET scraped_at = %[1]d, stale = FALSE, scrape_duration_secs = 5, serialized_scrape_state = '{"firstrate":1024,"secondrate":2048}', serialized_metrics = '{"limes_unittest_capacity_usage":{"lk":null,"m":[{"v":0,"l":null}]},"limes_unittest_things_usage":{"lk":null,"m":[{"v":4,"l":null}]}}', checked_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND service_id = 1;
-		UPDATE project_services_v2 SET scraped_at = %[3]d, stale = FALSE, scrape_duration_secs = 5, serialized_scrape_state = '{"firstrate":1024,"secondrate":2048}', serialized_metrics = '{"limes_unittest_capacity_usage":{"lk":null,"m":[{"v":0,"l":null}]},"limes_unittest_things_usage":{"lk":null,"m":[{"v":4,"l":null}]}}', checked_at = %[3]d, next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND service_id = 1;
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, physical_usage, historical_usage, backend_quota) VALUES (1, 1, 2, 0, 0, '{"t":[%[1]d],"v":[0]}', 50);
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, physical_usage, historical_usage, backend_quota) VALUES (2, 1, 3, 0, 0, '{"t":[%[1]d],"v":[0]}', 50);
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, subresources, historical_usage, backend_quota) VALUES (3, 1, 6, 2, '[{"name":"index","usage":0},{"name":"index","usage":1}]', '{"t":[%[1]d],"v":[2]}', 21);
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, subresources, historical_usage, backend_quota) VALUES (4, 1, 7, 2, '[{"name":"index","usage":2},{"name":"index","usage":3}]', '{"t":[%[1]d],"v":[2]}', 21);
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, physical_usage, historical_usage, backend_quota) VALUES (5, 2, 2, 0, 0, '{"t":[%[3]d],"v":[0]}', 50);
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, physical_usage, historical_usage, backend_quota) VALUES (6, 2, 3, 0, 0, '{"t":[%[3]d],"v":[0]}', 50);
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, subresources, historical_usage, backend_quota) VALUES (7, 2, 6, 2, '[{"name":"index","usage":0},{"name":"index","usage":1}]', '{"t":[%[3]d],"v":[2]}', 21);
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, subresources, historical_usage, backend_quota) VALUES (8, 2, 7, 2, '[{"name":"index","usage":2},{"name":"index","usage":3}]', '{"t":[%[3]d],"v":[2]}', 21);
+		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (3, 1, 1, '1024');
+		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (4, 1, 2, '2048');
+		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (5, 2, 1, '1024');
+		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (6, 2, 2, '2048');
+		INSERT INTO project_resources (id, project_id, resource_id) VALUES (1, 1, 1);
+		INSERT INTO project_resources (id, project_id, resource_id) VALUES (2, 1, 2);
+		INSERT INTO project_resources (id, project_id, resource_id) VALUES (3, 2, 1);
+		INSERT INTO project_resources (id, project_id, resource_id) VALUES (4, 2, 2);
+		UPDATE project_services SET scraped_at = %[1]d, stale = FALSE, scrape_duration_secs = 5, serialized_scrape_state = '{"firstrate":1024,"secondrate":2048}', serialized_metrics = '{"limes_unittest_capacity_usage":{"lk":null,"m":[{"v":0,"l":null}]},"limes_unittest_things_usage":{"lk":null,"m":[{"v":4,"l":null}]}}', checked_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND service_id = 1;
+		UPDATE project_services SET scraped_at = %[3]d, stale = FALSE, scrape_duration_secs = 5, serialized_scrape_state = '{"firstrate":1024,"secondrate":2048}', serialized_metrics = '{"limes_unittest_capacity_usage":{"lk":null,"m":[{"v":0,"l":null}]},"limes_unittest_things_usage":{"lk":null,"m":[{"v":4,"l":null}]}}', checked_at = %[3]d, next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND service_id = 1;
 		`,
 		scrapedAt1.Unix(), scrapedAt1.Add(scrapeInterval).Unix(),
 		scrapedAt2.Unix(), scrapedAt2.Add(scrapeInterval).Unix(),
 	)
 
 	// set some quota acpq values.
-	_, err := s.DB.Exec(`UPDATE project_az_resources_v2 SET quota = $1 WHERE az_resource_id BETWEEN 2 AND 4`, 20)
+	_, err := s.DB.Exec(`UPDATE project_az_resources SET quota = $1 WHERE az_resource_id BETWEEN 2 AND 4`, 20)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = s.DB.Exec(`UPDATE project_az_resources_v2 SET quota = $1 WHERE az_resource_id BETWEEN 6 AND 8`, 13)
+	_, err = s.DB.Exec(`UPDATE project_az_resources SET quota = $1 WHERE az_resource_id BETWEEN 6 AND 8`, 13)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = s.DB.Exec(`UPDATE project_services_v2 SET quota_desynced_at = $1`, s.Clock.Now())
+	_, err = s.DB.Exec(`UPDATE project_services SET quota_desynced_at = $1`, s.Clock.Now())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -847,16 +847,16 @@ func Test_TopologyScrapes(t *testing.T) {
 	mustT(t, syncJob.ProcessOne(s.Ctx, withLabel))
 
 	tr.DBChanges().AssertEqualf(`
-		UPDATE project_az_resources_v2 SET backend_quota = 20 WHERE id = 1 AND project_id = 1 AND az_resource_id = 2;
-		UPDATE project_az_resources_v2 SET backend_quota = 20 WHERE id = 2 AND project_id = 1 AND az_resource_id = 3;
-		UPDATE project_az_resources_v2 SET backend_quota = 13 WHERE id = 3 AND project_id = 1 AND az_resource_id = 6;
-		UPDATE project_az_resources_v2 SET backend_quota = 13 WHERE id = 4 AND project_id = 1 AND az_resource_id = 7;
-		UPDATE project_az_resources_v2 SET backend_quota = 20 WHERE id = 5 AND project_id = 2 AND az_resource_id = 2;
-		UPDATE project_az_resources_v2 SET backend_quota = 20 WHERE id = 6 AND project_id = 2 AND az_resource_id = 3;
-		UPDATE project_az_resources_v2 SET backend_quota = 13 WHERE id = 7 AND project_id = 2 AND az_resource_id = 6;
-		UPDATE project_az_resources_v2 SET backend_quota = 13 WHERE id = 8 AND project_id = 2 AND az_resource_id = 7;
-		UPDATE project_services_v2 SET quota_desynced_at = NULL, quota_sync_duration_secs = 5 WHERE id = 1 AND project_id = 1 AND service_id = 1;
-		UPDATE project_services_v2 SET quota_desynced_at = NULL, quota_sync_duration_secs = 5 WHERE id = 2 AND project_id = 2 AND service_id = 1;
+		UPDATE project_az_resources SET backend_quota = 20 WHERE id = 1 AND project_id = 1 AND az_resource_id = 2;
+		UPDATE project_az_resources SET backend_quota = 20 WHERE id = 2 AND project_id = 1 AND az_resource_id = 3;
+		UPDATE project_az_resources SET backend_quota = 13 WHERE id = 3 AND project_id = 1 AND az_resource_id = 6;
+		UPDATE project_az_resources SET backend_quota = 13 WHERE id = 4 AND project_id = 1 AND az_resource_id = 7;
+		UPDATE project_az_resources SET backend_quota = 20 WHERE id = 5 AND project_id = 2 AND az_resource_id = 2;
+		UPDATE project_az_resources SET backend_quota = 20 WHERE id = 6 AND project_id = 2 AND az_resource_id = 3;
+		UPDATE project_az_resources SET backend_quota = 13 WHERE id = 7 AND project_id = 2 AND az_resource_id = 6;
+		UPDATE project_az_resources SET backend_quota = 13 WHERE id = 8 AND project_id = 2 AND az_resource_id = 7;
+		UPDATE project_services SET quota_desynced_at = NULL, quota_sync_duration_secs = 5 WHERE id = 1 AND project_id = 1 AND service_id = 1;
+		UPDATE project_services SET quota_desynced_at = NULL, quota_sync_duration_secs = 5 WHERE id = 2 AND project_id = 2 AND service_id = 1;
 	`)
 
 	s.Clock.StepBy(scrapeInterval)
@@ -887,21 +887,21 @@ func Test_TopologyScrapes(t *testing.T) {
 		UPDATE cluster_resources SET liquid_version = 2 WHERE id = 2 AND service_id = 1 AND name = 'things';
 		DELETE FROM cluster_services WHERE id = 1 AND type = 'unittest' AND liquid_version = 1;
 		INSERT INTO cluster_services (id, type, next_scrape_at, liquid_version, usage_metric_families_json) VALUES (1, 'unittest', 0, 2, '{"limes_unittest_capacity_usage":{"type":"gauge","help":"","labelKeys":null},"limes_unittest_things_usage":{"type":"gauge","help":"","labelKeys":null}}');
-		UPDATE project_az_resources_v2 SET backend_quota = 50 WHERE id = 1 AND project_id = 1 AND az_resource_id = 2;
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, historical_usage) VALUES (10, 2, 5, 0, '{"t":[1830],"v":[0]}');
-		UPDATE project_az_resources_v2 SET backend_quota = 50 WHERE id = 2 AND project_id = 1 AND az_resource_id = 3;
-		UPDATE project_az_resources_v2 SET backend_quota = NULL WHERE id = 3 AND project_id = 1 AND az_resource_id = 6;
-		UPDATE project_az_resources_v2 SET backend_quota = NULL WHERE id = 4 AND project_id = 1 AND az_resource_id = 7;
-		UPDATE project_az_resources_v2 SET backend_quota = 50 WHERE id = 5 AND project_id = 2 AND az_resource_id = 2;
-		UPDATE project_az_resources_v2 SET backend_quota = 50 WHERE id = 6 AND project_id = 2 AND az_resource_id = 3;
-		UPDATE project_az_resources_v2 SET backend_quota = NULL WHERE id = 7 AND project_id = 2 AND az_resource_id = 6;
-		UPDATE project_az_resources_v2 SET backend_quota = NULL WHERE id = 8 AND project_id = 2 AND az_resource_id = 7;
-		INSERT INTO project_az_resources_v2 (id, project_id, az_resource_id, usage, historical_usage) VALUES (9, 1, 5, 0, '{"t":[1825],"v":[0]}');
-		DELETE FROM project_rates_v2 WHERE id = 2 AND project_id = 1 AND rate_id = 4;
-		UPDATE project_resources_v2 SET quota = 0, backend_quota = 42 WHERE id = 2 AND project_id = 1 AND resource_id = 2;
-		UPDATE project_resources_v2 SET quota = 0, backend_quota = 42 WHERE id = 4 AND project_id = 2 AND resource_id = 2;
-		UPDATE project_services_v2 SET scraped_at = %[1]d, checked_at = %[1]d, next_scrape_at = %[2]d, quota_desynced_at = %[1]d WHERE id = 1 AND project_id = 1 AND service_id = 1;
-		UPDATE project_services_v2 SET scraped_at = %[3]d, checked_at = %[3]d, next_scrape_at = %[4]d, quota_desynced_at = %[3]d WHERE id = 2 AND project_id = 2 AND service_id = 1;
+		UPDATE project_az_resources SET backend_quota = 50 WHERE id = 1 AND project_id = 1 AND az_resource_id = 2;
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, historical_usage) VALUES (10, 2, 5, 0, '{"t":[1830],"v":[0]}');
+		UPDATE project_az_resources SET backend_quota = 50 WHERE id = 2 AND project_id = 1 AND az_resource_id = 3;
+		UPDATE project_az_resources SET backend_quota = NULL WHERE id = 3 AND project_id = 1 AND az_resource_id = 6;
+		UPDATE project_az_resources SET backend_quota = NULL WHERE id = 4 AND project_id = 1 AND az_resource_id = 7;
+		UPDATE project_az_resources SET backend_quota = 50 WHERE id = 5 AND project_id = 2 AND az_resource_id = 2;
+		UPDATE project_az_resources SET backend_quota = 50 WHERE id = 6 AND project_id = 2 AND az_resource_id = 3;
+		UPDATE project_az_resources SET backend_quota = NULL WHERE id = 7 AND project_id = 2 AND az_resource_id = 6;
+		UPDATE project_az_resources SET backend_quota = NULL WHERE id = 8 AND project_id = 2 AND az_resource_id = 7;
+		INSERT INTO project_az_resources (id, project_id, az_resource_id, usage, historical_usage) VALUES (9, 1, 5, 0, '{"t":[1825],"v":[0]}');
+		DELETE FROM project_rates WHERE id = 2 AND project_id = 1 AND rate_id = 4;
+		UPDATE project_resources SET quota = 0, backend_quota = 42 WHERE id = 2 AND project_id = 1 AND resource_id = 2;
+		UPDATE project_resources SET quota = 0, backend_quota = 42 WHERE id = 4 AND project_id = 2 AND resource_id = 2;
+		UPDATE project_services SET scraped_at = %[1]d, checked_at = %[1]d, next_scrape_at = %[2]d, quota_desynced_at = %[1]d WHERE id = 1 AND project_id = 1 AND service_id = 1;
+		UPDATE project_services SET scraped_at = %[3]d, checked_at = %[3]d, next_scrape_at = %[4]d, quota_desynced_at = %[3]d WHERE id = 2 AND project_id = 2 AND service_id = 1;
 	`,
 		checkedAt1.Unix(), checkedAt1.Add(scrapeInterval).Unix(),
 		checkedAt2.Unix(), checkedAt2.Add(scrapeInterval).Unix(),

--- a/internal/core/mail.go
+++ b/internal/core/mail.go
@@ -32,7 +32,7 @@ type AZResourceLocation struct {
 
 // CommitmentNotification appears in type CommitmentGroupNotification.
 type CommitmentNotification struct {
-	Commitment db.ProjectCommitmentV2
+	Commitment db.ProjectCommitment
 	DateString string
 	Resource   AZResourceLocation
 }

--- a/internal/datamodel/allocation_stats.go
+++ b/internal/datamodel/allocation_stats.go
@@ -122,8 +122,8 @@ var (
 		  FROM cluster_services cs
 		  JOIN cluster_resources cr ON cr.service_id = cs.id
 		  JOIN cluster_az_resources cazr ON cazr.resource_id = cr.id
-		  JOIN project_az_resources_v2 pazr ON pazr.az_resource_id = cazr.id
-		  LEFT OUTER JOIN project_commitments_v2 pc ON pc.az_resource_id = cazr.id AND pc.project_id = pazr.project_id AND pc.state = 'active'
+		  JOIN project_az_resources pazr ON pazr.az_resource_id = cazr.id
+		  LEFT OUTER JOIN project_commitments pc ON pc.az_resource_id = cazr.id AND pc.project_id = pazr.project_id AND pc.state = 'active'
 		 WHERE cs.type = $1 AND cr.name = $2 AND ($3::text IS NULL OR cazr.az = $3)
 		 GROUP BY pazr.project_id, cazr.az, pazr.usage, pazr.historical_usage
 	`)

--- a/internal/datamodel/apply_computed_project_quota.go
+++ b/internal/datamodel/apply_computed_project_quota.go
@@ -35,7 +35,7 @@ var (
 
 	acpqGetLocalQuotaConstraintsQuery = sqlext.SimplifyWhitespace(`
 		SELECT project_id, forbidden, max_quota_from_outside_admin, max_quota_from_local_admin, override_quota_from_config
-		  FROM project_resources_v2
+		  FROM project_resources
 		 WHERE resource_id = $1 AND (forbidden IS NOT NULL
 		                          OR max_quota_from_outside_admin IS NOT NULL
 		                          OR max_quota_from_local_admin IS NOT NULL
@@ -45,17 +45,17 @@ var (
 	// This does not need to create any entries in project_az_resources, because
 	// Scrape() already created them for us.
 	acpqUpdateAZQuotaQuery = sqlext.SimplifyWhitespace(`
-		UPDATE project_az_resources_v2 pazr
+		UPDATE project_az_resources pazr
 		SET quota = $1
 		FROM cluster_az_resources cazr
 		WHERE pazr.az_resource_id = cazr.id AND cazr.az = $2 AND pazr.project_id = $3 AND cazr.resource_id = $4
 		AND pazr.quota IS DISTINCT FROM $1
 	`)
 	acpqUpdateProjectQuotaQuery = sqlext.SimplifyWhitespace(`
-		UPDATE project_resources_v2 SET quota = $1 WHERE quota IS DISTINCT FROM $1 AND project_id = $2 AND resource_id = $3
+		UPDATE project_resources SET quota = $1 WHERE quota IS DISTINCT FROM $1 AND project_id = $2 AND resource_id = $3
 	`)
 	acpqUpdateProjectServicesQuery = sqlext.SimplifyWhitespace(`
-		UPDATE project_services_v2 ps
+		UPDATE project_services ps
 		SET quota_desynced_at = $1
 		FROM cluster_services cs
 		WHERE ps.service_id = cs.id AND ps.project_id = $2 AND cs.type = $3

--- a/internal/datamodel/confirm_project_commitments.go
+++ b/internal/datamodel/confirm_project_commitments.go
@@ -29,7 +29,7 @@ var (
 		  FROM cluster_services cs
 		  JOIN cluster_resources cr ON cr.service_id = cs.id
 		  JOIN cluster_az_resources cazr ON cazr.resource_id = cr.id
-		  JOIN project_commitments_v2 pc ON pc.az_resource_id = cazr.id
+		  JOIN project_commitments pc ON pc.az_resource_id = cazr.id
 		 WHERE cs.type = $1 AND cr.name = $2 AND cazr.az = $3 AND pc.state = 'pending'
 		 ORDER BY pc.created_at ASC, pc.confirm_by ASC, pc.id ASC
 	`)
@@ -118,7 +118,7 @@ func ConfirmPendingCommitments(loc core.AZResourceLocation, cluster *core.Cluste
 		}
 
 		// confirm the commitment
-		_, err = dbi.Exec(`UPDATE project_commitments_v2 SET confirmed_at = $1, state = $2 WHERE id = $3`,
+		_, err = dbi.Exec(`UPDATE project_commitments SET confirmed_at = $1, state = $2 WHERE id = $3`,
 			now, db.CommitmentStateActive, c.CommitmentID)
 		if err != nil {
 			return nil, fmt.Errorf("while confirming commitment ID=%d for %s/%s in %s: %w", c.CommitmentID, loc.ServiceType, loc.ResourceName, loc.AvailabilityZone, err)
@@ -160,8 +160,8 @@ func prepareConfirmationMail(tpl core.MailTemplate, dbi db.Interface, loc core.A
 		return db.MailNotification{}, err
 	}
 
-	var commitments []db.ProjectCommitmentV2
-	_, err = dbi.Select(&commitments, `SELECT * FROM project_commitments_v2 WHERE id = ANY($1)`, pq.Array(confirmedCommitmentIDs))
+	var commitments []db.ProjectCommitment
+	_, err = dbi.Select(&commitments, `SELECT * FROM project_commitments WHERE id = ANY($1)`, pq.Array(confirmedCommitmentIDs))
 	if err != nil {
 		return db.MailNotification{}, err
 	}

--- a/internal/datamodel/resource_demand.go
+++ b/internal/datamodel/resource_demand.go
@@ -31,12 +31,12 @@ var (
 		  FROM cluster_services cs
 		  JOIN cluster_resources cr ON cr.service_id = cs.id
 		  JOIN cluster_az_resources cazr ON cazr.resource_id = cr.id
-		  JOIN project_az_resources_v2 pazr ON pazr.az_resource_id = cazr.id
+		  JOIN project_az_resources pazr ON pazr.az_resource_id = cazr.id
 		  LEFT OUTER JOIN (
 		    SELECT az_resource_id, project_id,
 		           SUM(amount) FILTER (WHERE state = 'active') AS active,
 		           SUM(amount) FILTER (WHERE state = 'pending') AS pending
-		      FROM project_commitments_v2
+		      FROM project_commitments
 		     GROUP BY az_resource_id, project_id
 		  ) pc_view ON pc_view.az_resource_id = cazr.id AND pc_view.project_id = pazr.project_id
 		 WHERE cs.type = $1 AND cr.name = $2

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -90,8 +90,8 @@ type Project struct {
 	ParentUUID string    `db:"parent_uuid"`
 }
 
-// ProjectServiceV2 contains a record from the `project_services_v2` table.
-type ProjectServiceV2 struct {
+// ProjectService contains a record from the `project_services` table.
+type ProjectService struct {
 	ID                    ProjectServiceID  `db:"id"`
 	ProjectID             ProjectID         `db:"project_id"`
 	ServiceID             ClusterServiceID  `db:"service_id"`
@@ -107,9 +107,9 @@ type ProjectServiceV2 struct {
 	QuotaSyncDurationSecs float64           `db:"quota_sync_duration_secs"`
 }
 
-// ProjectResourceV2 contains a record from the `project_resources_v2` table. Quota
+// ProjectResource contains a record from the `project_resources` table. Quota
 // values are NULL for resources that do not track quota.
-type ProjectResourceV2 struct {
+type ProjectResource struct {
 	ID                       ProjectResourceID `db:"id"`
 	ProjectID                ProjectID         `db:"project_id"`
 	ResourceID               ClusterResourceID `db:"resource_id"`
@@ -121,8 +121,8 @@ type ProjectResourceV2 struct {
 	OverrideQuotaFromConfig  Option[uint64]    `db:"override_quota_from_config"`
 }
 
-// ProjectAZResourceV2 contains a record from the `project_az_resources_v2` table.
-type ProjectAZResourceV2 struct {
+// ProjectAZResource contains a record from the `project_az_resources` table.
+type ProjectAZResource struct {
 	ID                  ProjectAZResourceID `db:"id"`
 	ProjectID           ProjectID           `db:"project_id"`
 	AZResourceID        ClusterAZResourceID `db:"az_resource_id"`
@@ -134,8 +134,8 @@ type ProjectAZResourceV2 struct {
 	HistoricalUsageJSON string              `db:"historical_usage"`
 }
 
-// ProjectRateV2 contains a record from the `project_rates_v2` table.
-type ProjectRateV2 struct {
+// ProjectRate contains a record from the `project_rates` table.
+type ProjectRate struct {
 	ID            ProjectRateID             `db:"id"`
 	ProjectID     ProjectID                 `db:"project_id"`
 	RateID        ClusterRateID             `db:"rate_id"`
@@ -147,8 +147,8 @@ type ProjectRateV2 struct {
 	//  use strings throughout and cast into bigints in the scraper only.
 }
 
-// ProjectCommitmentV2 contains a record from the `project_commitments_v2` table.
-type ProjectCommitmentV2 struct {
+// ProjectCommitment contains a record from the `project_commitments` table.
+type ProjectCommitment struct {
 	ID           ProjectCommitmentID               `db:"id"`
 	UUID         ProjectCommitmentUUID             `db:"uuid"`
 	ProjectID    ProjectID                         `db:"project_id"`
@@ -244,10 +244,10 @@ func initGorp(db *gorp.DbMap) {
 	db.AddTableWithName(ClusterAZResource{}, "cluster_az_resources").SetKeys(true, "id")
 	db.AddTableWithName(Domain{}, "domains").SetKeys(true, "id")
 	db.AddTableWithName(Project{}, "projects").SetKeys(true, "id")
-	db.AddTableWithName(ProjectServiceV2{}, "project_services_v2").SetKeys(true, "id")
-	db.AddTableWithName(ProjectResourceV2{}, "project_resources_v2").SetKeys(true, "id")
-	db.AddTableWithName(ProjectAZResourceV2{}, "project_az_resources_v2").SetKeys(true, "id")
-	db.AddTableWithName(ProjectRateV2{}, "project_rates_v2").SetKeys(true, "id")
-	db.AddTableWithName(ProjectCommitmentV2{}, "project_commitments_v2").SetKeys(true, "id")
+	db.AddTableWithName(ProjectService{}, "project_services").SetKeys(true, "id")
+	db.AddTableWithName(ProjectResource{}, "project_resources").SetKeys(true, "id")
+	db.AddTableWithName(ProjectAZResource{}, "project_az_resources").SetKeys(true, "id")
+	db.AddTableWithName(ProjectRate{}, "project_rates").SetKeys(true, "id")
+	db.AddTableWithName(ProjectCommitment{}, "project_commitments").SetKeys(true, "id")
 	db.AddTableWithName(MailNotification{}, "project_mail_notifications").SetKeys(true, "id")
 }

--- a/internal/reports/domain.go
+++ b/internal/reports/domain.go
@@ -32,7 +32,7 @@ var domainReportQuery2 = sqlext.SimplifyWhitespace(`
 	         SUM(pazr.usage) AS usage,
 	         SUM(COALESCE(pazr.physical_usage, pazr.usage)) AS physical_usage,
 	         COUNT(pazr.physical_usage) > 0 AS has_physical_usage
-	    FROM project_az_resources_v2 as pazr
+	    FROM project_az_resources as pazr
 		JOIN cluster_az_resources as cazr ON cazr.id = pazr.az_resource_id
 		JOIN cluster_resources as cr ON cr.id = cazr.resource_id
 	   GROUP BY pazr.project_id, cr.id
@@ -44,8 +44,8 @@ var domainReportQuery2 = sqlext.SimplifyWhitespace(`
 	  FROM cluster_services cs
 	  JOIN cluster_resources cr ON cr.service_id = cs.id {{AND cr.name = $resource_name}}
 	  CROSS JOIN projects p
-	  JOIN project_services_v2 ps ON ps.project_id = p.id AND ps.service_id = cs.id
-	  JOIN project_resources_v2 pr ON pr.project_id = p.id AND pr.resource_id = cr.id
+	  JOIN project_services ps ON ps.project_id = p.id AND ps.service_id = cs.id
+	  JOIN project_resources pr ON pr.project_id = p.id AND pr.resource_id = cr.id
 	  LEFT OUTER JOIN project_az_sums pas ON pas.project_id = p.id AND pas.resource_id = cr.id 
 	 WHERE %s {{AND cs.type = $service_type}} GROUP BY p.domain_id, cs.type, cr.name
 `)
@@ -53,7 +53,7 @@ var domainReportQuery2 = sqlext.SimplifyWhitespace(`
 var domainReportQuery3 = sqlext.SimplifyWhitespace(`
 	WITH project_commitment_sums AS (
 	  SELECT project_id, az_resource_id, SUM(amount) AS amount
-	    FROM project_commitments_v2
+	    FROM project_commitments
 	   WHERE state = 'active'
 	   GROUP BY project_id, az_resource_id
 	)
@@ -65,9 +65,9 @@ var domainReportQuery3 = sqlext.SimplifyWhitespace(`
 	  JOIN cluster_resources cr ON cr.service_id = cs.id {{AND cr.name = $resource_name}}
 	  JOIN cluster_az_resources cazr ON cazr.resource_id = cr.id
 	  CROSS JOIN projects p
-	  JOIN project_services_v2 ps ON ps.project_id = p.id AND ps.service_id = cs.id
-	  JOIN project_resources_v2 pr ON pr.project_id = p.id AND pr.resource_id = cr.id
-	  JOIN project_az_resources_v2 pazr ON pazr.project_id = p.id AND pazr.az_resource_id = cazr.id
+	  JOIN project_services ps ON ps.project_id = p.id AND ps.service_id = cs.id
+	  JOIN project_resources pr ON pr.project_id = p.id AND pr.resource_id = cr.id
+	  JOIN project_az_resources pazr ON pazr.project_id = p.id AND pazr.az_resource_id = cazr.id
 	  LEFT OUTER JOIN project_commitment_sums pcs ON pcs.az_resource_id = cazr.id AND pcs.project_id = p.id
 	 WHERE %s {{AND cs.type = $service_type}}
 	 GROUP BY p.domain_id, cs.type, cr.name, cazr.az
@@ -79,7 +79,7 @@ var domainReportQuery4 = sqlext.SimplifyWhitespace(`
 	         COALESCE(SUM(amount) FILTER (WHERE state = 'active'), 0) AS active,
 	         COALESCE(SUM(amount) FILTER (WHERE state = 'pending'), 0) AS pending,
 	         COALESCE(SUM(amount) FILTER (WHERE state = 'planned'), 0) AS planned
-	    FROM project_commitments_v2
+	    FROM project_commitments
 	   GROUP BY project_id, az_resource_id, duration
 	)
 	SELECT p.domain_id, cs.type, cr.name, cazr.az,
@@ -88,8 +88,8 @@ var domainReportQuery4 = sqlext.SimplifyWhitespace(`
 	  JOIN cluster_resources cr ON cr.service_id = cs.id {{AND cr.name = $resource_name}}
 	  JOIN cluster_az_resources cazr ON cazr.resource_id = cr.id
 	  CROSS JOIN projects p
-	  JOIN project_services_v2 ps ON ps.project_id = p.id AND ps.service_id = cs.id
-	  JOIN project_resources_v2 pr ON pr.project_id = p.id AND pr.resource_id = cr.id
+	  JOIN project_services ps ON ps.project_id = p.id AND ps.service_id = cs.id
+	  JOIN project_resources pr ON pr.project_id = p.id AND pr.resource_id = cr.id
 	  JOIN project_commitment_sums pcs ON pcs.az_resource_id = cazr.id AND pcs.project_id = p.id
 	 WHERE %s {{AND cs.type = $service_type}}
 	 GROUP BY p.domain_id, cs.type, cr.name, cazr.az, pcs.duration

--- a/internal/reports/error.go
+++ b/internal/reports/error.go
@@ -18,7 +18,7 @@ var scrapeErrorsQuery = sqlext.SimplifyWhitespace(`
 	SELECT d.uuid, d.name, p.uuid, p.name, cs.type, ps.checked_at, ps.scrape_error_message
 	  FROM projects p
 	  JOIN domains d ON d.id = p.domain_id
-	  JOIN project_services_v2 ps ON ps.project_id = p.id
+	  JOIN project_services ps ON ps.project_id = p.id
 	  JOIN cluster_services cs ON cs.id = ps.service_id
 	WHERE ps.scrape_error_message != ''
 	ORDER BY d.name, p.name, cs.type, ps.scrape_error_message

--- a/internal/reports/inconsistency.go
+++ b/internal/reports/inconsistency.go
@@ -51,11 +51,11 @@ var ospqReportQuery = sqlext.SimplifyWhitespace(`
 	SELECT d.uuid, d.name, p.uuid, p.name, cs.type, cr.name, pr.quota, SUM(pazr.usage)
 	  FROM projects p
 	  JOIN domains d ON d.id = p.domain_id
-	  JOIN project_resources_v2 pr ON pr.project_id = p.id
+	  JOIN project_resources pr ON pr.project_id = p.id
 	  JOIN cluster_resources cr ON pr.resource_id = cr.id {{AND cr.name = $resource_name}}
 	  JOIN cluster_services cs ON cr.service_id = cs.id {{AND cs.type = $service_type}}
 	  JOIN cluster_az_resources cazr ON cazr.resource_id = cr.id
-	  JOIN project_az_resources_v2 pazr ON pazr.az_resource_id = cazr.id AND pazr.project_id = pr.project_id
+	  JOIN project_az_resources pazr ON pazr.az_resource_id = cazr.id AND pazr.project_id = pr.project_id
 	 GROUP BY d.uuid, d.name, p.uuid, p.name, cs.type, cr.name, pr.quota
 	HAVING SUM(pazr.usage) > pr.quota
 	 ORDER BY d.name, p.name, cs.type, cr.name
@@ -65,7 +65,7 @@ var mmpqReportQuery = sqlext.SimplifyWhitespace(`
 	SELECT d.uuid, d.name, p.uuid, p.name, cs.type, cr.name, pr.quota, pr.backend_quota
 	  FROM projects p
 	  JOIN domains d ON d.id = p.domain_id
-	  JOIN project_resources_v2 pr ON pr.project_id = p.id 
+	  JOIN project_resources pr ON pr.project_id = p.id 
 	  JOIN cluster_resources cr ON pr.resource_id = cr.id {{AND cr.name = $resource_name}}
 	  JOIN cluster_services cs ON cr.service_id = cs.id {{AND cs.type = $service_type}}
 	WHERE pr.backend_quota != pr.quota

--- a/internal/reports/project.go
+++ b/internal/reports/project.go
@@ -32,8 +32,8 @@ var (
 	  FROM cluster_services cs
 	  JOIN cluster_rates cra ON cra.service_id = cs.id
 	  CROSS JOIN projects p
-	  JOIN project_services_v2 ps ON ps.service_id = cs.id AND ps.project_id = p.id
-	  JOIN project_rates_v2 pra ON pra.rate_id = cra.id AND pra.project_id = ps.project_id
+	  JOIN project_services ps ON ps.service_id = cs.id AND ps.project_id = p.id
+	  JOIN project_rates pra ON pra.rate_id = cra.id AND pra.project_id = ps.project_id
 	 WHERE %s {{AND cs.type = $service_type}}
 	 ORDER BY p.uuid
 `)
@@ -44,10 +44,10 @@ var (
 	  JOIN cluster_resources cr ON cr.service_id = cs.id {{AND cr.name = $resource_name}}
 	  JOIN cluster_az_resources cazr ON cazr.resource_id = cr.id
 	  CROSS JOIN projects p
-	  JOIN project_services_v2 ps ON ps.service_id = cs.id AND ps.project_id = p.id
-	  JOIN project_resources_v2 pr ON pr.resource_id = cr.id AND pr.project_id = p.id
+	  JOIN project_services ps ON ps.service_id = cs.id AND ps.project_id = p.id
+	  JOIN project_resources pr ON pr.resource_id = cr.id AND pr.project_id = p.id
 	  -- no left join, entries will only appear when there is some project level entry
-	  JOIN project_az_resources_v2 pazr ON pazr.az_resource_id = cazr.id AND pazr.project_id = p.id
+	  JOIN project_az_resources pazr ON pazr.az_resource_id = cazr.id AND pazr.project_id = p.id
 	 WHERE %s {{AND cs.type = $service_type}}
 	 ORDER BY p.uuid, cazr.az
 `)
@@ -60,7 +60,7 @@ var (
 	  FROM cluster_services cs
 	  JOIN cluster_resources cr on cr.service_id = cs.id
 	  JOIN cluster_az_resources cazr ON cazr.resource_id = cr.id
-	  JOIN project_commitments_v2 pc ON pc.az_resource_id = cazr.id
+	  JOIN project_commitments pc ON pc.az_resource_id = cazr.id
 	 WHERE pc.project_id = $1
 	 GROUP BY cs.type, cr.name, cazr.az, pc.duration
 	`)

--- a/internal/test/setup.go
+++ b/internal/test/setup.go
@@ -132,9 +132,9 @@ type Setup struct {
 	Handler http.Handler
 	// fields that are filled by WithProject and WithEmptyRecordsAsNeeded
 	Projects           []*db.Project
-	ProjectServices    []*db.ProjectServiceV2
-	ProjectResources   []*db.ProjectResourceV2
-	ProjectAZResources []*db.ProjectAZResourceV2
+	ProjectServices    []*db.ProjectService
+	ProjectResources   []*db.ProjectResource
+	ProjectAZResources []*db.ProjectAZResource
 }
 
 func GenerateDummyToken() string {
@@ -265,7 +265,7 @@ func NewSetup(t *testing.T, opts ...SetupOption) Setup {
 		mustDo(t, s.DB.SelectOne(&clusterService, `SELECT * FROM cluster_services WHERE type = $1`, serviceType))
 		for _, dbProject := range s.Projects {
 			t0 := time.Unix(0, 0).UTC()
-			dbProjectService := &db.ProjectServiceV2{
+			dbProjectService := &db.ProjectService{
 				ID:        db.ProjectServiceID(len(s.ProjectServices) + 1),
 				ProjectID: dbProject.ID,
 				ServiceID: clusterService.ID,
@@ -280,7 +280,7 @@ func NewSetup(t *testing.T, opts ...SetupOption) Setup {
 			var clusterResource *db.ClusterResource
 			mustDo(t, s.DB.SelectOne(&clusterResource, `SELECT * FROM cluster_resources WHERE name = $1 AND service_id = $2`, resName, clusterService.ID))
 			for _, dbProject := range s.Projects {
-				dbProjectResource := &db.ProjectResourceV2{
+				dbProjectResource := &db.ProjectResource{
 					ID:           db.ProjectResourceID(len(s.ProjectResources) + 1),
 					ProjectID:    dbProject.ID,
 					ResourceID:   clusterResource.ID,
@@ -300,7 +300,7 @@ func NewSetup(t *testing.T, opts ...SetupOption) Setup {
 				var clusterAZResource *db.ClusterAZResource
 				mustDo(t, s.DB.SelectOne(&clusterAZResource, `SELECT * FROM cluster_az_resources WHERE az = $1 AND resource_id = $2`, az, clusterResource.ID))
 				for _, dbProject := range s.Projects {
-					dbProjectAZResource := &db.ProjectAZResourceV2{
+					dbProjectAZResource := &db.ProjectAZResource{
 						ID:               db.ProjectAZResourceID(len(s.ProjectAZResources) + 1),
 						ProjectID:        dbProject.ID,
 						AZResourceID:     clusterAZResource.ID,
@@ -327,11 +327,11 @@ func mustDo(t *testing.T, err error) {
 
 func initDatabase(t *testing.T, extraOpts []easypg.TestSetupOption) *gorp.DbMap {
 	opts := append(slices.Clone(extraOpts),
-		easypg.ClearTables("project_commitments_v2", "cluster_services", "domains"),
+		easypg.ClearTables("project_commitments", "cluster_services", "domains"),
 		easypg.ResetPrimaryKeys(
 			"cluster_services", "cluster_resources", "cluster_rates", "cluster_az_resources",
-			"domains", "projects", "project_commitments_v2", "project_mail_notifications",
-			"project_services_v2", "project_resources_v2", "project_az_resources_v2", "project_rates_v2",
+			"domains", "projects", "project_commitments", "project_mail_notifications",
+			"project_services", "project_resources", "project_az_resources", "project_rates",
 		),
 	)
 	return db.InitORM(easypg.ConnectForTest(t, db.Configuration(), opts...))


### PR DESCRIPTION
Summary: Remove old `project_` artifacts, rename new `project_*_v2` artifacts, rename on application layer.

For now, I will put this to draft, as the rollout of the actual v2 DB change is not yet finished.