### PR TITLE
require resources.topology and rates.topology to be filled

### DIFF
--- a/internal/collector/capacity_scrape_test.go
+++ b/internal/collector/capacity_scrape_test.go
@@ -176,6 +176,7 @@ func Test_ScanCapacity(t *testing.T) {
 		ServiceID:     2,
 		Name:          "unknown",
 		Path:          db.ResourcePath{ServiceType: "unshared", ResourceName: "unknown"},
+		Topology:      liquid.FlatTopology,
 		LiquidVersion: 1,
 	}
 	s.MustDBInsert(unknownRes)

--- a/internal/collector/fixtures/scrape0.sql
+++ b/internal/collector/fixtures/scrape0.sql
@@ -23,7 +23,7 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (2, 1, 'dre
 INSERT INTO rates (id, service_id, name, liquid_version, topology, has_usage, path) VALUES (1, 1, 'firstrate', 1, 'flat', TRUE, 'unittest/firstrate');
 INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, has_usage, path) VALUES (2, 1, 'secondrate', 1, 'KiB', 'flat', TRUE, 'unittest/secondrate');
 INSERT INTO rates (id, service_id, name, liquid_version, topology, path) VALUES (3, 1, 'xOtherRate', 1, 'flat', 'unittest/xOtherRate');
-INSERT INTO rates (id, service_id, name, liquid_version, path, display_name) VALUES (4, 1, 'xAnotherRate', 1, 'unittest/xAnotherRate', 'X Another Rate');
+INSERT INTO rates (id, service_id, name, liquid_version, topology, path, display_name) VALUES (4, 1, 'xAnotherRate', 1, 'flat', 'unittest/xAnotherRate', 'X Another Rate');
 
 INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, needs_resource_demand, has_quota, path, display_name) VALUES (1, 1, 'capacity', 1, 'B', 'az-aware', TRUE, TRUE, TRUE, 'unittest/capacity', 'Capacity');
 INSERT INTO resources (id, service_id, name, liquid_version, topology, has_quota, path, display_name) VALUES (2, 1, 'things', 1, 'az-aware', TRUE, 'unittest/things', 'Things');

--- a/internal/collector/scrape_test.go
+++ b/internal/collector/scrape_test.go
@@ -129,21 +129,22 @@ func commonComplexScrapeTestSetup(t *testing.T) (s test.Setup, scrapeJob jobloop
 	// the scraper does not mess with those values
 	// cluster_rate xOtherRate comes from the rate_limits config
 	s.MustDBInsert(&db.Rate{
-		ServiceID:     1,
+		ServiceID:     s.GetServiceID("unittest"),
 		Name:          "xAnotherRate",
 		DisplayName:   "X Another Rate",
 		Path:          db.RatePath{ServiceType: "unittest", RateName: "xAnotherRate"},
+		Topology:      liquid.FlatTopology,
 		LiquidVersion: 1,
 	})
 	s.MustDBInsert(&db.ProjectRate{
-		ProjectID: 2,
-		RateID:    3,
+		ProjectID: s.GetProjectID("dresden"),
+		RateID:    s.GetRateID("unittest", "xOtherRate"),
 		Limit:     Some[uint64](10),
 		Window:    Some(1 * limesrates.WindowSeconds),
 	})
 	s.MustDBInsert(&db.ProjectRate{
-		ProjectID: 1,
-		RateID:    4,
+		ProjectID: s.GetProjectID("berlin"),
+		RateID:    s.GetRateID("unittest", "xAnotherRate"),
 		Limit:     Some[uint64](42),
 		Window:    Some(2 * limesrates.WindowMinutes),
 	})

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -100,4 +100,12 @@ var sqlMigrations = map[string]string{
 	`077_rate_category.down.sql`: `
 		ALTER TABLE rates DROP COLUMN category_id;
 	`,
+	`078_add_topology_check.up.sql`: `
+		ALTER TABLE resources ADD CONSTRAINT resources_topology_acceptable_values CHECK (topology IN ('flat', 'az-aware', 'az-separated'));
+		ALTER TABLE rates ADD CONSTRAINT rates_topology_acceptable_values CHECK (topology IN ('flat', 'az-aware', 'az-separated'));
+	`,
+	`078_add_topology_check.down.sql`: `
+		ALTER TABLE resources DROP CONSTRAINT resources_topology_acceptable_values;
+		ALTER TABLE rates DROP CONSTRAINT rates_topology_acceptable_values;
+	`,
 }


### PR DESCRIPTION
This was not upheld in some test scenarios, which might cause confusion down the line.