### PR TITLE
fix missing documentation lints

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -309,14 +309,14 @@ func Test_ScrapeErrorOperations(t *testing.T) {
 		ExpectBody:   assert.JSONObject{"scrape_errors": []assert.JSONObject{}},
 	}.Check(t, s.Handler)
 
-	// Add a scrape error to one specific service with type 'unshared'.
+	// add a scrape error to one specific service with type 'unshared'.
 	s.MustDBExec(
 		`UPDATE project_services SET scrape_error_message = $1 WHERE project_id = 1 AND service_id = $2`,
 		"could not scrape this specific unshared service",
 		s.GetServiceID("unshared"),
 	)
 
-	// Add the same scrape error to all services with type 'shared'. This will ensure that
+	// add the same scrape error to all services with type 'shared'. This will ensure that
 	// they get grouped under a dummy project.
 	s.MustDBExec(
 		`UPDATE project_services SET scrape_error_message = $1 WHERE service_id = $2`,

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -1733,7 +1733,7 @@ func (p *v1Provider) TransferCommitment(w http.ResponseWriter, r *http.Request) 
 	respondwith.JSON(w, http.StatusAccepted, map[string]any{"commitment": c})
 }
 
-// GetCommitmentConversion handles GET /v1/commitment-conversion/{service_type}/{resource_name}
+// GetCommitmentConversions handles GET /v1/commitment-conversion/{service_type}/{resource_name}
 func (p *v1Provider) GetCommitmentConversions(w http.ResponseWriter, r *http.Request) {
 	httpapi.IdentifyEndpoint(r, "/v1/commitment-conversion/:service_type/:resource_name")
 	token := p.CheckToken(r)
@@ -2113,7 +2113,7 @@ func (p *v1Provider) ConvertCommitment(w http.ResponseWriter, r *http.Request) {
 	respondwith.JSON(w, http.StatusAccepted, map[string]any{"commitment": c})
 }
 
-// ExtendCommitmentDuration handles POST /v1/domains/{domain_id}/projects/{project_id}/commitments/{commitment_id}/update-duration
+// UpdateCommitmentDuration handles POST /v1/domains/{domain_id}/projects/{project_id}/commitments/{commitment_id}/update-duration
 func (p *v1Provider) UpdateCommitmentDuration(w http.ResponseWriter, r *http.Request) {
 	httpapi.IdentifyEndpoint(r, "/v1/domains/:domain_id/projects/:project_id/commitments/:commitment_id/update-duration")
 	token := p.CheckToken(r)

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -101,11 +101,6 @@ func NewTokenValidator(provider *gophercloud.ProviderClient, eo gophercloud.Endp
 	return &tv, err
 }
 
-func (p *v1Provider) OverrideGenerateTransferToken(generateTransferToken func() string) *v1Provider {
-	p.generateTransferToken = generateTransferToken
-	return p
-}
-
 // AddTo implements the httpapi.API interface.
 func (p *v1Provider) AddTo(r *mux.Router) {
 	r.Methods("HEAD", "GET").Path("/").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/liquid.go
+++ b/internal/api/liquid.go
@@ -52,7 +52,7 @@ func (p *v1Provider) GetServiceCapacityRequest(w http.ResponseWriter, r *http.Re
 	respondwith.JSON(w, http.StatusOK, serviceCapacityRequest)
 }
 
-// p.GetServiceUsageRequest handles GET /admin/liquid/service-usage-request?service_type=:type&project_id=:id.
+// GetServiceUsageRequest handles GET /admin/liquid/service-usage-request?service_type=:type&project_id=:id.
 func (p *v1Provider) GetServiceUsageRequest(w http.ResponseWriter, r *http.Request) {
 	httpapi.IdentifyEndpoint(r, "/admin/liquid/service-usage-request")
 	token := p.CheckToken(r)

--- a/internal/api/stream.go
+++ b/internal/api/stream.go
@@ -37,6 +37,7 @@ type JSONListStream[T any] struct {
 	w *bufio.Writer
 }
 
+// NewJSONListStream creates a new JSONListStream instance.
 func NewJSONListStream[T any](w http.ResponseWriter, r *http.Request, outerFieldName string) *JSONListStream[T] {
 	return &JSONListStream[T]{
 		OuterFieldName: outerFieldName,

--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -22,7 +22,7 @@ func fromUnixEncodedTime(t limes.UnixEncodedTime) time.Time {
 	return t.Time
 }
 
-// Generates a token that is used to transfer a commitment from a source to a target project.
+// GenerateTransferToken generates a token that is used to transfer a commitment from a source to a target project.
 // The token will be attached to the commitment that will be transferred and stored in the database until the transfer is concluded.
 func GenerateTransferToken() string {
 	tokenBytes := make([]byte, 24)

--- a/internal/collector/consistency.go
+++ b/internal/collector/consistency.go
@@ -20,6 +20,9 @@ import (
 	"github.com/sapcc/limes/internal/db"
 )
 
+// CheckConsistencyJob returns a jobloop.Job that periodically ensures that all
+// services which exist in the configuration exist in the database and that
+// project_services are fully populated in the database.
 func (c *Collector) CheckConsistencyJob(registerer prometheus.Registerer) jobloop.Job {
 	return (&jobloop.CronJob{
 		Metadata: jobloop.JobMetadata{

--- a/internal/collector/mail_delivery.go
+++ b/internal/collector/mail_delivery.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sapcc/limes/internal/db"
 )
 
+// MailRequest is an interface for posting to the mail API.
 type MailRequest struct {
 	ProjectID string `json:"project_id"`
 	Subject   string `json:"subject"`

--- a/internal/collector/metrics.go
+++ b/internal/collector/metrics.go
@@ -340,7 +340,7 @@ type DataMetricsReporter struct {
 	ReportZeroes bool
 }
 
-// This is the same Content-Type that promhttp's GET /metrics implementation reports.
+// ContentTypeForPrometheusMetrics is the same Content-Type that promhttp's GET /metrics implementation reports.
 // If this changes because of a prometheus/client-go upgrade, we will know because our
 // test verifies that promhttp yields this Content-Type. In the case of a change,
 // the output format of promhttp should be carefully reviewed for changes, and then
@@ -841,6 +841,7 @@ func newResourceAndRateBehaviorCache(cluster *core.Cluster) resourceAndRateBehav
 	return resourceAndRateBehaviorCache{cluster, cache, rateCache, cbCache}
 }
 
+// Get returns the cached ResourceBehavior for the given service type and resource name.
 func (c resourceAndRateBehaviorCache) Get(srvType db.ServiceType, resName liquid.ResourceName) core.ResourceBehavior {
 	if c.cache[srvType] == nil {
 		c.cache[srvType] = make(map[liquid.ResourceName]core.ResourceBehavior)
@@ -853,6 +854,7 @@ func (c resourceAndRateBehaviorCache) Get(srvType db.ServiceType, resName liquid
 	return behavior
 }
 
+// GetForRate returns the cached RateBehavior for the given service type and rate name.
 func (c resourceAndRateBehaviorCache) GetForRate(srvType db.ServiceType, rateName liquid.RateName) core.RateBehavior {
 	if c.rateCache[srvType] == nil {
 		c.rateCache[srvType] = make(map[liquid.RateName]core.RateBehavior)
@@ -865,6 +867,7 @@ func (c resourceAndRateBehaviorCache) GetForRate(srvType db.ServiceType, rateNam
 	return behavior
 }
 
+// GetCommitmentBehavior returns the cached ScopedCommitmentBehavior for the given service type and resource name.
 func (c resourceAndRateBehaviorCache) GetCommitmentBehavior(srvType db.ServiceType, resName liquid.ResourceName) core.ScopedCommitmentBehavior {
 	if c.cbCache[srvType] == nil {
 		c.cbCache[srvType] = make(map[liquid.ResourceName]core.ScopedCommitmentBehavior)

--- a/internal/datamodel/allocation_stats.go
+++ b/internal/datamodel/allocation_stats.go
@@ -56,6 +56,9 @@ func (c clusterAZAllocationStats) allowsQuotaOvercommit(cfg core.AutogrowQuotaDi
 	}
 }
 
+// CanAcceptCommitmentChanges determines whether the given commitment additions
+// and subtractions can be accepted in this resources AZ capacity, which already
+// considers the overcommit factor for the resource.
 func (c clusterAZAllocationStats) CanAcceptCommitmentChanges(additions, subtractions map[db.ProjectID]uint64, behavior core.CommitmentBehavior) bool {
 	// calculate `sum_over_projects(max(committed, usage))` before and after the requested changes
 	var (

--- a/internal/datamodel/apply_computed_project_quota.go
+++ b/internal/datamodel/apply_computed_project_quota.go
@@ -68,6 +68,8 @@ type projectLocalQuotaConstraints struct {
 	MaxQuota Option[uint64]
 }
 
+// AddMinQuota updates the minimum quota constraint by taking the maximum
+// of the existing and the new value.
 func (c *projectLocalQuotaConstraints) AddMinQuota(value Option[uint64]) {
 	rhs, ok := value.Unpack()
 	if !ok {
@@ -81,6 +83,8 @@ func (c *projectLocalQuotaConstraints) AddMinQuota(value Option[uint64]) {
 	}
 }
 
+// AddMaxQuota updates the maximum quota constraint by taking the minimum
+// of the existing and the new value.
 func (c *projectLocalQuotaConstraints) AddMaxQuota(value Option[uint64]) {
 	rhs, ok := value.Unpack()
 	if !ok {
@@ -412,8 +416,8 @@ func acpqComputeQuotas(stats map[limes.AvailabilityZone]clusterAZAllocationStats
 	return target, allowsQuotaOvercommit
 }
 
-// After increasing Desired, but before increasing Allocated, this decreases
-// Desired in order to fit into project-local quota constraints.
+// EnforceConstraints decreases Desired in order to fit into project-local quota constraints
+// after increasing Desired, but before increasing Allocated.
 func (target acpqGlobalTarget) EnforceConstraints(stats map[limes.AvailabilityZone]clusterAZAllocationStats, constraints map[db.ProjectID]projectLocalQuotaConstraints, allAZs []limes.AvailabilityZone, isProjectID map[db.ProjectID]struct{}, isAZAware bool) {
 	// Quota should not be assgined to ANY AZ on AZ aware resources. This causes unusable quota distribution on manual quota overrides.
 	resourceAZs := allAZs
@@ -494,6 +498,8 @@ func (target acpqGlobalTarget) EnforceConstraints(stats map[limes.AvailabilityZo
 	}
 }
 
+// TryFulfillDesired tries to increase Allocated towards Desired
+// using any remaining capacity in the cluster.
 func (target acpqGlobalTarget) TryFulfillDesired(stats map[limes.AvailabilityZone]clusterAZAllocationStats, cfg core.AutogrowQuotaDistributionConfiguration, allowsQuotaOvercommit map[limes.AvailabilityZone]bool) {
 	// in AZs where quota overcommit is allowed, we do not have to be careful
 	for az, azTarget := range target {

--- a/internal/db/buildindex.go
+++ b/internal/db/buildindex.go
@@ -18,7 +18,7 @@ func BuildIndexOfDBResult[R any, K comparable](dbi Interface, keyFunc func(R) K,
 	return result, nil
 }
 
-// buildArrayIndexOfDBResult executes an SQL query and returns a map (index) of the result.
+// BuildArrayIndexOfDBResult executes an SQL query and returns a map (index) of the result.
 // The key should not be unique among the whole result set
 func BuildArrayIndexOfDBResult[R any, K comparable](dbi Interface, keyFunc func(R) K, query string, args ...any) (result map[K][]R, err error) {
 	var resultArray []R

--- a/internal/liquids/archer/client.go
+++ b/internal/liquids/archer/client.go
@@ -10,11 +10,12 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 )
 
+// Client is a gophercloud.ServiceClient for the Archer API.
 type Client struct {
 	*gophercloud.ServiceClient
 }
 
-func NewClient(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*Client, error) {
+func newClient(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*Client, error) {
 	serviceType := "endpoint-services"
 	eo.ApplyDefaults(serviceType)
 
@@ -31,7 +32,7 @@ func NewClient(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts
 	}, nil
 }
 
-type QuotaSet struct {
+type quotaSet struct {
 	// for both GET and PUT
 	Endpoint int64 `json:"endpoint"`
 	Service  int64 `json:"service"`
@@ -40,7 +41,7 @@ type QuotaSet struct {
 	InUseService  uint64 `json:"in_use_service"`
 }
 
-func (c *Client) GetQuotaSet(ctx context.Context, projectUUID string) (qs QuotaSet, err error) {
+func (c *Client) getQuotaSet(ctx context.Context, projectUUID string) (qs quotaSet, err error) {
 	url := c.ServiceURL("quotas", projectUUID)
 	var r gophercloud.Result
 	_, r.Header, r.Err = gophercloud.ParseResponse(c.Get(ctx, url, &r.Body, nil)) //nolint:bodyclose // already closed by gophercloud
@@ -48,7 +49,7 @@ func (c *Client) GetQuotaSet(ctx context.Context, projectUUID string) (qs QuotaS
 	return
 }
 
-func (c *Client) PutQuotaSet(ctx context.Context, projectUUID string, qs QuotaSet) error {
+func (c *Client) putQuotaSet(ctx context.Context, projectUUID string, qs quotaSet) error {
 	url := c.ServiceURL("quotas", projectUUID)
 	opts := gophercloud.RequestOpts{OkCodes: []int{http.StatusOK}}
 	_, _, err := gophercloud.ParseResponse(c.Put(ctx, url, qs, nil, &opts)) //nolint:bodyclose // already closed by gophercloud

--- a/internal/liquids/archer/liquid.go
+++ b/internal/liquids/archer/liquid.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sapcc/go-bits/respondwith"
 )
 
+// Logic implements the liquidapi.Logic interface for Archer.
 type Logic struct {
 	// connections
 	Archer *Client `yaml:"-"`
@@ -21,7 +22,7 @@ type Logic struct {
 
 // Init implements the liquidapi.Logic interface.
 func (l *Logic) Init(ctx context.Context, provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (err error) {
-	l.Archer, err = NewClient(provider, eo)
+	l.Archer, err = newClient(provider, eo)
 	return err
 }
 
@@ -52,7 +53,7 @@ func (l *Logic) ScanCapacity(ctx context.Context, req liquid.ServiceCapacityRequ
 
 // ScanUsage implements the liquidapi.Logic interface.
 func (l *Logic) ScanUsage(ctx context.Context, projectUUID string, req liquid.ServiceUsageRequest, serviceInfo liquid.ServiceInfo) (liquid.ServiceUsageReport, error) {
-	quotaSet, err := l.Archer.GetQuotaSet(ctx, projectUUID)
+	qs, err := l.Archer.getQuotaSet(ctx, projectUUID)
 	if err != nil {
 		return liquid.ServiceUsageReport{}, err
 	}
@@ -61,12 +62,12 @@ func (l *Logic) ScanUsage(ctx context.Context, projectUUID string, req liquid.Se
 		InfoVersion: serviceInfo.Version,
 		Resources: map[liquid.ResourceName]*liquid.ResourceUsageReport{
 			"endpoints": {
-				Quota: Some(quotaSet.Endpoint),
-				PerAZ: liquid.InAnyAZ(liquid.AZResourceUsageReport{Usage: quotaSet.InUseEndpoint}),
+				Quota: Some(qs.Endpoint),
+				PerAZ: liquid.InAnyAZ(liquid.AZResourceUsageReport{Usage: qs.InUseEndpoint}),
 			},
 			"services": {
-				Quota: Some(quotaSet.Service),
-				PerAZ: liquid.InAnyAZ(liquid.AZResourceUsageReport{Usage: quotaSet.InUseService}),
+				Quota: Some(qs.Service),
+				PerAZ: liquid.InAnyAZ(liquid.AZResourceUsageReport{Usage: qs.InUseService}),
 			},
 		},
 	}, nil
@@ -74,7 +75,7 @@ func (l *Logic) ScanUsage(ctx context.Context, projectUUID string, req liquid.Se
 
 // SetQuota implements the liquidapi.Logic interface.
 func (l *Logic) SetQuota(ctx context.Context, projectUUID string, req liquid.ServiceQuotaRequest, serviceInfo liquid.ServiceInfo) error {
-	return l.Archer.PutQuotaSet(ctx, projectUUID, QuotaSet{
+	return l.Archer.putQuotaSet(ctx, projectUUID, quotaSet{
 		Endpoint: int64(req.Resources["endpoints"].Quota), //nolint:gosec // uint64 -> int64 would only fail if quota is bigger than 2^63
 		Service:  int64(req.Resources["services"].Quota),  //nolint:gosec // uint64 -> int64 would only fail if quota is bigger than 2^63
 	})

--- a/internal/liquids/cronus/client.go
+++ b/internal/liquids/cronus/client.go
@@ -15,7 +15,7 @@ type Client struct {
 	*gophercloud.ServiceClient
 }
 
-func NewClient(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*Client, error) {
+func newClient(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*Client, error) {
 	serviceType := "email-aws"
 	eo.ApplyDefaults(serviceType)
 

--- a/internal/liquids/cronus/liquid.go
+++ b/internal/liquids/cronus/liquid.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sapcc/go-bits/respondwith"
 )
 
+// Logic implements the liquidapi.Logic interface for Cronus.
 type Logic struct {
 	// connections
 	CronusV1 *Client `json:"-"`
@@ -25,7 +26,7 @@ type Logic struct {
 
 // Init implements the liquidapi.Logic interface.
 func (l *Logic) Init(ctx context.Context, provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (err error) {
-	l.CronusV1, err = NewClient(provider, eo)
+	l.CronusV1, err = newClient(provider, eo)
 	return err
 }
 

--- a/internal/liquids/designate/client.go
+++ b/internal/liquids/designate/client.go
@@ -12,22 +12,23 @@ import (
 	"github.com/gophercloud/gophercloud/v2/pagination"
 )
 
+// Client is a gophercloud.ServiceClient for the Designate API.
 type Client struct {
 	*gophercloud.ServiceClient
 }
 
-func NewClient(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*Client, error) {
+func newClient(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*Client, error) {
 	sc, err := openstack.NewDNSV2(provider, eo)
 	return &Client{ServiceClient: sc}, err
 }
 
-type QuotaSet struct {
+type quotaSet struct {
 	Zones             int64 `json:"zones"`
 	RecordsetsPerZone int64 `json:"zone_recordsets"`
 	RecordsPerZone    int64 `json:"zone_records"`
 }
 
-func (c *Client) GetQuota(ctx context.Context, projectUUID string) (qs QuotaSet, err error) {
+func (c *Client) getQuota(ctx context.Context, projectUUID string) (qs quotaSet, err error) {
 	url := c.ServiceURL("quotas", projectUUID)
 	opts := gophercloud.RequestOpts{
 		MoreHeaders: map[string]string{"X-Auth-All-Projects": "true"},
@@ -39,7 +40,7 @@ func (c *Client) GetQuota(ctx context.Context, projectUUID string) (qs QuotaSet,
 	return
 }
 
-func (c *Client) SetQuota(ctx context.Context, projectUUID string, qs QuotaSet) error {
+func (c *Client) setQuota(ctx context.Context, projectUUID string, qs quotaSet) error {
 	url := c.ServiceURL("quotas", projectUUID)
 	opts := gophercloud.RequestOpts{
 		MoreHeaders: map[string]string{"X-Auth-All-Projects": "true"},
@@ -49,7 +50,7 @@ func (c *Client) SetQuota(ctx context.Context, projectUUID string, qs QuotaSet) 
 	return err
 }
 
-func (c *Client) ListZoneIDs(ctx context.Context, projectUUID string) ([]string, error) {
+func (c *Client) listZoneIDs(ctx context.Context, projectUUID string) ([]string, error) {
 	pager := zones.List(c.ServiceClient, zones.ListOpts{})
 	pager.Headers = map[string]string{
 		"X-Auth-All-Projects":    "false",
@@ -70,7 +71,7 @@ func (c *Client) ListZoneIDs(ctx context.Context, projectUUID string) ([]string,
 	return ids, err
 }
 
-func (c *Client) CountZoneRecordsets(ctx context.Context, projectUUID, zoneID string) (uint64, error) {
+func (c *Client) countZoneRecordsets(ctx context.Context, projectUUID, zoneID string) (uint64, error) {
 	url := c.ServiceURL("zones", zoneID, "recordsets")
 	url += "?limit=1" // do not need all data about all recordsets, just the total count
 	opts := gophercloud.RequestOpts{

--- a/internal/liquids/ironic/liquid.go
+++ b/internal/liquids/ironic/liquid.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sapcc/limes/internal/liquids/nova"
 )
 
+// Logic implements the liquidapi.Logic interface for Ironic.
 type Logic struct {
 	// configuration
 	WithSubcapacities bool                               `json:"with_subcapacities"`
@@ -97,7 +98,7 @@ func (l *Logic) BuildServiceInfo(ctx context.Context) (liquid.ServiceInfo, error
 			DiskGiB:   liquidapi.AtLeastZero(flavor.Disk),
 		})
 		if err != nil {
-			return liquid.ServiceInfo{}, fmt.Errorf("while serializing FlavorAttributes: %w", err)
+			return liquid.ServiceInfo{}, fmt.Errorf("while serializing flavorAttributes: %w", err)
 		}
 
 		resources[resourceNameForFlavorName(flavor.Name)] = liquid.ResourceInfo{

--- a/internal/liquids/ironic/usage.go
+++ b/internal/liquids/ironic/usage.go
@@ -110,10 +110,10 @@ func (l *Logic) addInstanceToReport(ctx context.Context, resources map[liquid.Re
 
 	// add subresource if requested
 	if l.WithSubresources {
-		builder := liquid.SubresourceBuilder[InstanceAttributes]{
+		builder := liquid.SubresourceBuilder[instanceAttributes]{
 			ID:   instance.ID,
 			Name: instance.Name,
-			Attributes: InstanceAttributes{
+			Attributes: instanceAttributes{
 				Status:   instance.Status,
 				Metadata: instance.Metadata,
 				OSType:   l.OSTypeProber.Get(ctx, instance),
@@ -145,8 +145,8 @@ func (l *Logic) SetQuota(ctx context.Context, projectUUID string, req liquid.Ser
 ////////////////////////////////////////////////////////////////////////////////
 // internal types for capacity reporting
 
-// InstanceAttributes is the Attributes payload type for an Ironic-based Nova instance subresource.
-type InstanceAttributes struct {
+// instanceAttributes is the Attributes payload type for an Ironic-based Nova instance subresource.
+type instanceAttributes struct {
 	// base metadata
 	Status   string            `json:"status"`
 	Metadata map[string]string `json:"metadata"`
@@ -160,6 +160,7 @@ type InstanceAttributes struct {
 
 type novaQuotaUpdateOpts map[string]uint64
 
+// ToComputeQuotaUpdateMap implements the quotasets.UpdateOptsBuilder interface.
 func (opts novaQuotaUpdateOpts) ToComputeQuotaUpdateMap() (map[string]any, error) {
 	return map[string]any{"quota_set": opts}, nil
 }

--- a/internal/liquids/manila/sharetype.go
+++ b/internal/liquids/manila/sharetype.go
@@ -11,39 +11,39 @@ import (
 	"github.com/sapcc/go-bits/regexpext"
 )
 
-// RealShareType is a share type name that can be used in the Manila API.
-type RealShareType string
+// realShareType is a share type name that can be used in the Manila API.
+type realShareType string
 
-// VirtualShareType is the configuration for a virtual share type.
-type VirtualShareType struct {
-	Name               RealShareType `json:"name"`
+// virtualShareType is the configuration for a virtual share type.
+type virtualShareType struct {
+	Name               realShareType `json:"name"`
 	ReplicationEnabled bool          `json:"replication_enabled"` // only used by Usage Collection
 	MappingRules       []struct {
 		FullProjectNamePattern regexpext.BoundedRegexp `json:"match_project_name"`
-		Name                   RealShareType           `json:"name"`
+		Name                   realShareType           `json:"name"`
 	} `json:"mapping_rules"`
 }
 
-func (vst VirtualShareType) SharesResourceName() liquid.ResourceName {
+func (vst virtualShareType) sharesResourceName() liquid.ResourceName {
 	return liquid.ResourceName("shares_" + string(vst.Name))
 }
-func (vst VirtualShareType) SnapshotsResourceName() liquid.ResourceName {
+func (vst virtualShareType) snapshotsResourceName() liquid.ResourceName {
 	return liquid.ResourceName("snapshots_" + string(vst.Name))
 }
-func (vst VirtualShareType) ShareCapacityResourceName() liquid.ResourceName {
+func (vst virtualShareType) shareCapacityResourceName() liquid.ResourceName {
 	return liquid.ResourceName("share_capacity_" + string(vst.Name))
 }
-func (vst VirtualShareType) SnapshotCapacityResourceName() liquid.ResourceName {
+func (vst virtualShareType) snapshotCapacityResourceName() liquid.ResourceName {
 	return liquid.ResourceName("snapshot_capacity_" + string(vst.Name))
 }
-func (vst VirtualShareType) SnapmirrorCapacityResourceName() liquid.ResourceName {
+func (vst virtualShareType) snapmirrorCapacityResourceName() liquid.ResourceName {
 	return liquid.ResourceName("snapmirror_capacity_" + string(vst.Name))
 }
 
-// RealShareTypeIn returns the real share type that we have to use on the Manila
+// realShareTypeIn returns the real share type that we have to use on the Manila
 // API for this particular project, or "" if this share type shall be skipped
 // for this project.
-func (vst VirtualShareType) RealShareTypeIn(project liquid.ProjectMetadata) (rst RealShareType, omit bool) {
+func (vst virtualShareType) realShareTypeIn(project liquid.ProjectMetadata) (rst realShareType, omit bool) {
 	fullName := fmt.Sprintf(`%s@%s`, project.Name, project.Domain.Name)
 	for _, rule := range vst.MappingRules {
 		if rule.FullProjectNamePattern.MatchString(fullName) {
@@ -53,9 +53,9 @@ func (vst VirtualShareType) RealShareTypeIn(project liquid.ProjectMetadata) (rst
 	return vst.Name, false
 }
 
-// AllRealShareTypes returns all real share types that can be used on the
+// allRealShareTypes returns all real share types that can be used on the
 // Manila API to set quota or read usage for this virtual share type.
-func (vst VirtualShareType) AllRealShareTypes() (result []RealShareType) {
+func (vst virtualShareType) allRealShareTypes() (result []realShareType) {
 	for _, rule := range vst.MappingRules {
 		// rules that make the share type inaccessible should not be considered
 		if rule.Name == "" {

--- a/internal/liquids/neutron/liquid.go
+++ b/internal/liquids/neutron/liquid.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sapcc/go-bits/respondwith"
 )
 
+// Logic implements the liquidapi.Logic interface for Neutron.
 type Logic struct {
 	// connections
 	NeutronV2 *gophercloud.ServiceClient `yaml:"-"`

--- a/internal/liquids/nova/flavor_selection.go
+++ b/internal/liquids/nova/flavor_selection.go
@@ -82,7 +82,7 @@ func ResourceNameForFlavor(flavorName string) liquid.ResourceName {
 }
 
 // FlavorMatchesHypervisor returns true if instances of this flavor can be placed on the given hypervisor.
-func FlavorMatchesHypervisor(f flavors.Flavor, mh MatchingHypervisor) bool {
+func FlavorMatchesHypervisor(f flavors.Flavor, mh matchingHypervisor) bool {
 	// extra specs like `"trait:FOO": "required"` or `"trait:BAR": "forbidden"`
 	// are used by the Nova scheduler to ignore hypervisors that do not (or do)
 	// have the respective traits

--- a/internal/liquids/nova/hypervisor_subcapacity.go
+++ b/internal/liquids/nova/hypervisor_subcapacity.go
@@ -10,22 +10,22 @@ import (
 	"github.com/sapcc/go-api-declarations/liquid"
 )
 
-// PooledSubcapacityBuilder is used to build subcapacity lists for pooled resources.
-type PooledSubcapacityBuilder struct {
+// pooledSubcapacityBuilder is used to build subcapacity lists for pooled resources.
+type pooledSubcapacityBuilder struct {
 	CoresSubcapacities     []liquid.Subcapacity
 	InstancesSubcapacities []liquid.Subcapacity
 	RAMSubcapacities       []liquid.Subcapacity
 }
 
-type SubcapacityAttributes struct {
+type subcapacityAttributes struct {
 	AggregateName string   `json:"aggregate_name"`
 	Traits        []string `json:"traits"`
 }
 
-func (b *PooledSubcapacityBuilder) AddHypervisor(h MatchingHypervisor, maxRootDiskSize float64) error {
-	pc := h.PartialCapacity()
+func (b *pooledSubcapacityBuilder) addHypervisor(h matchingHypervisor, maxRootDiskSize float64) error {
+	pc := h.partialCapacity()
 
-	attrs := SubcapacityAttributes{
+	attrs := subcapacityAttributes{
 		AggregateName: h.AggregateName,
 		Traits:        h.Traits,
 	}
@@ -34,21 +34,21 @@ func (b *PooledSubcapacityBuilder) AddHypervisor(h MatchingHypervisor, maxRootDi
 		return fmt.Errorf("while serializing Subcapacity Attributes: %w", err)
 	}
 
-	hvCoresCapa := pc.IntoCapacityData("cores", maxRootDiskSize, nil)
+	hvCoresCapa := pc.intoCapacityData("cores", maxRootDiskSize, nil)
 	b.CoresSubcapacities = append(b.CoresSubcapacities, liquid.Subcapacity{
 		Name:       h.Hypervisor.Service.Host,
 		Capacity:   hvCoresCapa.Capacity,
 		Usage:      hvCoresCapa.Usage,
 		Attributes: json.RawMessage(buf),
 	})
-	hvInstancesCapa := pc.IntoCapacityData("instances", maxRootDiskSize, nil)
+	hvInstancesCapa := pc.intoCapacityData("instances", maxRootDiskSize, nil)
 	b.InstancesSubcapacities = append(b.InstancesSubcapacities, liquid.Subcapacity{
 		Name:       h.Hypervisor.Service.Host,
 		Capacity:   hvInstancesCapa.Capacity,
 		Usage:      hvInstancesCapa.Usage,
 		Attributes: json.RawMessage(buf),
 	})
-	hvRAMCapa := pc.IntoCapacityData("ram", maxRootDiskSize, nil)
+	hvRAMCapa := pc.intoCapacityData("ram", maxRootDiskSize, nil)
 	b.RAMSubcapacities = append(b.RAMSubcapacities, liquid.Subcapacity{
 		Name:       h.Hypervisor.Service.Host,
 		Capacity:   hvRAMCapa.Capacity,

--- a/internal/liquids/nova/liquid.go
+++ b/internal/liquids/nova/liquid.go
@@ -22,13 +22,14 @@ import (
 	"github.com/sapcc/go-bits/respondwith"
 )
 
+// Logic implements the liquidapi.Logic interface for Nova.
 type Logic struct {
 	// configuration
-	HypervisorSelection HypervisorSelection `json:"hypervisor_selection"`
+	HypervisorSelection hypervisorSelection `json:"hypervisor_selection"`
 	FlavorSelection     FlavorSelection     `json:"flavor_selection"`
 	WithSubresources    bool                `json:"with_subresources"`
 	WithSubcapacities   bool                `json:"with_subcapacities"`
-	BinpackBehavior     BinpackBehavior     `json:"binpack_behavior"`
+	BinpackBehavior     binpackBehavior     `json:"binpack_behavior"`
 	IgnoredTraits       []string            `json:"ignored_traits"`
 	// connections
 	NovaV2            *gophercloud.ServiceClient `json:"-"`
@@ -79,7 +80,7 @@ func getDefaultQuotaClassSet(ctx context.Context, novaV2 *gophercloud.ServiceCli
 	}
 
 	var body struct {
-		//NOTE: cannot use map[string]int64 here because this object contains the
+		// NOTE: cannot use map[string]int64 here because this object contains the
 		// field "id": "default" (curse you, untyped JSON)
 		QuotaClassSet map[string]any `json:"quota_class_set"`
 	}
@@ -216,7 +217,7 @@ func (l *Logic) ReviewCommitmentChange(ctx context.Context, req liquid.Commitmen
 	return liquid.CommitmentChangeResponse{}, respondwith.CustomStatus(http.StatusBadRequest, err)
 }
 
-func (l *Logic) IsIgnoredFlavor(flavorName string) bool {
+func (l *Logic) isIgnoredFlavor(flavorName string) bool {
 	return slices.Contains(l.ignoredFlavorNames.Get(), flavorName)
 }
 
@@ -225,6 +226,7 @@ func (l *Logic) IsIgnoredFlavor(flavorName string) bool {
 
 type novaQuotaUpdateOpts map[string]uint64
 
+// ToComputeQuotaUpdateMap implements the quotasets.UpdateOptsBuilder interface.
 func (opts novaQuotaUpdateOpts) ToComputeQuotaUpdateMap() (map[string]any, error) {
 	return map[string]any{"quota_set": opts}, nil
 }

--- a/internal/liquids/nova/ostype_prober.go
+++ b/internal/liquids/nova/ostype_prober.go
@@ -40,6 +40,7 @@ func NewOSTypeProber(novaV2, cinderV3, glanceV2 *gophercloud.ServiceClient) *OST
 	}
 }
 
+// Get returns the OSType for the given instance.
 func (p *OSTypeProber) Get(ctx context.Context, instance servers.Server) string {
 	if instance.Image == nil {
 		return p.getFromBootVolume(ctx, instance.ID)

--- a/internal/liquids/nova/subresources.go
+++ b/internal/liquids/nova/subresources.go
@@ -14,7 +14,7 @@ import (
 	"github.com/sapcc/go-api-declarations/liquid"
 )
 
-type FlavorAttributes struct {
+type flavorAttributes struct {
 	Name           string  `json:"name"`
 	VCPUs          uint64  `json:"vcpu"`
 	MemoryMiB      uint64  `json:"ram_mib"`
@@ -23,8 +23,8 @@ type FlavorAttributes struct {
 	HWVersion      string  `json:"-"` // this is only used for sorting the subresource into the right resource
 }
 
-// SubresourceAttributes is the Attributes payload for a Nova instance subresource.
-type SubresourceAttributes struct {
+// subresourceAttributes is the Attributes payload for a Nova instance subresource.
+type subresourceAttributes struct {
 	// base metadata
 	Status   string            `json:"status"`
 	Metadata map[string]string `json:"metadata"`
@@ -32,17 +32,17 @@ type SubresourceAttributes struct {
 	// placement information
 	AZ liquid.AvailabilityZone `json:"-"`
 	// information from flavor
-	Flavor FlavorAttributes `json:"flavor"`
+	Flavor flavorAttributes `json:"flavor"`
 	// information from image
 	OSType string `json:"os_type"`
 }
 
-func (l *Logic) buildInstanceSubresource(ctx context.Context, instance servers.Server, allAZs []liquid.AvailabilityZone) (res liquid.SubresourceBuilder[SubresourceAttributes], err error) {
+func (l *Logic) buildInstanceSubresource(ctx context.Context, instance servers.Server, allAZs []liquid.AvailabilityZone) (res liquid.SubresourceBuilder[subresourceAttributes], err error) {
 	// copy base attributes
 	res.ID = instance.ID
 	res.Name = instance.Name
 
-	attrs := SubresourceAttributes{
+	attrs := subresourceAttributes{
 		Status:   instance.Status,
 		AZ:       liquid.NormalizeAZ(instance.AvailabilityZone, allAZs),
 		Metadata: instance.Metadata,
@@ -63,7 +63,7 @@ func (l *Logic) buildInstanceSubresource(ctx context.Context, instance servers.S
 	}
 
 	// copy attributes from flavor data
-	attrs.Flavor = FlavorAttributes{
+	attrs.Flavor = flavorAttributes{
 		Name:      flavorInfo.OriginalName,
 		VCPUs:     flavorInfo.VCPUs,
 		MemoryMiB: flavorInfo.MemoryMiB,
@@ -84,13 +84,13 @@ func (l *Logic) buildInstanceSubresource(ctx context.Context, instance servers.S
 	return res, nil
 }
 
-func (l *Logic) buildInstanceSubresources(ctx context.Context, projectUUID string, allAZs []liquid.AvailabilityZone) ([]liquid.SubresourceBuilder[SubresourceAttributes], error) {
+func (l *Logic) buildInstanceSubresources(ctx context.Context, projectUUID string, allAZs []liquid.AvailabilityZone) ([]liquid.SubresourceBuilder[subresourceAttributes], error) {
 	opts := servers.ListOpts{
 		AllTenants: true,
 		TenantID:   projectUUID,
 	}
 
-	var result []liquid.SubresourceBuilder[SubresourceAttributes]
+	var result []liquid.SubresourceBuilder[subresourceAttributes]
 	err := servers.List(l.NovaV2, opts).EachPage(ctx, func(ctx context.Context, page pagination.Page) (bool, error) {
 		var instances []servers.Server
 		err := servers.ExtractServersInto(page, &instances)

--- a/internal/liquids/nova/usage.go
+++ b/internal/liquids/nova/usage.go
@@ -25,6 +25,7 @@ func (l *Logic) pooledResourceName(hwVersion string, base liquid.ResourceName) l
 	return base
 }
 
+// ScanUsage implements the liquidapi.Logic interface.
 func (l *Logic) ScanUsage(ctx context.Context, projectUUID string, req liquid.ServiceUsageRequest, serviceInfo liquid.ServiceInfo) (liquid.ServiceUsageReport, error) {
 	var limitsData struct {
 		Limits struct {
@@ -90,7 +91,7 @@ func (l *Logic) ScanUsage(ctx context.Context, projectUUID string, req liquid.Se
 		},
 	}
 	for flavorName, flavorLimits := range limitsData.Limits.AbsolutePerFlavor {
-		if l.IsIgnoredFlavor(flavorName) {
+		if l.isIgnoredFlavor(flavorName) {
 			continue
 		}
 		resourceName := ResourceNameForFlavor(flavorName)
@@ -133,7 +134,7 @@ func (l *Logic) ScanUsage(ctx context.Context, projectUUID string, req liquid.Se
 
 		az := attrs.AZ
 
-		if l.IsIgnoredFlavor(attrs.Flavor.Name) {
+		if l.isIgnoredFlavor(attrs.Flavor.Name) {
 			continue
 		}
 

--- a/internal/liquids/octavia/client.go
+++ b/internal/liquids/octavia/client.go
@@ -33,7 +33,7 @@ func getUsage(ctx context.Context, client *gophercloud.ServiceClient, projectUUI
 
 type quotaSet map[string]uint64
 
-// ToQuotaUpdateMap implements the quotas.UpdateOpts interfaces.
+// ToQuotaUpdateMap implements the quotasets.UpdateOptsBuilder interfaces.
 func (q quotaSet) ToQuotaUpdateMap() (map[string]any, error) {
 	return map[string]any{"quota": map[string]uint64(q)}, nil
 }

--- a/internal/liquids/octavia/liquid.go
+++ b/internal/liquids/octavia/liquid.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sapcc/go-bits/respondwith"
 )
 
+// Logic implements the liquidapi.Logic interface for Octavia.
 type Logic struct {
 	// connections
 	OctaviaV2 *gophercloud.ServiceClient `yaml:"-"`

--- a/internal/liquids/types.go
+++ b/internal/liquids/types.go
@@ -11,7 +11,7 @@ import (
 ////////////////////////////////////////////////////////////////////////////////
 // OpenStack is being a mess once again
 
-// Used for the "total_capacity_gb" field in Cinder and Manila pools,
+// Float64WithStringErrors is used for the "total_capacity_gb" field in Cinder and Manila pools,
 // which may be a string like "infinite", "unknown" or "".
 type Float64WithStringErrors float64
 

--- a/internal/reports/filter.go
+++ b/internal/reports/filter.go
@@ -52,21 +52,21 @@ func ReadFilter(r *http.Request, cluster *core.Cluster, serviceInfos map[db.Serv
 
 	for _, dbServiceType := range slices.Sorted(maps.Keys(serviceInfos)) {
 		srvCfg, _ := cluster.Config.GetLiquidConfigurationForType(dbServiceType)
-		if !apiAreas.Matches(srvCfg.Area) {
+		if !apiAreas.matches(srvCfg.Area) {
 			continue
 		}
 
 		for dbResourceName := range serviceInfos[dbServiceType].Resources {
 			apiIdentity := cluster.BehaviorForResource(dbServiceType, dbResourceName).IdentityInV1API
 
-			if !apiServiceTypes.Matches(string(apiIdentity.ServiceType)) {
+			if !apiServiceTypes.matches(string(apiIdentity.ServiceType)) {
 				continue
 			}
 
 			if f.Includes[dbServiceType] == nil {
 				f.Includes[dbServiceType] = make(map[liquid.ResourceName]bool)
 			}
-			f.Includes[dbServiceType][dbResourceName] = apiResourceNames.Matches(string(apiIdentity.Name))
+			f.Includes[dbServiceType][dbResourceName] = apiResourceNames.matches(string(apiIdentity.Name))
 		}
 	}
 
@@ -78,7 +78,7 @@ func ReadFilter(r *http.Request, cluster *core.Cluster, serviceInfos map[db.Serv
 
 type apiFilter []string
 
-func (a apiFilter) Matches(value string) bool {
+func (a apiFilter) matches(value string) bool {
 	// A list filter from the URL query can either:
 	// - be empty and match all possible values, or
 	// - be non-empty and match the listed values.

--- a/internal/test/mock_liquid_client.go
+++ b/internal/test/mock_liquid_client.go
@@ -49,6 +49,7 @@ func (l *MockLiquidClient) GetInfo(ctx context.Context) (result liquid.ServiceIn
 	return l.ServiceInfo.get()
 }
 
+// IncrementServiceInfoVersion increments the ServiceInfo version number by 1.
 func (l *MockLiquidClient) IncrementServiceInfoVersion() {
 	l.ServiceInfo.Modify(func(info *liquid.ServiceInfo) { info.Version++ })
 }
@@ -58,6 +59,7 @@ func (l *MockLiquidClient) GetCapacityReport(ctx context.Context, req liquid.Ser
 	return l.CapacityReport.get()
 }
 
+// IncrementCapacityReportInfoVersion increments the CapacityReport InfoVersion by 1.
 func (l *MockLiquidClient) IncrementCapacityReportInfoVersion() {
 	l.CapacityReport.Modify(func(report *liquid.ServiceCapacityReport) { report.InfoVersion++ })
 }
@@ -67,10 +69,12 @@ func (l *MockLiquidClient) GetUsageReport(ctx context.Context, projectUUID strin
 	return l.UsageReport.get()
 }
 
+// IncrementUsageReportInfoVersion increments the UsageReport InfoVersion by 1.
 func (l *MockLiquidClient) IncrementUsageReportInfoVersion() {
 	l.UsageReport.Modify(func(report *liquid.ServiceUsageReport) { report.InfoVersion++ })
 }
 
+// SetQuotaError sets an error to be returned by PutQuota, or clears it if nil is given.
 func (l *MockLiquidClient) SetQuotaError(err error) {
 	l.quotaError = err
 }

--- a/internal/test/setup.go
+++ b/internal/test/setup.go
@@ -137,6 +137,7 @@ type Setup struct {
 	t *testing.T
 }
 
+// GenerateDummyToken generates a dummy token string.
 func GenerateDummyToken() string {
 	return "dummyToken"
 }

--- a/internal/util/datatypes.go
+++ b/internal/util/datatypes.go
@@ -11,7 +11,6 @@ import (
 
 // MarshalableTimeDuration is a time.Duration that can be unmarshaled
 // from a YAML string using time.ParseDuration.
-
 type MarshalableTimeDuration time.Duration
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/internal/util/http.go
+++ b/internal/util/http.go
@@ -20,6 +20,7 @@ type loggingRoundTripper struct {
 	Inner http.RoundTripper
 }
 
+// RoundTrip implements the http.RoundTripper interface.
 func (rt loggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	start := time.Now()
 	resp, err := rt.Inner.RoundTrip(req)

--- a/internal/util/timeseries.go
+++ b/internal/util/timeseries.go
@@ -94,7 +94,7 @@ func (s *TimeSeries[T]) AddMeasurement(now time.Time, value T) error {
 	return nil
 }
 
-// PruneOldValues removes all measurements that fall before `now.Add(-retentionPeriod)`.
+// PruneOldValues removes all measurements that fall before `now.add(-retentionPeriod)`.
 func (s *TimeSeries[T]) PruneOldValues(now time.Time, retentionPeriod time.Duration) {
 	cutoff := s.findCutoffIndex(now, retentionPeriod)
 	if cutoff > 0 {


### PR DESCRIPTION
This is a PR to showcase the impact of the `exported`-linting of the revive linter, for which I introduced support in go-makefile-maker: https://github.com/sapcc/go-makefile-maker/pull/403

As you can see, this lint this does not just highlight missing comments, you have different root causes for missing comments:
* find comments which were forgotten to update when a function was renamed (`/api/commitment.go`)
* find missing interface implementation comments (As interface implementations are not explicit in go, I find this to be important)
* highlight functions which can actually be un-exported (the majority of changes in `/liquids` )