### PR TITLE
RenderMailTemplate: change endpoint permission

### DIFF
--- a/docs/example-policy.json
+++ b/docs/example-policy.json
@@ -25,5 +25,6 @@
     "cluster:edit": "rule:cluster_admin",
     "v2:cluster:info": "rule:cluster_admin",
     "v2:domain:info": "rule:domain_viewer",
-    "v2:project:info": "rule:project_viewer"
+    "v2:project:info": "rule:project_viewer",
+    "v2:cluster:validation": "project_name:service and project_domain_name:Default and user_name:limes-validation and user_domain_name:Default"
 }

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -95,7 +95,6 @@ func NewTokenValidator(provider *gophercloud.ProviderClient, eo gophercloud.Endp
 func (p *v1Provider) AddTo(r *mux.Router) {
 	r.Methods("GET").Path("/v1/clusters/current").HandlerFunc(p.GetCluster)
 	r.Methods("GET").Path("/rates/v1/clusters/current").HandlerFunc(p.GetClusterRates)
-	r.Methods("GET").Path("/v1/mail/render").HandlerFunc(p.RenderMailTemplate)
 
 	r.Methods("GET").Path("/v1/inconsistencies").HandlerFunc(p.ListInconsistencies)
 	r.Methods("GET").Path("/v1/admin/scrape-errors").HandlerFunc(p.ListScrapeErrors)
@@ -139,6 +138,7 @@ func (p *v1Provider) AddTo(r *mux.Router) {
 
 	r.Methods("GET").Path("/admin/liquid/service-capacity-request").HandlerFunc(p.GetServiceCapacityRequest)
 	r.Methods("GET").Path("/admin/liquid/service-usage-request").HandlerFunc(p.GetServiceUsageRequest)
+	r.Methods("GET").Path("/admin/mail/render").HandlerFunc(p.RenderMailTemplate)
 }
 
 // RequireJSON will parse the request body into the given data structure, or

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -95,6 +95,7 @@ func NewTokenValidator(provider *gophercloud.ProviderClient, eo gophercloud.Endp
 func (p *v1Provider) AddTo(r *mux.Router) {
 	r.Methods("GET").Path("/v1/clusters/current").HandlerFunc(p.GetCluster)
 	r.Methods("GET").Path("/rates/v1/clusters/current").HandlerFunc(p.GetClusterRates)
+	r.Methods("GET").Path("/v1/mail/render").HandlerFunc(p.RenderMailTemplate)
 
 	r.Methods("GET").Path("/v1/inconsistencies").HandlerFunc(p.ListInconsistencies)
 	r.Methods("GET").Path("/v1/admin/scrape-errors").HandlerFunc(p.ListScrapeErrors)
@@ -138,7 +139,6 @@ func (p *v1Provider) AddTo(r *mux.Router) {
 
 	r.Methods("GET").Path("/admin/liquid/service-capacity-request").HandlerFunc(p.GetServiceCapacityRequest)
 	r.Methods("GET").Path("/admin/liquid/service-usage-request").HandlerFunc(p.GetServiceUsageRequest)
-	r.Methods("GET").Path("/admin/mail/render").HandlerFunc(p.RenderMailTemplate)
 }
 
 // RequireJSON will parse the request body into the given data structure, or

--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -54,9 +54,9 @@ var everythingCommitment db.ProjectCommitment = db.ProjectCommitment{
 	NotifiedForExpiration: true,
 }
 
-// RenderMailTemplate handles GET /v1/mail/render
+// RenderMailTemplate handles GET /admin/mail/render
 func (p *v1Provider) RenderMailTemplate(w http.ResponseWriter, r *http.Request) {
-	httpapi.IdentifyEndpoint(r, "/v1/mail/render")
+	httpapi.IdentifyEndpoint(r, "/admin/mail/render")
 	token := p.CheckToken(r)
 	if !token.Require(w, "v2:cluster:validation") {
 		return

--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -54,11 +54,11 @@ var everythingCommitment db.ProjectCommitment = db.ProjectCommitment{
 	NotifiedForExpiration: true,
 }
 
-// RenderMailTemplate handles GET /admin/mail/render
+// RenderMailTemplate handles GET /v1/mail/render
 func (p *v1Provider) RenderMailTemplate(w http.ResponseWriter, r *http.Request) {
-	httpapi.IdentifyEndpoint(r, "/admin/mail/render")
+	httpapi.IdentifyEndpoint(r, "/v1/mail/render")
 	token := p.CheckToken(r)
-	if !token.Require(w, "cluster:show") {
+	if !token.Require(w, "cluster:show_basic") {
 		return
 	}
 

--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -58,7 +58,7 @@ var everythingCommitment db.ProjectCommitment = db.ProjectCommitment{
 func (p *v1Provider) RenderMailTemplate(w http.ResponseWriter, r *http.Request) {
 	httpapi.IdentifyEndpoint(r, "/v1/mail/render")
 	token := p.CheckToken(r)
-	if !token.Require(w, "cluster:show_basic") {
+	if !token.Require(w, "v2:cluster:validation") {
 		return
 	}
 

--- a/internal/api/mail_test.go
+++ b/internal/api/mail_test.go
@@ -53,13 +53,13 @@ func TestRenderMailTemplate(t *testing.T) {
 	ctx := t.Context()
 
 	// endpoint requires cluster show permissions
-	s.TokenValidator.Enforcer.AllowView = false
-	resp := s.Handler.RespondTo(ctx, "GET /admin/mail/render")
+	s.TokenValidator.Enforcer.AllowCluster = false
+	resp := s.Handler.RespondTo(ctx, "GET /v1/mail/render")
 	resp.ExpectStatus(t, http.StatusForbidden)
-	s.TokenValidator.Enforcer.AllowView = true
+	s.TokenValidator.Enforcer.AllowCluster = true
 
 	// happy path - renders all templates as JSON
-	resp = s.Handler.RespondTo(ctx, "GET /admin/mail/render")
+	resp = s.Handler.RespondTo(ctx, "GET /v1/mail/render")
 	resp.ExpectJSON(t, http.StatusOK, jsonmatch.Object{
 		"confirmed_commitments":   "<!DOCTYPE html><html><body>Confirmed</body></html>",
 		"expiring_commitments":    "<!DOCTYPE html><html><body>Expiring</body></html>",
@@ -106,7 +106,7 @@ func TestRenderMailTemplateInvalidHTML(t *testing.T) {
 	)
 
 	ctx := t.Context()
-	resp := s.Handler.RespondTo(ctx, "GET /admin/mail/render")
+	resp := s.Handler.RespondTo(ctx, "GET /v1/mail/render")
 	resp.ExpectText(t, http.StatusInternalServerError, "template \"confirmed_commitments\" returned invalid HTML: XML syntax error on line 1: unexpected EOF\n")
 }
 
@@ -149,6 +149,6 @@ func TestRenderMailTemplateOverEscaped(t *testing.T) {
 	)
 
 	ctx := t.Context()
-	resp := s.Handler.RespondTo(ctx, "GET /admin/mail/render")
+	resp := s.Handler.RespondTo(ctx, "GET /v1/mail/render")
 	resp.ExpectText(t, http.StatusInternalServerError, "template \"confirmed_commitments\" was escaped multiple times\n")
 }

--- a/internal/api/mail_test.go
+++ b/internal/api/mail_test.go
@@ -54,12 +54,12 @@ func TestRenderMailTemplate(t *testing.T) {
 
 	// endpoint requires cluster show permissions
 	s.TokenValidator.Enforcer.AllowCluster = false
-	resp := s.Handler.RespondTo(ctx, "GET /v1/mail/render")
+	resp := s.Handler.RespondTo(ctx, "GET /admin/mail/render")
 	resp.ExpectStatus(t, http.StatusForbidden)
 	s.TokenValidator.Enforcer.AllowCluster = true
 
 	// happy path - renders all templates as JSON
-	resp = s.Handler.RespondTo(ctx, "GET /v1/mail/render")
+	resp = s.Handler.RespondTo(ctx, "GET /admin/mail/render")
 	resp.ExpectJSON(t, http.StatusOK, jsonmatch.Object{
 		"confirmed_commitments":   "<!DOCTYPE html><html><body>Confirmed</body></html>",
 		"expiring_commitments":    "<!DOCTYPE html><html><body>Expiring</body></html>",
@@ -106,7 +106,7 @@ func TestRenderMailTemplateInvalidHTML(t *testing.T) {
 	)
 
 	ctx := t.Context()
-	resp := s.Handler.RespondTo(ctx, "GET /v1/mail/render")
+	resp := s.Handler.RespondTo(ctx, "GET /admin/mail/render")
 	resp.ExpectText(t, http.StatusInternalServerError, "template \"confirmed_commitments\" returned invalid HTML: XML syntax error on line 1: unexpected EOF\n")
 }
 
@@ -149,6 +149,6 @@ func TestRenderMailTemplateOverEscaped(t *testing.T) {
 	)
 
 	ctx := t.Context()
-	resp := s.Handler.RespondTo(ctx, "GET /v1/mail/render")
+	resp := s.Handler.RespondTo(ctx, "GET /admin/mail/render")
 	resp.ExpectText(t, http.StatusInternalServerError, "template \"confirmed_commitments\" was escaped multiple times\n")
 }


### PR DESCRIPTION
the smoke-test user that is used in the pipeline only has `show_basic` permissions, which conflicts with this endpoint. Instead of granting the user more permissions, the endpoint permission gets changed instead.
