### PR TITLE
[manila] use netapp harvest recording rules for physical usage metrics

### DIFF
--- a/internal/liquids/manila/liquid.go
+++ b/internal/liquids/manila/liquid.go
@@ -248,8 +248,8 @@ const (
 	snapshotCapacityQuery = `sum   by (availability_zone_name, project_id, share_type_id) (max by (availability_zone_name, id, project_id, share_id, share_type_id) (last_over_time(openstack_manila_snapshot_size_gauge[15m])))`
 
 	// queries for netapp-exporter metrics
-	sharePhysicalUsageQuery      = `sum by (availability_zone, project_id, share_type) (max by (availability_zone, project_id, share_id, share_type) (last_over_time(netapp_volume_used_bytes         {project_id!="",share_type!="",volume_type!="dp",volume_state="online"}[15m])))`
-	snapshotPhysicalUsageQuery   = `sum by (availability_zone, project_id, share_type) (max by (availability_zone, project_id, share_id, share_type) (last_over_time(netapp_volume_snapshot_used_bytes{project_id!="",share_type!="",volume_type!="dp",volume_state="online"}[15m])))`
+	sharePhysicalUsageQuery      = `sum by (availability_zone, project_id, share_type) (netapp_volume_used_bytes_for_limes)`
+	snapshotPhysicalUsageQuery   = `sum by (availability_zone, project_id, share_type) (netapp_snapshot_used_bytes_for_limes)`
 	snapmirrorUsageQuery         = `sum by (availability_zone, project_id, share_type) (netapp_snapmirror_capacity_total_bytes_for_limes)`
 	snapmirrorPhysicalUsageQuery = `sum by (availability_zone, project_id, share_type) (netapp_snapmirror_capacity_used_bytes_for_limes)`
 )


### PR DESCRIPTION
Switch sharePhysicalUsageQuery and snapshotPhysicalUsageQuery to use
the pre-aggregated _for_limes recording rules. Move the max/last_over_time/filter
logic into the recording rules where it belongs.
