### PR TITLE
liquid-ironic: limit memory usage when listing instances

### DIFF
--- a/docs/liquids/ironic.md
+++ b/docs/liquids/ironic.md
@@ -18,6 +18,7 @@ This liquid provides support for the baremetal compute service Ironic.
 | `with_subcapacities` | boolean | If true, subcapacities are reported. |
 | `with_subresources` | boolean | If true, subresources are reported. |
 | `node_page_limit` | integer | When listing baremetal nodes during capacity calculation, only this many nodes will be listed at once. Defaults to 100. This number has a major impact on the peak memory usage of this liquid, because Ironic nodes often have an absurd amount of metadata on them that we need to parse temporarily. Reducing this number reduces memory consumption nearly linearly, at the cost of linearly increasing the amount of requests that need to be made to Ironic. |
+| `instance_page_limit` | integer | When listing Nova instances during usage calculation, only this many instances will be listed at once. Defaults to 250. Similar to `node_page_limit`, this can have a major impact on the peak memory usage of this liquid, though usually setting this is only required when there are projects with a very high number of Ironic-based Nova instances. |
 
 ## Resources
 

--- a/internal/liquids/ironic/capacity.go
+++ b/internal/liquids/ironic/capacity.go
@@ -72,9 +72,8 @@ func (l *Logic) ScanCapacity(ctx context.Context, req liquid.ServiceCapacityRequ
 	//
 	nodesByFlavorName := make(map[string][]Node)
 	// set a base value if the value is not provided by config
-	opts := &nodes.ListOpts{Limit: 100}
-	if l.NodePageLimit > 0 {
-		opts.Limit = l.NodePageLimit
+	opts := &nodes.ListOpts{
+		Limit: l.NodePageLimit.UnwrapOr(100),
 	}
 	err = ListNodesDetail(l.IronicV1, opts).EachPage(ctx, func(ctx context.Context, page pagination.Page) (bool, error) {
 		var nodes []Node

--- a/internal/liquids/ironic/liquid.go
+++ b/internal/liquids/ironic/liquid.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors"
+	. "github.com/majewsky/gg/option"
 	"github.com/sapcc/go-api-declarations/liquid"
 	"github.com/sapcc/go-bits/liquidapi"
 	"github.com/sapcc/go-bits/respondwith"
@@ -27,7 +28,8 @@ type Logic struct {
 	WithSubcapacities bool                               `json:"with_subcapacities"`
 	WithSubresources  bool                               `json:"with_subresources"`
 	NodeToAZOverrides map[string]liquid.AvailabilityZone `json:"node_to_az_overrides"`
-	NodePageLimit     int                                `json:"node_page_limit"`
+	NodePageLimit     Option[int]                        `json:"node_page_limit"`
+	InstancePageLimit Option[int]                        `json:"instance_page_limit"`
 	// connections
 	NovaV2       *gophercloud.ServiceClient `json:"-"`
 	IronicV1     *gophercloud.ServiceClient `json:"-"`

--- a/internal/liquids/ironic/usage.go
+++ b/internal/liquids/ironic/usage.go
@@ -66,6 +66,7 @@ func (l *Logic) ScanUsage(ctx context.Context, projectUUID string, req liquid.Se
 		opts := servers.ListOpts{
 			AllTenants: true,
 			TenantID:   projectUUID,
+			Limit:      l.InstancePageLimit.UnwrapOr(250),
 		}
 		err := servers.List(l.NovaV2, opts).EachPage(ctx, func(ctx context.Context, page pagination.Page) (bool, error) {
 			var instances []servers.Server


### PR DESCRIPTION
There is so much crap in the JSON returned by Nova /servers/detail that it reliably blows over our 128 MiB memory limit in prod regions with large customer projects (one project has nearly 1k baremetal nodes).

Usually, I dislike pagination, because OpenStack is rather bad at implementing pagination well. But I'm not increasing that memory limit. More than that for a single liquid is preposterous.

Tested against eu-de-1:
```
$ limesctl liquid report-usage ironic $BIG_PROJECT_UUID -c -e http://localhost:8180/
ServiceUsageReports are identical
```