### PR TITLE
convert leftover timestamps to timestamptz

### DIFF
--- a/internal/api/fixtures/start-data-small.sql
+++ b/internal/api/fixtures/start-data-small.sql
@@ -1,10 +1,9 @@
 -- This start-data contains exactly one project and one service, with all capacity/quota/usage values at 0.
 -- It can be used as a base to set up isolated tests for individual reporting features.
 
-CREATE OR REPLACE FUNCTION UNIXUTC(i integer) RETURNS timestamp AS $$ SELECT TO_TIMESTAMP(i) AT TIME ZONE 'Etc/UTC' $$ LANGUAGE SQL;
 CREATE OR REPLACE FUNCTION UNIX(i integer) RETURNS timestamp AS $$ SELECT TO_TIMESTAMP(i) AT LOCAL $$ LANGUAGE SQL;
 
-INSERT INTO services (id, type, scraped_at, next_scrape_at, liquid_version) VALUES (1, 'first', UNIXUTC(1000), UNIXUTC(2000), 1);
+INSERT INTO services (id, type, scraped_at, next_scrape_at, liquid_version) VALUES (1, 'first', UNIX(1000), UNIX(2000), 1);
 
 INSERT INTO resources (id, service_id, name, liquid_version, topology, has_quota, path) VALUES (1, 1, 'things', 1, 'flat', TRUE, 'first/things');
 INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, needs_resource_demand, has_quota, path) VALUES (2, 1, 'capacity', 1, 'B', 'az-aware', TRUE, TRUE, TRUE, 'first/capacity');

--- a/internal/api/fixtures/start-data.sql
+++ b/internal/api/fixtures/start-data.sql
@@ -1,8 +1,7 @@
-CREATE OR REPLACE FUNCTION UNIXUTC(i integer) RETURNS timestamp AS $$ SELECT TO_TIMESTAMP(i) AT TIME ZONE 'Etc/UTC' $$ LANGUAGE SQL;
 CREATE OR REPLACE FUNCTION UNIX(i integer) RETURNS timestamp AS $$ SELECT TO_TIMESTAMP(i) AT LOCAL $$ LANGUAGE SQL;
 
-INSERT INTO services (id, type, scraped_at, next_scrape_at, liquid_version) VALUES (1, 'unshared', UNIXUTC(1000), UNIXUTC(2000), 1);
-INSERT INTO services (id, type, scraped_at, next_scrape_at, liquid_version) VALUES (2, 'shared', UNIXUTC(1100), UNIXUTC(2100), 1);
+INSERT INTO services (id, type, scraped_at, next_scrape_at, liquid_version) VALUES (1, 'unshared', UNIX(1000), UNIX(2000), 1);
+INSERT INTO services (id, type, scraped_at, next_scrape_at, liquid_version) VALUES (2, 'shared', UNIX(1100), UNIX(2100), 1);
 
 INSERT INTO rates (id, service_id, name, liquid_version, topology, has_usage) VALUES (1, 1, 'service/unshared/instances:create', 1, 'flat', TRUE);
 INSERT INTO rates (id, service_id, name, liquid_version, topology, has_usage) VALUES (2, 1, 'service/unshared/instances:delete', 1, 'flat', TRUE);

--- a/internal/collector/fixtures/capacity_scrape_with_commitments.sql
+++ b/internal/collector/fixtures/capacity_scrape_with_commitments.sql
@@ -1,11 +1,10 @@
 -- This DB forms the baseline for Test_ScanCapacityWithCommitments.
 
-CREATE OR REPLACE FUNCTION UNIXUTC(i integer) RETURNS timestamp AS $$ SELECT TO_TIMESTAMP(i) AT TIME ZONE 'Etc/UTC' $$ LANGUAGE SQL;
 CREATE OR REPLACE FUNCTION UNIX(i integer) RETURNS timestamp AS $$ SELECT TO_TIMESTAMP(i) AT LOCAL $$ LANGUAGE SQL;
 
 -- capacity scrape needs these as a baseline (these are usually created by the CheckConsistencyJob)
