### PR TITLE
require all rates to be declared in liquid.ServiceInfo

### DIFF
--- a/docs/liquids/swift.md
+++ b/docs/liquids/swift.md
@@ -13,7 +13,9 @@ This liquid provides support for the object storage service Swift.
 
 ## Service-specific configuration
 
-None.
+| Field | Type | Description |
+| --- | --- | --- |
+| `rate_display_names` | object of strings | If provided, causes the liquid to declare one limit-only rate per entry in this object, with the key as the rate name and the value as the display name. This is a facility to afford testing of limit-only rates in QA scenarios and may be removed at any time. |
 
 ## Resources
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.67.5
 	github.com/rs/cors v1.11.1
-	github.com/sapcc/go-api-declarations v1.21.1
+	github.com/sapcc/go-api-declarations v1.22.0
 	github.com/sapcc/go-bits v0.0.0-20260504092817-9df533508379
 	go.xyrillian.de/gg v1.7.0
 	go.xyrillian.de/schwift/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjR
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=
 github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
-github.com/sapcc/go-api-declarations v1.21.1 h1:7mv8+bT95f5mZtEV6/IXQ8dLGD0sZAQ4vZetPzO+EbU=
-github.com/sapcc/go-api-declarations v1.21.1/go.mod h1:x3V8bzg7Y4kmbA+DeWWwKteFEdCCSiVQdwRXj4fGAYY=
+github.com/sapcc/go-api-declarations v1.22.0 h1:nU/eJ6OO54Z9YSo1gWinD0A2etrfZObCwYdB9xA0VWE=
+github.com/sapcc/go-api-declarations v1.22.0/go.mod h1:x3V8bzg7Y4kmbA+DeWWwKteFEdCCSiVQdwRXj4fGAYY=
 github.com/sapcc/go-bits v0.0.0-20260504092817-9df533508379 h1:NJ1gqb2S4CNrdsCk90iM3TTG9QXKrrgb/tG3sxuzxfw=
 github.com/sapcc/go-bits v0.0.0-20260504092817-9df533508379/go.mod h1:DxXen6GflUaHbQ9qQFwxJp4xQWzRKm3mzUgGrXbwn84=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -116,6 +116,7 @@ func setupTest(t *testing.T) test.Setup {
 		"objects:create":    {Topology: liquid.FlatTopology, HasUsage: true},
 		"objects:delete":    {Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: true},
 		"objects:update":    {Topology: liquid.FlatTopology, HasUsage: true},
+		"objects:read":      {Topology: liquid.FlatTopology, HasUsage: false},
 		"objects:unlimited": {Unit: liquid.UnitKibibytes, Topology: liquid.FlatTopology, HasUsage: true},
 	}
 	srvInfoUnshared := test.DefaultLiquidServiceInfo("Unshared")

--- a/internal/api/api_v2/info_test.go
+++ b/internal/api/api_v2/info_test.go
@@ -8,11 +8,10 @@ import (
 	"net/http"
 	"testing"
 
-	. "go.xyrillian.de/gg/option"
-
 	"github.com/sapcc/go-api-declarations/liquid"
 	"github.com/sapcc/go-bits/easypg"
 	"github.com/sapcc/go-bits/httptest"
+	. "go.xyrillian.de/gg/option"
 
 	"github.com/sapcc/limes/internal/test"
 )
@@ -70,9 +69,15 @@ const configJSON = `{
 }`
 
 func TestV2ResourcesInfoAPI(t *testing.T) {
+	srvInfoFirst := test.DefaultLiquidServiceInfo("First")
+	srvInfoFirst.Rates = map[liquid.RateName]liquid.RateInfo{
+		"objects:create": {Topology: liquid.FlatTopology, HasUsage: false},
+		"objects:update": {Topology: liquid.FlatTopology, HasUsage: false},
+	}
+
 	s := test.NewSetup(t,
 		test.WithConfig(configJSON),
-		test.WithPersistedServiceInfo("first", test.DefaultLiquidServiceInfo("First")),
+		test.WithPersistedServiceInfo("first", srvInfoFirst),
 		test.WithPersistedServiceInfo("second", test.DefaultLiquidServiceInfo("Second")),
 		test.WithInitialDiscovery,
 		test.WithEmptyResourceRecordsAsNeeded,

--- a/internal/collector/fixtures/scrape0.sql
+++ b/internal/collector/fixtures/scrape0.sql
@@ -20,8 +20,8 @@ INSERT INTO project_services (id, project_id, service_id, stale, next_scrape_at)
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany');
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (2, 1, 'dresden', 'uuid-for-dresden', 'uuid-for-berlin');
 
-INSERT INTO rates (id, service_id, name, liquid_version, topology, has_usage, path, from_liquid) VALUES (1, 1, 'firstrate', 1, 'flat', TRUE, 'unittest/firstrate', TRUE);
-INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, has_usage, path, from_liquid) VALUES (2, 1, 'secondrate', 1, 'KiB', 'flat', TRUE, 'unittest/secondrate', TRUE);
+INSERT INTO rates (id, service_id, name, liquid_version, topology, has_usage, path) VALUES (1, 1, 'firstrate', 1, 'flat', TRUE, 'unittest/firstrate');
+INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, has_usage, path) VALUES (2, 1, 'secondrate', 1, 'KiB', 'flat', TRUE, 'unittest/secondrate');
 INSERT INTO rates (id, service_id, name, liquid_version, topology, path) VALUES (3, 1, 'xOtherRate', 1, 'flat', 'unittest/xOtherRate');
 INSERT INTO rates (id, service_id, name, liquid_version, topology, path, display_name) VALUES (4, 1, 'xAnotherRate', 1, 'flat', 'unittest/xAnotherRate', 'X Another Rate');
 

