### PR TITLE
Liquid-ironic: add restricted_flavors config option for managing instances_hv_* quotas

### DIFF
--- a/docs/liquids/ironic.md
+++ b/docs/liquids/ironic.md
@@ -19,6 +19,7 @@ This liquid provides support for the baremetal compute service Ironic.
 | `with_subresources` | boolean | If true, subresources are reported. |
 | `node_page_limit` | integer | When listing baremetal nodes during capacity calculation, only this many nodes will be listed at once. Defaults to 100. This number has a major impact on the peak memory usage of this liquid, because Ironic nodes often have an absurd amount of metadata on them that we need to parse temporarily. Reducing this number reduces memory consumption nearly linearly, at the cost of linearly increasing the amount of requests that need to be made to Ironic. |
 | `instance_page_limit` | integer | When listing Nova instances during usage calculation, only this many instances will be listed at once. Defaults to 250. Similar to `node_page_limit`, this can have a major impact on the peak memory usage of this liquid, though usually setting this is only required when there are projects with a very high number of Ironic-based Nova instances. |
+| `restricted_flavors` | map[string][ConfigSet](../operators/config.md#configset) keyed on `domain/project` | This option maps flavor names to allow lists containing project name regexes. It is intended to explicitly allow certain projects to access otherwise restricted flavors. |
 
 ## Resources
 

--- a/internal/liquids/ironic/liquid.go
+++ b/internal/liquids/ironic/liquid.go
@@ -18,6 +18,7 @@ import (
 	. "github.com/majewsky/gg/option"
 	"github.com/sapcc/go-api-declarations/liquid"
 	"github.com/sapcc/go-bits/liquidapi"
+	"github.com/sapcc/go-bits/regexpext"
 	"github.com/sapcc/go-bits/respondwith"
 
 	"github.com/sapcc/limes/internal/liquids/nova"
@@ -26,11 +27,12 @@ import (
 // Logic implements the liquidapi.Logic interface for Ironic.
 type Logic struct {
 	// configuration
-	WithSubcapacities bool                               `json:"with_subcapacities"`
-	WithSubresources  bool                               `json:"with_subresources"`
-	NodeToAZOverrides map[string]liquid.AvailabilityZone `json:"node_to_az_overrides"`
-	NodePageLimit     Option[int]                        `json:"node_page_limit"`
-	InstancePageLimit Option[int]                        `json:"instance_page_limit"`
+	WithSubcapacities bool                                         `json:"with_subcapacities"`
+	WithSubresources  bool                                         `json:"with_subresources"`
+	NodeToAZOverrides map[string]liquid.AvailabilityZone           `json:"node_to_az_overrides"`
+	NodePageLimit     Option[int]                                  `json:"node_page_limit"`
+	InstancePageLimit Option[int]                                  `json:"instance_page_limit"`
+	RestrictedFlavors map[string]regexpext.ConfigSet[string, bool] `json:"restricted_flavors"`
 	// connections
 	NovaV2       *gophercloud.ServiceClient `json:"-"`
 	IronicV1     *gophercloud.ServiceClient `json:"-"`
@@ -123,6 +125,7 @@ func (l *Logic) BuildServiceInfo(ctx context.Context) (liquid.ServiceInfo, error
 				Help: "Number of available/active Ironic nodes without matching flavor.",
 			},
 		},
+		UsageReportNeedsProjectMetadata: true,
 	}, nil
 }
 


### PR DESCRIPTION
Checklist:

- [x] I updated the documentation to describe the semantical or interface changes I introduced.