-INSERT INTO services (id, type, next_scrape_at, scrape_duration_secs) VALUES (1, 'first',  UNIXUTC(0), 5);
-INSERT INTO services (id, type, next_scrape_at, scrape_duration_secs) VALUES (2, 'second', UNIXUTC(0), 5);
+INSERT INTO services (id, type, next_scrape_at, scrape_duration_secs) VALUES (1, 'first',  UNIX(0), 5);
+INSERT INTO services (id, type, next_scrape_at, scrape_duration_secs) VALUES (2, 'second', UNIX(0), 5);
 
 -- capacity scrape would fill resources and az_resources
 -- on its own, but we do it here to minimize the inline diffs in the test code

--- a/internal/collector/fixtures/mail_delivery.sql
+++ b/internal/collector/fixtures/mail_delivery.sql
@@ -1,11 +1,11 @@
-CREATE OR REPLACE FUNCTION UNIXUTC(i integer) RETURNS timestamp AS $$ SELECT TO_TIMESTAMP(i) AT TIME ZONE 'Etc/UTC' $$ LANGUAGE SQL;
+CREATE OR REPLACE FUNCTION UNIX(i integer) RETURNS timestamp AS $$ SELECT TO_TIMESTAMP(i) AT LOCAL $$ LANGUAGE SQL;
 
 INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
 INSERT INTO projects(id, domain_id, name, uuid, parent_uuid) VALUES (1, 1, 'waldorf', 'uuid-for-waldorf', 'uuid-for-germany');
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (2, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-waldorf');
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (3, 1, 'dresden', 'uuid-for-dresden', 'uuid-for-berlin');
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (4, 1, 'frankfurt', 'uuid-for-frankfurt', 'uuid-for-dresden');
-INSERT INTO project_mail_notifications (id, project_id, subject, body, next_submission_at) VALUES (1, 1, 'dummy', 'dummy', UNIXUTC(0));
-INSERT INTO project_mail_notifications (id, project_id, subject, body, next_submission_at) VALUES (2, 2, 'dummy', 'dummy', UNIXUTC(86400));
-INSERT INTO project_mail_notifications (id, project_id, subject, body, next_submission_at) VALUES (3, 3, 'dummy', 'dummy', UNIXUTC(172800));
-INSERT INTO project_mail_notifications (id, project_id, subject, body, next_submission_at) VALUES (4, 4, 'dummy', 'dummy', UNIXUTC(259200));
+INSERT INTO project_mail_notifications (id, project_id, subject, body, next_submission_at) VALUES (1, 1, 'dummy', 'dummy', UNIX(0));
+INSERT INTO project_mail_notifications (id, project_id, subject, body, next_submission_at) VALUES (2, 2, 'dummy', 'dummy', UNIX(86400));
+INSERT INTO project_mail_notifications (id, project_id, subject, body, next_submission_at) VALUES (3, 3, 'dummy', 'dummy', UNIX(172800));
+INSERT INTO project_mail_notifications (id, project_id, subject, body, next_submission_at) VALUES (4, 4, 'dummy', 'dummy', UNIX(259200));

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -151,4 +151,14 @@ var sqlMigrations = map[string]string{
 			END;
 			$$ LANGUAGE plpgsql;
 	`,
+	`063_localize_cluster_level_timestamps.up.sql`: `
+		ALTER TABLE services ALTER COLUMN scraped_at TYPE TIMESTAMPTZ USING scraped_at AT TIME ZONE 'UTC';
+		ALTER TABLE services ALTER COLUMN next_scrape_at TYPE TIMESTAMPTZ USING next_scrape_at AT TIME ZONE 'UTC';
+		ALTER TABLE project_mail_notifications ALTER COLUMN next_submission_at TYPE TIMESTAMPTZ USING next_submission_at AT TIME ZONE 'UTC';
+	`,
+	`063_localize_cluster_level_timestamps.down.sql`: `
+		ALTER TABLE services ALTER COLUMN scraped_at TYPE TIMESTAMP USING scraped_at AT TIME ZONE 'UTC';
+		ALTER TABLE services ALTER COLUMN next_scrape_at TYPE TIMESTAMP USING next_scrape_at AT TIME ZONE 'UTC';
+		ALTER TABLE project_mail_notifications ALTER COLUMN next_submission_at TYPE TIMESTAMP USING next_submission_at AT TIME ZONE 'UTC';
+	`,
 }


### PR DESCRIPTION
I have a feeling this was too easy and I might be missing something: Because we use `limes.UnixEncodedTime` it does not matter which timestamp we handover to the API-report structures where we need the unix-time. Everything else works with `time.Time` and just remains in its `time.Location` when entered into the DB.