### PR TITLE
remove liquidServiceType (only used for testing)

### DIFF
--- a/docs/liquids/index.md
+++ b/docs/liquids/index.md
@@ -38,8 +38,8 @@ configuration file must be passed in this variable. |
 
 In order for Limes to be able to find the liquid's API, it must be registered in the Keystone service catalog.
 The documentation for each liquid provides a suggestion for what to put as the service type.
-Finally, the `liquids` list in the Limes configuration must be extended with a entry referring to that liquid
-(set `liquid_service_type` if not using the standard naming).
+Finally, the `liquids` list in the Limes configuration must be extended with a entry referring to that liquid.
+The name in the keystone catalog should equal to the name in the `liquids` list, prefixed with `liquid-`.
 
 ## Policy
 

--- a/docs/operators/config.md
+++ b/docs/operators/config.md
@@ -166,7 +166,6 @@ The value for `mime_type` is guaranteed to be either `text/plain` or `text/html`
 liquids:
   nova:
     area: compute
-    liquid_service_type: liquid-nova
     commitment_behavior_per_resource:
     - key: 'cores|ram'
       value:
@@ -191,7 +190,7 @@ exposes data of a corresponding OpenStack Service. There is no possibility to co
 liquid. For information on liquids provided by Limes itself, please refer to the [liquids documentation](../liquids/index.md). Each
 `liquids[]` section of the configuration file must contain the fields `service_type` (how the service is identified) and `area`
 (a grouping of services, e.g. `network, compute, storage`). The liquid endpoint will be located in the Keystone service catalog at
-service type `liquid-$SERVICE_TYPE`, unless this default is overridden by `liquid_service_type` (to be deprecated soon).
+service type `liquid-$SERVICE_TYPE`.
 
 The data from the `liquids[]` config section is read by the collector service on startup and used to instantiate connections to the liquids.
 The connection is used to query the`ServiceInfo` objects, which are then persisted in the database. When a liquid is not accessible on collector
@@ -248,7 +247,6 @@ allows to track capacity values along with other configuration in a Git reposito
 liquids:
 nova:
   area: compute
