### PR TITLE
switch condition for "forbidden" in quota-sync

### DIFF
--- a/internal/collector/sync_quota_to_backend.go
+++ b/internal/collector/sync_quota_to_backend.go
@@ -169,7 +169,7 @@ func (c *Collector) performQuotaSync(ctx context.Context, srv db.ProjectService,
 			return nil
 		}
 
-		if forbidden && currentQuotaPtr.UnwrapOr(0) != 0 {
+		if forbidden && currentQuotaPtr.UnwrapOr(0) == 0 {
 			return nil
 		}
 


### PR DESCRIPTION
I think it makes no sense that a forbidden-entry is skipped, only if the quota is `!=0`