### PR TITLE
add endpoint: forbid-autogrowth

### DIFF
--- a/docs/users/api-spec-resources.md
+++ b/docs/users/api-spec-resources.md
@@ -434,6 +434,56 @@ Returns 200 (OK) on success and a JSON document with a similar structure as the 
 /v1/domains/:domain_id/projects` endpoint. Instead of a list of objects in the top-level field `projects`, only a single
 such object with identical substructure will be returned in the top-level field `project`.
 
+### PUT /v1/domains/:domain\_id/projects/:project_id/max-quota
+Sets the maximum quota growth for the provided resources to the specified max-quota value. 
+This endpoint does not override the current resource quotas; it only restricts their growth based on the specified limits.
+
+Returns 202 (Accepted) on success. Requires a JSON document like:
+```
+{
+  "project": {
+    "services": [
+      {
+        "type": "compute",
+        "resources": [
+          {
+            "name": "RAM",
+            "max_quota": 1024,
+            "unit": "MiB"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### PUT /v1/domains/:domain\_id/projects/:project_id/forbid-autogrowth
+Disables or enables the autogrowth feature for the provided resources.
+This endpoint does not override the current resource quotas; it only toggles the capability of resources to automatically grow their quota.
+The following values are accepted:
+- forbid_autogrowth: true - Disables quota autogrowth.
+- forbid_autogrowth: false - Enables quota autogrowth.
+
+Returns 202 (Accepted) on success. Requires a JSON document like:
+```
+{
+  "project": {
+    "services": [
+      {
+        "type": "compute",
+        "resources": [
+          {
+            "name": "RAM",
+            "forbid_autogrowth": true
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
 ### PUT /v1/domains/:domain\_id/projects/:project\_id
 
 **Deprecated.** Always returns 405 (Method Not Allowed) because support for setting quotas manually has been removed from Limes.

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1141,7 +1141,7 @@ func Test_PutQuotaAutogrowth(t *testing.T) {
 	}.Check(t, s.Handler)
 
 	// error case: resource does not track quota
-	_, err := s.DB.Exec("UPDATE cluster_resources SET has_quota = FALSE WHERE id = 4")
+	_, err := s.DB.Exec("UPDATE cluster_resources SET has_quota = FALSE WHERE path = $1", "shared/capacity")
 	if err != nil {
 		t.Error(err)
 	}

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1139,7 +1139,7 @@ func Test_PutQuotaAutogrowth(t *testing.T) {
 	}.Check(t, s.Handler)
 
 	// error case: resource does not track quota
-	_, err := s.DB.Exec("UPDATE cluster_resources SET has_quota = FALSE WHERE path = $1", "shared/capacity")
+	_, err := s.DB.Exec("UPDATE resources SET has_quota = FALSE WHERE path = $1", "shared/capacity")
 	if err != nil {
 		t.Error(err)
 	}

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1068,7 +1068,7 @@ func Test_PutQuotaAutogrowth(t *testing.T) {
 	}
 
 	// happy case: enable autogrowth twice, only update the database once.
-	for _, value := range []bool{true, true} {
+	for range 2 {
 		assert.HTTPRequest{
 			Method:       "PUT",
 			Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/forbid-autogrowth",

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -427,6 +427,18 @@ func Test_ProjectOperations(t *testing.T) {
 		ExpectBody:   assert.JSONFixtureFile("./fixtures/project-get-paris.json"),
 	}.Check(t, s.Handler)
 
+	// paris has forbid_autogrowth setting
+	_, dberr = s.DB.Exec("UPDATE project_resources SET forbid_autogrowth=true where id=12")
+	if dberr != nil {
+		t.Fatal(dberr)
+	}
+	assert.HTTPRequest{
+		Method:       "GET",
+		Path:         "/v1/domains/uuid-for-france/projects/uuid-for-paris",
+		ExpectStatus: 200,
+		ExpectBody:   assert.JSONFixtureFile("./fixtures/project-get-paris-forbid-autogrowth.json"),
+	}.Check(t, s.Handler)
+
 	// check GetProjectRates
 	assert.HTTPRequest{
 		Method:       "GET",

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1072,7 +1072,7 @@ func Test_PutQuotaAutogrowth(t *testing.T) {
 		assert.HTTPRequest{
 			Method:       "PUT",
 			Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/forbid-autogrowth",
-			Body:         makeRequest("shared", assert.JSONObject{"name": "things", "forbid_autogrowth": value}),
+			Body:         makeRequest("shared", assert.JSONObject{"name": "things", "forbid_autogrowth": true}),
 			ExpectStatus: http.StatusAccepted,
 		}.Check(t, s.Handler)
 	}

--- a/internal/api/audit.go
+++ b/internal/api/audit.go
@@ -19,23 +19,18 @@ import (
 
 // maxQuotaEventTarget renders a cadf.Event.Target for a max_quota change event.
 type maxQuotaEventTarget struct {
-	DomainID         string
-	DomainName       string
-	ProjectID        liquid.ProjectUUID
-	ProjectName      string
-	ServiceType      limes.ServiceType
-	ResourceName     limesresources.ResourceName
-	RequestedChange  maxQuotaChange
-	AutogrowthChange autogrowthChange
+	DomainID        string
+	DomainName      string
+	ProjectID       liquid.ProjectUUID
+	ProjectName     string
+	ServiceType     limes.ServiceType
+	ResourceName    limesresources.ResourceName
+	RequestedChange maxQuotaChange
 }
 
 type maxQuotaChange struct {
 	OldValue Option[uint64] `json:"oldMaxQuota"`
 	NewValue Option[uint64] `json:"newMaxQuota"`
-}
-
-type autogrowthChange struct {
-	ForbidAutogrowth bool `json:"forbid_autogrowth"`
 }
 
 // Render implements the audittools.Target interface.
@@ -49,6 +44,34 @@ func (t maxQuotaEventTarget) Render() cadf.Resource {
 		ProjectName: t.ProjectName,
 		Attachments: []cadf.Attachment{
 			must.Return(cadf.NewJSONAttachment("payload", t.RequestedChange)),
+		},
+	}
+}
+
+type autogrowthEventTarget struct {
+	DomainID         string
+	DomainName       string
+	ProjectID        liquid.ProjectUUID
+	ProjectName      string
+	ServiceType      limes.ServiceType
+	ResourceName     limesresources.ResourceName
+	AutogrowthChange autogrowthChange
+}
+type autogrowthChange struct {
+	ForbidAutogrowth bool `json:"forbid_autogrowth"`
+}
+
+// Render implements the audittools.Target interface.
+func (t autogrowthEventTarget) Render() cadf.Resource {
+	return cadf.Resource{
+		TypeURI:     fmt.Sprintf("service/%s/%s/forbid-autogrowth", t.ServiceType, t.ResourceName),
+		ID:          string(t.ProjectID),
+		DomainID:    t.DomainID,
+		DomainName:  t.DomainName,
+		ProjectID:   string(t.ProjectID),
+		ProjectName: t.ProjectName,
+		Attachments: []cadf.Attachment{
+			must.Return(cadf.NewJSONAttachment("payload", t.AutogrowthChange)),
 		},
 	}
 }

--- a/internal/api/audit.go
+++ b/internal/api/audit.go
@@ -19,18 +19,23 @@ import (
 
 // maxQuotaEventTarget renders a cadf.Event.Target for a max_quota change event.
 type maxQuotaEventTarget struct {
-	DomainID        string
-	DomainName      string
-	ProjectID       liquid.ProjectUUID
-	ProjectName     string
-	ServiceType     limes.ServiceType
-	ResourceName    limesresources.ResourceName
-	RequestedChange maxQuotaChange
+	DomainID         string
+	DomainName       string
+	ProjectID        liquid.ProjectUUID
+	ProjectName      string
+	ServiceType      limes.ServiceType
+	ResourceName     limesresources.ResourceName
+	RequestedChange  maxQuotaChange
+	AutogrowthChange autogrowthChange
 }
 
 type maxQuotaChange struct {
 	OldValue Option[uint64] `json:"oldMaxQuota"`
 	NewValue Option[uint64] `json:"newMaxQuota"`
+}
+
+type autogrowthChange struct {
+	ForbidAutogrowth bool `json:"forbid_autogrowth"`
 }
 
 // Render implements the audittools.Target interface.

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -140,6 +140,7 @@ func (p *v1Provider) AddTo(r *mux.Router) {
 	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/simulate-put").HandlerFunc(p.SimulatePutProject)
 	r.Methods("PUT").Path("/v1/domains/{domain_id}/projects/{project_id}").HandlerFunc(p.PutProject)
 	r.Methods("PUT").Path("/v1/domains/{domain_id}/projects/{project_id}/max-quota").HandlerFunc(p.PutProjectMaxQuota)
+	r.Methods("PUT").Path("/v1/domains/{domain_id}/projects/{project_id}/forbid-autogrowth").HandlerFunc(p.PutQuotaAutogrowth)
 	r.Methods("GET").Path("/rates/v1/domains/{domain_id}/projects").HandlerFunc(p.ListProjectRates)
 	r.Methods("GET").Path("/rates/v1/domains/{domain_id}/projects/{project_id}").HandlerFunc(p.GetProjectRates)
 	r.Methods("POST").Path("/rates/v1/domains/{domain_id}/projects/{project_id}/sync").HandlerFunc(p.SyncProjectRates)

--- a/internal/api/fixtures/project-get-paris-forbid-autogrowth.json
+++ b/internal/api/fixtures/project-get-paris-forbid-autogrowth.json
@@ -1,0 +1,72 @@
+{
+  "project": {
+    "id": "uuid-for-paris",
+    "name": "paris",
+    "parent_id": "uuid-for-france",
+    "services": [
+      {
+        "type": "shared",
+        "area": "shared",
+        "resources": [
+          {
+            "name": "capacity",
+            "unit": "B",
+            "quota_distribution_model": "autogrow",
+            "commitment_config": {
+              "durations": [
+                "1 hour",
+                "2 hours"
+              ],
+              "min_confirm_by": 604800
+            },
+            "quota": 10,
+            "usable_quota": 10,
+            "max_quota": 200,
+            "forbid_autogrowth": true,
+            "usage": 2,
+            "physical_usage": 1
+          },
+          {
+            "name": "things",
+            "quota_distribution_model": "autogrow",
+            "commitment_config": {
+              "durations": [
+                "1 hour",
+                "2 hours"
+              ],
+              "min_confirm_by": 604800
+            },
+            "quota": 10,
+            "usable_quota": 10,
+            "usage": 2
+          }
+        ],
+        "scraped_at": 66
+      },
+      {
+        "type": "unshared",
+        "area": "unshared",
+        "resources": [
+          {
+            "name": "capacity",
+            "unit": "B",
+            "quota_distribution_model": "autogrow",
+            "quota": 10,
+            "usable_quota": 10,
+            "usage": 2,
+            "physical_usage": 1
+          },
+          {
+            "name": "things",
+            "quota_distribution_model": "autogrow",
+            "quota": 10,
+            "usable_quota": 10,
+            "usage": 2,
+            "backend_quota": -1
+          }
+        ],
+        "scraped_at": 55
+      }
+    ]
+  }
+}

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -410,9 +410,9 @@ func (p *v1Provider) PutQuotaAutogrowth(w http.ResponseWriter, r *http.Request) 
 	}
 	defer sqlext.RollbackUnlessCommitted(tx)
 
-	var services []db.ClusterService
+	var services []db.Service
 	_, err = tx.Select(&services,
-		`SELECT cs.* FROM cluster_services cs JOIN project_services ps ON ps.service_id = cs.id and ps.project_id = $1 ORDER BY cs.type`, dbProject.ID)
+		`SELECT cs.* FROM services cs JOIN project_services ps ON ps.service_id = cs.id and ps.project_id = $1 ORDER BY cs.type`, dbProject.ID)
 	if respondwith.ErrorText(w, err) {
 		return
 	}

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -354,7 +354,7 @@ func (p *v1Provider) PutQuotaAutogrowth(w http.ResponseWriter, r *http.Request) 
 				Type      limes.ServiceType `json:"type"`
 				Resources []struct {
 					Name             limesresources.ResourceName `json:"name"`
-					ForbidAutogrowth *bool                       `json:"forbid_autogrowth"`
+					ForbidAutogrowth Option[bool]                `json:"forbid_autogrowth"`
 				} `json:"resources"`
 			} `json:"services"`
 		} `json:"project"`

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -329,3 +329,143 @@ func (p *v1Provider) PutProjectMaxQuota(w http.ResponseWriter, r *http.Request) 
 
 	w.WriteHeader(http.StatusAccepted)
 }
+
+// PutQuotaAutogrowth handles PUT /v1/domains/:domain_id/projects/:project_id/forbid-autogrowth.
+func (p *v1Provider) PutQuotaAutogrowth(w http.ResponseWriter, r *http.Request) {
+	httpapi.IdentifyEndpoint(r, "/v1/domains/:id/projects/:id/forbid-autogrowth")
+	requestTime := p.timeNow()
+	token := p.CheckToken(r)
+	if !token.Require(w, "project:edit") {
+		return
+	}
+	dbDomain := p.FindDomainFromRequest(w, r)
+	if dbDomain == nil {
+		return
+	}
+	dbProject := p.FindProjectFromRequest(w, r, dbDomain)
+	if dbProject == nil {
+		return
+	}
+
+	// parse request body
+	var parseTarget struct {
+		Project struct {
+			Services []struct {
+				Type      limes.ServiceType `json:"type"`
+				Resources []struct {
+					Name             limesresources.ResourceName `json:"name"`
+					ForbidAutogrowth *bool                       `json:"forbid_autogrowth"`
+				} `json:"resources"`
+			} `json:"services"`
+		} `json:"project"`
+	}
+	if !RequireJSON(w, r, &parseTarget) {
+		return
+	}
+
+	serviceInfos, err := p.Cluster.AllServiceInfos()
+	if respondwith.ErrorText(w, err) {
+		return
+	}
+
+	// validate request
+	nm := core.BuildResourceNameMapping(p.Cluster, serviceInfos)
+	requested := make(map[db.ServiceType]map[liquid.ResourceName]*autogrowthChange)
+	for _, srvRequest := range parseTarget.Project.Services {
+		for _, resRequest := range srvRequest.Resources {
+			dbServiceType, dbResourceName, exists := nm.MapFromV1API(srvRequest.Type, resRequest.Name)
+			if !exists {
+				msg := fmt.Sprintf("no such service and/or resource: %s/%s", srvRequest.Type, resRequest.Name)
+				http.Error(w, msg, http.StatusUnprocessableEntity)
+				return
+			}
+
+			if resRequest.ForbidAutogrowth == nil {
+				msg := fmt.Sprintf("malformed request body for resource: %s/%s", srvRequest.Type, resRequest.Name)
+				http.Error(w, msg, http.StatusUnprocessableEntity)
+				return
+			}
+
+			serviceInfo := core.InfoForService(serviceInfos, dbServiceType)
+			resInfo := core.InfoForResource(serviceInfo, dbResourceName)
+			if !resInfo.HasQuota {
+				msg := fmt.Sprintf("resource %s/%s does not track quota", dbServiceType, dbResourceName)
+				http.Error(w, msg, http.StatusUnprocessableEntity)
+				return
+			}
+
+			if requested[dbServiceType] == nil {
+				requested[dbServiceType] = make(map[liquid.ResourceName]*autogrowthChange)
+			}
+
+			requested[dbServiceType][dbResourceName] = &autogrowthChange{ForbidAutogrowth: *resRequest.ForbidAutogrowth}
+		}
+	}
+
+	// write requested values to DB
+	tx, err := p.DB.Begin()
+	if respondwith.ErrorText(w, err) {
+		return
+	}
+	defer sqlext.RollbackUnlessCommitted(tx)
+
+	var services []db.ClusterService
+	_, err = tx.Select(&services,
+		`SELECT cs.* FROM cluster_services cs JOIN project_services ps ON ps.service_id = cs.id and ps.project_id = $1 ORDER BY cs.type`, dbProject.ID)
+	if respondwith.ErrorText(w, err) {
+		return
+	}
+
+	for _, srv := range services {
+		requestedInService, exists := requested[srv.Type]
+		if !exists {
+			continue
+		}
+
+		_, err := datamodel.ProjectResourceUpdate{
+			UpdateResource: func(res *db.ProjectResource, resName liquid.ResourceName) error {
+				requestedChange := requestedInService[resName]
+				if requestedChange != nil && requestedChange.ForbidAutogrowth != res.ForbidAutogrowth {
+					res.ForbidAutogrowth = requestedChange.ForbidAutogrowth
+					return nil
+				}
+				return nil
+			},
+		}.Run(tx, serviceInfos[srv.Type], p.timeNow(), *dbDomain, *dbProject, srv)
+		if respondwith.ErrorText(w, err) {
+			return
+		}
+	}
+
+	err = tx.Commit()
+	if respondwith.ErrorText(w, err) {
+		return
+	}
+
+	// write audit trail
+	for dbServiceType, requestedInService := range requested {
+		for dbResourceName, requestedChange := range requestedInService {
+			apiServiceType, apiResourceName, exists := nm.MapToV1API(dbServiceType, dbResourceName)
+			if exists {
+				p.auditor.Record(audittools.Event{
+					Time:       requestTime,
+					Request:    r,
+					User:       token,
+					ReasonCode: http.StatusAccepted,
+					Action:     cadf.UpdateAction,
+					Target: maxQuotaEventTarget{
+						DomainID:         dbDomain.UUID,
+						DomainName:       dbDomain.Name,
+						ProjectID:        dbProject.UUID,
+						ProjectName:      dbProject.Name,
+						ServiceType:      apiServiceType,
+						ResourceName:     apiResourceName,
+						AutogrowthChange: *requestedChange,
+					},
+				})
+			}
+		}
+	}
+
+	w.WriteHeader(http.StatusAccepted)
+}

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -380,7 +380,8 @@ func (p *v1Provider) PutQuotaAutogrowth(w http.ResponseWriter, r *http.Request) 
 				return
 			}
 
-			if resRequest.ForbidAutogrowth == nil {
+			forbidAutogrowth, isSome := resRequest.ForbidAutogrowth.Unpack()
+			if !isSome {
 				msg := fmt.Sprintf("malformed request body for resource: %s/%s", srvRequest.Type, resRequest.Name)
 				http.Error(w, msg, http.StatusUnprocessableEntity)
 				return
@@ -398,7 +399,7 @@ func (p *v1Provider) PutQuotaAutogrowth(w http.ResponseWriter, r *http.Request) 
 				requested[dbServiceType] = make(map[liquid.ResourceName]*autogrowthChange)
 			}
 
-			requested[dbServiceType][dbResourceName] = &autogrowthChange{ForbidAutogrowth: *resRequest.ForbidAutogrowth}
+			requested[dbServiceType][dbResourceName] = &autogrowthChange{ForbidAutogrowth: forbidAutogrowth}
 		}
 	}
 

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -425,7 +425,7 @@ func (p *v1Provider) PutQuotaAutogrowth(w http.ResponseWriter, r *http.Request) 
 		_, err := datamodel.ProjectResourceUpdate{
 			UpdateResource: func(res *db.ProjectResource, resName liquid.ResourceName) error {
 				requestedChange := requestedInService[resName]
-				if requestedChange != nil && requestedChange.ForbidAutogrowth != res.ForbidAutogrowth {
+				if requestedChange != nil {
 					res.ForbidAutogrowth = requestedChange.ForbidAutogrowth
 					return nil
 				}

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -454,7 +454,7 @@ func (p *v1Provider) PutQuotaAutogrowth(w http.ResponseWriter, r *http.Request) 
 					User:       token,
 					ReasonCode: http.StatusAccepted,
 					Action:     cadf.UpdateAction,
-					Target: maxQuotaEventTarget{
+					Target: autogrowthEventTarget{
 						DomainID:         dbDomain.UUID,
 						DomainName:       dbDomain.Name,
 						ProjectID:        dbProject.UUID,

--- a/internal/datamodel/apply_computed_project_quota.go
+++ b/internal/datamodel/apply_computed_project_quota.go
@@ -34,11 +34,12 @@ var (
 	`)
 
 	acpqGetLocalQuotaConstraintsQuery = sqlext.SimplifyWhitespace(`
-		SELECT project_id, forbidden, max_quota_from_outside_admin, max_quota_from_local_admin, override_quota_from_config
+		SELECT project_id, forbidden, max_quota_from_outside_admin, max_quota_from_local_admin, forbid_autogrowth, override_quota_from_config
 		  FROM project_resources
 		 WHERE resource_id = $1 AND (forbidden IS NOT NULL
 		                          OR max_quota_from_outside_admin IS NOT NULL
 		                          OR max_quota_from_local_admin IS NOT NULL
+								  OR forbid_autogrowth IS NOT NULL
 		                          OR override_quota_from_config IS NOT NULL)
 	`)
 
@@ -131,19 +132,20 @@ func ApplyComputedProjectQuota(serviceType db.ServiceType, resourceName liquid.R
 	constraints := make(map[db.ProjectID]projectLocalQuotaConstraints)
 	err = sqlext.ForeachRow(tx, acpqGetLocalQuotaConstraintsQuery, []any{clusterResourceID}, func(rows *sql.Rows) error {
 		var (
-			projectID                db.ProjectID
-			forbidden                bool
-			maxQuotaFromOutsideAdmin Option[uint64]
-			maxQuotaFromLocalAdmin   Option[uint64]
-			overrideQuotaFromConfig  Option[uint64]
+			projectID                 db.ProjectID
+			forbidden                 bool
+			maxQuotaFromOutsideAdmin  Option[uint64]
+			maxQuotaFromLocalAdmin    Option[uint64]
+			forbidAutogrowthFromAdmin bool
+			overrideQuotaFromConfig   Option[uint64]
 		)
-		err := rows.Scan(&projectID, &forbidden, &maxQuotaFromOutsideAdmin, &maxQuotaFromLocalAdmin, &overrideQuotaFromConfig)
+		err := rows.Scan(&projectID, &forbidden, &maxQuotaFromOutsideAdmin, &maxQuotaFromLocalAdmin, &forbidAutogrowthFromAdmin, &overrideQuotaFromConfig)
 		if err != nil {
 			return err
 		}
 
 		var c projectLocalQuotaConstraints
-		if forbidden {
+		if forbidden || forbidAutogrowthFromAdmin {
 			c.AddMaxQuota(Some(uint64(0)))
 		}
 		c.AddMaxQuota(maxQuotaFromOutsideAdmin)

--- a/internal/datamodel/apply_computed_project_quota.go
+++ b/internal/datamodel/apply_computed_project_quota.go
@@ -39,7 +39,7 @@ var (
 		 WHERE resource_id = $1 AND (forbidden IS NOT NULL
 		                          OR max_quota_from_outside_admin IS NOT NULL
 		                          OR max_quota_from_local_admin IS NOT NULL
-								  OR forbid_autogrowth IS NOT NULL
+		                          OR forbid_autogrowth IS NOT NULL
 		                          OR override_quota_from_config IS NOT NULL)
 	`)
 

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -33,4 +33,10 @@ var sqlMigrations = map[string]string{
 		DROP TABLE cluster_resources;
 		DROP TABLE cluster_services;
 	`,
+	"062_forbid_autogrowth.down.sql": `
+		ALTER TABLE project_resources DROP COLUMN forbid_autogrowth;
+	`,
+	"062_forbid_autogrowth.up.sql": `
+		ALTER TABLE project_resources ADD COLUMN forbid_autogrowth BOOLEAN NOT NULL DEFAULT FALSE;
+	`,
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -122,6 +122,7 @@ type ProjectResource struct {
 	Quota                    Option[uint64]    `db:"quota"`
 	BackendQuota             Option[int64]     `db:"backend_quota"`
 	Forbidden                bool              `db:"forbidden"`
+	ForbidAutogrowth         bool              `db:"forbid_autogrowth"`
 	MaxQuotaFromOutsideAdmin Option[uint64]    `db:"max_quota_from_outside_admin"`
 	MaxQuotaFromLocalAdmin   Option[uint64]    `db:"max_quota_from_local_admin"`
 	OverrideQuotaFromConfig  Option[uint64]    `db:"override_quota_from_config"`

--- a/internal/reports/project.go
+++ b/internal/reports/project.go
@@ -218,9 +218,6 @@ func GetProjectResources(cluster *core.Cluster, domain db.Domain, project *db.Pr
 					if maxQuotaFromOutsideAdmin != nil && MaxQuotaFromLocalAdmin == nil {
 						resReport.MaxQuota = maxQuotaFromOutsideAdmin
 					}
-					if ForbidAutogrowth {
-						resReport.ForbidAutogrowth = ForbidAutogrowth
-					}
 					if MaxQuotaFromLocalAdmin != nil && maxQuotaFromOutsideAdmin == nil {
 						resReport.MaxQuota = MaxQuotaFromLocalAdmin
 					}
@@ -231,6 +228,7 @@ func GetProjectResources(cluster *core.Cluster, domain db.Domain, project *db.Pr
 					if backendQuota != nil && (*backendQuota < 0 || uint64(*backendQuota) != *quota) {
 						resReport.BackendQuota = backendQuota
 					}
+					resReport.ForbidAutogrowth = ForbidAutogrowth
 				}
 			}
 

--- a/vendor/github.com/sapcc/go-api-declarations/limes/resources/report_project.go
+++ b/vendor/github.com/sapcc/go-api-declarations/limes/resources/report_project.go
@@ -31,14 +31,15 @@ type ProjectResourceReport struct {
 	QuotaDistributionModel QuotaDistributionModel   `json:"quota_distribution_model,omitempty"`
 	CommitmentConfig       *CommitmentConfiguration `json:"commitment_config,omitempty"`
 	// PerAZ is only rendered by Limes when the v2 API feature preview is enabled.
-	PerAZ         ProjectAZResourceReports `json:"per_az,omitempty"`
-	Quota         *uint64                  `json:"quota,omitempty"`
-	UsableQuota   *uint64                  `json:"usable_quota,omitempty"`
-	MaxQuota      *uint64                  `json:"max_quota,omitempty"` // refers to max_quota constraint maintained via API
-	Usage         uint64                   `json:"usage"`
-	PhysicalUsage *uint64                  `json:"physical_usage,omitempty"`
-	BackendQuota  *int64                   `json:"backend_quota,omitempty"`
-	Subresources  json.RawMessage          `json:"subresources,omitempty"`
+	PerAZ            ProjectAZResourceReports `json:"per_az,omitempty"`
+	Quota            *uint64                  `json:"quota,omitempty"`
+	UsableQuota      *uint64                  `json:"usable_quota,omitempty"`
+	MaxQuota         *uint64                  `json:"max_quota,omitempty"` // refers to max_quota constraint maintained via API
+	ForbidAutogrowth bool                     `json:"forbid_autogrowth,omitempty"`
+	Usage            uint64                   `json:"usage"`
+	PhysicalUsage    *uint64                  `json:"physical_usage,omitempty"`
+	BackendQuota     *int64                   `json:"backend_quota,omitempty"`
+	Subresources     json.RawMessage          `json:"subresources,omitempty"`
 }
 
 // ProjectAZResourceReport is a substructure of ProjectResourceReport containing


### PR DESCRIPTION
This implements the endpoint to enable or disable quota autogrowth for provided resources. The deconstruction of the `max-quota` endpoint will be performed when the UI is ready. There, we will remove the confusing double management of max-quota between outside and local admins (Cluster/Domain vs. Project level).

Checklist:

- [x] I updated the documentation to describe the semantical or interface changes I introduced.

Before merging:
Add the `ForbidAutogrowth` attribute for the project resource report to go-api-declarations.
