### PR TITLE
do not crash on impossible delete while starting collector

### DIFF
--- a/internal/collector/capacity_scrape_test.go
+++ b/internal/collector/capacity_scrape_test.go
@@ -1302,9 +1302,10 @@ func Test_ScanCapacityWithCommitments(t *testing.T) {
 	s.Clock.StepBy(1 * time.Hour)
 	err := jobloop.ProcessMany(job, s.Ctx, len(s.Cluster.LiquidConnections))
 	assert.ErrEqual(t, err, regexp.MustCompile(
-		// the error is that ON DELETE CASCADE on services -> resources is stopped by ON DELETE RESTRICT on resources -> commitments;
-		// we do not match the specific phrasing of the PostgreSQL error since it may change between versions
-		`^failed in iteration 2: while scraping service 2: could not delete db.Resource record with key capacity:.*"project_commitments_az_resource_id_fkey"`,
+		// We explicitly model the leftover commitment constraint by selecting from the
+		// db in advance of deletion to have a better handling on collector startup. So
+		// the error message matches on that and not a DELETE CASCADE error.
+		`^failed in iteration 2: while scraping service 2: pre-delete callback failed for db.Resource record with key capacity: ErrLeftoverCommitment.*`,
 	))
 }
 

--- a/internal/core/cluster.go
+++ b/internal/core/cluster.go
@@ -134,6 +134,13 @@ func (c *Cluster) Connect(ctx context.Context, provider *gophercloud.ProviderCli
 			continue
 		}
 		err = conn.Init(ctx, client)
+		if errors.Is(err, ErrLeftoverCommitment) {
+			// we just log this error here and ignore it, so that the startup does not fail
+			// this will produce errors on every scrape subsequently (as if the collector was
+			// already running) and those will trigger alerts subsequently.
+			logg.Error(`failed to initialize service %s: %v`, serviceType, err)
+			continue
+		}
 		if err != nil {
 			errs.Addf("failed to initialize service %s: %w", serviceType, gophercloudext.UnpackError(err))
 		}
@@ -344,8 +351,33 @@ func RatesForService(serviceInfos map[db.ServiceType]liquid.ServiceInfo, service
 	return serviceInfo.Rates
 }
 
+// ErrLeftoverCommitment is a custom error to define when a leftover commitment
+// prevents deletion of a service, resource or az_resource.
+var ErrLeftoverCommitment = errors.New("ErrLeftoverCommitment")
+
 ////////////////////////////////////////////////////////////////////////////////
 // Utility functions for working with ServiceInfo and DB
+
+var deleteFuncCheckQuery = sqlext.SimplifyWhitespace(db.ExpandEnumPlaceholders(`
+			SELECT count(*)
+			FROM project_commitments pc
+			JOIN az_resources azr
+			ON pc.az_resource_id = azr.id 
+			WHERE path LIKE $1
+			AND status NOT IN ({{liquid.CommitmentStatusSuperseded}}, {{liquid.CommitmentStatusExpired}}, {{util.CommitmentStatusDeleted}})`))
+
+func generateDeleteFunc[T any](dbm *gorp.DbMap, getAZResourcePathPattern func(o T) string) func(T) error {
+	return func(o T) error {
+		count, err := dbm.SelectInt(deleteFuncCheckQuery, getAZResourcePathPattern(o))
+		if err != nil {
+			return fmt.Errorf("cannot get project commitments count: %w", err)
+		}
+		if count > 0 {
+			return ErrLeftoverCommitment
+		}
+		return nil
+	}
+}
 
 // SaveServiceInfoToDB ensures consistency of tables services, resources, az_resources
 // and rates with the given serviceInfo. It is called whenever the LiquidVersion changes during Scrape
@@ -407,6 +439,7 @@ func SaveServiceInfoToDB(serviceType db.ServiceType, serviceInfo liquid.ServiceI
 			service.QuotaUpdateNeedsProjectMetadata = serviceInfo.QuotaUpdateNeedsProjectMetadata
 			return nil
 		},
