### PR TITLE
rename old cluster level table abbreviations

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -732,10 +732,10 @@ func Test_ProjectOperations(t *testing.T) {
 	err := s.DB.QueryRow(`
 		SELECT pra.rate_limit, pra.window_ns
 		FROM project_rates pra
-		JOIN rates cra ON cra.id = pra.rate_id
-		JOIN services cs ON cs.id = cra.service_id
+		JOIN rates ra ON ra.id = pra.rate_id
+		JOIN services s ON s.id = ra.service_id
 		JOIN projects p ON p.id = pra.project_id
-		WHERE p.name = $1 AND cs.type = $2 AND cra.name = $3`,
+		WHERE p.name = $1 AND s.type = $2 AND ra.name = $3`,
 		"berlin", "shared", "service/shared/notexistent:bogus").Scan(&actualLimit, &actualWindow)
 	// There shouldn't be anything in the DB.
 	if !errors.Is(err, sql.ErrNoRows) {
@@ -775,10 +775,10 @@ func Test_ProjectOperations(t *testing.T) {
 	getProjectRateQuery := `
 		SELECT pra.id, pra.rate_limit, pra.window_ns
 		FROM project_rates pra
-		JOIN rates cra ON cra.id = pra.rate_id
-		JOIN services cs ON cs.id = cra.service_id
+		JOIN rates ra ON ra.id = pra.rate_id
+		JOIN services s ON s.id = ra.service_id
 		JOIN projects p ON p.id = pra.project_id
-		WHERE p.name = $1 AND cs.type = $2 AND cra.name = $3`
+		WHERE p.name = $1 AND s.type = $2 AND ra.name = $3`
 	err = s.DB.QueryRow(getProjectRateQuery, "berlin", "shared", rateName).Scan(&projectRateId, &actualLimit, &actualWindow)
 	if err != nil {
 		t.Fatal(err)
@@ -827,11 +827,11 @@ func expectStaleProjectServices(t *testing.T, dbm *gorp.DbMap, pairs ...string) 
 	t.Helper()
 
 	queryStr := sqlext.SimplifyWhitespace(`
-		SELECT p.name, cs.type
+		SELECT p.name, s.type
 		 FROM projects p JOIN project_services ps ON ps.project_id = p.id
-		 JOIN services cs on ps.service_id = cs.id
+		 JOIN services s on ps.service_id = s.id
 		 WHERE ps.stale
-		 ORDER BY p.name, cs.type
+		 ORDER BY p.name, s.type
 	`)
 	var actualPairs []string
 

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -266,7 +266,7 @@ func (p *v1Provider) PutProjectMaxQuota(w http.ResponseWriter, r *http.Request) 
 
 	var services []db.Service
 	_, err = tx.Select(&services,
-		`SELECT cs.* FROM services cs JOIN project_services ps ON ps.service_id = cs.id and ps.project_id = $1 ORDER BY cs.type`, dbProject.ID)
+		`SELECT s.* FROM services s JOIN project_services ps ON ps.service_id = s.id and ps.project_id = $1 ORDER BY s.type`, dbProject.ID)
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
@@ -412,7 +412,7 @@ func (p *v1Provider) PutQuotaAutogrowth(w http.ResponseWriter, r *http.Request) 
 
 	var services []db.Service
 	_, err = tx.Select(&services,
-		`SELECT cs.* FROM services cs JOIN project_services ps ON ps.service_id = cs.id and ps.project_id = $1 ORDER BY cs.type`, dbProject.ID)
+		`SELECT s.* FROM services s JOIN project_services ps ON ps.service_id = s.id and ps.project_id = $1 ORDER BY s.type`, dbProject.ID)
 	if respondwith.ErrorText(w, err) {
 		return
 	}

--- a/internal/collector/capacity_scrape.go
+++ b/internal/collector/capacity_scrape.go
@@ -80,11 +80,11 @@ var (
 		                     WHEN confirmed_at IS NULL      THEN {{liquid.CommitmentStatusPending}}
 		                     ELSE {{liquid.CommitmentStatusConfirmed}} END
 		WHERE status NOT IN ({{liquid.CommitmentStatusSuperseded}}, {{liquid.CommitmentStatusExpired}}) AND az_resource_id IN (
-			SELECT cazr.id
-			  FROM services cs
-			  JOIN resources cr ON cr.service_id = cs.id
-			  JOIN az_resources cazr ON cazr.resource_id = cr.id
-			 WHERE cs.type = $1 AND cr.name = $2
+			SELECT azr.id
+			  FROM services s
+			  JOIN resources r ON r.service_id = s.id
+			  JOIN az_resources azr ON azr.resource_id = r.id
+			 WHERE s.type = $1 AND r.name = $2
 		)
 	`))
 )
@@ -157,7 +157,7 @@ func (c *Collector) processCapacityScrapeTask(ctx context.Context, task capacity
 	// a resources update is not necessary, as it is done within c.scrapeLiquidCapacity if necessary
 	// collect existing resources
 	var dbResources []db.Resource
-	_, err = tx.Select(&dbResources, `SELECT cr.* FROM resources as cr JOIN services as cs ON cr.service_id = cs.id WHERE cs.type = $1`, service.Type)
+	_, err = tx.Select(&dbResources, `SELECT r.* FROM resources as r JOIN services as s ON r.service_id = s.id WHERE s.type = $1`, service.Type)
 	if err != nil {
 		return fmt.Errorf("cannot inspect existing resources: %w", err)
 	}

--- a/internal/collector/consistency.go
+++ b/internal/collector/consistency.go
@@ -48,10 +48,10 @@ var (
 	// See `initProjectServicesQuery` for rationale regarding `next_scrape_at = NOW(), stale = TRUE`.
 	insertMissingProjectServicesQuery = sqlext.SimplifyWhitespace(`
 		INSERT INTO project_services (project_id, service_id, next_scrape_at, stale)
-		SELECT p.id, cs.id, $1::TIMESTAMPTZ, TRUE
-		  FROM services cs
-		  JOIN projects p ON TRUE -- this is intentionally a full cross join between "cs" and "p"
-		  LEFT OUTER JOIN project_services ps ON ps.project_id = p.id AND ps.service_id = cs.id
+		SELECT p.id, s.id, $1::TIMESTAMPTZ, TRUE
+		  FROM services s
+		  JOIN projects p ON TRUE -- this is intentionally a full cross join between "s" and "p"
+		  LEFT OUTER JOIN project_services ps ON ps.project_id = p.id AND ps.service_id = s.id
 		 WHERE ps.id IS NULL
 		RETURNING project_id, service_id
 	`)

--- a/internal/collector/expiring_commitments.go
+++ b/internal/collector/expiring_commitments.go
@@ -47,13 +47,13 @@ var (
 		 WHERE expires_at <= $1 AND status = {{liquid.CommitmentStatusConfirmed}} AND renew_context_json IS NULL AND NOT notified_for_expiration
 	`))
 	locateExpiringCommitmentsQuery = sqlext.SimplifyWhitespace(`
-		SELECT pc.project_id, cs.type, cr.name, cazr.az, pc.id
-		  FROM services cs
-		  JOIN resources cr ON cr.service_id = cs.id
-		  JOIN az_resources cazr ON cazr.resource_id = cr.id
-		  JOIN project_commitments pc ON pc.az_resource_id = cazr.id
+		SELECT pc.project_id, s.type, r.name, azr.az, pc.id
+		  FROM services s
+		  JOIN resources r ON r.service_id = s.id
+		  JOIN az_resources azr ON azr.resource_id = r.id
+		  JOIN project_commitments pc ON pc.az_resource_id = azr.id
 		WHERE pc.id = ANY($1)
-		ORDER BY cs.type, cr.name, cazr.az ASC, pc.amount DESC
+		ORDER BY s.type, r.name, azr.az ASC, pc.amount DESC
 	`)
 	updateCommitmentAsNotifiedQuery = `UPDATE project_commitments SET notified_for_expiration = true WHERE id = ANY($1)`
 )

