### PR TITLE
only allow setting forbid_autogrowth on committable resources

### DIFF
--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -389,6 +389,13 @@ func (p *v1Provider) PutQuotaAutogrowth(w http.ResponseWriter, r *http.Request) 
 				return
 			}
 
+			behavior := p.Cluster.CommitmentBehaviorForResource(dbServiceType, dbResourceName).ForDomain(dbDomain.Name)
+			if len(behavior.Durations) == 0 {
+				msg := fmt.Sprintf("resource %s/%s does not allow commitments", dbServiceType, dbResourceName)
+				http.Error(w, msg, http.StatusUnprocessableEntity)
+				return
+			}
+
 			if requested[dbServiceType] == nil {
 				requested[dbServiceType] = make(map[liquid.ResourceName]*autogrowthChange)
 			}


### PR DESCRIPTION
This setting is only relevant in practice for customers who want to avoid paying the non-rebated price for usage not covered by commitments, so we will reject its use on non-committable resources, where setting it could lock the user out of the resource entirely.
