### PR TITLE
liquids/ironic: fix infinite loop

### DIFF
--- a/internal/liquids/ironic/capacity.go
+++ b/internal/liquids/ironic/capacity.go
@@ -268,7 +268,11 @@ type nodePage struct {
 // next page of results.
 func (r nodePage) NextPageURL() (string, error) {
 	var s struct {
+		// we prefer this field
 		Next string `json:"next"`
+		// this field is used by the default implementation in nodes.NodePage.NextPageURL()
+		// (we only use it as a fallback because this field does not exist in the API responses we have observed in prod)
+		Links []gophercloud.Link `json:"nodes_links"`
 	}
 	err := r.ExtractInto(&s)
 	if err != nil {
@@ -277,6 +281,5 @@ func (r nodePage) NextPageURL() (string, error) {
 	if s.Next != "" {
 		return s.Next, nil
 	}
-	// fallback
-	return r.NextPageURL()
+	return gophercloud.ExtractNextURL(s.Links)
 }


### PR DESCRIPTION
The automated simplification of `r.NodePage.NextPageURL()` into `r.NextPageURL()` in 4d4482d261747532b7840b905e95207eee8a17e1 was incorrect and caused an infinite recursion back into the same function.

To avoid running into this trap again, and also do avoid double work on the unmarshal, I'm rewriting this to incorporate the library implementation instead of calling into it.