### PR TITLE
apiv2: proofread and format API documentation

### DIFF
--- a/internal/apideclarations/apiv2/doc.go
+++ b/internal/apideclarations/apiv2/doc.go
@@ -1,53 +1,93 @@
 // SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
 // SPDX-License-Identifier: Apache-2.0
 
-// Package apiv2 provides the specification for the [Limes] /v2 API.
+// Package apiv2 contains the specification for the v2 API of [Limes], an OpenStack service for managing quotas as well as usage and capacity data.
 //
 // # Concepts
-// TODO: copy this section from v1 API when the API is finished
 //
-// # Common Request Headers
-// **X-Auth-Token**: As with all OpenStack services, this header must always contain a [Keystone token](https://docs.openstack.org/api-ref/identity/v3/index.html#password-authentication-with-scoped-authorization).
-// In the /v2 API, the token often determines the scope of the data you get back from the API.
-// I.e. when you provide a project-scoped token, you get back data for that project.
-// When you provide a domain-scoped token, you get back data for that domain.
-// When you provide a cloud-admin-scoped token, you get back all data.
-// Unscoped tokens are not supported.
+// TODO: copy this section from v1 API and/or the LIQUID API when the API is finished
 //
-// # Common Query Arguments
+// # API structure
+//
+// The Limes v2 API is structured as a REST-like HTTP API akin to those of the various OpenStack services.
+// Like with any other OpenStack API, clients authenticate by providing their [Keystone token] in the HTTP header "X-Auth-Token".
+// Requests without a valid token will be rejected with status 401 (Unauthorized).
+// Requests with a valid token that confers insufficient access will be rejected with status 403 (Forbidden).
+//
+// Some endpoints will provide different information based on the scope of the token, as documented in the section for the respective endpoint.
+// In this context, a "cloud-admin token" refers to whatever scope the administrator of the respective OpenStack has designated as cloud-admin scope.
+// This may either mean a system-scoped token, or a token scoped to a certain well-known cloud-admin project.
+//
+// Each individual endpoint is documented in a section of this docstring whose title starts with "Endpoint:".
+// Unless noted otherwise, a liquid must implement all documented endpoints.
+// The full URL of the endpoint is obtained by appending the subpath from the section header to the liquid's base URL from the Keystone service catalog.
+//
+// The documentation for an endpoint may refer to a request body being expected or a response body being generated on success.
+// In all such cases, the request or response body will be encoded as "Content-Type: application/json".
+// The structure of the payload must conform to how the referenced Go type would be serialized by the Go standard library's "encoding/json" package.
+//
+// When producing a successful response, the status code shall be 200 (OK) unless noted otherwise.
+// When producing an error response (with a status code between 400 and 599), the liquid shall include a response body of "Content-Type: text/plain" to indicate the error.
+//
+// # Common query arguments
+//
 // TODO: fill when implemented
 //
-// # Endpoints
-// ## GET /resources/v2/info
-// Returns information about the clusters resources.
-// **On success**: Returns an object of type resourcesv2.InfoReport.
-// **On failure**: Returns an error string with an appropriate HTTP status code.
+// # Endpoint: GET /resources/v2/info
 //
-// ## GET /resources/v2/cluster
+// Returns information about the cluster's resources, potentially limited to those resources that are accessible within the authenticated scope:
+// A project-scoped token will receive information about all resources available in that project.
+// A domain-scoped token will receive information about all resources available in at least one project of that domain.
+// A cloud-admin token will receive information about all resources.
+//   - On success, the response body payload will be of type [resourcesv2.InfoReport].
+//
+// # Endpoint: GET /resources/v2/cluster
+//
 // TODO: fill when implemented
 //
-// ## GET /resources/v2/domains(/:domain_id)?
+// # Endpoint: GET /resources/v2/domains(/:domain_id)?
+//
 // TODO: fill when implemented
 //
-// ## GET /resources/v2/projects(/:project_id)?
+// # Endpoint: GET /resources/v2/projects(/:project_id)?
+//
 // TODO: fill when implemented
 //
-// ## GET /resources/v2/availability
+// # Endpoint: GET /resources/v2/availability
+//
 // TODO: fill when implemented
 //
-// ## GET /rates/v2/info
-// Returns information about the clusters rates.
-// **On success**: Returns an object of type ratesv2.InfoReport.
-// **On failure**: Returns an error string with an appropriate HTTP status code.
+// # Endpoint: GET /rates/v2/info
 //
-// ## GET /rates/v2/cluster
+// Returns information about the cluster's rates, potentially limited to those rates that are accessible within the authenticated scope:
+// A project-scoped token will receive information about all rates available in that project.
+// A domain-scoped token will receive information about all rates available in at least one project of that domain.
+// A cloud-admin token will receive information about all rates.
+//   - On success, the response body payload will be of type [ratesv2.InfoReport].
+//
+// # Endpoint: GET /rates/v2/cluster
+//
 // TODO: fill when implemented
 //