--- a/internal/collector/metrics.go
+++ b/internal/collector/metrics.go
@@ -60,11 +60,11 @@ func (c *AggregateMetricsCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 var scrapedAtAggregateQuery = sqlext.SimplifyWhitespace(`
-	SELECT cs.type, MIN(ps.scraped_at), MAX(ps.scraped_at), MIN(ps.scraped_at), MAX(ps.scraped_at)
+	SELECT s.type, MIN(ps.scraped_at), MAX(ps.scraped_at), MIN(ps.scraped_at), MAX(ps.scraped_at)
 	  FROM project_services ps
-	  JOIN services cs ON cs.id = ps.service_id
+	  JOIN services s ON s.id = ps.service_id
 	 WHERE ps.scraped_at IS NOT NULL
-	 GROUP BY cs.type
+	 GROUP BY s.type
 `)
 
 // Collect implements the prometheus.Collector interface.
@@ -247,11 +247,11 @@ func (c *UsageCollectionMetricsCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 var quotaSerializedMetricsGetQuery = sqlext.SimplifyWhitespace(`
-	SELECT d.name, d.uuid, p.name, p.uuid, p.parent_uuid, cs.type, ps.serialized_metrics
-	  FROM services cs
+	SELECT d.name, d.uuid, p.name, p.uuid, p.parent_uuid, s.type, ps.serialized_metrics
+	  FROM services s
 	  CROSS JOIN domains d
 	  JOIN projects p ON p.domain_id = d.id
-	  JOIN project_services ps ON ps.service_id = cs.id AND ps.project_id = p.id
+	  JOIN project_services ps ON ps.service_id = s.id AND ps.project_id = p.id
 	 WHERE ps.serialized_metrics != '' AND ps.serialized_metrics != '{}'
 `)
 
@@ -405,54 +405,54 @@ func printDataMetrics(w io.Writer, metricsBySeries map[string][]dataMetric, seri
 }
 
 var clusterMetricsQuery = sqlext.SimplifyWhitespace(`
-	SELECT cs.type, cr.name, JSON_OBJECT_AGG(car.az, car.raw_capacity), JSON_OBJECT_AGG(car.az, car.usage)
-	  FROM services cs
-	  JOIN resources cr ON cr.service_id = cs.id
-	  JOIN az_resources car ON car.resource_id = cr.id
-	 GROUP BY cs.type, cr.name
+	SELECT s.type, r.name, JSON_OBJECT_AGG(azr.az, azr.raw_capacity), JSON_OBJECT_AGG(azr.az, azr.usage)
+	  FROM services s
+	  JOIN resources r ON r.service_id = s.id
+	  JOIN az_resources azr ON azr.resource_id = r.id
+	 GROUP BY s.type, r.name
 `)
 
 var domainMetricsQuery = sqlext.SimplifyWhitespace(`
-	SELECT d.name, d.uuid, cs.type, cr.name, SUM(pr.quota)
-	  FROM services cs
-	  JOIN resources cr ON cr.service_id = cs.id
+	SELECT d.name, d.uuid, s.type, r.name, SUM(pr.quota)
+	  FROM services s
+	  JOIN resources r ON r.service_id = s.id
 	  CROSS JOIN domains d
 	  JOIN projects p ON p.domain_id = d.id
-	  JOIN project_services ps ON ps.project_id = p.id AND ps.service_id = cs.id
-	  JOIN project_resources pr ON pr.project_id = p.id AND pr.resource_id = cr.id
-	 GROUP BY d.name, d.uuid, cs.type, cr.name
+	  JOIN project_services ps ON ps.project_id = p.id AND ps.service_id = s.id
+	  JOIN project_resources pr ON pr.project_id = p.id AND pr.resource_id = r.id
+	 GROUP BY d.name, d.uuid, s.type, r.name
 `)
 
 var projectMetricsQuery = sqlext.SimplifyWhitespace(`
 	WITH project_sums AS (
-	  SELECT cazr.resource_id, pazr.project_id,
+	  SELECT azr.resource_id, pazr.project_id,
 	         SUM(pazr.usage) AS usage,
 	         SUM(COALESCE(pazr.physical_usage, pazr.usage)) AS physical_usage,
 	         COUNT(pazr.physical_usage) > 0 AS has_physical_usage
 	    FROM project_az_resources pazr
-	    JOIN az_resources cazr ON cazr.id = pazr.az_resource_id
-	   GROUP BY cazr.resource_id, pazr.project_id
+	    JOIN az_resources azr ON azr.id = pazr.az_resource_id
+	   GROUP BY azr.resource_id, pazr.project_id
 	),
 	project_commitment_minExpiresAt AS (
-		SELECT p.domain_id, p.id AS project_id, cs.type, cr.name, MIN(expires_at) AS project_commitment_min_expires_at
-		FROM services cs
-		JOIN resources cr ON cr.service_id = cs.id
-		JOIN az_resources cazr ON cazr.resource_id = cr.id
-		JOIN project_commitments pc ON pc.az_resource_id = cazr.id AND pc.status = 'confirmed'
+		SELECT p.domain_id, p.id AS project_id, s.type, r.name, MIN(expires_at) AS project_commitment_min_expires_at
+		FROM services s
+		JOIN resources r ON r.service_id = s.id
+		JOIN az_resources azr ON azr.resource_id = r.id
+		JOIN project_commitments pc ON pc.az_resource_id = azr.id AND pc.status = 'confirmed'
 		JOIN projects p ON p.id = pc.project_id
-		GROUP BY p.domain_id, p.id, cs.type, cr.name
+		GROUP BY p.domain_id, p.id, s.type, r.name
 	)
-	SELECT d.name, d.uuid, p.name, p.uuid, cs.type, cr.name,
+	SELECT d.name, d.uuid, p.name, p.uuid, s.type, r.name,
 	       pr.quota, pr.backend_quota, pr.override_quota_from_config,
 	       psums.usage, psums.physical_usage, psums.has_physical_usage,
 	       pcmea.project_commitment_min_expires_at
-	  FROM services cs
-	  JOIN resources cr ON cr.service_id = cs.id
+	  FROM services s
+	  JOIN resources r ON r.service_id = s.id
 	  CROSS JOIN domains d
 	  JOIN projects p ON p.domain_id = d.id
-	  JOIN project_resources pr ON pr.resource_id = cr.id AND pr.project_id = p.id
-	  JOIN project_sums psums ON psums.resource_id = cr.id AND psums.project_id = p.id
-	  LEFT JOIN project_commitment_minExpiresAt pcmea ON d.id = pcmea.domain_id AND p.id = pcmea.project_id AND cs.type= pcmea.TYPE AND cr.name = pcmea.name
+	  JOIN project_resources pr ON pr.resource_id = r.id AND pr.project_id = p.id
+	  JOIN project_sums psums ON psums.resource_id = r.id AND psums.project_id = p.id
+	  LEFT JOIN project_commitment_minExpiresAt pcmea ON d.id = pcmea.domain_id AND p.id = pcmea.project_id AND s.type= pcmea.TYPE AND r.name = pcmea.name
 `)
 
 var projectAZMetricsQuery = sqlext.SimplifyWhitespace(`
@@ -466,23 +466,23 @@ var projectAZMetricsQuery = sqlext.SimplifyWhitespace(`
 	    FROM project_commitment_sums_by_status
 	   GROUP BY az_resource_id, project_id
 	)
-	SELECT d.name, d.uuid, p.name, p.uuid, cs.type, cr.name, cazr.az, pazr.usage, pcs.amount_by_status
-	  FROM services cs
-	  JOIN resources cr ON cr.service_id = cs.id
-	  JOIN az_resources cazr ON cazr.resource_id = cr.id
+	SELECT d.name, d.uuid, p.name, p.uuid, s.type, r.name, azr.az, pazr.usage, pcs.amount_by_status
+	  FROM services s
+	  JOIN resources r ON r.service_id = s.id
+	  JOIN az_resources azr ON azr.resource_id = r.id
 	  CROSS JOIN domains d
 	  JOIN projects p ON p.domain_id = d.id
-	  JOIN project_az_resources pazr ON pazr.az_resource_id = cazr.id AND pazr.project_id = p.id
-	  LEFT OUTER JOIN project_commitment_sums pcs ON pcs.az_resource_id = cazr.id AND pcs.project_id = p.id
+	  JOIN project_az_resources pazr ON pazr.az_resource_id = azr.id AND pazr.project_id = p.id
+	  LEFT OUTER JOIN project_commitment_sums pcs ON pcs.az_resource_id = azr.id AND pcs.project_id = p.id
 `)
 
 var projectRateMetricsQuery = sqlext.SimplifyWhitespace(`
-	SELECT d.name, d.uuid, p.name, p.uuid, cs.type, cra.name, pra.usage_as_bigint
-	  FROM services cs
-	  JOIN rates cra ON cra.service_id = cs.id
+	SELECT d.name, d.uuid, p.name, p.uuid, s.type, ra.name, pra.usage_as_bigint
+	  FROM services s
+	  JOIN rates ra ON ra.service_id = s.id
 	  CROSS JOIN domains d
 	  JOIN projects p ON p.domain_id = d.id
-	  JOIN project_rates pra ON pra.rate_id = cra.id AND pra.project_id = p.id
+	  JOIN project_rates pra ON pra.rate_id = ra.id AND pra.project_id = p.id
 	 WHERE pra.usage_as_bigint != ''
 `)
 

--- a/internal/collector/quota_overrides.go
+++ b/internal/collector/quota_overrides.go
@@ -91,24 +91,24 @@ var (
 		  FROM domains d
 		  JOIN projects p ON p.domain_id = d.id
 		  JOIN project_services ps ON ps.project_id = p.id
-		  JOIN services cs ON cs.id = ps.service_id
-		 WHERE d.name = $1 AND p.name = $2 AND cs.type = $3
+		  JOIN services s ON s.id = ps.service_id
+		 WHERE d.name = $1 AND p.name = $2 AND s.type = $3
 	`)
 	aqoUpdateOverrideQuery = sqlext.SimplifyWhitespace(`
 		UPDATE project_resources pr
 		   SET override_quota_from_config = $1
-		 FROM resources cr
-		 JOIN project_services ps ON ps.service_id = cr.service_id
-		 WHERE cr.id = pr.resource_id AND ps.project_id = pr.project_id
-		 AND ps.id = $2 AND cr.name = $3
+		 FROM resources r
+		 JOIN project_services ps ON ps.service_id = r.service_id
+		 WHERE r.id = pr.resource_id AND ps.project_id = pr.project_id
+		 AND ps.id = $2 AND r.name = $3
 	`)
 	aqoListOverridesQuery = sqlext.SimplifyWhitespace(`
-		SELECT pr.id, d.name, p.name, cs.type, cr.name
+		SELECT pr.id, d.name, p.name, s.type, r.name
 		  FROM domains d
 		  JOIN projects p ON p.domain_id = d.id
 		  JOIN project_resources pr ON pr.project_id = p.id
-		  JOIN resources cr ON cr.id = pr.resource_id
-		  JOIN services cs ON cs.id = cr.service_id
+		  JOIN resources r ON r.id = pr.resource_id
+		  JOIN services s ON s.id = r.service_id
 		 WHERE pr.override_quota_from_config IS NOT NULL
 	`)
 	aqoClearOverrideQuery = sqlext.SimplifyWhitespace(`

--- a/internal/core/cluster.go
+++ b/internal/core/cluster.go
@@ -447,7 +447,7 @@ func SaveServiceInfoToDB(serviceType db.ServiceType, serviceInfo liquid.ServiceI
 
 	// collect existing az_resources
 	var dbAZResources []db.AZResource
-	_, err = tx.Select(&dbAZResources, `SELECT car.* FROM az_resources car JOIN resources cr ON car.resource_id = cr.id WHERE cr.service_id = $1`, srv.ID)
+	_, err = tx.Select(&dbAZResources, `SELECT azr.* FROM az_resources azr JOIN resources r ON azr.resource_id = r.id WHERE r.service_id = $1`, srv.ID)
 	if err != nil {
 		return srv, fmt.Errorf("cannot inspect existing AZ resources for %s: %w", serviceType, err)
 	}

--- a/internal/datamodel/allocation_stats.go
+++ b/internal/datamodel/allocation_stats.go
@@ -110,22 +110,22 @@ type projectAZAllocationStats struct {
 
 var (
 	getRawCapacityInResourceQuery = sqlext.SimplifyWhitespace(`
-		SELECT car.az, car.raw_capacity, car.last_nonzero_raw_capacity IS NOT NULL
-		  FROM services cs
-		  JOIN resources cr ON cr.service_id = cs.id
-		  JOIN az_resources car ON car.resource_id = cr.id
-		  WHERE cs.type = $1 AND cr.name = $2 AND ($3::text IS NULL OR car.az = $3)
+		SELECT azr.az, azr.raw_capacity, azr.last_nonzero_raw_capacity IS NOT NULL
+		  FROM services s
+		  JOIN resources r ON r.service_id = s.id
+		  JOIN az_resources azr ON azr.resource_id = r.id
+		  WHERE s.type = $1 AND r.name = $2 AND ($3::text IS NULL OR azr.az = $3)
 	`)
 
 	getUsageInResourceQuery = sqlext.SimplifyWhitespace(db.ExpandEnumPlaceholders(`
-		SELECT pazr.project_id, cazr.az, pazr.usage, pazr.historical_usage, COALESCE(SUM(pc.amount), 0)
-		  FROM services cs
-		  JOIN resources cr ON cr.service_id = cs.id
-		  JOIN az_resources cazr ON cazr.resource_id = cr.id
-		  JOIN project_az_resources pazr ON pazr.az_resource_id = cazr.id
-		  LEFT OUTER JOIN project_commitments pc ON pc.az_resource_id = cazr.id AND pc.project_id = pazr.project_id AND pc.status = {{liquid.CommitmentStatusConfirmed}}
-		 WHERE cs.type = $1 AND cr.name = $2 AND ($3::text IS NULL OR cazr.az = $3)
-		 GROUP BY pazr.project_id, cazr.az, pazr.usage, pazr.historical_usage
+		SELECT pazr.project_id, azr.az, pazr.usage, pazr.historical_usage, COALESCE(SUM(pc.amount), 0)
+		  FROM services s
+		  JOIN resources r ON r.service_id = s.id
+		  JOIN az_resources azr ON azr.resource_id = r.id
+		  JOIN project_az_resources pazr ON pazr.az_resource_id = azr.id
+		  LEFT OUTER JOIN project_commitments pc ON pc.az_resource_id = azr.id AND pc.project_id = pazr.project_id AND pc.status = {{liquid.CommitmentStatusConfirmed}}
+		 WHERE s.type = $1 AND r.name = $2 AND ($3::text IS NULL OR azr.az = $3)
+		 GROUP BY pazr.project_id, azr.az, pazr.usage, pazr.historical_usage
 	`))
 )
 

--- a/internal/datamodel/apply_computed_project_quota.go
+++ b/internal/datamodel/apply_computed_project_quota.go
@@ -27,10 +27,10 @@ import (
 
 var (
 	acpqGetResourceIDQuery = sqlext.SimplifyWhitespace(`
-		SELECT cr.id
-		  FROM services cs
-		  JOIN resources cr ON cr.service_id = cs.id
-		 WHERE cs.type = $1 AND cr.name = $2
+		SELECT r.id
+		  FROM services s
+		  JOIN resources r ON r.service_id = s.id
+		 WHERE s.type = $1 AND r.name = $2
 	`)
 
 	acpqGetLocalQuotaConstraintsQuery = sqlext.SimplifyWhitespace(`
@@ -48,8 +48,8 @@ var (
 	acpqUpdateAZQuotaQuery = sqlext.SimplifyWhitespace(`
 		UPDATE project_az_resources pazr
 		SET quota = $1
-		FROM az_resources cazr
-		WHERE pazr.az_resource_id = cazr.id AND cazr.az = $2 AND pazr.project_id = $3 AND cazr.resource_id = $4
+		FROM az_resources azr
+		WHERE pazr.az_resource_id = azr.id AND azr.az = $2 AND pazr.project_id = $3 AND azr.resource_id = $4
 		AND pazr.quota IS DISTINCT FROM $1
 	`)
 	acpqUpdateProjectQuotaQuery = sqlext.SimplifyWhitespace(`
@@ -58,8 +58,8 @@ var (
 	acpqUpdateProjectServicesQuery = sqlext.SimplifyWhitespace(`
 		UPDATE project_services ps
 		SET quota_desynced_at = $1
-		FROM services cs
-		WHERE ps.service_id = cs.id AND ps.project_id = $2 AND cs.type = $3
+		FROM services s
+		WHERE ps.service_id = s.id AND ps.project_id = $2 AND s.type = $3
 		AND quota_desynced_at IS NULL
 	`)
 )

--- a/internal/datamodel/confirm_project_commitments.go
+++ b/internal/datamodel/confirm_project_commitments.go
@@ -30,11 +30,11 @@ var (
 	// The final `BY pc.id` ordering ensures deterministic behavior in tests.
 	getConfirmableCommitmentsQuery = sqlext.SimplifyWhitespace(db.ExpandEnumPlaceholders(`
 		SELECT pc.project_id, pc.id, pc.amount, pc.notify_on_confirm
-		  FROM services cs
-		  JOIN resources cr ON cr.service_id = cs.id
-		  JOIN az_resources cazr ON cazr.resource_id = cr.id
-		  JOIN project_commitments pc ON pc.az_resource_id = cazr.id
-		 WHERE cs.type = $1 AND cr.name = $2 AND cazr.az = $3 AND pc.status = {{liquid.CommitmentStatusPending}}
+		  FROM services s
+		  JOIN resources r ON r.service_id = s.id
+		  JOIN az_resources azr ON azr.resource_id = r.id
+		  JOIN project_commitments pc ON pc.az_resource_id = azr.id
+		 WHERE s.type = $1 AND r.name = $2 AND azr.az = $3 AND pc.status = {{liquid.CommitmentStatusPending}}
 		 ORDER BY pc.created_at ASC, pc.confirm_by ASC, pc.id ASC
 	`))
 )

--- a/internal/datamodel/project_resource_update.go
+++ b/internal/datamodel/project_resource_update.go
@@ -72,7 +72,7 @@ func (u ProjectResourceUpdate) Run(dbi db.Interface, serviceInfo liquid.ServiceI
 
 	// collect existing project_resources for this service
 	var dbResources []db.ProjectResource
-	_, err = dbi.Select(&dbResources, `SELECT pr.* FROM project_resources pr JOIN resources cr ON pr.resource_id = cr.id WHERE cr.service_id = $1 AND pr.project_id = $2`, srv.ID, project.ID)
+	_, err = dbi.Select(&dbResources, `SELECT pr.* FROM project_resources pr JOIN resources r ON pr.resource_id = r.id WHERE r.service_id = $1 AND pr.project_id = $2`, srv.ID, project.ID)
 	if err != nil {
 		return nil, fmt.Errorf("while loading %s project resources: %w", srv.Type, err)
 	}
@@ -157,7 +157,7 @@ func (u ProjectResourceUpdate) Run(dbi db.Interface, serviceInfo liquid.ServiceI
 	// if this update caused `quota != backend_quota` anywhere,
 	// request SetQuotaJob to take over (unless we already have an open request)
 	if hasBackendQuotaDrift {
-		query := `UPDATE project_services ps SET quota_desynced_at = $1 FROM services cs WHERE cs.id = ps.service_id AND cs.id = $2 AND ps.project_id = $3 AND quota_desynced_at IS NULL`
+		query := `UPDATE project_services ps SET quota_desynced_at = $1 FROM services s WHERE s.id = ps.service_id AND s.id = $2 AND ps.project_id = $3 AND quota_desynced_at IS NULL`
 		_, err := dbi.Exec(query, now, srv.ID, project.ID)
 		if err != nil {
 			return nil, fmt.Errorf("while scheduling backend sync for %s quotas: %w", srv.Type, err)

--- a/internal/datamodel/resource_demand.go
+++ b/internal/datamodel/resource_demand.go
@@ -27,19 +27,19 @@ type capacityScrapeBackchannelImpl struct {
 
 var (
 	getResourceDemandQuery = sqlext.SimplifyWhitespace(db.ExpandEnumPlaceholders(`
-		SELECT cazr.az, pazr.usage, COALESCE(pc_view.confirmed, 0), COALESCE(pc_view.pending, 0), cr.topology
-		  FROM services cs
-		  JOIN resources cr ON cr.service_id = cs.id
-		  JOIN az_resources cazr ON cazr.resource_id = cr.id
-		  JOIN project_az_resources pazr ON pazr.az_resource_id = cazr.id
+		SELECT azr.az, pazr.usage, COALESCE(pc_view.confirmed, 0), COALESCE(pc_view.pending, 0), r.topology
+		  FROM services s
+		  JOIN resources r ON r.service_id = s.id
+		  JOIN az_resources azr ON azr.resource_id = r.id
+		  JOIN project_az_resources pazr ON pazr.az_resource_id = azr.id
 		  LEFT OUTER JOIN (
 		    SELECT az_resource_id, project_id,
 		           SUM(amount) FILTER (WHERE status = {{liquid.CommitmentStatusConfirmed}}) AS confirmed,
 		           SUM(amount) FILTER (WHERE status = {{liquid.CommitmentStatusPending}}) AS pending
 		      FROM project_commitments
 		     GROUP BY az_resource_id, project_id
-		  ) pc_view ON pc_view.az_resource_id = cazr.id AND pc_view.project_id = pazr.project_id
-		 WHERE cs.type = $1 AND cr.name = $2
+		  ) pc_view ON pc_view.az_resource_id = azr.id AND pc_view.project_id = pazr.project_id
+		 WHERE s.type = $1 AND r.name = $2
 	`))
 )
 

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -132,17 +132,17 @@ var sqlMigrations = map[string]string{
 				problem RECORD;
 			BEGIN
 				FOR problem IN
-					SELECT cr.id AS id, cr.path AS actual, CONCAT(cs.type, '/', cr.name) AS expected
-					FROM resources cr JOIN services cs ON cr.service_id = cs.id
-					WHERE cr.path != CONCAT(cs.type, '/', cr.name)
+					SELECT r.id AS id, r.path AS actual, CONCAT(s.type, '/', r.name) AS expected
+					FROM resources r JOIN services s ON r.service_id = s.id
+					WHERE r.path != CONCAT(s.type, '/', r.name)
 				LOOP
 					RAISE EXCEPTION 'inconsistent value for resources.path: expected "%", but got "%" for ID %', problem.expected, problem.actual, problem.id;
 				END LOOP;
 
 				FOR problem IN
-					SELECT cazr.id AS id, cazr.path AS actual, CONCAT(cr.path, '/', cazr.az) AS expected
-					FROM az_resources cazr JOIN resources cr ON cazr.resource_id = cr.id
-					WHERE cazr.path != CONCAT(cr.path, '/', cazr.az)
+					SELECT azr.id AS id, azr.path AS actual, CONCAT(r.path, '/', azr.az) AS expected
+					FROM az_resources azr JOIN resources r ON azr.resource_id = r.id
+					WHERE azr.path != CONCAT(r.path, '/', azr.az)
 				LOOP
 					RAISE EXCEPTION 'inconsistent value for az_resources.path: expected "%", but got "%" for ID %', problem.expected, problem.actual, problem.id;
 				END LOOP;

--- a/internal/reports/error.go
+++ b/internal/reports/error.go
@@ -15,13 +15,13 @@ import (
 )
 
 var scrapeErrorsQuery = sqlext.SimplifyWhitespace(`
-	SELECT d.uuid, d.name, p.uuid, p.name, cs.type, ps.checked_at, ps.scrape_error_message
+	SELECT d.uuid, d.name, p.uuid, p.name, s.type, ps.checked_at, ps.scrape_error_message
 	  FROM projects p
 	  JOIN domains d ON d.id = p.domain_id
 	  JOIN project_services ps ON ps.project_id = p.id
-	  JOIN services cs ON cs.id = ps.service_id
+	  JOIN services s ON s.id = ps.service_id
 	WHERE ps.scrape_error_message != ''
-	ORDER BY d.name, p.name, cs.type, ps.scrape_error_message
+	ORDER BY d.name, p.name, s.type, ps.scrape_error_message
 `)
 
 type ScrapeError struct {

--- a/internal/reports/inconsistency.go
+++ b/internal/reports/inconsistency.go
@@ -48,28 +48,28 @@ type MismatchProjectQuota struct {
 }
 
 var ospqReportQuery = sqlext.SimplifyWhitespace(`
-	SELECT d.uuid, d.name, p.uuid, p.name, cs.type, cr.name, pr.quota, SUM(pazr.usage)
+	SELECT d.uuid, d.name, p.uuid, p.name, s.type, r.name, pr.quota, SUM(pazr.usage)
 	  FROM projects p
 	  JOIN domains d ON d.id = p.domain_id
 	  JOIN project_resources pr ON pr.project_id = p.id
-	  JOIN resources cr ON pr.resource_id = cr.id {{AND cr.name = $resource_name}}
-	  JOIN services cs ON cr.service_id = cs.id {{AND cs.type = $service_type}}
-	  JOIN az_resources cazr ON cazr.resource_id = cr.id
-	  JOIN project_az_resources pazr ON pazr.az_resource_id = cazr.id AND pazr.project_id = pr.project_id
-	 GROUP BY d.uuid, d.name, p.uuid, p.name, cs.type, cr.name, pr.quota
+	  JOIN resources r ON pr.resource_id = r.id {{AND r.name = $resource_name}}
+	  JOIN services s ON r.service_id = s.id {{AND s.type = $service_type}}
+	  JOIN az_resources azr ON azr.resource_id = r.id
+	  JOIN project_az_resources pazr ON pazr.az_resource_id = azr.id AND pazr.project_id = pr.project_id
+	 GROUP BY d.uuid, d.name, p.uuid, p.name, s.type, r.name, pr.quota
 	HAVING SUM(pazr.usage) > pr.quota
-	 ORDER BY d.name, p.name, cs.type, cr.name
+	 ORDER BY d.name, p.name, s.type, r.name
 `)
 
 var mmpqReportQuery = sqlext.SimplifyWhitespace(`
-	SELECT d.uuid, d.name, p.uuid, p.name, cs.type, cr.name, pr.quota, pr.backend_quota
+	SELECT d.uuid, d.name, p.uuid, p.name, s.type, r.name, pr.quota, pr.backend_quota
 	  FROM projects p
 	  JOIN domains d ON d.id = p.domain_id
 	  JOIN project_resources pr ON pr.project_id = p.id 
-	  JOIN resources cr ON pr.resource_id = cr.id {{AND cr.name = $resource_name}}
-	  JOIN services cs ON cr.service_id = cs.id {{AND cs.type = $service_type}}
+	  JOIN resources r ON pr.resource_id = r.id {{AND r.name = $resource_name}}
+	  JOIN services s ON r.service_id = s.id {{AND s.type = $service_type}}
 	WHERE pr.backend_quota != pr.quota
-	ORDER BY d.name, p.name, cs.type, cr.name
+	ORDER BY d.name, p.name, s.type, r.name
 `)
 
 // GetInconsistencies returns Inconsistency reports for all inconsistencies and their projects in the current cluster.

--- a/internal/test/setup.go
+++ b/internal/test/setup.go
@@ -279,11 +279,11 @@ func NewSetup(t *testing.T, opts ...SetupOption) Setup {
 		// and all ProjectAZResource entries (for each pair of resource and AZ according to topology)
 		s.MustDBExec(db.ExpandEnumPlaceholders(`
 			WITH tmp AS (
-				SELECT cr.id AS id, CASE
-					WHEN NOT cr.has_quota THEN NULL
-					WHEN cr.topology = {{liquid.AZSeparatedTopology}} THEN NULL
+				SELECT r.id AS id, CASE
+					WHEN NOT r.has_quota THEN NULL
+					WHEN r.topology = {{liquid.AZSeparatedTopology}} THEN NULL
 					ELSE 0
-				END AS default_quota FROM resources cr
+				END AS default_quota FROM resources r
 			)
 			INSERT INTO project_resources (project_id, resource_id, quota, backend_quota) SELECT
 				p.id              AS project_id,
@@ -295,12 +295,12 @@ func NewSetup(t *testing.T, opts ...SetupOption) Setup {
 
 		s.MustDBExec(db.ExpandEnumPlaceholders(`
 			WITH tmp AS (
-				SELECT cazr.id AS id, CASE
-					WHEN NOT cr.has_quota THEN NULL
-					WHEN cr.topology != {{liquid.AZSeparatedTopology}} THEN NULL
-					WHEN cazr.az = {{liquid.AvailabilityZoneUnknown}} THEN NULL
+				SELECT azr.id AS id, CASE
+					WHEN NOT r.has_quota THEN NULL
+					WHEN r.topology != {{liquid.AZSeparatedTopology}} THEN NULL
+					WHEN azr.az = {{liquid.AvailabilityZoneUnknown}} THEN NULL
 					ELSE 0
-				END AS default_quota FROM az_resources cazr JOIN resources cr ON cazr.resource_id = cr.id
+				END AS default_quota FROM az_resources azr JOIN resources r ON azr.resource_id = r.id
 			)
 			INSERT INTO project_az_resources (project_id, az_resource_id, quota, usage, subresources) SELECT
 				p.id              AS project_id,


### PR DESCRIPTION
This PR renames
* `services=cs` to `services=s`
* `resources=cr` to `resources=r`
* `az_resources=cazr` to `az_resources=azr`
* `rates=cra` to `rates=ra`
in response to @VoigtS's comment here: https://github.com/sapcc/limes/pull/771#discussion_r2315856828

I had a brief discussion with him, he mentioned to me that @majewsky found `r` and `s` to be possibly too short for recognition. I personally found it weird to leave the old abbreviations ("why the `c`?" a new-joiner might ask) when I wanted to start on the commitment functionality. IMHO it's okay, when we use these abbreviations consistently - everywhere. The conflict of `r` between `rates` and `resources` requires a convention anyway - so please let me know your opinions.

Sidenote: I would also be fine to use this chance to switch to `resources=re` if that helps someone.