--- a/internal/collector/quota_overrides_test.go
+++ b/internal/collector/quota_overrides_test.go
@@ -20,6 +20,9 @@ import (
 func TestApplyQuotaOverrides(t *testing.T) {
 	// setup enough to have fully populated project_services and project_resources
 	srvInfo := test.DefaultLiquidServiceInfo("Unit Test")
+	srvInfo.Rates = map[liquid.RateName]liquid.RateInfo{
+		"xOtherRate": {Topology: liquid.FlatTopology, HasUsage: false},
+	}
 	s := test.NewSetup(t,
 		test.WithConfig(testScrapeBasicConfigJSON),
 		test.WithMockLiquidClient("unittest", srvInfo),

--- a/internal/collector/scrape.go
+++ b/internal/collector/scrape.go
@@ -493,17 +493,10 @@ func (c *Collector) writeRateScrapeResult(task projectScrapeTask, serviceType db
 			rateName := ratesByID[projectRate.RateID].Name
 			rateExists[rateName] = true
 
-			usageData, exists := rateData[rateName]
-			if !exists {
-				if projectRate.UsageAsBigint != "" {
-					c.LogError(
-						"could not scrape new data for rate %s in project service %d (was this rate type removed from the scraper connection for %s?)",
-						rateName, projectRate.ID, serviceType,
-					)
-				}
-				continue
+			usageAsBigint := ""
+			if usage, exists := rateData[rateName]; exists {
+				usageAsBigint = usage.String()
 			}
-			usageAsBigint := usageData.String()
 			if usageAsBigint != projectRate.UsageAsBigint {
 				_, err := stmt.Exec(usageAsBigint, projectRate.ID)
 				if err != nil {
@@ -516,27 +509,20 @@ func (c *Collector) writeRateScrapeResult(task projectScrapeTask, serviceType db
 	// insert missing project_rates entries
 	for _, rateName := range slices.Sorted(maps.Keys(rates)) {
 		rate := rates[rateName]
-		if !rate.FromLiquid {
-			// special case for rates: the rates in the database/ SIC are mixed between
-			// configuration-only rates (=rate limits) and one's which are also defined
-			// in the liquid. Without this early return, we would write missing values
-			// for the config-only rates.
-			continue
-		}
 		if _, exists := rateExists[rateName]; exists {
 			continue
 		}
-		usageData := rateData[rateName]
 
-		projectRate := &db.ProjectRate{
-			ProjectID: projectService.ProjectID,
-			RateID:    rates[rateName].ID,
-		}
-		if usageData != nil {
-			projectRate.UsageAsBigint = usageData.String()
+		usageAsBigint := ""
+		if usage, exists := rateData[rateName]; exists {
+			usageAsBigint = usage.String()
 		}
 
-		err = tx.Insert(projectRate)
+		err = tx.Insert(&db.ProjectRate{
+			ProjectID:     projectService.ProjectID,
+			RateID:        rate.ID,
+			UsageAsBigint: usageAsBigint,
+		})
 		if err != nil {
 			return err
 		}

--- a/internal/collector/scrape_test.go
+++ b/internal/collector/scrape_test.go
@@ -108,6 +108,7 @@ func commonComplexScrapeTestSetup(t *testing.T) (s test.Setup, scrapeJob jobloop
 		Rates: map[liquid.RateName]liquid.RateInfo{
 			"firstrate":  {Topology: liquid.FlatTopology, HasUsage: true},
 			"secondrate": {Unit: liquid.UnitKibibytes, Topology: liquid.FlatTopology, HasUsage: true},
+			"xOtherRate": {Topology: liquid.FlatTopology, HasUsage: false},
 		},
 		UsageMetricFamilies: map[liquid.MetricName]liquid.MetricFamilyInfo{
 			"limes_unittest_capacity_usage": {Type: liquid.MetricTypeGauge},
@@ -238,8 +239,10 @@ func Test_ScrapeSuccess(t *testing.T) {
 		INSERT INTO project_az_resources (id, project_id, az_resource_id, quota, usage, historical_usage) VALUES (9, 2, 1, 0, 0, '{"t":[%[3]d],"v":[0]}');
 		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (3, 1, 1, '1024');
 		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (4, 1, 2, '2048');
-		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (5, 2, 1, '1024');
-		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (6, 2, 2, '2048');
+		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (5, 1, 3, '');
+		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (6, 2, 1, '1024');
+		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (7, 2, 2, '2048');
+		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (8, 2, 4, '');
 		INSERT INTO project_resources (id, project_id, resource_id) VALUES (1, 1, 1);
 		INSERT INTO project_resources (id, project_id, resource_id) VALUES (2, 1, 2);
 		INSERT INTO project_resources (id, project_id, resource_id) VALUES (3, 2, 1);
@@ -493,8 +496,8 @@ func Test_ScrapeSuccess(t *testing.T) {
 	tr.DBChanges().AssertEqualf(`
 		UPDATE project_rates SET usage_as_bigint = '2048' WHERE id = 3 AND project_id = 1 AND rate_id = 1;
 		UPDATE project_rates SET usage_as_bigint = '4096' WHERE id = 4 AND project_id = 1 AND rate_id = 2;
-		UPDATE project_rates SET usage_as_bigint = '4096' WHERE id = 5 AND project_id = 2 AND rate_id = 1;
-		UPDATE project_rates SET usage_as_bigint = '8192' WHERE id = 6 AND project_id = 2 AND rate_id = 2;
+		UPDATE project_rates SET usage_as_bigint = '4096' WHERE id = 6 AND project_id = 2 AND rate_id = 1;
+		UPDATE project_rates SET usage_as_bigint = '8192' WHERE id = 7 AND project_id = 2 AND rate_id = 2;
 		UPDATE project_services SET scraped_at = %[1]d, serialized_scrape_state = '{"firstrate":2048,"secondrate":4096}', checked_at = %[1]d, next_scrape_at = %[2]d WHERE id = 1 AND project_id = 1 AND service_id = 1;
 		UPDATE project_services SET scraped_at = %[3]d, serialized_scrape_state = '{"firstrate":4096,"secondrate":8192}', checked_at = %[3]d, next_scrape_at = %[4]d WHERE id = 2 AND project_id = 2 AND service_id = 1;
 	`,
@@ -652,8 +655,10 @@ func Test_ScrapeFailure(t *testing.T) {
 		UPDATE project_az_resources SET historical_usage = '{"t":[5430],"v":[0]}' WHERE id = 9 AND project_id = 2 AND az_resource_id = 1;
 		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (3, 1, 1, '1024');
 		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (4, 1, 2, '2048');
-		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (5, 2, 1, '1024');
-		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (6, 2, 2, '2048');
+		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (5, 1, 3, '');
+		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (6, 2, 1, '1024');
+		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (7, 2, 2, '2048');
+		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (8, 2, 4, '');
 		UPDATE project_resources SET forbidden = FALSE WHERE id = 1 AND project_id = 1 AND resource_id = 1;
 		UPDATE project_resources SET forbidden = FALSE WHERE id = 2 AND project_id = 1 AND resource_id = 2;
 		UPDATE project_resources SET forbidden = FALSE WHERE id = 3 AND project_id = 2 AND resource_id = 1;
@@ -852,8 +857,9 @@ func Test_TopologyScrapes(t *testing.T) {
 		DELETE FROM project_rates WHERE id = 2 AND project_id = 1 AND rate_id = 4;
 		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (3, 1, 1, '1024');
 		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (4, 1, 2, '2048');
-		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (5, 2, 1, '1024');
-		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (6, 2, 2, '2048');
+		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (5, 1, 3, '');
+		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (6, 2, 1, '1024');
+		INSERT INTO project_rates (id, project_id, rate_id, usage_as_bigint) VALUES (7, 2, 2, '2048');
 		INSERT INTO project_resources (id, project_id, resource_id) VALUES (1, 1, 1);
 		INSERT INTO project_resources (id, project_id, resource_id) VALUES (2, 1, 2);
 		INSERT INTO project_resources (id, project_id, resource_id) VALUES (3, 2, 1);

--- a/internal/core/cluster.go
+++ b/internal/core/cluster.go
@@ -547,25 +547,28 @@ func SaveServiceInfoToDB(serviceType db.ServiceType, serviceInfo liquid.ServiceI
 	if err != nil {
 		return fmt.Errorf("cannot inspect existing rates for %s: %w", serviceType, err)
 	}
-	liquidRateUnitsByName := make(map[liquid.RateName]liquid.Unit, len(serviceInfo.Rates))
-	globalLimitUnitsByName := make(map[liquid.RateName]liquid.Unit, len(rateLimits.Global))
-	projectLimitUnitsByName := make(map[liquid.RateName]liquid.Unit, len(rateLimits.ProjectDefault))
-	for rateName, rate := range serviceInfo.Rates {
-		liquidRateUnitsByName[rateName] = rate.Unit
-	}
 	for _, rateLimit := range rateLimits.Global {
-		globalLimitUnitsByName[rateLimit.Name] = rateLimit.Unit
+		rateInfo, ok := serviceInfo.Rates[rateLimit.Name]
+		if !ok {
+			return fmt.Errorf("configuration declares a global rate limit for %s/%s which is not declared by the liquid",
+				serviceType, rateLimit.Name)
+		}
+		if rateLimit.Unit != rateInfo.Unit {
+			return fmt.Errorf("configuration uses unit %q for rate %s/%s, but liquid declared unit %q",
+				rateLimit.Unit, serviceType, rateLimit.Name, rateInfo.Unit)
+		}
 	}
 	for _, rateLimit := range rateLimits.ProjectDefault {
-		projectLimitUnitsByName[rateLimit.Name] = rateLimit.Unit
+		rateInfo, ok := serviceInfo.Rates[rateLimit.Name]
+		if !ok {
+			return fmt.Errorf("configuration declares a project-default rate limit for %s/%s which is not declared by the liquid",
+				serviceType, rateLimit.Name)
+		}
+		if rateLimit.Unit != rateInfo.Unit {
+			return fmt.Errorf("configuration uses unit %q for rate %s/%s, but liquid declared unit %q",
+				rateLimit.Unit, serviceType, rateLimit.Name, rateInfo.Unit)
+		}
 	}
-	// extend the list of wanted rates with the rates from limits which are configured (they may not be in the serviceInfo.Rates)
-	// TODO: the special handling of this is a little ugly - we should switch to all rates + limits coming from liquid at some point
-	wantedRates := slices.Collect(maps.Keys(liquidRateUnitsByName))
-	wantedRates = append(wantedRates, slices.Collect(maps.Keys(globalLimitUnitsByName))...)
-	wantedRates = append(wantedRates, slices.Collect(maps.Keys(projectLimitUnitsByName))...)
-	slices.Sort(wantedRates)
-	wantedRates = slices.Compact(wantedRates)
 
 	// for unit changes, we need to have some special handling, else we will interpret
 	// the old values from the database with the new unit!
@@ -574,85 +577,44 @@ func SaveServiceInfoToDB(serviceType db.ServiceType, serviceInfo liquid.ServiceI
 	// do update for rates
 	rateUpdate := db.SetUpdate[db.Rate, liquid.RateName]{
 		ExistingRecords: dbRates,
-		WantedKeys:      wantedRates,
+		WantedKeys:      slices.Sorted(maps.Keys(serviceInfo.Rates)),
 		KeyForRecord: func(rate db.Rate) liquid.RateName {
 			return rate.Name
 		},
 		Create: func(rateName liquid.RateName) (db.Rate, error) {
-			liquidUnit, liquidRateExists := liquidRateUnitsByName[rateName]
-			globalLimitUnit, globalLimitExists := globalLimitUnitsByName[rateName]
-			projectLimitUnit, projectLimitExists := projectLimitUnitsByName[rateName]
-			if (globalLimitExists && liquidRateExists && liquidUnit != globalLimitUnit) ||
-				(projectLimitExists && liquidRateExists && liquidUnit != projectLimitUnit) ||
-				(globalLimitExists && projectLimitExists && globalLimitUnit != projectLimitUnit) {
-				logg.Fatal(`cannot create rate %s/%s, because the units from the liquid and/ or the rate limit configuration don't match!`, serviceType, rateName)
-			}
-			unit := limes.UnitNone
-			topology := liquid.FlatTopology
-			hasUsage := false
-			fromLiquid := false
-			switch {
-			case liquidRateExists:
-				unit = liquidUnit
-				topology = serviceInfo.Rates[rateName].Topology
-				hasUsage = serviceInfo.Rates[rateName].HasUsage
-				fromLiquid = true
-			case globalLimitExists:
-				unit = globalLimitUnit
-			case projectLimitExists:
-				unit = projectLimitUnit
-			}
-			categoryID := options.Map(serviceInfo.Rates[rateName].Category,
+			rateInfo := serviceInfo.Rates[rateName]
+			categoryID := options.Map(rateInfo.Category,
 				func(cn liquid.CategoryName) db.CategoryID { return categoryByName[cn].ID })
 			return db.Rate{
 				ServiceID:     dbServices[0].ID,
 				Name:          rateName,
-				DisplayName:   serviceInfo.Rates[rateName].DisplayName,
+				DisplayName:   rateInfo.DisplayName,
 				CategoryID:    categoryID,
 				Path:          db.RatePath{ServiceType: serviceType, RateName: rateName},
-				FromLiquid:    fromLiquid,
 				LiquidVersion: serviceInfo.Version,
-				Unit:          unit,
-				Topology:      topology,
-				HasUsage:      hasUsage,
+				Unit:          rateInfo.Unit,
+				Topology:      rateInfo.Topology,
+				HasUsage:      rateInfo.HasUsage,
 			}, nil
 		},
 		Update: func(rate *db.Rate) (err error) {
-			liquidUnit, liquidRateExists := liquidRateUnitsByName[rate.Name]
-			globalLimitUnit, globalLimitExists := globalLimitUnitsByName[rate.Name]
-			projectLimitUnit, projectLimitExists := projectLimitUnitsByName[rate.Name]
-			if (globalLimitExists && liquidRateExists && liquidUnit != globalLimitUnit) ||
-				(projectLimitExists && liquidRateExists && liquidUnit != projectLimitUnit) ||
-				(globalLimitExists && projectLimitExists && globalLimitUnit != projectLimitUnit) {
-				logg.Fatal(`cannot update rate %s/%s, because the units from the liquid and/ or the rate limit configuration don't match!`, serviceType, rate.Name)
-			}
-			newUnit := rate.Unit
+			rateInfo := serviceInfo.Rates[rate.Name]
+
 			rate.LiquidVersion = serviceInfo.Version
-			rate.DisplayName = serviceInfo.Rates[rate.Name].DisplayName
-			rate.CategoryID = options.Map(serviceInfo.Rates[rate.Name].Category,
+			rate.DisplayName = rateInfo.DisplayName
+			rate.CategoryID = options.Map(rateInfo.Category,
 				func(cn liquid.CategoryName) db.CategoryID { return categoryByName[cn].ID })
-			rate.Topology = liquid.FlatTopology
-			rate.HasUsage = false
-			switch {
-			case liquidRateExists:
-				rate.FromLiquid = true
-				newUnit = liquidUnit
-				rate.Topology = serviceInfo.Rates[rate.Name].Topology
-				rate.HasUsage = serviceInfo.Rates[rate.Name].HasUsage
-			case globalLimitExists:
-				rate.FromLiquid = false
-				newUnit = globalLimitUnit
-			case projectLimitExists:
-				rate.FromLiquid = false
-				newUnit = projectLimitUnit
-			}
-			if newUnit != rate.Unit {
+			rate.Topology = rateInfo.Topology
+			rate.HasUsage = rateInfo.HasUsage
+
+			if rate.Unit != rateInfo.Unit {
 				unitChangesByRateID[rate.ID] = unitChange{
 					oldUnit: rate.Unit,
-					newUnit: newUnit,
+					newUnit: rateInfo.Unit,
 				}
+				rate.Unit = rateInfo.Unit
 			}
-			rate.Unit = newUnit
+
 			return nil
 		},
 	}

--- a/internal/core/cluster_test.go
+++ b/internal/core/cluster_test.go
@@ -52,14 +52,10 @@ const (
 				"area": "unshared",
 				"rate_limits": {
 					"global": [
-						{"name": "in_global_and_liquid", "limit": 10, "window": "1m", "unit": "MiB"},
-						{"name": "in_global_and_project", "limit": 20, "window": "1m"},
-						{"name": "only_in_global", "limit": 30, "window": "1m"}
+						{"name": "with_global_limit", "limit": 10, "window": "1m", "unit": "MiB"}
 					],
 					"project_default": [
-						{"name": "in_global_and_project", "limit": 2, "window": "1m"},
-						{"name": "in_liquid_and_project", "limit": 4, "window": "1m", "unit": "MiB"},
-						{"name": "only_in_project", "limit": 5, "window": "1m"}
+						{"name": "with_project_limit", "limit": 5, "window": "1m"}
 					]
 				}
 			}
@@ -97,13 +93,9 @@ func Test_ClusterSaveServiceInfo(t *testing.T) {
 	srvInfoShared := test.DefaultLiquidServiceInfo("Shared")
 	srvInfoUnshared := test.DefaultLiquidServiceInfo("Unshared")
 	srvInfoUnshared.Rates = map[liquid.RateName]liquid.RateInfo{
-		"in_global_and_liquid":  {Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: true},
-		"in_liquid_and_project": {Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: true},
-		"only_in_liquid":        {Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: true, Category: Some(liquid.CategoryName("foo_category"))},
-		// The names of these units are from a time when LIQUID only declared rates that have usage.
-		"only_in_global":        {Unit: liquid.UnitNone, Topology: liquid.FlatTopology, HasUsage: false},
-		"in_global_and_project": {Unit: liquid.UnitNone, Topology: liquid.FlatTopology, HasUsage: false},
-		"only_in_project":       {Unit: liquid.UnitNone, Topology: liquid.FlatTopology, HasUsage: false},
+		"only_usage":         {Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: true, Category: Some(liquid.CategoryName("foo_category"))},
+		"with_global_limit":  {Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: false},
+		"with_project_limit": {Unit: liquid.UnitNone, Topology: liquid.FlatTopology, HasUsage: false},
 	}
 
 	s := test.NewSetup(t,
@@ -126,12 +118,9 @@ func Test_ClusterSaveServiceInfo(t *testing.T) {
 		INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (14, 4, 'total', 0, 'unshared/things/total');
 		INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (8, 3, 'any', 0, 'unshared/capacity/any');
 		INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (9, 3, 'az-one', 0, 'unshared/capacity/az-one');
-		INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, has_usage, path) VALUES (1, 2, 'in_global_and_liquid', 1, 'MiB', 'flat', TRUE, 'unshared/in_global_and_liquid');
-		INSERT INTO rates (id, service_id, name, liquid_version, topology, path) VALUES (2, 2, 'in_global_and_project', 1, 'flat', 'unshared/in_global_and_project');
-		INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, has_usage, path) VALUES (3, 2, 'in_liquid_and_project', 1, 'MiB', 'flat', TRUE, 'unshared/in_liquid_and_project');
-		INSERT INTO rates (id, service_id, name, liquid_version, topology, path) VALUES (4, 2, 'only_in_global', 1, 'flat', 'unshared/only_in_global');
-		INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, has_usage, path, category_id) VALUES (5, 2, 'only_in_liquid', 1, 'MiB', 'flat', TRUE, 'unshared/only_in_liquid', 1);
-		INSERT INTO rates (id, service_id, name, liquid_version, topology, path) VALUES (6, 2, 'only_in_project', 1, 'flat', 'unshared/only_in_project');
+		INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, has_usage, path, category_id) VALUES (1, 2, 'only_usage', 1, 'MiB', 'flat', TRUE, 'unshared/only_usage', 1);
+		INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, path) VALUES (2, 2, 'with_global_limit', 1, 'MiB', 'flat', 'unshared/with_global_limit');
+		INSERT INTO rates (id, service_id, name, liquid_version, topology, path) VALUES (3, 2, 'with_project_limit', 1, 'flat', 'unshared/with_project_limit');
 		INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, needs_resource_demand, has_quota, path, display_name, category_id) VALUES (3, 2, 'capacity', 1, 'B', 'az-aware', TRUE, TRUE, TRUE, 'unshared/capacity', 'Capacity', 1);
 		INSERT INTO resources (id, service_id, name, liquid_version, topology, has_quota, path, display_name) VALUES (4, 2, 'things', 1, 'flat', TRUE, 'unshared/things', 'Things');
 		INSERT INTO services (id, type, next_scrape_at, liquid_version, display_name) VALUES (2, 'unshared', 0, 1, 'Unshared');
@@ -185,19 +174,16 @@ func Test_ClusterSaveServiceInfo(t *testing.T) {
 		DisplayName: "Foo Category",
 	}
 	srvInfoUnshared.Categories = newCategories
-	srvInfoUnshared.Rates["in_global_and_liquid"] = liquid.RateInfo{Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: true, Category: Some(liquid.CategoryName("foo_category"))}
-	srvInfoUnshared.Rates["only_in_liquid"] = liquid.RateInfo{Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: true, Category: Some(liquid.CategoryName("bar_category"))}
+	srvInfoUnshared.Rates["only_usage"] = liquid.RateInfo{Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: true, Category: Some(liquid.CategoryName("bar_category"))}
+	srvInfoUnshared.Rates["with_global_limit"] = liquid.RateInfo{Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: false, Category: Some(liquid.CategoryName("foo_category"))}
 	srvInfoUnshared.Version = 2
 	s.LiquidClients["unshared"].ServiceInfo.Set(srvInfoUnshared)
 	generateNewClusterWithPersistingServiceInfo(t, s, true)
 	tr.DBChanges().AssertEqual(`
 		INSERT INTO categories (id, name, display_name) VALUES (2, 'bar_category', 'Foo Category');
-		UPDATE rates SET liquid_version = 2, category_id = 1 WHERE id = 1 AND service_id = 2 AND name = 'in_global_and_liquid' AND path = 'unshared/in_global_and_liquid';
-		UPDATE rates SET liquid_version = 2 WHERE id = 2 AND service_id = 2 AND name = 'in_global_and_project' AND path = 'unshared/in_global_and_project';
-		UPDATE rates SET liquid_version = 2 WHERE id = 3 AND service_id = 2 AND name = 'in_liquid_and_project' AND path = 'unshared/in_liquid_and_project';
-		UPDATE rates SET liquid_version = 2 WHERE id = 4 AND service_id = 2 AND name = 'only_in_global' AND path = 'unshared/only_in_global';
-		UPDATE rates SET liquid_version = 2, category_id = 2 WHERE id = 5 AND service_id = 2 AND name = 'only_in_liquid' AND path = 'unshared/only_in_liquid';
-		UPDATE rates SET liquid_version = 2 WHERE id = 6 AND service_id = 2 AND name = 'only_in_project' AND path = 'unshared/only_in_project';
+		UPDATE rates SET liquid_version = 2, category_id = 2 WHERE id = 1 AND service_id = 2 AND name = 'only_usage' AND path = 'unshared/only_usage';
+		UPDATE rates SET liquid_version = 2, category_id = 1 WHERE id = 2 AND service_id = 2 AND name = 'with_global_limit' AND path = 'unshared/with_global_limit';
+		UPDATE rates SET liquid_version = 2 WHERE id = 3 AND service_id = 2 AND name = 'with_project_limit' AND path = 'unshared/with_project_limit';
 		UPDATE resources SET liquid_version = 2 WHERE id = 3 AND service_id = 2 AND name = 'capacity' AND path = 'unshared/capacity';
 		UPDATE resources SET liquid_version = 2 WHERE id = 4 AND service_id = 2 AND name = 'things' AND path = 'unshared/things';
 		DELETE FROM services WHERE id = 2 AND type = 'unshared' AND liquid_version = 1;
@@ -236,13 +222,9 @@ func Test_ClusterServiceInfoUnitsChange(t *testing.T) {
 	srvInfoShared := test.DefaultLiquidServiceInfo("Shared")
 	srvInfoUnshared := test.DefaultLiquidServiceInfo("Unshared")
 	srvInfoUnshared.Rates = map[liquid.RateName]liquid.RateInfo{
-		"in_global_and_liquid":  {Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: true},
-		"in_liquid_and_project": {Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: true},
-		"only_in_liquid":        {Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: true},
-		// The names of these units are from a time when LIQUID only declared rates that have usage.
-		"only_in_global":        {Unit: liquid.UnitNone, Topology: liquid.FlatTopology, HasUsage: false},
-		"in_global_and_project": {Unit: liquid.UnitNone, Topology: liquid.FlatTopology, HasUsage: false},
-		"only_in_project":       {Unit: liquid.UnitNone, Topology: liquid.FlatTopology, HasUsage: false},
+		"only_usage":         {Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: true},
+		"with_global_limit":  {Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: false},
+		"with_project_limit": {Unit: liquid.UnitNone, Topology: liquid.FlatTopology, HasUsage: false},
 	}
 
 	s := test.NewSetup(t,
@@ -376,24 +358,24 @@ func Test_ClusterServiceInfoUnitsChange(t *testing.T) {
 	s.LiquidClients["shared"].ServiceInfo.Set(srvInfoShared)
 
 	// we try to do an impossible change for rates: unitMebibytes to unitNone
-	rateOnlyInLiquid := srvInfoUnshared.Rates["only_in_liquid"]
-	rateOnlyInLiquid.Unit = liquid.UnitNone
-	srvInfoUnshared.Rates["only_in_liquid"] = rateOnlyInLiquid
+	rateOnlyUsage := srvInfoUnshared.Rates["only_usage"]
+	rateOnlyUsage.Unit = liquid.UnitNone
+	srvInfoUnshared.Rates["only_usage"] = rateOnlyUsage
 	s.LiquidClients["unshared"].ServiceInfo.Set(srvInfoUnshared)
 
 	errs = generateNewClusterWithPersistingServiceInfo(t, s, false)
 	assert.Equal(t, len(errs), 1)
-	assert.ErrEqual(t, errs[0], `failed to initialize service unshared: saving ServiceInfo: cannot change unit of rate with id 5 from "MiB" to "", because the base units differ`)
+	assert.ErrEqual(t, errs[0], `failed to initialize service unshared: saving ServiceInfo: cannot change unit of rate with id 1 from "MiB" to "", because the base units differ`)
 	tr.DBChanges().AssertEmpty()
 
 	// now, we enter some values and do a conversion
-	rateOnlyInLiquid.Unit = liquid.UnitGibibytes
-	srvInfoUnshared.Rates["only_in_liquid"] = rateOnlyInLiquid
+	rateOnlyUsage.Unit = liquid.UnitGibibytes
+	srvInfoUnshared.Rates["only_usage"] = rateOnlyUsage
 	s.LiquidClients["unshared"].ServiceInfo.Set(srvInfoUnshared)
-	unsharedRateOnlyInLiquidID := s.GetRateID("unshared", "only_in_liquid")
+	unsharedRateOnlyUsageID := s.GetRateID("unshared", "only_usage")
 	s.MustDBInsert(&db.ProjectRate{
 		ProjectID:     1,
-		RateID:        unsharedRateOnlyInLiquidID,
+		RateID:        unsharedRateOnlyUsageID,
 		Limit:         Some(uint64(10 * 1024)),
 		Window:        Some(must.Return(limesrates.ParseWindow("1m"))),
 		UsageAsBigint: "5120",
@@ -402,23 +384,23 @@ func Test_ClusterServiceInfoUnitsChange(t *testing.T) {
 
 	errs = generateNewClusterWithPersistingServiceInfo(t, s, false)
 	assert.Equal(t, len(errs), 0)
-	tr.DBChanges().AssertEqual(`
-		UPDATE project_rates SET rate_limit = 10, usage_as_bigint = '5' WHERE id = 1 AND project_id = 1 AND rate_id = 5;
-		UPDATE rates SET unit = 'GiB' WHERE id = 5 AND service_id = 2 AND name = 'only_in_liquid' AND path = 'unshared/only_in_liquid';
-	`)
+	tr.DBChanges().AssertEqualf(`
+		UPDATE project_rates SET rate_limit = 10, usage_as_bigint = '5' WHERE id = 1 AND project_id = 1 AND rate_id = %[1]d;
+		UPDATE rates SET unit = 'GiB' WHERE id = %[1]d AND service_id = 2 AND name = 'only_usage' AND path = 'unshared/only_usage';
+	`, unsharedRateOnlyUsageID)
 
 	// check that rounding is ignored for rates also
 	s.MustDBExec(`UPDATE project_rates SET rate_limit = 1234, usage_as_bigint = '1234'`)
-	rateOnlyInLiquid.Unit = liquid.UnitTebibytes
-	srvInfoUnshared.Rates["only_in_liquid"] = rateOnlyInLiquid
+	rateOnlyUsage.Unit = liquid.UnitTebibytes
+	srvInfoUnshared.Rates["only_usage"] = rateOnlyUsage
 	s.LiquidClients["unshared"].ServiceInfo.Set(srvInfoUnshared)
 
 	errs = generateNewClusterWithPersistingServiceInfo(t, s, false)
 	assert.Equal(t, len(errs), 0)
-	tr.DBChanges().AssertEqual(`
-		UPDATE project_rates SET rate_limit = 1, usage_as_bigint = '1' WHERE id = 1 AND project_id = 1 AND rate_id = 5;
-		UPDATE rates SET unit = 'TiB' WHERE id = 5 AND service_id = 2 AND name = 'only_in_liquid' AND path = 'unshared/only_in_liquid';
-	`)
+	tr.DBChanges().AssertEqualf(`
+		UPDATE project_rates SET rate_limit = 1, usage_as_bigint = '1' WHERE id = 1 AND project_id = 1 AND rate_id = %[1]d;
+		UPDATE rates SET unit = 'TiB' WHERE id = %[1]d AND service_id = 2 AND name = 'only_usage' AND path = 'unshared/only_usage';
+	`, unsharedRateOnlyUsageID)
 }
 
 func Test_ClusterServiceInfoRateLimitsUnitIncompatible(t *testing.T) {
@@ -438,9 +420,9 @@ func Test_ClusterServiceInfoRateLimitsUnitIncompatible(t *testing.T) {
 	srvInfoShared := test.DefaultLiquidServiceInfo("Shared")
 	srvInfoUnshared := test.DefaultLiquidServiceInfo("Unshared")
 	srvInfoUnshared.Rates = map[liquid.RateName]liquid.RateInfo{
-		"in_global_and_liquid":  {Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: true},
-		"in_liquid_and_project": {Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: true},
-		"only_in_liquid":        {Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: true},
+		"only_usage":         {Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: true},
+		"with_global_limit":  {Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: false},
+		"with_project_limit": {Unit: liquid.UnitNone, Topology: liquid.FlatTopology, HasUsage: false},
 	}
 
 	s := test.NewSetup(t,
@@ -453,9 +435,9 @@ func Test_ClusterServiceInfoRateLimitsUnitIncompatible(t *testing.T) {
 	)
 
 	// rate updates should fail, when units are unequal between config and liquid
-	rateInGlobalAndLiquid := srvInfoUnshared.Rates["in_global_and_liquid"]
-	rateInGlobalAndLiquid.Unit = liquid.UnitGibibytes // config has MiB
-	srvInfoUnshared.Rates["in_global_and_liquid"] = rateInGlobalAndLiquid
+	rateWithGlobalLimit := srvInfoUnshared.Rates["with_global_limit"]
+	rateWithGlobalLimit.Unit = liquid.UnitGibibytes // config has MiB
+	srvInfoUnshared.Rates["with_global_limit"] = rateWithGlobalLimit
 	s.LiquidClients["unshared"].ServiceInfo.Set(srvInfoUnshared)
 
 	generateNewClusterWithPersistingServiceInfo(t, s, false)

--- a/internal/core/cluster_test.go
+++ b/internal/core/cluster_test.go
@@ -84,6 +84,12 @@ func generateNewClusterWithPersistingServiceInfo(t *testing.T, s test.Setup, fai
 }
 
 func TestMain(m *testing.M) {
+	// When running as a subprocess (e.g. to test crash behavior), skip the DB
+	// lifecycle management to avoid stopping the parent process's Postgres server.
+	// TODO: Can we replace the $TO_CRASH thing below by something that does not require spawning a subprocess?
+	if os.Getenv("TO_CRASH") == "1" {
+		os.Exit(m.Run())
+	}
 	easypg.WithTestDB(m, func() int { return m.Run() })
 }
 
@@ -94,6 +100,10 @@ func Test_ClusterSaveServiceInfo(t *testing.T) {
 		"in_global_and_liquid":  {Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: true},
 		"in_liquid_and_project": {Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: true},
 		"only_in_liquid":        {Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: true, Category: Some(liquid.CategoryName("foo_category"))},
+		// The names of these units are from a time when LIQUID only declared rates that have usage.
+		"only_in_global":        {Unit: liquid.UnitNone, Topology: liquid.FlatTopology, HasUsage: false},
+		"in_global_and_project": {Unit: liquid.UnitNone, Topology: liquid.FlatTopology, HasUsage: false},
+		"only_in_project":       {Unit: liquid.UnitNone, Topology: liquid.FlatTopology, HasUsage: false},
 	}
 
 	s := test.NewSetup(t,
@@ -116,11 +126,11 @@ func Test_ClusterSaveServiceInfo(t *testing.T) {
 		INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (14, 4, 'total', 0, 'unshared/things/total');
 		INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (8, 3, 'any', 0, 'unshared/capacity/any');
 		INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (9, 3, 'az-one', 0, 'unshared/capacity/az-one');
-		INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, has_usage, path, from_liquid) VALUES (1, 2, 'in_global_and_liquid', 1, 'MiB', 'flat', TRUE, 'unshared/in_global_and_liquid', TRUE);
+		INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, has_usage, path) VALUES (1, 2, 'in_global_and_liquid', 1, 'MiB', 'flat', TRUE, 'unshared/in_global_and_liquid');
 		INSERT INTO rates (id, service_id, name, liquid_version, topology, path) VALUES (2, 2, 'in_global_and_project', 1, 'flat', 'unshared/in_global_and_project');
-		INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, has_usage, path, from_liquid) VALUES (3, 2, 'in_liquid_and_project', 1, 'MiB', 'flat', TRUE, 'unshared/in_liquid_and_project', TRUE);
+		INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, has_usage, path) VALUES (3, 2, 'in_liquid_and_project', 1, 'MiB', 'flat', TRUE, 'unshared/in_liquid_and_project');
 		INSERT INTO rates (id, service_id, name, liquid_version, topology, path) VALUES (4, 2, 'only_in_global', 1, 'flat', 'unshared/only_in_global');
-		INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, has_usage, path, category_id, from_liquid) VALUES (5, 2, 'only_in_liquid', 1, 'MiB', 'flat', TRUE, 'unshared/only_in_liquid', 1, TRUE);
+		INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, has_usage, path, category_id) VALUES (5, 2, 'only_in_liquid', 1, 'MiB', 'flat', TRUE, 'unshared/only_in_liquid', 1);
 		INSERT INTO rates (id, service_id, name, liquid_version, topology, path) VALUES (6, 2, 'only_in_project', 1, 'flat', 'unshared/only_in_project');
 		INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, needs_resource_demand, has_quota, path, display_name, category_id) VALUES (3, 2, 'capacity', 1, 'B', 'az-aware', TRUE, TRUE, TRUE, 'unshared/capacity', 'Capacity', 1);
 		INSERT INTO resources (id, service_id, name, liquid_version, topology, has_quota, path, display_name) VALUES (4, 2, 'things', 1, 'flat', TRUE, 'unshared/things', 'Things');
@@ -229,6 +239,10 @@ func Test_ClusterServiceInfoUnitsChange(t *testing.T) {
 		"in_global_and_liquid":  {Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: true},
 		"in_liquid_and_project": {Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: true},
 		"only_in_liquid":        {Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: true},
+		// The names of these units are from a time when LIQUID only declared rates that have usage.
+		"only_in_global":        {Unit: liquid.UnitNone, Topology: liquid.FlatTopology, HasUsage: false},
+		"in_global_and_project": {Unit: liquid.UnitNone, Topology: liquid.FlatTopology, HasUsage: false},
+		"only_in_project":       {Unit: liquid.UnitNone, Topology: liquid.FlatTopology, HasUsage: false},
 	}
 
 	s := test.NewSetup(t,

--- a/internal/core/cluster_test.go
+++ b/internal/core/cluster_test.go
@@ -5,10 +5,7 @@ package core_test
 
 import (
 	"encoding/json"
-	"errors"
 	"net/url"
-	"os"
-	"os/exec"
 	"testing"
 	"time"
 
@@ -80,12 +77,6 @@ func generateNewClusterWithPersistingServiceInfo(t *testing.T, s test.Setup, fai
 }
 
 func TestMain(m *testing.M) {
-	// When running as a subprocess (e.g. to test crash behavior), skip the DB
-	// lifecycle management to avoid stopping the parent process's Postgres server.
-	// TODO: Can we replace the $TO_CRASH thing below by something that does not require spawning a subprocess?
-	if os.Getenv("TO_CRASH") == "1" {
-		os.Exit(m.Run())
-	}
 	easypg.WithTestDB(m, func() int { return m.Run() })
 }
 
@@ -404,19 +395,6 @@ func Test_ClusterServiceInfoUnitsChange(t *testing.T) {
 }
 
 func Test_ClusterServiceInfoRateLimitsUnitIncompatible(t *testing.T) {
-	// we want to test that this crashes, so we spawn a subprocess which can crash
-	if os.Getenv("TO_CRASH") != "1" {
-		cmd := exec.Command(os.Args[0], "-test.run=Test_ClusterServiceInfoRateLimitsUnitIncompatible") //nolint:gosec // G204: this is intentional in tests
-		cmd.Env = append(os.Environ(), "TO_CRASH=1")
-		err := cmd.Run()
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			return
-		}
-		t.Fatalf("process ran with err %v, want exit status 1", err)
-	}
-
-	// actual test
 	srvInfoShared := test.DefaultLiquidServiceInfo("Shared")
 	srvInfoUnshared := test.DefaultLiquidServiceInfo("Unshared")
 	srvInfoUnshared.Rates = map[liquid.RateName]liquid.RateInfo{
@@ -434,11 +412,13 @@ func Test_ClusterServiceInfoRateLimitsUnitIncompatible(t *testing.T) {
 		test.WithInitialDiscovery,
 	)
 
-	// rate updates should fail, when units are unequal between config and liquid
+	// rate updates should fail when units are unequal between config and liquid
 	rateWithGlobalLimit := srvInfoUnshared.Rates["with_global_limit"]
 	rateWithGlobalLimit.Unit = liquid.UnitGibibytes // config has MiB
 	srvInfoUnshared.Rates["with_global_limit"] = rateWithGlobalLimit
 	s.LiquidClients["unshared"].ServiceInfo.Set(srvInfoUnshared)
 
-	generateNewClusterWithPersistingServiceInfo(t, s, false)
+	errs := generateNewClusterWithPersistingServiceInfo(t, s, false)
+	assert.Equal(t, len(errs), 1)
+	assert.ErrEqual(t, errs[0], `failed to initialize service unshared: saving ServiceInfo: configuration uses unit "MiB" for rate unshared/with_global_limit, but liquid declared unit "GiB"`)
 }

--- a/internal/core/service_info_cache.go
+++ b/internal/core/service_info_cache.go
@@ -466,10 +466,6 @@ func (s *ServiceInfoCache) GetServiceInfo(serviceType db.ServiceType) (info liqu
 	}
 	// reconstruct rate infos
 	for name, rate := range rates {
-		if !rate.FromLiquid {
-			// important, so that we don't report missing rates when validating reports coming from liquid
-			continue
-		}
 		rateInfo := liquid.RateInfo{
 			DisplayName: rate.DisplayName,
 			Unit:        rate.Unit,

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -116,4 +116,10 @@ var sqlMigrations = map[string]string{
 		ALTER TABLE services DROP COLUMN commitment_handling_needs_project_metadata;
 		ALTER TABLE rates DROP COLUMN from_liquid;
 	`,
+	`080_drop_rates_from_liquid.up.sql`: `
+		ALTER TABLE rates DROP COLUMN from_liquid;
+	`,
+	`080_drop_rates_from_liquid.down.sql`: `
+		ALTER TABLE rates ADD COLUMN from_liquid BOOLEAN NOT NULL DEFAULT FALSE;
+	`,
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -84,9 +84,7 @@ type Rate struct {
 	CategoryID  Option[CategoryID] `db:"category_id"`
 	// a unique identifier for this record in the form "servicetype/ratename"; mostly intended for manual lookup
 	Path RatePath `db:"path"`
-	// Rates are special, as some only exist in config to manage limits
-	FromLiquid bool `db:"from_liquid"`
-	// following fields get filled from liquid.ServiceInfo (if FromLiquid=true)
+	// following fields get filled from liquid.ServiceInfo
 	LiquidVersion int64           `db:"liquid_version"`
 	Unit          liquid.Unit     `db:"unit"`
 	Topology      liquid.Topology `db:"topology"`

--- a/internal/liquids/swift/liquid.go
+++ b/internal/liquids/swift/liquid.go
@@ -21,6 +21,9 @@ import (
 
 // Logic implements the liquidapi.Logic interface for Swift.
 type Logic struct {
+	// configuration
+	RateDisplayNames map[liquid.RateName]string `json:"rate_display_names"`
+
 	// connections
 	ResellerAccount *schwift.Account `json:"-"`
 }
@@ -37,9 +40,19 @@ func (l *Logic) Init(ctx context.Context, provider *gophercloud.ProviderClient, 
 
 // BuildServiceInfo implements the liquidapi.Logic interface.
 func (l *Logic) BuildServiceInfo(ctx context.Context) (liquid.ServiceInfo, error) {
+	rates := make(map[liquid.RateName]liquid.RateInfo, len(l.RateDisplayNames))
+	for rateName, rateDisplayName := range l.RateDisplayNames {
+		rates[rateName] = liquid.RateInfo{
+			DisplayName: rateDisplayName,
+			Topology:    liquid.FlatTopology,
+			HasUsage:    false,
+		}
+	}
+
 	return liquid.ServiceInfo{
 		Version:     2,
 		DisplayName: "Object Storage",
+		Rates:       rates,
 		Resources: map[liquid.ResourceName]liquid.ResourceInfo{
 			"capacity": {
 				DisplayName: "Capacity",

--- a/vendor/github.com/sapcc/go-api-declarations/liquid/info.go
+++ b/vendor/github.com/sapcc/go-api-declarations/liquid/info.go
@@ -237,8 +237,6 @@ type RateInfo struct {
 	Topology Topology `json:"topology"`
 
 	// Whether the liquid reports usage for this rate on the project level.
-	// This must currently be true because there is no other reason for a rate to exist.
-	// This requirement may be relaxed in the future, if LIQUID starts modelling rate limits and there are rates that have limits, but no usage tracking.
 	HasUsage bool `json:"hasUsage"`
 }
 

--- a/vendor/github.com/sapcc/go-api-declarations/liquid/report_usage.go
+++ b/vendor/github.com/sapcc/go-api-declarations/liquid/report_usage.go
@@ -48,7 +48,7 @@ type ServiceUsageReport struct {
 	// Must contain an entry for each resource that was declared in type [ServiceInfo].
 	Resources map[ResourceName]*ResourceUsageReport `json:"resources,omitempty"`
 
-	// Must contain an entry for each rate that was declared in type [ServiceInfo].
+	// Must contain an entry for each rate that was declared in type [ServiceInfo] with "HasUsage = true".
 	Rates map[RateName]*RateUsageReport `json:"rates,omitempty"`
 
 	// Must contain an entry for each metric family that was declared for usage metrics in type [ServiceInfo].

--- a/vendor/github.com/sapcc/go-api-declarations/liquid/validation.go
+++ b/vendor/github.com/sapcc/go-api-declarations/liquid/validation.go
@@ -25,7 +25,6 @@ func isValidIdentifier[S ~string](s S) bool {
 //   - Each resource and rate must have a valid name, according to ResourceName.IsValid() and RateName.IsValid().
 //   - Each resource is declared with a valid topology.
 //   - Each rate is declared with a valid topology.
-//   - Each rate is declared with HasUsage = true.
 //
 // Additional validations may be added in the future.
 func ValidateServiceInfo(srv ServiceInfo) error {
@@ -67,9 +66,6 @@ func validateServiceInfoImpl(srv ServiceInfo) (errs errorset.ErrorSet) {
 		}
 		if !rate.Topology.IsValid() {
 			errs.Addf(".Rates[%q] has invalid topology %q", rateName, srv.Rates[rateName].Topology)
-		}
-		if !rate.HasUsage {
-			errs.Addf(".Rates[%q] declared with HasUsage = false, but must be true", rateName)
 		}
 		category, hasCategory := rate.Category.Unpack()
 		if hasCategory {
@@ -212,9 +208,8 @@ func validateUsageReportImpl(report ServiceUsageReport, req ServiceUsageRequest,
 		errs.Add(validateQuotaAgainstTopology(res, resInfo.HasQuota, resInfo.Topology, resName, req.AllAZs))
 	}
 	// validate rate reports
-	for rateName := range info.Rates {
-		// HasUsage = true is implicit and gets verified in the ServiceInfo
-		if !hasKey(report.Rates, rateName) {
+	for rateName, rateInfo := range info.Rates {
+		if rateInfo.HasUsage && !hasKey(report.Rates, rateName) {
 			errs.Addf("missing value for .Rates[%q]", rateName)
 		}
 	}
@@ -222,6 +217,10 @@ func validateUsageReportImpl(report ServiceUsageReport, req ServiceUsageRequest,
 		rateInfo, exists := info.Rates[rateName]
 		if !exists {
 			errs.Addf("unexpected value for .Rates[%q] (rate was not declared)", rateName)
+			continue
+		}
+		if !rateInfo.HasUsage {
+			errs.Addf("unexpected value for .Rates[%q] (rate was declared with HasUsage = false)", rateName)
 			continue
 		}
 		errs.Add(validatePerAZAgainstTopology(rate.PerAZ, rateInfo.Topology, ".Rates", rateName, req.AllAZs))

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -141,7 +141,7 @@ github.com/rabbitmq/amqp091-go
 ## explicit; go 1.13
 github.com/rs/cors
 github.com/rs/cors/internal
-# github.com/sapcc/go-api-declarations v1.21.1
+# github.com/sapcc/go-api-declarations v1.22.0
 ## explicit; go 1.24
 github.com/sapcc/go-api-declarations/bininfo
 github.com/sapcc/go-api-declarations/cadf


### PR DESCRIPTION
The application code gets simplified nicely by this. The main complication in the drafting of this changeset was from having to adjust all the testcases that declare random rates left and right.

Since we currently have an MVP in QA with some random Swift rate limits, I'm extending liquid-swift to optionally keep supporting this setup.