-// ## GET /rates/v2/domains(/:domain_id)?
+// # Endpoint: GET /rates/v2/domains(/:domain_id)?
+//
 // TODO: fill when implemented
 //
-// ## GET /rates/v2/projects(/:project_id)?
+// # Endpoint: GET /rates/v2/projects(/:project_id)?
+//
 // TODO: fill when implemented
 //
+// [Keystone token]: https://docs.openstack.org/api-ref/identity/v3/index.html#password-authentication-with-scoped-authorization
 // [Limes]: https://github.com/sapcc/limes
 package apiv2
+
+import (
+	ratesv2 "github.com/sapcc/limes/internal/apideclarations/apiv2/rates"
+	resourcesv2 "github.com/sapcc/limes/internal/apideclarations/apiv2/resources"
+)
+
+var (
+	// need to make sure these packages are imported for docstring links to work
+	_ = resourcesv2.InfoReport{}
+	_ = ratesv2.InfoReport{}
+)

--- a/internal/apideclarations/apiv2/rates/info.go
+++ b/internal/apideclarations/apiv2/rates/info.go
@@ -6,16 +6,15 @@ package ratesv2
 import (
 	limesrates "github.com/sapcc/go-api-declarations/limes/rates"
 	"github.com/sapcc/go-api-declarations/liquid"
-
 	. "go.xyrillian.de/gg/option"
 
 	"github.com/sapcc/limes/internal/db"
 )
 
 // InfoReport is the response type for GET /rates/v2/info.
-// It contains all metadata information about the clusters services and rates.
+// It contains all metadata information about the cluster's services and rates.
 type InfoReport struct {
-	// The Area is a grouping of multiple services, which serve the same purpose.
+	// The Area is a grouping of multiple services which serve similar purposes.
 	// E.g. compute, storage, network, etc.
 	Areas map[string]AreaInfoReport `json:"service_areas"`
 }
@@ -40,7 +39,7 @@ type ServiceInfoReport struct {
 //
 // Currently, there is no way to configure rates into categories, so all rates
 // reside within a category with the same name as the service.
-// This structure currently only exists for symmetry with resources.InfoReport,
+// This structure currently only exists for symmetry with [resourcesv2.InfoReport],
 // and for being able to add full support for categories later if required.
 type CategoryInfoReport struct {
 	DisplayName string                             `json:"display_name"`

--- a/internal/apideclarations/apiv2/resources/info.go
+++ b/internal/apideclarations/apiv2/resources/info.go
@@ -5,21 +5,20 @@ package resourcesv2
 
 import (
 	"github.com/sapcc/go-api-declarations/liquid"
-
 	. "go.xyrillian.de/gg/option"
 
 	"github.com/sapcc/limes/internal/db"
 )
 
 // InfoReport is the response type for GET /resources/v2/info.
-// It contains all metadata information about the clusters services and resources.
+// It contains all metadata information about the cluster's services and resources.
 type InfoReport struct {
-	// The Area is a grouping of multiple services, which serve the same purpose.
+	// The Area is a grouping of multiple services which serve similar purposes.
 	// E.g. compute, storage, network, etc.
 	Areas map[string]AreaInfoReport `json:"service_areas"`
 }
 
-// AreaInfoReport groups services into areas, which are defined in the config.
+// AreaInfoReport groups services into areas, which are defined in the Limes config.
 // It appears in [InfoReport].
 type AreaInfoReport struct {
 	DisplayName string                               `json:"display_name"`
@@ -34,7 +33,7 @@ type ServiceInfoReport struct {
 	Categories  map[liquid.CategoryName]CategoryInfoReport `json:"categories"`
 }
 
-// CategoryInfoReport groups resources into categories, which are defined in the config.
+// CategoryInfoReport groups resources into categories, which are defined in the Limes config.
 // It appears in [ServiceInfoReport].
 type CategoryInfoReport struct {
 	DisplayName string                                     `json:"display_name"`

--- a/internal/apideclarations/apiv2/resources/metadata.go
+++ b/internal/apideclarations/apiv2/resources/metadata.go
@@ -11,7 +11,7 @@ import (
 
 // CommitmentConfiguration describes how commitments are configured for a given resource.
 //
-// This appears as a field on resource reports, if the respective resource allows commitments.
+// It appears in [ResourceInfoReport] if the respective resource allows commitments.
 type CommitmentConfiguration struct {
 	// Allowed durations for commitments on this resource.
 	Durations []limesresources.CommitmentDuration `json:"durations"`


### PR DESCRIPTION
This appears to have been written under the expectation that godoc supports Markdown, but it only supports an extremely limited subset of Markdown (e.g. only first-level headings, not second level or below).

For "API structure", I copied and adjusted the equivalent section from the LIQUID API.