### PR TITLE
remove max_quota setting for project level

### DIFF
--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -176,11 +176,9 @@ func (p *v1Provider) PutProjectMaxQuota(w http.ResponseWriter, r *http.Request) 
 	httpapi.IdentifyEndpoint(r, "/v1/domains/:id/projects/:id/max-quota")
 	requestTime := p.timeNow()
 	token := p.CheckToken(r)
-	if !token.Require(w, "project:edit") {
+	if !token.Require(w, "project:edit_as_outside_admin") {
 		return
 	}
-	// domain admins have project edit rights by inheritance.
-	domainAccess := token.Check("project:edit_as_outside_admin")
 	dbDomain := p.FindDomainFromRequest(w, r)
 	if dbDomain == nil {
 		return
@@ -250,7 +248,7 @@ func (p *v1Provider) PutProjectMaxQuota(w http.ResponseWriter, r *http.Request) 
 				if err != nil {
 					msg := fmt.Sprintf("invalid input for %s/%s: %s", dbServiceType, dbResourceName, err.Error())
 					http.Error(w, msg, http.StatusUnprocessableEntity)
-					return
+					break
 				}
 				requested[dbServiceType][dbResourceName] = &maxQuotaChange{NewValue: Some(convertedMaxQuota)}
 			}
@@ -280,14 +278,10 @@ func (p *v1Provider) PutProjectMaxQuota(w http.ResponseWriter, r *http.Request) 
 		_, err := datamodel.ProjectResourceUpdate{
 			UpdateResource: func(res *db.ProjectResource, resName liquid.ResourceName) error {
 				requestedChange := requestedInService[resName]
-				if requestedChange != nil && domainAccess {
+				if requestedChange != nil {
 					requestedChange.OldValue = res.MaxQuotaFromOutsideAdmin // remember for audit event
 					res.MaxQuotaFromOutsideAdmin = requestedChange.NewValue
 					return nil
-				}
-				if requestedChange != nil {
-					requestedChange.OldValue = res.MaxQuotaFromLocalAdmin
-					res.MaxQuotaFromLocalAdmin = requestedChange.NewValue
 				}
 				return nil
 			},

--- a/internal/datamodel/apply_computed_project_quota.go
+++ b/internal/datamodel/apply_computed_project_quota.go
@@ -34,7 +34,7 @@ var (
 	`)
 
 	acpqGetLocalQuotaConstraintsQuery = sqlext.SimplifyWhitespace(`
-		SELECT project_id, forbidden, max_quota_from_outside_admin, max_quota_from_local_admin, forbid_autogrowth, override_quota_from_config
+		SELECT project_id, forbidden, max_quota_from_outside_admin, forbid_autogrowth, override_quota_from_config
 		  FROM project_resources
 		 WHERE resource_id = $1 AND (forbidden IS NOT NULL
 		                          OR max_quota_from_outside_admin IS NOT NULL
@@ -135,11 +135,10 @@ func ApplyComputedProjectQuota(serviceType db.ServiceType, resourceName liquid.R
 			projectID                 db.ProjectID
 			forbidden                 bool
 			maxQuotaFromOutsideAdmin  Option[uint64]
-			maxQuotaFromLocalAdmin    Option[uint64]
 			forbidAutogrowthFromAdmin bool
 			overrideQuotaFromConfig   Option[uint64]
 		)
-		err := rows.Scan(&projectID, &forbidden, &maxQuotaFromOutsideAdmin, &maxQuotaFromLocalAdmin, &forbidAutogrowthFromAdmin, &overrideQuotaFromConfig)
+		err := rows.Scan(&projectID, &forbidden, &maxQuotaFromOutsideAdmin, &forbidAutogrowthFromAdmin, &overrideQuotaFromConfig)
 		if err != nil {
 			return err
 		}
@@ -149,7 +148,6 @@ func ApplyComputedProjectQuota(serviceType db.ServiceType, resourceName liquid.R
 			c.AddMaxQuota(Some(uint64(0)))
 		}
 		c.AddMaxQuota(maxQuotaFromOutsideAdmin)
-		c.AddMaxQuota(maxQuotaFromLocalAdmin)
 		c.AddMinQuota(overrideQuotaFromConfig)
 		c.AddMaxQuota(overrideQuotaFromConfig)
 


### PR DESCRIPTION
Because local admins are now able to use the `forbid autogrowth` setting, the `max-quota` setting should be limited to external admins. This PR removes the local admin settings for the API. The table column remains active until all user notifications are processed, including an appropriate reaction time.