### PR TITLE
remove maxQuota setting for local admins (project level)

### DIFF
--- a/internal/datamodel/apply_computed_project_quota.go
+++ b/internal/datamodel/apply_computed_project_quota.go
@@ -34,11 +34,10 @@ var (
 	`)
 
 	acpqGetLocalQuotaConstraintsQuery = sqlext.SimplifyWhitespace(`
-		SELECT project_id, forbidden, max_quota_from_outside_admin, max_quota_from_local_admin, forbid_autogrowth, override_quota_from_config
+		SELECT project_id, forbidden, max_quota_from_outside_admin, forbid_autogrowth, override_quota_from_config
 		  FROM project_resources
 		 WHERE resource_id = $1 AND (forbidden IS NOT NULL
 		                          OR max_quota_from_outside_admin IS NOT NULL
-		                          OR max_quota_from_local_admin IS NOT NULL
 		                          OR forbid_autogrowth IS NOT NULL
 		                          OR override_quota_from_config IS NOT NULL)
 	`)
@@ -135,11 +134,10 @@ func ApplyComputedProjectQuota(serviceType db.ServiceType, resourceName liquid.R
 			projectID                 db.ProjectID
 			forbidden                 bool
 			maxQuotaFromOutsideAdmin  Option[uint64]
-			maxQuotaFromLocalAdmin    Option[uint64]
 			forbidAutogrowthFromAdmin bool
 			overrideQuotaFromConfig   Option[uint64]
 		)
-		err := rows.Scan(&projectID, &forbidden, &maxQuotaFromOutsideAdmin, &maxQuotaFromLocalAdmin, &forbidAutogrowthFromAdmin, &overrideQuotaFromConfig)
+		err := rows.Scan(&projectID, &forbidden, &maxQuotaFromOutsideAdmin, &forbidAutogrowthFromAdmin, &overrideQuotaFromConfig)
 		if err != nil {
 			return err
 		}
@@ -149,7 +147,6 @@ func ApplyComputedProjectQuota(serviceType db.ServiceType, resourceName liquid.R
 			c.AddMaxQuota(Some(uint64(0)))
 		}
 		c.AddMaxQuota(maxQuotaFromOutsideAdmin)
-		c.AddMaxQuota(maxQuotaFromLocalAdmin)
 		c.AddMinQuota(overrideQuotaFromConfig)
 		c.AddMaxQuota(overrideQuotaFromConfig)
 

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -217,4 +217,10 @@ var sqlMigrations = map[string]string{
 	"066_forbid_autogrowth.up.sql": `
 		ALTER TABLE project_resources ADD COLUMN forbid_autogrowth BOOLEAN NOT NULL DEFAULT FALSE;
 	`,
+	"067_maxQuotaFromLocalAdmin.up.sql": `
+		ALTER TABLE project_resources DROP COLUMN max_quota_from_local_admin;
+	`,
+	"067_maxQuotaFromLocalAdmin.down.sql": `
+		ALTER TABLE project_resources ADD COLUMN max_quota_from_local_admin BIGINT;
+	`,
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -125,7 +125,6 @@ type ProjectResource struct {
 	Forbidden                bool              `db:"forbidden"`
 	ForbidAutogrowth         bool              `db:"forbid_autogrowth"`
 	MaxQuotaFromOutsideAdmin Option[uint64]    `db:"max_quota_from_outside_admin"`
-	MaxQuotaFromLocalAdmin   Option[uint64]    `db:"max_quota_from_local_admin"`
 	OverrideQuotaFromConfig  Option[uint64]    `db:"override_quota_from_config"`
 }
 


### PR DESCRIPTION
The maxQuota values for local admins have already been reset. We can now remove the remaining references within the codebase. Local admins can either forbid or allow quota autogrowth, while external admins are able to set a specific max_quota value.

