### PR TITLE
use liquid.ProjectUUID for Project.UUID

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -772,7 +772,7 @@ func Test_LargeProjectList(t *testing.T) {
 	}
 
 	// template for how a single project will look in the output JSON
-	makeProjectJSON := func(idx int, projectName, projectUUID string) assert.JSONObject {
+	makeProjectJSON := func(idx int, projectName string, projectUUID liquid.ProjectUUID) assert.JSONObject {
 		return assert.JSONObject{
 			"id":        projectUUID,
 			"name":      projectName,
@@ -850,7 +850,7 @@ func Test_LargeProjectList(t *testing.T) {
 			t.Fatal(err)
 		}
 		projectName := fmt.Sprintf("test-project%04d", idx)
-		projectUUID := projectUUIDGen.String()
+		projectUUID := liquid.ProjectUUID(projectUUIDGen.String())
 		scrapedAt := time.Unix(int64(idx), 0).UTC()
 		expectedProjectsJSON = append(expectedProjectsJSON, makeProjectJSON(idx, projectName, projectUUID))
 
@@ -908,7 +908,7 @@ func Test_LargeProjectList(t *testing.T) {
 	sort.Slice(expectedProjectsJSON, func(i, j int) bool {
 		left := expectedProjectsJSON[i]
 		right := expectedProjectsJSON[j]
-		return left["id"].(string) < right["id"].(string)
+		return left["id"].(liquid.ProjectUUID) < right["id"].(liquid.ProjectUUID)
 	})
 	assert.HTTPRequest{
 		Method:       "GET",

--- a/internal/api/audit.go
+++ b/internal/api/audit.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sapcc/go-api-declarations/limes"
 	limesrates "github.com/sapcc/go-api-declarations/limes/rates"
 	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
+	"github.com/sapcc/go-api-declarations/liquid"
 	"github.com/sapcc/go-bits/must"
 
 	"github.com/sapcc/limes/internal/db"
@@ -20,7 +21,7 @@ import (
 type maxQuotaEventTarget struct {
 	DomainID        string
 	DomainName      string
-	ProjectID       string
+	ProjectID       liquid.ProjectUUID
 	ProjectName     string
 	ServiceType     limes.ServiceType
 	ResourceName    limesresources.ResourceName
@@ -36,10 +37,10 @@ type maxQuotaChange struct {
 func (t maxQuotaEventTarget) Render() cadf.Resource {
 	return cadf.Resource{
 		TypeURI:     fmt.Sprintf("service/%s/%s/max-quota", t.ServiceType, t.ResourceName),
-		ID:          t.ProjectID,
+		ID:          string(t.ProjectID),
 		DomainID:    t.DomainID,
 		DomainName:  t.DomainName,
-		ProjectID:   t.ProjectID,
+		ProjectID:   string(t.ProjectID),
 		ProjectName: t.ProjectName,
 		Attachments: []cadf.Attachment{
 			must.Return(cadf.NewJSONAttachment("payload", t.RequestedChange)),
@@ -52,7 +53,7 @@ func (t maxQuotaEventTarget) Render() cadf.Resource {
 type rateLimitEventTarget struct {
 	DomainID    string
 	DomainName  string
-	ProjectID   string
+	ProjectID   liquid.ProjectUUID
 	ProjectName string
 	ServiceType limes.ServiceType
 	Name        limesrates.RateName
@@ -73,10 +74,10 @@ type rateLimitChange struct {
 func (t rateLimitEventTarget) Render() cadf.Resource {
 	return cadf.Resource{
 		TypeURI:     fmt.Sprintf("service/%s/%s/rates", t.ServiceType, t.Name),
-		ID:          t.ProjectID,
+		ID:          string(t.ProjectID),
 		DomainID:    t.DomainID,
 		DomainName:  t.DomainName,
-		ProjectID:   t.ProjectID,
+		ProjectID:   string(t.ProjectID),
 		ProjectName: t.ProjectName,
 		Attachments: []cadf.Attachment{
 			must.Return(cadf.NewJSONAttachment("payload", t.Payload)),
@@ -89,7 +90,7 @@ func (t rateLimitEventTarget) Render() cadf.Resource {
 type commitmentEventTarget struct {
 	DomainID        string
 	DomainName      string
-	ProjectID       string
+	ProjectID       liquid.ProjectUUID
 	ProjectName     string
 	Commitments     []limesresources.Commitment // must have at least one entry
 	WorkflowContext Option[db.CommitmentWorkflowContext]
@@ -105,7 +106,7 @@ func (t commitmentEventTarget) Render() cadf.Resource {
 		ID:          t.Commitments[0].UUID,
 		DomainID:    t.DomainID,
 		DomainName:  t.DomainName,
-		ProjectID:   t.ProjectID,
+		ProjectID:   string(t.ProjectID),
 		ProjectName: t.ProjectName,
 		Attachments: []cadf.Attachment{},
 	}

--- a/internal/collector/keystone.go
+++ b/internal/collector/keystone.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/lib/pq"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sapcc/go-api-declarations/liquid"
 	"github.com/sapcc/go-bits/jobloop"
 	"github.com/sapcc/go-bits/logg"
 	"github.com/sapcc/go-bits/sqlext"
@@ -142,7 +143,7 @@ func (c *Collector) ScanProjects(ctx context.Context, domain *db.Domain) (result
 	if err != nil {
 		return nil, fmt.Errorf("while listing projects in domain %q: %w", domain.Name, util.UnpackError(err))
 	}
-	isProjectUUID := make(map[string]bool)
+	isProjectUUID := make(map[liquid.ProjectUUID]bool)
 	for _, project := range projects {
 		isProjectUUID[project.UUID] = true
 	}
@@ -150,7 +151,7 @@ func (c *Collector) ScanProjects(ctx context.Context, domain *db.Domain) (result
 	// when a project has been deleted in Keystone, remove it from our database,
 	// too (the deletion from the `projects` table includes the projects' resource
 	// records through `ON DELETE CASCADE`)
-	existingProjectsByUUID := make(map[string]*db.Project)
+	existingProjectsByUUID := make(map[liquid.ProjectUUID]*db.Project)
 	var dbProjects []*db.Project
 	_, err = c.DB.Select(&dbProjects, `SELECT * FROM projects WHERE domain_id = $1`, domain.ID)
 	if err != nil {
@@ -201,7 +202,7 @@ func (c *Collector) ScanProjects(ctx context.Context, domain *db.Domain) (result
 		if err != nil {
 			return result, err
 		}
-		result = append(result, project.UUID)
+		result = append(result, string(project.UUID))
 	}
 
 	return result, nil

--- a/internal/collector/metrics.go
+++ b/internal/collector/metrics.go
@@ -292,7 +292,7 @@ func (c *UsageCollectionMetricsCollector) collectOneProjectService(ch chan<- pro
 
 	err := liquidCollectMetrics(ch, []byte(instance.SerializedMetrics), connection.ServiceInfo().UsageMetricFamilies,
 		[]string{"domain_id", "project_id"},
-		[]string{instance.Project.Domain.UUID, instance.Project.UUID},
+		[]string{instance.Project.Domain.UUID, string(instance.Project.UUID)},
 	)
 	successAsFloat := 1.0
 	if err != nil {
@@ -305,7 +305,7 @@ func (c *UsageCollectionMetricsCollector) collectOneProjectService(ch chan<- pro
 	ch <- prometheus.MustNewConstMetric(
 		collectionMetricsOkDesc,
 		prometheus.GaugeValue, successAsFloat,
-		instance.Project.Domain.Name, instance.Project.Domain.UUID, instance.Project.Name, instance.Project.UUID,
+		instance.Project.Domain.Name, instance.Project.Domain.UUID, instance.Project.Name, string(instance.Project.UUID),
 		string(instance.ServiceType), string(instance.ServiceType),
 	)
 }

--- a/internal/core/keystone.go
+++ b/internal/core/keystone.go
@@ -33,10 +33,10 @@ func KeystoneDomainFromDB(dbDomain db.Domain) KeystoneDomain {
 
 // KeystoneProject describes the basic attributes of a Keystone project.
 type KeystoneProject struct {
-	UUID       string         `json:"id" yaml:"id"`
-	Name       string         `json:"name" yaml:"name"`
-	ParentUUID string         `json:"parent_id,omitempty" yaml:"parent_id,omitempty"`
-	Domain     KeystoneDomain `json:"domain" yaml:"domain"`
+	UUID       liquid.ProjectUUID `json:"id" yaml:"id"`
+	Name       string             `json:"name" yaml:"name"`
+	ParentUUID string             `json:"parent_id,omitempty" yaml:"parent_id,omitempty"`
+	Domain     KeystoneDomain     `json:"domain" yaml:"domain"`
 }
 
 // KeystoneProjectFromDB converts a db.Project into a KeystoneProject.
@@ -52,7 +52,7 @@ func KeystoneProjectFromDB(dbProject db.Project, domain KeystoneDomain) Keystone
 // ForLiquid casts this KeystoneProject into the format used in LIQUID requests.
 func (p KeystoneProject) ForLiquid() liquid.ProjectMetadata {
 	return liquid.ProjectMetadata{
-		UUID: p.UUID,
+		UUID: string(p.UUID),
 		Name: p.Name,
 		Domain: liquid.DomainMetadata{
 			UUID: p.Domain.UUID,
@@ -134,7 +134,7 @@ func (p *listDiscoveryPlugin) ListProjects(ctx context.Context, domain KeystoneD
 	var result []KeystoneProject
 	for _, p := range allProjects {
 		result = append(result, KeystoneProject{
-			UUID:       p.ID,
+			UUID:       liquid.ProjectUUID(p.ID),
 			Name:       p.Name,
 			ParentUUID: p.ParentID,
 			Domain:     domain,

--- a/internal/core/liquid.go
+++ b/internal/core/liquid.go
@@ -176,7 +176,7 @@ func (l *LiquidConnection) Scrape(ctx context.Context, project KeystoneProject, 
 		return liquid.ServiceUsageReport{}, err
 	}
 
-	result, err = l.LiquidClient.GetUsageReport(ctx, project.UUID, req)
+	result, err = l.LiquidClient.GetUsageReport(ctx, string(project.UUID), req)
 	if err != nil {
 		return liquid.ServiceUsageReport{}, err
 	}
@@ -358,7 +358,7 @@ func (l *LiquidConnection) SetQuota(ctx context.Context, project KeystoneProject
 		req.ProjectMetadata = Some(project.ForLiquid())
 	}
 
-	return l.LiquidClient.PutQuota(ctx, project.UUID, req)
+	return l.LiquidClient.PutQuota(ctx, string(project.UUID), req)
 }
 
 // ScrapeRates queries the backend service for the usage data of all rates.
@@ -389,7 +389,7 @@ func (l *LiquidConnection) ScrapeRates(ctx context.Context, project KeystoneProj
 		req.ProjectMetadata = Some(project.ForLiquid())
 	}
 
-	resp, err := l.LiquidClient.GetUsageReport(ctx, project.UUID, req)
+	resp, err := l.LiquidClient.GetUsageReport(ctx, string(project.UUID), req)
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -83,11 +83,11 @@ type Domain struct {
 
 // Project contains a record from the `projects` table.
 type Project struct {
-	ID         ProjectID `db:"id"`
-	DomainID   DomainID  `db:"domain_id"`
-	Name       string    `db:"name"`
-	UUID       string    `db:"uuid"`
-	ParentUUID string    `db:"parent_uuid"`
+	ID         ProjectID          `db:"id"`
+	DomainID   DomainID           `db:"domain_id"`
+	Name       string             `db:"name"`
+	UUID       liquid.ProjectUUID `db:"uuid"`
+	ParentUUID string             `db:"parent_uuid"`
 }
 
 // ProjectService contains a record from the `project_services` table.

--- a/internal/reports/project.go
+++ b/internal/reports/project.go
@@ -97,7 +97,7 @@ func GetProjectResources(cluster *core.Cluster, domain db.Domain, project *db.Pr
 		allProjectReports[project.ID] = &limesresources.ProjectReport{
 			ProjectInfo: limes.ProjectInfo{
 				Name:       project.Name,
-				UUID:       project.UUID,
+				UUID:       string(project.UUID),
 				ParentUUID: project.ParentUUID,
 			},
 			Services: make(limesresources.ProjectServiceReports),
@@ -431,7 +431,7 @@ func GetProjectRates(cluster *core.Cluster, domain db.Domain, project *db.Projec
 	for _, project := range allProjects {
 		allProjectInfos[project.ID] = limes.ProjectInfo{
 			Name:       project.Name,
-			UUID:       project.UUID,
+			UUID:       string(project.UUID),
 			ParentUUID: project.ParentUUID,
 		}
 	}


### PR DESCRIPTION
The idea behind this PR was to reduce the number of type conversions in #756. 
When implementing it, I quickly hit 2 roadblocks: Lot's of the interfaces require string, partially defined in go-bits (in our hands) but partially also gophercloud with way too many users.

Do we want to extend this to interfaces in go-bits?