+		PreDelete: Some(generateDeleteFunc[db.Service](dbm, func(_ db.Service) string { return string(serviceType) + "/%/%" })),
 	}
 	dbServices, err = serviceUpdate.Execute(tx)
 	if err != nil {
@@ -495,6 +528,7 @@ func SaveServiceInfoToDB(serviceType db.ServiceType, serviceInfo liquid.ServiceI
 			res.HandlesCommitments = serviceInfo.Resources[res.Name].HandlesCommitments
 			return nil
 		},
+		PreDelete: Some(generateDeleteFunc[db.Resource](dbm, func(r db.Resource) string { return r.Path.String() + "/%" })),
 	}
 	dbResources, err = resourceUpdate.Execute(tx)
 	if err != nil {
@@ -612,6 +646,7 @@ func SaveServiceInfoToDB(serviceType db.ServiceType, serviceInfo liquid.ServiceI
 				// we don't know more than the existence of the AZ, so we don't update anything
 				return nil
 			},
+			PreDelete: Some(generateDeleteFunc[db.AZResource](dbm, func(azr db.AZResource) string { return azr.Path.String() })),
 		}
 		_, err = setUpdate.Execute(tx)
 		if err != nil {

--- a/internal/core/cluster_test.go
+++ b/internal/core/cluster_test.go
@@ -98,6 +98,7 @@ func Test_ClusterSaveServiceInfo(t *testing.T) {
 
 	s := test.NewSetup(t,
 		test.WithConfig(testConfigJSON),
+		test.WithInitialDiscovery,
 		test.WithPersistedServiceInfo("shared", srvInfoShared),
 		test.WithMockLiquidClient("shared", srvInfoShared),
 		test.WithMockLiquidClient("unshared", srvInfoUnshared),
@@ -192,6 +193,33 @@ func Test_ClusterSaveServiceInfo(t *testing.T) {
 		DELETE FROM services WHERE id = 2 AND type = 'unshared' AND liquid_version = 1;
 		INSERT INTO services (id, type, next_scrape_at, liquid_version, display_name) VALUES (2, 'unshared', 0, 2, 'Unshared');
 	`)
+
+	// When we remove a resource for which commitments exist, we want to fail
+	// softly so that the startup is not completely interrupted. Instead, every
+	// subsequent scrape will fail from there.
+	sharedThingsAny := s.GetAZResourceID("shared", "things", "any")
+	berlin := s.GetProjectID("berlin")
+	s.MustDBInsert(&db.ProjectCommitment{
+		UUID:                s.Collector.GenerateProjectCommitmentUUID(),
+		ProjectID:           berlin,
+		AZResourceID:        sharedThingsAny,
+		Amount:              10,
+		Duration:            must.Return(limesresources.ParseCommitmentDuration("10 days")),
+		CreatedAt:           s.Clock.Now(),
+		CreatorUUID:         "dummy",
+		CreatorName:         "dummy",
+		ConfirmedAt:         Some(s.Clock.Now()),
+		ExpiresAt:           s.Clock.Now().AddDate(1, 0, 0),
+		CreationContextJSON: must.Return(json.Marshal(db.CommitmentWorkflowContext{Reason: db.CommitmentReasonCreate})),
+		Status:              liquid.CommitmentStatusConfirmed,
+	})
+	s.LiquidClients["shared"].ServiceInfo.Modify(func(info *liquid.ServiceInfo) {
+		delete(info.Resources, "things")
+		info.Version = 5
+	})
+	tr.DBChanges().Ignore()
+	generateNewClusterWithPersistingServiceInfo(t, s, true)
+	tr.DBChanges().AssertEqual("")
 }
 
 func Test_ClusterServiceInfoUnitsChange(t *testing.T) {

--- a/internal/db/setupdate.go
+++ b/internal/db/setupdate.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 
 	gorp "github.com/go-gorp/gorp/v3"
+	. "github.com/majewsky/gg/option"
 )
 
 // SetUpdate describes an operation where we have an existing set of records (type R),
@@ -35,6 +36,8 @@ type SetUpdate[R any, K comparable] struct {
 	Create func(K) (R, error)
 	// Callback for updating an existing record.
 	Update func(*R) error
+	// Callback for deleting a record (a modification of the record has no purpose).
+	PreDelete Option[func(R) error]
 }
 
 // Execute executes this SetUpdate.
@@ -82,6 +85,12 @@ func (u SetUpdate[R, K]) Execute(tx *gorp.Transaction) ([]R, error) {
 	for _, r := range u.ExistingRecords {
 		k := u.KeyForRecord(r)
 		if !slices.Contains(u.WantedKeys, k) {
+			if preDeleteFunc, ok := u.PreDelete.Unpack(); ok {
+				err := preDeleteFunc(r)
+				if err != nil {
+					return nil, fmt.Errorf("pre-delete callback failed for %T record with key %v: %w", r, k, err)
+				}
+			}
 			_, err := tx.Delete(&r)
 			if err != nil {
 				return nil, fmt.Errorf("could not delete %T record with key %v: %w", r, k, err)


### PR DESCRIPTION
Basically, this prevents that we crash on startup when we cannot save the `ServiceInfo` changes to the DB.
This will not go unnoticed, as any subsequent scrape/ capacity scrape will fail, too.