### PR TITLE
internal/core: fix rates records created from configured rates

### DIFF
--- a/internal/collector/fixtures/scrape0.sql
+++ b/internal/collector/fixtures/scrape0.sql
@@ -20,7 +20,7 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (2, 1, 'dre
 
 INSERT INTO rates (id, service_id, name, liquid_version, topology, has_usage) VALUES (1, 1, 'firstrate', 1, 'flat', TRUE);
 INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, has_usage) VALUES (2, 1, 'secondrate', 1, 'KiB', 'flat', TRUE);
-INSERT INTO rates (id, service_id, name, liquid_version) VALUES (3, 1, 'xOtherRate', 1);
+INSERT INTO rates (id, service_id, name, liquid_version, topology) VALUES (3, 1, 'xOtherRate', 1, 'flat');
 INSERT INTO rates (id, service_id, name, liquid_version) VALUES (4, 1, 'xAnotherRate', 1);
 
 INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, needs_resource_demand, has_quota, path) VALUES (1, 1, 'capacity', 1, 'B', 'az-aware', TRUE, TRUE, TRUE, 'unittest/capacity');


### PR DESCRIPTION
We only relied on the RateInfo returned by LIQUID when creating `rates` records, but for rates that are only configured (i.e. limit only and no usage), we do not have a RateInfo. In this case, we're now putting in UnitNone and FlatTopology as reasonable fallbacks. If anything else needs to be supported in the future, we need to extend the config format.