### PR TITLE
add missing liquid delegation for commitmentChangeRequest

### DIFF
--- a/internal/collector/capacity_scrape.go
+++ b/internal/collector/capacity_scrape.go
@@ -260,7 +260,7 @@ func (c *Collector) processCapacityScrapeTask(ctx context.Context, task capacity
 
 	// for all resources thus updated, try to confirm pending commitments
 	for _, res := range dbResources {
-		err := c.confirmPendingCommitmentsIfNecessary(service.Type, res.Name, serviceInfos)
+		err := c.confirmPendingCommitmentsIfNecessary(ctx, service.Type, res.Name, serviceInfos)
 		if err != nil {
 			return err
 		}
@@ -292,7 +292,7 @@ func (c *Collector) scrapeLiquidCapacity(ctx context.Context, connection *core.L
 	return capacityData, srv, serializedMetrics, nil
 }
 
-func (c *Collector) confirmPendingCommitmentsIfNecessary(serviceType db.ServiceType, resourceName liquid.ResourceName, serviceInfos map[db.ServiceType]liquid.ServiceInfo) error {
+func (c *Collector) confirmPendingCommitmentsIfNecessary(ctx context.Context, serviceType db.ServiceType, resourceName liquid.ResourceName, serviceInfos map[db.ServiceType]liquid.ServiceInfo) error {
 	behavior := c.Cluster.CommitmentBehaviorForResource(serviceType, resourceName).ForCluster()
 	serviceInfo := core.InfoForService(serviceInfos, serviceType)
 	resInfo := core.InfoForResource(serviceInfo, resourceName)
@@ -327,7 +327,7 @@ func (c *Collector) confirmPendingCommitmentsIfNecessary(serviceType db.ServiceT
 			},
 			Request: audit.CollectorDummyRequest,
 		}
-		azAuditEvents, err := datamodel.ConfirmPendingCommitments(loc, resInfo.Unit, c.Cluster, tx, now, c.GenerateProjectCommitmentUUID, c.GenerateTransferToken, auditContext)
+		azAuditEvents, err := datamodel.ConfirmPendingCommitments(ctx, loc, resInfo.Unit, c.Cluster, tx, now, c.GenerateProjectCommitmentUUID, c.GenerateTransferToken, auditContext)
 		if err != nil {
 			return err
 		}

--- a/internal/test/setup.go
+++ b/internal/test/setup.go
@@ -386,6 +386,16 @@ func (s Setup) GetProjectID(name string) (result db.ProjectID) {
 	return result
 }
 
+// GetProjectUUID is a helper function for finding the UUID of a db.Project record.
+func (s Setup) GetProjectUUID(name string) (result liquid.ProjectUUID) {
+	s.t.Helper()
+	err := s.DB.QueryRow(`SELECT uuid FROM projects WHERE name = $1`, name).Scan(&result)
+	if err != nil {
+		s.t.Fatalf("could not find projects.uuid for name = %q: %s", name, err.Error())
+	}
+	return result
+}
+
 // MustDBExec is a shorthand for s.DB.Exec() + t.Fatal() on error.
 func (s Setup) MustDBExec(query string, args ...any) {
 	s.t.Helper()


### PR DESCRIPTION
For once I can file a more self-contained and small PR without 1k lines of changes ^^

Basically, we are just adding the missing liquid call to check for capacity when confirming commitments. 
The existing tests stay as they are and check for capa locally.
A new test checks that the `liquid.CommitmentChangeRequest` has the right format.

Next step for this part of the code: make the allocation logic more clever, so that the local capacity check skips parts of the confirmed commitments which consume already confirmed transfer commitments.