### PR TITLE
liquid: Add project not found handling for quota syncs

### DIFF
--- a/internal/collector/scrape_test.go
+++ b/internal/collector/scrape_test.go
@@ -347,7 +347,7 @@ func Test_ScrapeSuccess(t *testing.T) {
 		failedAt2.Add(30*time.Second).Unix(),
 	)
 
-	// StatusNotFound errors
+	// Projects that are not known by the backend service should return a StatusNotFound error and should not be processed further.
 	notFoundError := gophercloud.ErrUnexpectedResponseCode{Expected: []int{204}, Actual: http.StatusNotFound, URL: "setQuota"}
 	s.LiquidClients["unittest"].SetQuotaError(notFoundError)
 	expectedErrorNotFoundRx := regexp.MustCompile(regexp.QuoteMeta(notFoundError.Error()))


### PR DESCRIPTION
As mentioned by @kayrus, the setQuota endpoint should handle 404 errors for projects that are not managed by the backend service. I implemented this suggestion in this PR and included a unit test. I also included a change. If a notFound error is provided, the error will be returned to the caller to avoid silencing it.

This is not a good implementation however, which is why this is a draft.
- Limes ignores the projects and doesn't requeue them to set quotas.
- I'm also not sure if we should use the gophercloud error structure or if we should opt for a custom one. 

I would like to hand over this decision to @majewsky.

I close this draft for now as it appears the quota sync can be skipped by providing `forbidden=true` to the corresponding resource.