-  liquid_service_type: liquid-nova
   capacity_values_from_prometheus:
      api:
         url: https://prometheus.example.com

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -56,7 +56,6 @@ const (
 		liquids:
 			shared:
 				area: shared
-				liquid_service_type: %[1]s
 				rate_limits:
 					global:
 						- name:   service/shared/objects:create
@@ -83,7 +82,6 @@ const (
 
 			unshared:
 				area: unshared
-				liquid_service_type: %[2]s
 				rate_limits:
 					project_default:
 						- name:   service/unshared/instances:create
@@ -117,13 +115,13 @@ func setupTest(t *testing.T, startData string) (s test.Setup) {
 		"service/unshared/instances:delete": {Topology: liquid.FlatTopology, HasUsage: true},
 		"service/unshared/instances:update": {Topology: liquid.FlatTopology, HasUsage: true},
 	}
-	_, liquidServiceTypeShared := test.NewMockLiquidClient(srvInfoShared)
-	_, liquidServiceTypeUnshared := test.NewMockLiquidClient(srvInfoUnshared)
+	test.NewMockLiquidClient(srvInfoShared, "shared")
+	test.NewMockLiquidClient(srvInfoUnshared, "unshared")
 
 	t.Helper()
 	s = test.NewSetup(t,
 		test.WithDBFixtureFile(startData),
-		test.WithConfig(fmt.Sprintf(testConfigYAML, liquidServiceTypeShared, liquidServiceTypeUnshared)),
+		test.WithConfig(testConfigYAML),
 		test.WithAPIHandler(NewV1API),
 	)
 	return

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -2180,10 +2180,9 @@ func (p *v1Provider) DelegateChangeCommitments(ctx context.Context, req liquid.C
 		c := p.Cluster
 		if len(c.LiquidConnections) == 0 {
 			// find the right ServiceType
-			liquidServiceType := c.Config.Liquids[serviceType].LiquidServiceType
-			liquidClient, err = core.NewLiquidClient(c.Provider, c.EO, liquidapi.ClientOpts{ServiceType: liquidServiceType})
+			liquidClient, err = core.NewLiquidClient(c.Provider, c.EO, liquidapi.ClientOpts{ServiceType: "liquid-" + string(serviceType)})
 			if err != nil {
-				return result, fmt.Errorf("failed to create LiquidClient for service %s: %w", liquidServiceType, err)
+				return result, fmt.Errorf("failed to create LiquidClient for service %s: %w", serviceType, err)
 			}
 		} else {
 			liquidClient = c.LiquidConnections[serviceType].LiquidClient

--- a/internal/api/commitment_test.go
+++ b/internal/api/commitment_test.go
@@ -5,7 +5,6 @@ package api
 
 import (
 	"encoding/json"
-	"fmt"
 	"maps"
 	"net/http"
 	"testing"
@@ -41,7 +40,6 @@ const testCommitmentsYAML = `
 	liquids:
 		first:
 			area: first
-			liquid_service_type: %[1]s
 			commitment_behavior_per_resource:
 				- key: '.*'
 					value:
@@ -49,7 +47,6 @@ const testCommitmentsYAML = `
 						min_confirm_date: '1970-01-08T00:00:00Z' # one week after start of mock.Clock
 		second:
 			area: second
-			liquid_service_type: %[2]s
 			commitment_behavior_per_resource: []
 `
 const testCommitmentsYAMLWithoutMinConfirmDate = `
@@ -69,11 +66,9 @@ const testCommitmentsYAMLWithoutMinConfirmDate = `
 	liquids:
 		first:
 			area: first
-			liquid_service_type: %[1]s
 			commitment_behavior_per_resource: []
 		second:
 			area: second
-			liquid_service_type: %[2]s
 			commitment_behavior_per_resource:
 				- key: '.*'
 					value:
@@ -97,7 +92,6 @@ const testConvertCommitmentsYAML = `
 	liquids:
 		third:
 			area: third
-			liquid_service_type: %[1]s
 			commitment_behavior_per_resource:
 				- key: capacity_c32
 					value:
@@ -123,7 +117,6 @@ const testConvertCommitmentsYAML = `
 					value: { durations_per_domain: *durations }
 		fourth:
 			area: fourth
-			liquid_service_type: %[2]s
 			commitment_behavior_per_resource:
 				- key: capacity_a
 					value:
@@ -138,11 +131,11 @@ const testConvertCommitmentsYAML = `
 `
 
 func TestCommitmentLifecycleWithDelayedConfirmation(t *testing.T) {
-	liquidClientFirst, liquidServiceTypeFirst := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
-	_, liquidServiceTypeSecond := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
+	liquidClientFirst := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "first")
+	test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "second")
 	s := test.NewSetup(t,
 		test.WithDBFixtureFile("fixtures/start-data-commitments.sql"),
-		test.WithConfig(fmt.Sprintf(testCommitmentsYAML, liquidServiceTypeFirst, liquidServiceTypeSecond)),
+		test.WithConfig(testCommitmentsYAML),
 		test.WithAPIHandler(NewV1API),
 	)
 
@@ -500,11 +493,11 @@ func TestCommitmentLifecycleWithDelayedConfirmation(t *testing.T) {
 }
 
 func TestCommitmentLifecycleWithImmediateConfirmation(t *testing.T) {
-	liquidClientFirst, liquidServiceTypeFirst := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
-	_, liquidServiceTypeSecond := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
+	liquidClientFirst := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "first")
+	test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "second")
 	s := test.NewSetup(t,
 		test.WithDBFixtureFile("fixtures/start-data-commitments.sql"),
-		test.WithConfig(fmt.Sprintf(testCommitmentsYAML, liquidServiceTypeFirst, liquidServiceTypeSecond)),
+		test.WithConfig(testCommitmentsYAML),
 		test.WithAPIHandler(NewV1API),
 	)
 
@@ -727,11 +720,11 @@ func TestCommitmentLifecycleWithImmediateConfirmation(t *testing.T) {
 }
 
 func TestCommitmentDelegationToDB(t *testing.T) {
-	liquidClientFirst, liquidServiceTypeFirst := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
-	_, liquidServiceTypeSecond := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
+	liquidClientFirst := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "first")
+	test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "second")
 	s := test.NewSetup(t,
 		test.WithDBFixtureFile("fixtures/start-data-commitments.sql"),
-		test.WithConfig(fmt.Sprintf(testCommitmentsYAML, liquidServiceTypeFirst, liquidServiceTypeSecond)),
+		test.WithConfig(testCommitmentsYAML),
 		test.WithAPIHandler(NewV1API),
 	)
 
@@ -763,11 +756,11 @@ func TestCommitmentDelegationToDB(t *testing.T) {
 }
 
 func TestGetCommitmentsErrorCases(t *testing.T) {
-	_, liquidServiceTypeFirst := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
-	_, liquidServiceTypeSecond := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
+	test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "first")
+	test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "second")
 	s := test.NewSetup(t,
 		test.WithDBFixtureFile("fixtures/start-data-commitments.sql"),
-		test.WithConfig(fmt.Sprintf(testCommitmentsYAML, liquidServiceTypeFirst, liquidServiceTypeSecond)),
+		test.WithConfig(testCommitmentsYAML),
 		test.WithAPIHandler(NewV1API),
 	)
 
@@ -794,11 +787,11 @@ func TestGetCommitmentsErrorCases(t *testing.T) {
 }
 
 func TestPutCommitmentErrorCases(t *testing.T) {
-	_, liquidServiceTypeFirst := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
-	_, liquidServiceTypeSecond := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
+	test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "first")
+	test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "second")
 	s := test.NewSetup(t,
 		test.WithDBFixtureFile("fixtures/start-data-commitments.sql"),
-		test.WithConfig(fmt.Sprintf(testCommitmentsYAML, liquidServiceTypeFirst, liquidServiceTypeSecond)),
+		test.WithConfig(testCommitmentsYAML),
 		test.WithAPIHandler(NewV1API),
 	)
 
@@ -955,11 +948,11 @@ func TestPutCommitmentErrorCases(t *testing.T) {
 }
 
 func TestDeleteCommitmentErrorCases(t *testing.T) {
-	_, liquidServiceTypeFirst := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
-	_, liquidServiceTypeSecond := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
+	test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "first")
+	test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "second")
 	s := test.NewSetup(t,
 		test.WithDBFixtureFile("fixtures/start-data-commitments.sql"),
-		test.WithConfig(fmt.Sprintf(testCommitmentsYAML, liquidServiceTypeFirst, liquidServiceTypeSecond)),
+		test.WithConfig(testCommitmentsYAML),
 		test.WithAPIHandler(NewV1API),
 	)
 
@@ -1009,11 +1002,11 @@ func TestDeleteCommitmentErrorCases(t *testing.T) {
 }
 
 func Test_StartCommitmentTransfer(t *testing.T) {
-	_, liquidServiceTypeFirst := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
-	liquidClientSecond, liquidServiceTypeSecond := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
+	test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "first")
+	liquidClientSecond := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "second")
 	s := test.NewSetup(t,
 		test.WithDBFixtureFile("fixtures/start-data-commitments.sql"),
-		test.WithConfig(fmt.Sprintf(testCommitmentsYAMLWithoutMinConfirmDate, liquidServiceTypeFirst, liquidServiceTypeSecond)),
+		test.WithConfig(testCommitmentsYAMLWithoutMinConfirmDate),
 		test.WithAPIHandler(NewV1API),
 	)
 
@@ -1167,11 +1160,11 @@ func Test_StartCommitmentTransfer(t *testing.T) {
 }
 
 func Test_GetCommitmentByToken(t *testing.T) {
-	_, liquidServiceTypeFirst := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
-	_, liquidServiceTypeSecond := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
+	test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "first")
+	test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "second")
 	s := test.NewSetup(t,
 		test.WithDBFixtureFile("fixtures/start-data-commitments.sql"),
-		test.WithConfig(fmt.Sprintf(testCommitmentsYAMLWithoutMinConfirmDate, liquidServiceTypeFirst, liquidServiceTypeSecond)),
+		test.WithConfig(testCommitmentsYAMLWithoutMinConfirmDate),
 		test.WithAPIHandler(NewV1API),
 	)
 
@@ -1237,11 +1230,11 @@ func Test_GetCommitmentByToken(t *testing.T) {
 }
 
 func Test_TransferCommitment(t *testing.T) {
-	_, liquidServiceTypeFirst := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
-	liquidClientSecond, liquidServiceTypeSecond := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
+	test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "first")
+	liquidClientSecond := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "second")
 	s := test.NewSetup(t,
 		test.WithDBFixtureFile("fixtures/start-data-commitments.sql"),
-		test.WithConfig(fmt.Sprintf(testCommitmentsYAMLWithoutMinConfirmDate, liquidServiceTypeFirst, liquidServiceTypeSecond)),
+		test.WithConfig(testCommitmentsYAMLWithoutMinConfirmDate),
 		test.WithAPIHandler(NewV1API),
 	)
 
@@ -1487,11 +1480,11 @@ func Test_TransferCommitment(t *testing.T) {
 }
 
 func Test_TransferCommitmentForbiddenByCapacityCheck(t *testing.T) {
-	_, liquidServiceTypeFirst := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
-	liquidClientSecond, liquidServiceTypeSecond := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
+	test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "first")
+	liquidClientSecond := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "second")
 	s := test.NewSetup(t,
 		test.WithDBFixtureFile("fixtures/start-data-commitments.sql"),
-		test.WithConfig(fmt.Sprintf(testCommitmentsYAMLWithoutMinConfirmDate, liquidServiceTypeFirst, liquidServiceTypeSecond)),
+		test.WithConfig(testCommitmentsYAMLWithoutMinConfirmDate),
 		test.WithAPIHandler(NewV1API),
 	)
 
@@ -1610,12 +1603,12 @@ func Test_TransferCommitmentForbiddenByCapacityCheck(t *testing.T) {
 }
 
 func Test_GetCommitmentConversion(t *testing.T) {
-	_, liquidServiceTypeFirst := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
-	_, liquidServiceTypeSecond := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
-	_, liquidServiceTypeThird := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
+	test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "first")
+	test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "second")
+	test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "third")
 	s := test.NewSetup(t,
 		test.WithDBFixtureFile("fixtures/start-data-commitments.sql"),
-		test.WithConfig(fmt.Sprintf(testConvertCommitmentsYAML, liquidServiceTypeFirst, liquidServiceTypeSecond, liquidServiceTypeThird)),
+		test.WithConfig(testConvertCommitmentsYAML),
 		test.WithAPIHandler(NewV1API),
 	)
 
@@ -1680,11 +1673,11 @@ func Test_ConvertCommitments(t *testing.T) {
 		"capacity_a": {Unit: liquid.UnitBytes, Topology: liquid.AZAwareTopology, HasCapacity: true, HasQuota: true, NeedsResourceDemand: true, HandlesCommitments: true},
 		"capacity_b": {Unit: liquid.UnitBytes, Topology: liquid.AZAwareTopology, HasCapacity: true, HasQuota: true, NeedsResourceDemand: true, HandlesCommitments: true},
 	}
-	_, liquidServiceTypeThird := test.NewMockLiquidClient(srvInfoThird)
-	liquidClientFourth, liquidServiceTypeFourth := test.NewMockLiquidClient(srvInfoFourth)
+	test.NewMockLiquidClient(srvInfoThird, "third")
+	liquidClientFourth := test.NewMockLiquidClient(srvInfoFourth, "fourth")
 	s := test.NewSetup(t,
 		test.WithDBFixtureFile("fixtures/start-data-commitments.sql"),
-		test.WithConfig(fmt.Sprintf(testConvertCommitmentsYAML, liquidServiceTypeThird, liquidServiceTypeFourth)),
+		test.WithConfig(testConvertCommitmentsYAML),
 		test.WithAPIHandler(NewV1API),
 	)
 
@@ -1962,11 +1955,11 @@ func Test_ConvertCommitments(t *testing.T) {
 }
 
 func Test_UpdateCommitmentDuration(t *testing.T) {
-	_, liquidServiceTypeFirst := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
-	liquidClientSecond, liquidServiceTypeSecond := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
+	test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "first")
+	liquidClientSecond := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "second")
 	s := test.NewSetup(t,
 		test.WithDBFixtureFile("fixtures/start-data-commitments.sql"),
-		test.WithConfig(fmt.Sprintf(testCommitmentsYAMLWithoutMinConfirmDate, liquidServiceTypeFirst, liquidServiceTypeSecond)),
+		test.WithConfig(testCommitmentsYAMLWithoutMinConfirmDate),
 		test.WithAPIHandler(NewV1API),
 	)
 
@@ -2173,11 +2166,11 @@ func Test_UpdateCommitmentDuration(t *testing.T) {
 }
 
 func Test_MergeCommitments(t *testing.T) {
-	_, liquidServiceTypeFirst := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
-	liquidClientSecond, liquidServiceTypeSecond := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
+	test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "first")
+	liquidClientSecond := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "second")
 	s := test.NewSetup(t,
 		test.WithDBFixtureFile("fixtures/start-data-commitments.sql"),
-		test.WithConfig(fmt.Sprintf(testCommitmentsYAMLWithoutMinConfirmDate, liquidServiceTypeFirst, liquidServiceTypeSecond)),
+		test.WithConfig(testCommitmentsYAMLWithoutMinConfirmDate),
 		test.WithAPIHandler(NewV1API),
 	)
 
@@ -2451,11 +2444,11 @@ func Test_MergeCommitments(t *testing.T) {
 }
 
 func Test_RenewCommitments(t *testing.T) {
-	_, liquidServiceTypeFirst := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
-	liquidClientSecond, liquidServiceTypeSecond := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
+	test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "first")
+	liquidClientSecond := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "second")
 	s := test.NewSetup(t,
 		test.WithDBFixtureFile("fixtures/start-data-commitments.sql"),
-		test.WithConfig(fmt.Sprintf(testCommitmentsYAMLWithoutMinConfirmDate, liquidServiceTypeFirst, liquidServiceTypeSecond)),
+		test.WithConfig(testCommitmentsYAMLWithoutMinConfirmDate),
 		test.WithAPIHandler(NewV1API),
 	)
 

--- a/internal/api/inconsistencies_test.go
+++ b/internal/api/inconsistencies_test.go
@@ -4,7 +4,6 @@
 package api
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/sapcc/go-bits/assert"
@@ -30,20 +29,18 @@ const (
 		liquids:
 			shared:
 				area: testing
-				liquid_service_type: %[1]s
 			unshared:
 				area: testing
-				liquid_service_type: %[2]s
 	`
 )
 
 func TestFullInconsistencyReport(t *testing.T) {
-	_, liquidServiceType := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
-	_, liquidServiceType2 := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
+	test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "shared")
+	test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "unshared")
 	t.Helper()
 	s := test.NewSetup(t,
 		test.WithDBFixtureFile("fixtures/start-data-inconsistencies.sql"),
-		test.WithConfig(fmt.Sprintf(inconsistenciesTestConfigYAML, liquidServiceType, liquidServiceType2)),
+		test.WithConfig(inconsistenciesTestConfigYAML),
 		test.WithAPIHandler(NewV1API),
 	)
 
@@ -56,11 +53,11 @@ func TestFullInconsistencyReport(t *testing.T) {
 }
 
 func TestEmptyInconsistencyReport(t *testing.T) {
-	_, liquidServiceType := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
-	_, liquidServiceType2 := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
+	test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "shared")
+	test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "unshared")
 	t.Helper()
 	s := test.NewSetup(t,
-		test.WithConfig(fmt.Sprintf(inconsistenciesTestConfigYAML, liquidServiceType, liquidServiceType2)),
+		test.WithConfig(inconsistenciesTestConfigYAML),
 		test.WithAPIHandler(NewV1API),
 	)
 

--- a/internal/api/liquid_test.go
+++ b/internal/api/liquid_test.go
@@ -4,7 +4,6 @@
 package api
 
 import (
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -33,18 +32,17 @@ const (
 		liquids:
 			unittest:
 				area: testing
-				liquid_service_type: %[1]s
 		resource_behavior:
 		- { resource: unittest/capacity, overcommit_factor: 1.5 }
 	`
 )
 
 func commonLiquidTestSetup(t *testing.T, srvInfo liquid.ServiceInfo) (s test.Setup) {
-	_, liquidServiceType := test.NewMockLiquidClient(srvInfo)
+	test.NewMockLiquidClient(srvInfo, "unittest")
 
 	t.Helper()
 	s = test.NewSetup(t,
-		test.WithConfig(fmt.Sprintf(liquidCapacityTestConfigYAML, liquidServiceType)),
+		test.WithConfig(liquidCapacityTestConfigYAML),
 		test.WithAPIHandler(NewV1API),
 		test.WithProject(core.KeystoneProject{
 			Name: "project-1",

--- a/internal/api/removed_test.go
+++ b/internal/api/removed_test.go
@@ -5,7 +5,6 @@ package api
 
 import (
 	"bytes"
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -17,9 +16,9 @@ import (
 
 func TestForbidClusterIDHeader(t *testing.T) {
 	srvInfo := test.DefaultLiquidServiceInfo()
-	_, liquidServiceType := test.NewMockLiquidClient(srvInfo)
+	test.NewMockLiquidClient(srvInfo, "foo")
 	s := test.NewSetup(t,
-		test.WithConfig(fmt.Sprintf(`
+		test.WithConfig(`
 			availability_zones: [ az-one, az-two ]
 			discovery:
 				method: static
@@ -36,8 +35,7 @@ func TestForbidClusterIDHeader(t *testing.T) {
 			liquids:
 				foo:
 					area: testing
-					liquid_service_type: %[1]s
-		`, liquidServiceType)),
+		`),
 		test.WithAPIHandler(NewV1API,
 			httpapi.WithGlobalMiddleware(ForbidClusterIDHeader),
 		),

--- a/internal/api/translation_test.go
+++ b/internal/api/translation_test.go
@@ -5,7 +5,6 @@ package api
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -34,7 +33,6 @@ const (
 		liquids:
 			first:
 				area: first
-				liquid_service_type: %[1]s
 	`
 )
 
@@ -42,7 +40,7 @@ const (
 // subcapacity translation
 
 func TestTranslateManilaSubcapacities(t *testing.T) {
-	_, liquidServiceType := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
+	test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "first")
 
 	// this is what liquid-manila (or liquid-cinder) writes into the DB
 	subcapacitiesInLiquidFormat := []assert.JSONObject{
@@ -81,7 +79,7 @@ func TestTranslateManilaSubcapacities(t *testing.T) {
 		},
 	}
 
-	testSubcapacityTranslation(t, "cinder-manila-capacity", string(liquidServiceType), subcapacitiesInLiquidFormat, subcapacitiesInLegacyFormat)
+	testSubcapacityTranslation(t, "cinder-manila-capacity", subcapacitiesInLiquidFormat, subcapacitiesInLegacyFormat)
 }
 
 func TestTranslateIronicSubcapacities(t *testing.T) {
@@ -96,7 +94,7 @@ func TestTranslateIronicSubcapacities(t *testing.T) {
 	resInfo := srvInfo.Resources["capacity"]
 	resInfo.Attributes = json.RawMessage(buf)
 	srvInfo.Resources["capacity"] = resInfo
-	_, liquidServiceType := test.NewMockLiquidClient(srvInfo)
+	test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "first")
 
 	subcapacitiesInLiquidFormat := []assert.JSONObject{
 		{
@@ -146,11 +144,11 @@ func TestTranslateIronicSubcapacities(t *testing.T) {
 		},
 	}
 
-	testSubcapacityTranslation(t, "ironic-flavors", string(liquidServiceType), subcapacitiesInLiquidFormat, subcapacitiesInLegacyFormat, test.WithPersistedServiceInfo("first", srvInfo))
+	testSubcapacityTranslation(t, "ironic-flavors", subcapacitiesInLiquidFormat, subcapacitiesInLegacyFormat, test.WithPersistedServiceInfo("first", srvInfo))
 }
 
 func TestTranslateNovaSubcapacities(t *testing.T) {
-	_, liquidServiceType := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
+	test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "first")
 
 	subcapacitiesInLiquidFormat := []assert.JSONObject{
 		{
@@ -192,13 +190,13 @@ func TestTranslateNovaSubcapacities(t *testing.T) {
 		},
 	}
 
-	testSubcapacityTranslation(t, "nova-flavors", string(liquidServiceType), subcapacitiesInLiquidFormat, subcapacitiesInLegacyFormat)
+	testSubcapacityTranslation(t, "nova-flavors", subcapacitiesInLiquidFormat, subcapacitiesInLegacyFormat)
 }
 
-func testSubcapacityTranslation(t *testing.T, ruleID, liquidServiceType string, subcapacitiesInLiquidFormat, subcapacitiesInLegacyFormat []assert.JSONObject, opts ...test.SetupOption) {
+func testSubcapacityTranslation(t *testing.T, ruleID string, subcapacitiesInLiquidFormat, subcapacitiesInLegacyFormat []assert.JSONObject, opts ...test.SetupOption) {
 	opts = append([]test.SetupOption{
 		test.WithDBFixtureFile("fixtures/start-data-small.sql"),
-		test.WithConfig(fmt.Sprintf(testSmallConfigYAML, liquidServiceType)),
+		test.WithConfig(testSmallConfigYAML),
 		test.WithAPIHandler(NewV1API),
 	}, opts...)
 	s := test.NewSetup(t,
@@ -259,7 +257,7 @@ func testSubcapacityTranslation(t *testing.T, ruleID, liquidServiceType string, 
 // subresource translation
 
 func TestTranslateCinderVolumeSubresources(t *testing.T) {
-	_, liquidServiceType := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
+	test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "first")
 
 	subresourcesInLiquidFormat := []assert.JSONObject{
 		{
@@ -297,11 +295,11 @@ func TestTranslateCinderVolumeSubresources(t *testing.T) {
 		},
 	}
 
-	testSubresourceTranslation(t, "cinder-volumes", string(liquidServiceType), subresourcesInLiquidFormat, subresourcesInLegacyFormat)
+	testSubresourceTranslation(t, "cinder-volumes", subresourcesInLiquidFormat, subresourcesInLegacyFormat)
 }
 
 func TestTranslateCinderSnapshotSubresources(t *testing.T) {
-	_, liquidServiceType := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
+	test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "first")
 
 	subresourcesInLiquidFormat := []assert.JSONObject{
 		{
@@ -325,7 +323,7 @@ func TestTranslateCinderSnapshotSubresources(t *testing.T) {
 		},
 	}
 
-	testSubresourceTranslation(t, "cinder-snapshots", string(liquidServiceType), subresourcesInLiquidFormat, subresourcesInLegacyFormat)
+	testSubresourceTranslation(t, "cinder-snapshots", subresourcesInLiquidFormat, subresourcesInLegacyFormat)
 }
 
 func TestTranslateIronicSubresources(t *testing.T) {
@@ -341,7 +339,7 @@ func TestTranslateIronicSubresources(t *testing.T) {
 	srvInfo.Resources["capacity"] = resInfo
 
 	// this subcapacity translation depends on ResourceInfo.Attributes on the respective resource
-	_, liquidServiceType := test.NewMockLiquidClient(srvInfo)
+	test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "first")
 
 	subresourcesInLiquidFormat := []assert.JSONObject{
 		{
@@ -395,11 +393,11 @@ func TestTranslateIronicSubresources(t *testing.T) {
 		},
 	}
 
-	testSubresourceTranslation(t, "ironic-flavors", string(liquidServiceType), subresourcesInLiquidFormat, subresourcesInLegacyFormat, test.WithPersistedServiceInfo("first", srvInfo))
+	testSubresourceTranslation(t, "ironic-flavors", subresourcesInLiquidFormat, subresourcesInLegacyFormat, test.WithPersistedServiceInfo("first", srvInfo))
 }
 
 func TestTranslateNovaSubresources(t *testing.T) {
-	_, liquidServiceType := test.NewMockLiquidClient(test.DefaultLiquidServiceInfo())
+	test.NewMockLiquidClient(test.DefaultLiquidServiceInfo(), "first")
 
 	subresourcesInLiquidFormat := []assert.JSONObject{
 		{
@@ -497,13 +495,13 @@ func TestTranslateNovaSubresources(t *testing.T) {
 		},
 	}
 
-	testSubresourceTranslation(t, "nova-flavors", string(liquidServiceType), subresourcesInLiquidFormat, subresourcesInLegacyFormat)
+	testSubresourceTranslation(t, "nova-flavors", subresourcesInLiquidFormat, subresourcesInLegacyFormat)
 }
 
-func testSubresourceTranslation(t *testing.T, ruleID, liquidServiceType string, subresourcesInLiquidFormat, subresourcesInLegacyFormat []assert.JSONObject, opts ...test.SetupOption) {
+func testSubresourceTranslation(t *testing.T, ruleID string, subresourcesInLiquidFormat, subresourcesInLegacyFormat []assert.JSONObject, opts ...test.SetupOption) {
 	localOpts := []test.SetupOption{
 		test.WithDBFixtureFile("fixtures/start-data-small.sql"),
-		test.WithConfig(fmt.Sprintf(testSmallConfigYAML, liquidServiceType)),
+		test.WithConfig(testSmallConfigYAML),
 		test.WithAPIHandler(NewV1API),
 	}
 	opts = append(localOpts, opts...)

--- a/internal/collector/capacity_scrape_test.go
+++ b/internal/collector/capacity_scrape_test.go
@@ -45,10 +45,8 @@ const (
 		liquids:
 			shared:
 				area: shared
-				liquid_service_type: %[1]s
 			unshared:
 				area: unshared
-				liquid_service_type: %[2]s
 	`
 
 	testScanCapacitySingleLiquidConfigYAML = `
@@ -68,7 +66,6 @@ const (
 		liquids:
 			shared:
 				area: shared
-				liquid_service_type: %[1]s
 	`
 
 	testScanCapacityWithCommitmentsConfigYAML = `
@@ -85,14 +82,12 @@ const (
 		liquids:
 			first:
 				area: first
-				liquid_service_type: %[1]s
 				commitment_behavior_per_resource: &commitment-on-capacity
 					- key: capacity
 						value:
 							durations_per_domain: [{ key: '.*', value: [ '1 hour', '10 days' ] }]
 			second:
 				area: second
-				liquid_service_type: %[2]s
 				commitment_behavior_per_resource: *commitment-on-capacity
 		resource_behavior:
 			# test that overcommit factor is considered when confirming commitments
@@ -133,10 +128,10 @@ func Test_ScanCapacity(t *testing.T) {
 			},
 		},
 	}
-	mockLiquidClient, liquidServiceType := test.NewMockLiquidClient(srvInfo)
-	mockLiquidClient2, liquidServiceType2 := test.NewMockLiquidClient(srvInfo2)
+	mockLiquidClient := test.NewMockLiquidClient(srvInfo, "shared")
+	mockLiquidClient2 := test.NewMockLiquidClient(srvInfo2, "unshared")
 	s := test.NewSetup(t,
-		test.WithConfig(fmt.Sprintf(testScanCapacityConfigYAML, liquidServiceType, liquidServiceType2)),
+		test.WithConfig(testScanCapacityConfigYAML),
 		// services must be created as a baseline
 		test.WithLiquidConnections,
 	)
@@ -294,9 +289,9 @@ func Test_ScanCapacityWithSubcapacities(t *testing.T) {
 			"limes_unittest_capacity_larger_half":  {Type: liquid.MetricTypeGauge},
 		},
 	}
-	mockLiquidClient, liquidServiceType := test.NewMockLiquidClient(srvInfo)
+	mockLiquidClient := test.NewMockLiquidClient(srvInfo, "shared")
 	s := test.NewSetup(t,
-		test.WithConfig(fmt.Sprintf(testScanCapacitySingleLiquidConfigYAML, liquidServiceType)),
+		test.WithConfig(testScanCapacitySingleLiquidConfigYAML),
 		// services must be created as a baseline
 		test.WithLiquidConnections,
 	)
@@ -436,9 +431,9 @@ func Test_ScanCapacityAZAware(t *testing.T) {
 			},
 		},
 	}
-	mockLiquidClient, liquidServiceType := test.NewMockLiquidClient(srvInfo)
+	mockLiquidClient := test.NewMockLiquidClient(srvInfo, "shared")
 	s := test.NewSetup(t,
-		test.WithConfig(fmt.Sprintf(testScanCapacitySingleLiquidConfigYAML, liquidServiceType)),
+		test.WithConfig(testScanCapacitySingleLiquidConfigYAML),
 		// services must be created as a baseline
 		test.WithLiquidConnections,
 	)
@@ -526,9 +521,9 @@ func Test_ScanCapacityAZAware(t *testing.T) {
 
 func TestScanCapacityReportsZeroValues(t *testing.T) {
 	srvInfo := test.DefaultLiquidServiceInfo()
-	mockLiquidClient, liquidServiceType := test.NewMockLiquidClient(srvInfo)
+	mockLiquidClient := test.NewMockLiquidClient(srvInfo, "shared")
 	s := test.NewSetup(t,
-		test.WithConfig(fmt.Sprintf(testScanCapacitySingleLiquidConfigYAML, liquidServiceType)),
+		test.WithConfig(testScanCapacitySingleLiquidConfigYAML),
 		// services must be created as a baseline
 		test.WithLiquidConnections,
 	)
@@ -623,9 +618,9 @@ func setClusterCapacitorsStale(t *testing.T, s test.Setup) {
 
 func Test_ScanCapacityButNoResources(t *testing.T) {
 	srvInfo := test.DefaultLiquidServiceInfo()
-	mockLiquidClient, liquidServiceType := test.NewMockLiquidClient(srvInfo)
+	mockLiquidClient := test.NewMockLiquidClient(srvInfo, "shared")
 	s := test.NewSetup(t,
-		test.WithConfig(fmt.Sprintf(testScanCapacitySingleLiquidConfigYAML, liquidServiceType)),
+		test.WithConfig(testScanCapacitySingleLiquidConfigYAML),
 		// services must be created as a baseline
 		test.WithLiquidConnections,
 	)
@@ -700,9 +695,9 @@ func Test_ScanManualCapacity(t *testing.T) {
 	testScanCapacityManualConfigYAML := testScanCapacitySingleLiquidConfigYAML + `
 				fixed_capacity_values:
 					things: 1000000`
-	mockLiquidClient, liquidServiceType := test.NewMockLiquidClient(srvInfo)
+	mockLiquidClient := test.NewMockLiquidClient(srvInfo, "shared")
 	s := test.NewSetup(t,
-		test.WithConfig(fmt.Sprintf(testScanCapacityManualConfigYAML, liquidServiceType)),
+		test.WithConfig(testScanCapacityManualConfigYAML),
 		test.WithLiquidConnections,
 	)
 
@@ -801,10 +796,10 @@ func CommonScanCapacityWithCommitmentsSetup(t *testing.T) (
 			},
 		},
 	}
-	firstLiquidClient, liquidServiceType := test.NewMockLiquidClient(firstServiceInfo)
-	secondLiquidClient, liquidServiceType2 := test.NewMockLiquidClient(secondServiceInfo)
+	firstLiquidClient = test.NewMockLiquidClient(firstServiceInfo, "first")
+	secondLiquidClient = test.NewMockLiquidClient(secondServiceInfo, "second")
 	s = test.NewSetup(t,
-		test.WithConfig(fmt.Sprintf(testScanCapacityWithCommitmentsConfigYAML, liquidServiceType, liquidServiceType2)),
+		test.WithConfig(testScanCapacityWithCommitmentsConfigYAML),
 		test.WithDBFixtureFile("fixtures/capacity_scrape_with_commitments.sql"),
 		test.WithLiquidConnections,
 	)

--- a/internal/collector/commitment_cleanup_test.go
+++ b/internal/collector/commitment_cleanup_test.go
@@ -5,7 +5,6 @@ package collector
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 	"time"
 
@@ -37,7 +36,6 @@ const (
 		liquids:
 			unittest:
 				area: testing
-				liquid_service_type: %[1]s
 				commitment_behavior_per_resource:
 					- key: capacity
 						value:
@@ -47,9 +45,9 @@ const (
 
 func TestCleanupOldCommitmentsJob(t *testing.T) {
 	srvInfo := test.DefaultLiquidServiceInfo()
-	mockLiquidClient, liquidServiceType := test.NewMockLiquidClient(srvInfo)
+	mockLiquidClient := test.NewMockLiquidClient(srvInfo, "unittest")
 	s := test.NewSetup(t,
-		test.WithConfig(fmt.Sprintf(testCleanupOldCommitmentsConfigYAML, liquidServiceType)),
+		test.WithConfig(testCleanupOldCommitmentsConfigYAML),
 		test.WithLiquidConnections,
 	)
 	c := getCollector(t, s)

--- a/internal/collector/expiring_commitments_test.go
+++ b/internal/collector/expiring_commitments_test.go
@@ -4,7 +4,6 @@
 package collector
 
 import (
-	"fmt"
 	"html/template"
 	"testing"
 
@@ -32,7 +31,6 @@ const (
 		liquids:
 			shared:
 				area: testing
-				liquid_service_type: %[1]s
 		resource_behavior:
 		- resource: first/things
 			identity_in_v1_api: service/resource
@@ -46,9 +44,9 @@ const (
 
 func Test_ExpiringCommitmentNotification(t *testing.T) {
 	srvInfo := test.DefaultLiquidServiceInfo()
-	_, liquidServiceType := test.NewMockLiquidClient(srvInfo)
+	test.NewMockLiquidClient(srvInfo, "shared")
 	s := test.NewSetup(t,
-		test.WithConfig(fmt.Sprintf(testMailNoopWithTemplateYAML, liquidServiceType)),
+		test.WithConfig(testMailNoopWithTemplateYAML),
 		test.WithDBFixtureFile("fixtures/mail_expiring_commitments.sql"))
 	c := getCollector(t, s)
 

--- a/internal/collector/keystone_test.go
+++ b/internal/collector/keystone_test.go
@@ -5,7 +5,6 @@ package collector
 
 import (
 	"encoding/json"
-	"fmt"
 	"sort"
 	"testing"
 	"time"
@@ -39,18 +38,17 @@ const (
 		liquids:
 			shared:
 				area: shared
-				liquid_service_type: %[1]s
 			unshared:
 				area: unshared
-				liquid_service_type: %[1]s
 	`
 )
 
 func keystoneTestCluster(t *testing.T) (test.Setup, *core.Cluster) {
 	srvInfo := test.DefaultLiquidServiceInfo()
-	_, liquidServiceType := test.NewMockLiquidClient(srvInfo)
+	test.NewMockLiquidClient(srvInfo, "shared")
+	test.NewMockLiquidClient(srvInfo, "unshared")
 	s := test.NewSetup(t,
-		test.WithConfig(fmt.Sprintf(testKeystoneConfigYAML, liquidServiceType)),
+		test.WithConfig(testKeystoneConfigYAML),
 		// the functions called from the tests of this setup run in collect task, so we use the LiquidConnections
 		test.WithLiquidConnections,
 	)

--- a/internal/collector/mail_delivery_test.go
+++ b/internal/collector/mail_delivery_test.go
@@ -6,7 +6,6 @@ package collector
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 	"time"
 
@@ -34,7 +33,6 @@ const (
 		liquids:
 			shared:
 				area: testing
-				liquid_service_type: %[1]s
 `
 )
 
@@ -61,9 +59,9 @@ func (m *MockMail) PostMail(ctx context.Context, req MailRequest) error {
 
 func Test_MailDelivery(t *testing.T) {
 	srvInfo := test.DefaultLiquidServiceInfo()
-	_, liquidServiceType := test.NewMockLiquidClient(srvInfo)
+	test.NewMockLiquidClient(srvInfo, "shared")
 	s := test.NewSetup(t,
-		test.WithConfig(fmt.Sprintf(testMailNoopYAML, liquidServiceType)),
+		test.WithConfig(testMailNoopYAML),
 		test.WithDBFixtureFile("fixtures/mail_delivery.sql"))
 	c := getCollector(t, s)
 

--- a/internal/collector/quota_overrides_test.go
+++ b/internal/collector/quota_overrides_test.go
@@ -4,7 +4,6 @@
 package collector
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -20,9 +19,9 @@ import (
 func TestApplyQuotaOverrides(t *testing.T) {
 	// setup enough to have fully populated project_services and project_resources
 	srvInfo := test.DefaultLiquidServiceInfo()
-	mockLiquidClient, liquidServiceType := test.NewMockLiquidClient(srvInfo)
+	mockLiquidClient := test.NewMockLiquidClient(srvInfo, "unittest")
 	s := test.NewSetup(t,
-		test.WithConfig(fmt.Sprintf(testScrapeBasicConfigYAML, liquidServiceType)),
+		test.WithConfig(testScrapeBasicConfigYAML),
 		// here, we use the LiquidConnections, as this runs within the collect task
 		test.WithLiquidConnections,
 	)

--- a/internal/collector/scrape_test.go
+++ b/internal/collector/scrape_test.go
@@ -78,7 +78,6 @@ const (
 		liquids:
 			unittest:
 				area: testing
-				liquid_service_type: %[1]s
 				# to check how they are merged with the ServiceInfo of the liquids
 				rate_limits: 
 					global:
@@ -119,9 +118,9 @@ func commonComplexScrapeTestSetup(t *testing.T) (s test.Setup, scrapeJob jobloop
 			"limes_unittest_things_usage":   {Type: liquid.MetricTypeGauge},
 		},
 	}
-	mockLiquidClient, liquidServiceType := test.NewMockLiquidClient(srvInfo)
+	mockLiquidClient = test.NewMockLiquidClient(srvInfo, "unittest")
 	s = test.NewSetup(t,
-		test.WithConfig(fmt.Sprintf(testScrapeBasicConfigYAML, liquidServiceType)),
+		test.WithConfig(testScrapeBasicConfigYAML),
 		test.WithLiquidConnections,
 	)
 	prepareDomainsAndProjectsForScrape(t, s)
@@ -682,7 +681,6 @@ const (
 		liquids:
 			noop:
 				area: testing
-				liquid_service_type: %[1]s
 	`
 )
 
@@ -691,9 +689,9 @@ func Test_ScrapeButNoResources(t *testing.T) {
 		Version:   1,
 		Resources: map[liquid.ResourceName]liquid.ResourceInfo{},
 	}
-	mockLiquidClient, liquidServiceType := test.NewMockLiquidClient(srvInfo)
+	mockLiquidClient := test.NewMockLiquidClient(srvInfo, "noop")
 	s := test.NewSetup(t,
-		test.WithConfig(fmt.Sprintf(testNoopConfigYAML, liquidServiceType)),
+		test.WithConfig(testNoopConfigYAML),
 		test.WithLiquidConnections,
 	)
 	prepareDomainsAndProjectsForScrape(t, s)
@@ -733,9 +731,9 @@ func Test_ScrapeReturnsNoUsageData(t *testing.T) {
 			"things": {Unit: limes.UnitNone, HasQuota: true, Topology: liquid.AZAwareTopology},
 		},
 	}
-	mockLiquidClient, liquidServiceType := test.NewMockLiquidClient(srvInfo)
+	mockLiquidClient := test.NewMockLiquidClient(srvInfo, "noop")
 	s := test.NewSetup(t,
-		test.WithConfig(fmt.Sprintf(testNoopConfigYAML, liquidServiceType)),
+		test.WithConfig(testNoopConfigYAML),
 		test.WithLiquidConnections,
 	)
 	prepareDomainsAndProjectsForScrape(t, s)

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -88,8 +88,6 @@ func (c DiscoveryConfiguration) FilterDomains(domains []KeystoneDomain) []Keysto
 // It holds configurations for how to deal with the service on project level (quota, usage, commitment) as well as cluster level (capacity).
 type LiquidConfiguration struct {
 	Area string `yaml:"area"`
-	// LiquidServiceType is the service type under which the liquid is registered in the Keystone catalog.
-	LiquidServiceType string `yaml:"liquid_service_type"`
 
 	// FixedCapacityConfiguration and PrometheusCapacityConfiguration are additional means of providing capacity for this
 	// service_type besides the liquid.ServiceCapacityReport. All means are not exclusive and can be combined, as long as

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -49,7 +49,6 @@ func TestConfigValidation(t *testing.T) {
 		liquids:
 			shared:
 				area: testing
-				liquid_service_type: shared
 	`, "\t", "  ")), time.Now, nil, true)
 	assert.DeepEqual(t, "errs", errs.Join(","), "invalid value for availability_zones[0]: \"\" is not an acceptable name for a real AZ,invalid value for availability_zones[1]: \"any\" is not an acceptable name for a real AZ")
 
@@ -58,7 +57,6 @@ func TestConfigValidation(t *testing.T) {
 		availability_zones: [ foo ]
 		liquids:
 			shared:
-				liquid_service_type: shared
 	`, "\t", "  ")), time.Now, nil, true)
 	assert.DeepEqual(t, "errs", errs.Join(","), "missing configuration value: liquids.shared.area")
 
@@ -68,7 +66,6 @@ func TestConfigValidation(t *testing.T) {
 		liquids:
 			shared:
 				area: testing
-				liquid_service_type: shared
 		resource_behavior:
 			- resource:
 		rate_behavior:
@@ -82,7 +79,6 @@ func TestConfigValidation(t *testing.T) {
 		liquids:
 			shared:
 				area: testing
-				liquid_service_type: shared
 		quota_distribution_configs:
 			- { resource: '', model: invalid, autogrow: { growth_multiplier: 1.0, usage_data_retention_period: 48h } }
 	`, "\t", "  ")), time.Now, nil, true)
@@ -94,7 +90,6 @@ func TestConfigValidation(t *testing.T) {
 		liquids:
 			shared:
 				area: testing
-				liquid_service_type: shared
 		quota_distribution_configs:
 			- { resource: unittest/capacity, model: autogrow }
 	`, "\t", "  ")), time.Now, nil, true)
@@ -106,7 +101,6 @@ func TestConfigValidation(t *testing.T) {
 		liquids:
 			shared:
 				area: testing
-				liquid_service_type: shared
 		quota_distribution_configs:
 			- { resource: shared/capacity, model: autogrow, autogrow: { growth_multiplier: -5.0, usage_data_retention_period: 0h } }
 	`, "\t", "  ")), time.Now, nil, true)
@@ -118,7 +112,6 @@ func TestConfigValidation(t *testing.T) {
 		liquids:
 			first:
 				area: first
-				liquid_service_type: foo
 				commitment_behavior_per_resource:
 					- key: capacity_c32
 						value:
@@ -130,7 +123,6 @@ func TestConfigValidation(t *testing.T) {
 							conversion_rule: { identifier: flavor2, weight: 144 }
 			second:
 				area: second
-				liquid_service_type: bar
 				commitment_behavior_per_resource:
 					- key: capacity_a
 						value:
@@ -147,10 +139,8 @@ func TestConfigValidation(t *testing.T) {
 		liquids:
 			shared:
 				area: testing
-				liquid_service_type: shared
 			unshared:
 				area: testing
-				liquid_service_type: unshared
 		resource_behavior:
 			- { resource: shared/capacity, overcommit_factor: 10.0 }
 			- resource: unshared/capacity

--- a/internal/core/liquid.go
+++ b/internal/core/liquid.go
@@ -32,7 +32,6 @@ import (
 // in case of configuration changes.
 type LiquidConnection struct {
 	// configuration
-	LiquidServiceType               string
 	ServiceType                     db.ServiceType
 	FixedCapacityConfiguration      Option[map[liquid.ResourceName]uint64]
 	PrometheusCapacityConfiguration Option[PrometheusCapacityConfiguration]
@@ -51,11 +50,7 @@ type LiquidConnection struct {
 
 // MakeLiquidConnection is a factory to fill all necessary configuration fields
 func MakeLiquidConnection(lc LiquidConfiguration, serviceType db.ServiceType, availabilityZones []limes.AvailabilityZone, rateLimits ServiceRateLimitConfiguration, timeNow func() time.Time, dbm *gorp.DbMap) LiquidConnection {
-	if lc.LiquidServiceType == "" {
-		lc.LiquidServiceType = "liquid-" + string(serviceType)
-	}
 	return LiquidConnection{
-		LiquidServiceType:               lc.LiquidServiceType,
 		ServiceType:                     serviceType,
 		FixedCapacityConfiguration:      lc.FixedCapacityConfiguration,
 		PrometheusCapacityConfiguration: lc.PrometheusCapacityConfiguration,
@@ -69,7 +64,7 @@ func MakeLiquidConnection(lc LiquidConfiguration, serviceType db.ServiceType, av
 // Init is called before any other interface methods, and allows the LiquidConnection to
 // perform first-time initialization.
 func (l *LiquidConnection) Init(ctx context.Context, client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (err error) {
-	l.LiquidClient, err = NewLiquidClient(client, eo, liquidapi.ClientOpts{ServiceType: l.LiquidServiceType})
+	l.LiquidClient, err = NewLiquidClient(client, eo, liquidapi.ClientOpts{ServiceType: "liquid-" + string(l.ServiceType)})
 	if err != nil {
 		return err
 	}
@@ -104,7 +99,7 @@ func (l *LiquidConnection) compareServiceInfoVersions(ctx context.Context, infoV
 		return srv, nil
 	}
 
-	logg.Info("ServiceInfo version for %s changed from %d to %d; reloading and persisting ServiceInfo.", l.LiquidServiceType, currentVersion, infoVersion)
+	logg.Info("ServiceInfo version for %s changed from %d to %d; reloading and persisting ServiceInfo.", l.ServiceType, currentVersion, infoVersion)
 	serviceInfo, _, err := l.retrieveServiceInfo(ctx, false)
 	if err != nil {
 		return srv, err
@@ -112,7 +107,7 @@ func (l *LiquidConnection) compareServiceInfoVersions(ctx context.Context, infoV
 	// recheck to be sure, that there was no update between pulling the report and getting the ServiceInfo
 	newVersion := serviceInfo.Version
 	if infoVersion != newVersion {
-		return srv, fmt.Errorf("ServiceInfo version mismatch for %s after update: GetInfo %d, report %d", l.LiquidServiceType, newVersion, infoVersion)
+		return srv, fmt.Errorf("ServiceInfo version mismatch for %s after update: GetInfo %d, report %d", l.ServiceType, newVersion, infoVersion)
 	}
 	srv, err = SaveServiceInfoToDB(l.ServiceType, serviceInfo, l.AvailabilityZones, l.RateLimits, l.timeNow(), l.DB)
 	if err != nil {
@@ -134,7 +129,7 @@ func (l *LiquidConnection) retrieveServiceInfo(ctx context.Context, dbFallback b
 	// result, err := liquid.ServiceInfo{}, errors.New("some error")
 	if err != nil && dbFallback {
 		apiSuccess = false
-		logg.Info("request to Liquid failed for %s, falling back to DB: %w", l.LiquidServiceType, err)
+		logg.Info("request to Liquid failed for %s, falling back to DB: %w", l.ServiceType, err)
 		var serviceInfos map[db.ServiceType]liquid.ServiceInfo
 		serviceInfos, err = readServiceInfoFromDB(l.DB, Some(l.ServiceType))
 		result = serviceInfos[l.ServiceType]

--- a/internal/datamodel/quota_overrides_test.go
+++ b/internal/datamodel/quota_overrides_test.go
@@ -4,7 +4,6 @@
 package datamodel
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/sapcc/go-api-declarations/liquid"
@@ -37,10 +36,8 @@ const (
 		liquids:
 			first:
 				area: first
-				liquid_service_type: %[1]s
 			second:
 				area: second
-				liquid_service_type: %[1]s
 	`
 
 	testQuotaOverridesWithRenamingConfigYAML = `
@@ -60,10 +57,8 @@ const (
 		liquids:
 			first:
 				area: first
-				liquid_service_type: %[1]s
 			second:
 				area: second
-				liquid_service_type: %[1]s
 		resource_behavior:
 		- resource: first/capacity
 			identity_in_v1_api: capacities/first
@@ -108,9 +103,10 @@ var expectedQuotaOverrides = map[string]map[string]map[db.ServiceType]map[liquid
 func TestQuotaOverridesWithoutResourceRenaming(t *testing.T) {
 	t.Setenv("LIMES_QUOTA_OVERRIDES_PATH", "fixtures/quota-overrides-no-renaming.json")
 	srvInfo := test.DefaultLiquidServiceInfo()
-	_, liquidServiceType := test.NewMockLiquidClient(srvInfo)
+	test.NewMockLiquidClient(srvInfo, "first")
+	test.NewMockLiquidClient(srvInfo, "second")
 	s := test.NewSetup(t,
-		test.WithConfig(fmt.Sprintf(testQuotaOverridesNoRenamingConfigYAML, liquidServiceType)),
+		test.WithConfig(testQuotaOverridesNoRenamingConfigYAML),
 		// here, we use the LiquidConnections, as this runs within the collect task
 		test.WithLiquidConnections,
 	)
@@ -124,9 +120,10 @@ func TestQuotaOverridesWithoutResourceRenaming(t *testing.T) {
 func TestQuotaOverridesWithResourceRenaming(t *testing.T) {
 	t.Setenv("LIMES_QUOTA_OVERRIDES_PATH", "fixtures/quota-overrides-with-renaming.json")
 	srvInfo := test.DefaultLiquidServiceInfo()
-	_, liquidServiceType := test.NewMockLiquidClient(srvInfo)
+	test.NewMockLiquidClient(srvInfo, "first")
+	test.NewMockLiquidClient(srvInfo, "second")
 	s := test.NewSetup(t,
-		test.WithConfig(fmt.Sprintf(testQuotaOverridesWithRenamingConfigYAML, liquidServiceType)),
+		test.WithConfig(testQuotaOverridesWithRenamingConfigYAML),
 		// here, we use the LiquidConnections, as this runs within the collect task
 		test.WithLiquidConnections,
 	)

--- a/internal/test/mock_liquid_client.go
+++ b/internal/test/mock_liquid_client.go
@@ -9,11 +9,9 @@ import (
 	"maps"
 	"slices"
 
-	"github.com/gofrs/uuid/v5"
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/sapcc/go-api-declarations/liquid"
 	"github.com/sapcc/go-bits/liquidapi"
-	"github.com/sapcc/go-bits/must"
 
 	"github.com/sapcc/limes/internal/core"
 	"github.com/sapcc/limes/internal/db"
@@ -69,14 +67,9 @@ var mockLiquidClients = make(map[db.ServiceType]core.LiquidClient)
 // Additionally, the client is put into an internal registry under the returned
 // service type string. This value shall be put into the cluster configuration
 // to allow the core.Cluster object to find your mock client.
-func NewMockLiquidClient(serviceInfo liquid.ServiceInfo) (client *MockLiquidClient, serviceType db.ServiceType) {
-	// We use a randomly-generated service type here, in order to allow for
-	// multiple tests to proceed in parallel without interfering with each other
-	// (once we deem this actually safe to do).
-	serviceType = db.ServiceType(must.Return(uuid.NewV4()).String())
-
+func NewMockLiquidClient(serviceInfo liquid.ServiceInfo, serviceType db.ServiceType) (client *MockLiquidClient) {
 	client = &MockLiquidClient{serviceInfo: serviceInfo}
-	mockLiquidClients[serviceType] = client
+	mockLiquidClients["liquid-"+serviceType] = client
 	return
 }
 


### PR DESCRIPTION
The `LiquidServiceType` was only used for testing, for productive use, we only have configurations which use `"liquid-"+serviceType` anyways. 

I ran the collect job once locally to check that all liquids are found properly and did not spot any issues.