### PR TITLE
replace core.AZResourceLocation with db.AZResourcePath

### DIFF
--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -50,7 +50,7 @@ var (
 	`))
 
 	getAZResourceLocationsQuery = sqlext.SimplifyWhitespace(`
-		SELECT azr.id, s.type, r.name, azr.az
+		SELECT azr.id, azr.path
 		  FROM project_az_resources pazr
 		  JOIN az_resources azr on pazr.az_resource_id = azr.id
 		  JOIN resources r ON azr.resource_id = r.id {{AND r.name = $resource_name}}
@@ -78,24 +78,19 @@ var (
 		SELECT azr.id, pr.forbidden IS NOT TRUE as resource_allows_commitments, COALESCE(total_confirmed, 0) as total_confirmed
 		FROM az_resources azr
 		JOIN resources r ON azr.resource_id = r.id
-		JOIN services s ON r.service_id = s.id
 		JOIN project_resources pr ON pr.resource_id = r.id
 		LEFT JOIN (
 			SELECT SUM(pc.amount) as total_confirmed
 			FROM az_resources azr
-			JOIN resources r ON azr.resource_id = r.id
-			JOIN services s ON r.service_id = s.id
 			JOIN project_commitments pc ON azr.id = pc.az_resource_id
-			WHERE pc.project_id = $1 AND s.type = $2 AND r.name = $3 AND azr.az = $4 AND status = {{liquid.CommitmentStatusConfirmed}}
+			WHERE pc.project_id = $1 AND azr.path = $2 AND status = {{liquid.CommitmentStatusConfirmed}}
 		) pc ON 1=1
-		WHERE pr.project_id = $1 AND s.type = $2 AND r.name = $3 AND azr.az = $4
+		WHERE pr.project_id = $1 AND azr.path = $2
 	`))
 
 	findAZResourceLocationByIDQuery = sqlext.SimplifyWhitespace(db.ExpandEnumPlaceholders(`
-		SELECT s.type, r.name, azr.az, COALESCE(pc.total_confirmed,0) AS total_confirmed
+		SELECT azr.path, COALESCE(pc.total_confirmed,0) AS total_confirmed
 		FROM az_resources azr
-		JOIN resources r ON azr.resource_id = r.id
-		JOIN services s ON r.service_id = s.id
 		LEFT JOIN (
 				SELECT SUM(amount) as total_confirmed
 				FROM project_commitments pc
@@ -132,18 +127,17 @@ func (p *v1Provider) GetProjectCommitments(w http.ResponseWriter, r *http.Reques
 	filter := reports.ReadFilter(r, p.Cluster, resources)
 	queryStr, joinArgs := filter.PrepareQuery(getAZResourceLocationsQuery)
 	whereStr, whereArgs := db.BuildSimpleWhereClause(map[string]any{"pazr.project_id": dbProject.ID}, len(joinArgs))
-	azResourceLocationsByID := make(map[db.AZResourceID]core.AZResourceLocation)
+	azResourcePathsByID := make(map[db.AZResourceID]db.AZResourcePath)
 	err := sqlext.ForeachRow(p.DB, fmt.Sprintf(queryStr, whereStr), append(joinArgs, whereArgs...), func(rows *sql.Rows) error {
 		var (
-			id  db.AZResourceID
-			loc core.AZResourceLocation
+			id   db.AZResourceID
+			path db.AZResourcePath
 		)
-		err := rows.Scan(&id, &loc.ServiceType, &loc.ResourceName, &loc.AvailabilityZone)
+		err := rows.Scan(&id, &path)
 		if err != nil {
 			return err
 		}
-		azResourceLocationsByID[id] = loc
-
+		azResourcePathsByID[id] = path
 		return nil
 	})
 	if respondwith.ObfuscatedErrorText(w, err) {
@@ -162,14 +156,14 @@ func (p *v1Provider) GetProjectCommitments(w http.ResponseWriter, r *http.Reques
 	// render response
 	result := make([]limesresources.Commitment, 0, len(dbCommitments))
 	for _, c := range dbCommitments {
-		loc, lExists := azResourceLocationsByID[c.AZResourceID]
-		resource, rExists := resources[loc.ServiceType][loc.ResourceName]
-		if !lExists || !rExists {
+		path, pExists := azResourcePathsByID[c.AZResourceID]
+		resource, rExists := resources[path.ServiceType][path.ResourceName]
+		if !pExists || !rExists {
 			// defense in depth (the DB should not change that much between the 2 queries and the state of SIC)
 			continue
 		}
 
-		result = append(result, datamodel.ConvertCommitmentToDisplayForm(c, loc.AvailabilityZone, p.Cluster.BehaviorForResourceLocation(loc).IdentityInV1API, datamodel.CanDeleteCommitment(token, c, p.timeNow), resource.Unit))
+		result = append(result, datamodel.ConvertCommitmentToDisplayForm(c, path.AvailabilityZone, p.Cluster.BehaviorForResourcePath(path.Resource()).IdentityInV1API, datamodel.CanDeleteCommitment(token, c, p.timeNow), resource.Unit))
 	}
 
 	respondwith.JSON(w, http.StatusOK, map[string]any{"commitments": result})
@@ -269,17 +263,17 @@ func (p *v1Provider) GetPublicCommitments(w http.ResponseWriter, r *http.Request
 	}
 	queryStr, joinArgs := filter.PrepareQuery(getAZResourceLocationsQuery)
 	whereStr, whereArgs := db.BuildSimpleWhereClause(nil, len(joinArgs))
-	azResourceLocationsByID := make(map[db.AZResourceID]core.AZResourceLocation)
+	azResourcePathsByID := make(map[db.AZResourceID]db.AZResourcePath)
 	err := sqlext.ForeachRow(p.DB, fmt.Sprintf(queryStr, whereStr), append(joinArgs, whereArgs...), func(rows *sql.Rows) error {
 		var (
-			id  db.AZResourceID
-			loc core.AZResourceLocation
+			id   db.AZResourceID
+			path db.AZResourcePath
 		)
-		err := rows.Scan(&id, &loc.ServiceType, &loc.ResourceName, &loc.AvailabilityZone)
+		err := rows.Scan(&id, &path)
 		if err != nil {
 			return err
 		}
-		azResourceLocationsByID[id] = loc
+		azResourcePathsByID[id] = path
 		return nil
 	})
 	if respondwith.ObfuscatedErrorText(w, err) {
@@ -295,11 +289,11 @@ func (p *v1Provider) GetPublicCommitments(w http.ResponseWriter, r *http.Request
 
 	result := make([]limesresources.Commitment, 0, len(dbCommitments))
 	for _, dbCommitment := range dbCommitments {
-		loc, exists := azResourceLocationsByID[dbCommitment.AZResourceID]
+		path, exists := azResourcePathsByID[dbCommitment.AZResourceID]
 		if !exists {
 			continue // like above, this is just defense in depth (the DB should be consistent with itself)
 		}
-		c := datamodel.ConvertCommitmentToDisplayForm(dbCommitment, loc.AvailabilityZone, p.Cluster.BehaviorForResourceLocation(loc).IdentityInV1API, datamodel.CanDeleteCommitment(token, dbCommitment, p.timeNow), resource.Unit)
+		c := datamodel.ConvertCommitmentToDisplayForm(dbCommitment, path.AvailabilityZone, p.Cluster.BehaviorForResourcePath(path.Resource()).IdentityInV1API, datamodel.CanDeleteCommitment(token, dbCommitment, p.timeNow), resource.Unit)
 		// hide some fields that we should not be showing in this very public list
 		c.CreatorUUID = ""
 		c.CreatorName = ""
@@ -316,7 +310,7 @@ func (p *v1Provider) GetPublicCommitments(w http.ResponseWriter, r *http.Request
 // parseAndValidateCommitmentRequest parses and validates the request body for a commitment creation or confirmation.
 // This function in its current form should only be used if the serviceInfo is not necessary to be used outside
 // of this validation to avoid unnecessary database queries.
-func (p *v1Provider) parseAndValidateCommitmentRequest(w http.ResponseWriter, r *http.Request, dbDomain db.Domain) (_ *limesresources.CommitmentRequest, _ *core.AZResourceLocation, _ *core.ScopedCommitmentBehavior, service db.Service, resources core.ResourcesByName) {
+func (p *v1Provider) parseAndValidateCommitmentRequest(w http.ResponseWriter, r *http.Request, dbDomain db.Domain) (_ *limesresources.CommitmentRequest, _ *db.AZResourcePath, _ *core.ScopedCommitmentBehavior, service db.Service, resources core.ResourcesByName) {
 	// parse request
 	var parseTarget struct {
 		Request limesresources.CommitmentRequest `json:"commitment"`
@@ -364,13 +358,13 @@ func (p *v1Provider) parseAndValidateCommitmentRequest(w http.ResponseWriter, r 
 		return nil, nil, nil, service, resources
 	}
 
-	loc := core.AZResourceLocation{
+	path := db.AZResourcePath{
 		ServiceType:      dbServiceType,
 		ResourceName:     dbResourceName,
 		AvailabilityZone: req.AvailabilityZone,
 	}
 	// when the name mapping succeeded, service and resource must be found
-	return &req, &loc, &behavior, services[dbServiceType], allResources[dbServiceType]
+	return &req, &path, &behavior, services[dbServiceType], allResources[dbServiceType]
 }
 
 // CanConfirmNewProjectCommitment handles POST /v1/domains/:domain_id/projects/:project_id/commitments/can-confirm.
@@ -388,7 +382,7 @@ func (p *v1Provider) CanConfirmNewProjectCommitment(w http.ResponseWriter, r *ht
 	if dbProject == nil {
 		return
 	}
-	req, loc, behavior, service, resources := p.parseAndValidateCommitmentRequest(w, r, *dbDomain)
+	req, path, behavior, service, resources := p.parseAndValidateCommitmentRequest(w, r, *dbDomain)
 	if req == nil {
 		return
 	}
@@ -398,7 +392,7 @@ func (p *v1Provider) CanConfirmNewProjectCommitment(w http.ResponseWriter, r *ht
 		resourceAllowsCommitments bool
 		totalConfirmed            uint64
 	)
-	err := p.DB.QueryRow(findAZResourceIDByLocationQuery, dbProject.ID, loc.ServiceType, loc.ResourceName, loc.AvailabilityZone).
+	err := p.DB.QueryRow(findAZResourceIDByLocationQuery, dbProject.ID, path).
 		Scan(&azResourceID, &resourceAllowsCommitments, &totalConfirmed)
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
@@ -443,7 +437,7 @@ func (p *v1Provider) CanConfirmNewProjectCommitment(w http.ResponseWriter, r *ht
 
 	// check for committable capacity via the transferableCommitmentCache
 	// it automatically does the delegation to liquid if required
-	transferableCommitmentCache, err := datamodel.NewTransferableCommitmentCache(p.DB, p.Cluster, service, resources, *loc, now, p.generateProjectCommitmentUUID, p.generateTransferToken, None[core.MailTemplate]())
+	transferableCommitmentCache, err := datamodel.NewTransferableCommitmentCache(p.DB, p.Cluster, service, resources, *path, now, p.generateProjectCommitmentUUID, p.generateTransferToken, None[core.MailTemplate]())
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
@@ -470,7 +464,7 @@ func (p *v1Provider) CreateProjectCommitment(w http.ResponseWriter, r *http.Requ
 	if dbProject == nil {
 		return
 	}
-	req, loc, behavior, service, resources := p.parseAndValidateCommitmentRequest(w, r, *dbDomain)
+	req, path, behavior, service, resources := p.parseAndValidateCommitmentRequest(w, r, *dbDomain)
 	if req == nil {
 		return
 	}
@@ -480,7 +474,7 @@ func (p *v1Provider) CreateProjectCommitment(w http.ResponseWriter, r *http.Requ
 		resourceAllowsCommitments bool
 		totalConfirmed            uint64
 	)
-	err := p.DB.QueryRow(findAZResourceIDByLocationQuery, dbProject.ID, loc.ServiceType, loc.ResourceName, loc.AvailabilityZone).
+	err := p.DB.QueryRow(findAZResourceIDByLocationQuery, dbProject.ID, path).
 		Scan(&azResourceID, &resourceAllowsCommitments, &totalConfirmed)
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
@@ -553,7 +547,7 @@ func (p *v1Provider) CreateProjectCommitment(w http.ResponseWriter, r *http.Requ
 		if mailConfig, exists := p.Cluster.Config.MailNotifications.Unpack(); exists {
 			mailTemplate = Some(mailConfig.Templates.TransferredCommitments)
 		}
-		transferableCommitmentCache, err := datamodel.NewTransferableCommitmentCache(tx, p.Cluster, service, resources, *loc, now, p.generateProjectCommitmentUUID, p.generateTransferToken, mailTemplate)
+		transferableCommitmentCache, err := datamodel.NewTransferableCommitmentCache(tx, p.Cluster, service, resources, *path, now, p.generateProjectCommitmentUUID, p.generateTransferToken, mailTemplate)
 		if respondwith.ObfuscatedErrorText(w, err) {
 			return
 		}
@@ -571,7 +565,7 @@ func (p *v1Provider) CreateProjectCommitment(w http.ResponseWriter, r *http.Requ
 
 		// retrieve mails and audit event
 		auditEvents = append(auditEvents, transferableCommitmentCache.RetrieveAuditEvents()...)
-		err = transferableCommitmentCache.GenerateTransferMails(p.Cluster.BehaviorForResourceLocation(*loc).IdentityInV1API)
+		err = transferableCommitmentCache.GenerateTransferMails(p.Cluster.BehaviorForResourcePath(path.Resource()).IdentityInV1API)
 		if respondwith.ObfuscatedErrorText(w, err) {
 			return
 		}
@@ -582,13 +576,13 @@ func (p *v1Provider) CreateProjectCommitment(w http.ResponseWriter, r *http.Requ
 		// when the commitment is not to be confirmed immediately, we check
 		// (or inform the liquid) about the capacity independently.
 		ccr := liquid.CommitmentChangeRequest{
-			AZ:          loc.AvailabilityZone,
+			AZ:          path.AvailabilityZone,
 			InfoVersion: service.LiquidVersion,
 			ByProject: map[liquid.ProjectUUID]liquid.ProjectCommitmentChangeset{
 				dbProject.UUID: {
 					ProjectMetadata: datamodel.LiquidProjectMetadataFromDBProject(*dbProject, *dbDomain),
 					ByResource: map[liquid.ResourceName]liquid.ResourceCommitmentChangeset{
-						loc.ResourceName: {
+						path.ResourceName: {
 							TotalConfirmedBefore: totalConfirmed,
 							TotalConfirmedAfter:  totalConfirmed,
 							// TODO: change when introducing "guaranteed" commitments
@@ -609,7 +603,7 @@ func (p *v1Provider) CreateProjectCommitment(w http.ResponseWriter, r *http.Requ
 				},
 			},
 		}
-		commitmentChangeResponse, err := datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, *loc, service, resources, tx)
+		commitmentChangeResponse, err := datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, service, resources, tx)
 		if respondwith.ObfuscatedErrorText(w, err) {
 			return
 		}
@@ -647,14 +641,14 @@ func (p *v1Provider) CreateProjectCommitment(w http.ResponseWriter, r *http.Requ
 	// if the commitment is immediately confirmed, trigger a capacity scrape in
 	// order to ApplyComputedProjectQuotas based on the new commitment
 	if dbCommitment.ConfirmedAt.IsSome() {
-		_, err := p.DB.Exec(`UPDATE services SET next_scrape_at = $1 WHERE type = $2`, now, loc.ServiceType)
+		_, err := p.DB.Exec(`UPDATE services SET next_scrape_at = $1 WHERE type = $2`, now, path.ServiceType)
 		if err != nil {
 			logg.Error("could not trigger a new capacity scrape after creating commitment %s: %s", dbCommitment.UUID, err.Error())
 		}
 	}
 
 	// render response
-	commitment := datamodel.ConvertCommitmentToDisplayForm(dbCommitment, loc.AvailabilityZone, p.Cluster.BehaviorForResourceLocation(*loc).IdentityInV1API, datamodel.CanDeleteCommitment(token, dbCommitment, p.timeNow), resources[loc.ResourceName].Unit)
+	commitment := datamodel.ConvertCommitmentToDisplayForm(dbCommitment, path.AvailabilityZone, p.Cluster.BehaviorForResourcePath(path.Resource()).IdentityInV1API, datamodel.CanDeleteCommitment(token, dbCommitment, p.timeNow), resources[path.ResourceName].Unit)
 	respondwith.JSON(w, http.StatusCreated, map[string]any{"commitment": commitment})
 }
 
@@ -721,11 +715,11 @@ func (p *v1Provider) MergeProjectCommitments(w http.ResponseWriter, r *http.Requ
 	}
 
 	var (
-		loc            core.AZResourceLocation
+		path           db.AZResourcePath
 		totalConfirmed uint64
 	)
 	err := p.DB.QueryRow(findAZResourceLocationByIDQuery, azResourceID, dbProject.ID).
-		Scan(&loc.ServiceType, &loc.ResourceName, &loc.AvailabilityZone, &totalConfirmed)
+		Scan(&path, &totalConfirmed)
 	if errors.Is(err, sql.ErrNoRows) {
 		http.Error(w, "no route to this commitment", http.StatusNotFound)
 		return
@@ -733,9 +727,9 @@ func (p *v1Provider) MergeProjectCommitments(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	service, _ := p.Cluster.SIC.GetServiceForLoc(loc)
-	resources, _ := p.Cluster.SIC.GetResourcesForType(loc.ServiceType)
-	resource, rExists := p.Cluster.SIC.GetResourceForLoc(loc)
+	service, _ := p.Cluster.SIC.GetServiceForType(path.ServiceType)
+	resources, _ := p.Cluster.SIC.GetResourcesForType(path.ServiceType)
+	resource, rExists := resources[path.ResourceName]
 	if !rExists { // checking the deepest level is enough
 		http.Error(w, "service not found", http.StatusNotFound)
 		return
@@ -835,13 +829,13 @@ func (p *v1Provider) MergeProjectCommitments(w http.ResponseWriter, r *http.Requ
 		})
 	}
 	ccr := liquid.CommitmentChangeRequest{
-		AZ:          loc.AvailabilityZone,
+		AZ:          path.AvailabilityZone,
 		InfoVersion: service.LiquidVersion,
 		ByProject: map[liquid.ProjectUUID]liquid.ProjectCommitmentChangeset{
 			dbProject.UUID: {
 				ProjectMetadata: datamodel.LiquidProjectMetadataFromDBProject(*dbProject, *dbDomain),
 				ByResource: map[liquid.ResourceName]liquid.ResourceCommitmentChangeset{
-					loc.ResourceName: {
+					path.ResourceName: {
 						TotalConfirmedBefore: totalConfirmed,
 						TotalConfirmedAfter:  totalConfirmed,
 						// TODO: change when introducing "guaranteed" commitments
@@ -853,7 +847,7 @@ func (p *v1Provider) MergeProjectCommitments(w http.ResponseWriter, r *http.Requ
 			},
 		},
 	}
-	_, err = datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, loc, service, resources, tx)
+	_, err = datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, service, resources, tx)
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
@@ -863,7 +857,7 @@ func (p *v1Provider) MergeProjectCommitments(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	c := datamodel.ConvertCommitmentToDisplayForm(dbMergedCommitment, loc.AvailabilityZone, p.Cluster.BehaviorForResourceLocation(loc).IdentityInV1API, datamodel.CanDeleteCommitment(token, dbMergedCommitment, p.timeNow), resource.Unit)
+	c := datamodel.ConvertCommitmentToDisplayForm(dbMergedCommitment, path.AvailabilityZone, p.Cluster.BehaviorForResourcePath(path.Resource()).IdentityInV1API, datamodel.CanDeleteCommitment(token, dbMergedCommitment, p.timeNow), resource.Unit)
 
 	auditEvents := audit.CommitmentEventTarget{
 		CommitmentChangeRequest: ccr,
@@ -939,11 +933,11 @@ func (p *v1Provider) RenewProjectCommitments(w http.ResponseWriter, r *http.Requ
 	defer sqlext.RollbackUnlessCommitted(tx)
 
 	var (
-		loc            core.AZResourceLocation
+		path           db.AZResourcePath
 		totalConfirmed uint64
 	)
 	err = tx.QueryRow(findAZResourceLocationByIDQuery, dbCommitment.AZResourceID, dbProject.ID).
-		Scan(&loc.ServiceType, &loc.ResourceName, &loc.AvailabilityZone, &totalConfirmed)
+		Scan(&path, &totalConfirmed)
 	if errors.Is(err, sql.ErrNoRows) {
 		http.Error(w, "no route to this commitment", http.StatusNotFound)
 		return
@@ -951,9 +945,9 @@ func (p *v1Provider) RenewProjectCommitments(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	service, _ := p.Cluster.SIC.GetServiceForLoc(loc)
-	resources, _ := p.Cluster.SIC.GetResourcesForType(loc.ServiceType)
-	resource, rExists := p.Cluster.SIC.GetResourceForLoc(loc)
+	service, _ := p.Cluster.SIC.GetServiceForType(path.ServiceType)
+	resources, _ := p.Cluster.SIC.GetResourcesForType(path.ServiceType)
+	resource, rExists := resources[path.ResourceName]
 	if !rExists { // checking the deepest level is enough
 		http.Error(w, "service not found", http.StatusNotFound)
 		return
@@ -1008,13 +1002,13 @@ func (p *v1Provider) RenewProjectCommitments(w http.ResponseWriter, r *http.Requ
 	// TODO: for now, this is CommitmentChangeRequest.RequiresConfirmation() = false, because totalConfirmed stays and guaranteed is not used yet.
 	// when we change this, we need to evaluate the response of the liquid
 	ccr := liquid.CommitmentChangeRequest{
-		AZ:          loc.AvailabilityZone,
+		AZ:          path.AvailabilityZone,
 		InfoVersion: service.LiquidVersion,
 		ByProject: map[liquid.ProjectUUID]liquid.ProjectCommitmentChangeset{
 			dbProject.UUID: {
 				ProjectMetadata: datamodel.LiquidProjectMetadataFromDBProject(*dbProject, *dbDomain),
 				ByResource: map[liquid.ResourceName]liquid.ResourceCommitmentChangeset{
-					loc.ResourceName: {
+					path.ResourceName: {
 						TotalConfirmedBefore: totalConfirmed,
 						TotalConfirmedAfter:  totalConfirmed,
 						// TODO: change when introducing "guaranteed" commitments
@@ -1035,7 +1029,7 @@ func (p *v1Provider) RenewProjectCommitments(w http.ResponseWriter, r *http.Requ
 			},
 		},
 	}
-	_, err = datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, loc, service, resources, tx)
+	_, err = datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, service, resources, tx)
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
@@ -1046,7 +1040,7 @@ func (p *v1Provider) RenewProjectCommitments(w http.ResponseWriter, r *http.Requ
 	}
 
 	// Create resultset and auditlogs
-	c := datamodel.ConvertCommitmentToDisplayForm(dbRenewedCommitment, loc.AvailabilityZone, p.Cluster.BehaviorForResourceLocation(loc).IdentityInV1API, datamodel.CanDeleteCommitment(token, dbRenewedCommitment, p.timeNow), resource.Unit)
+	c := datamodel.ConvertCommitmentToDisplayForm(dbRenewedCommitment, path.AvailabilityZone, p.Cluster.BehaviorForResourcePath(path.Resource()).IdentityInV1API, datamodel.CanDeleteCommitment(token, dbRenewedCommitment, p.timeNow), resource.Unit)
 
 	auditEvents := audit.CommitmentEventTarget{
 		CommitmentChangeRequest: ccr,
@@ -1090,11 +1084,11 @@ func (p *v1Provider) DeleteProjectCommitment(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	var (
-		loc            core.AZResourceLocation
+		path           db.AZResourcePath
 		totalConfirmed uint64
 	)
 	err = p.DB.QueryRow(findAZResourceLocationByIDQuery, dbCommitment.AZResourceID, dbProject.ID).
-		Scan(&loc.ServiceType, &loc.ResourceName, &loc.AvailabilityZone, &totalConfirmed)
+		Scan(&path, &totalConfirmed)
 	if errors.Is(err, sql.ErrNoRows) {
 		// defense in depth: this should not happen because all the relevant tables are connected by FK constraints
 		http.Error(w, "no route to this commitment", http.StatusNotFound)
@@ -1103,8 +1097,8 @@ func (p *v1Provider) DeleteProjectCommitment(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	service, sExists := p.Cluster.SIC.GetServiceForLoc(loc)
-	resources, _ := p.Cluster.SIC.GetResourcesForType(loc.ServiceType)
+	service, sExists := p.Cluster.SIC.GetServiceForType(path.ServiceType)
+	resources, _ := p.Cluster.SIC.GetResourcesForType(path.ServiceType)
 	if !sExists {
 		http.Error(w, "service not found", http.StatusNotFound)
 		return
@@ -1128,13 +1122,13 @@ func (p *v1Provider) DeleteProjectCommitment(w http.ResponseWriter, r *http.Requ
 	}
 
 	ccr := liquid.CommitmentChangeRequest{
-		AZ:          loc.AvailabilityZone,
+		AZ:          path.AvailabilityZone,
 		InfoVersion: service.LiquidVersion,
 		ByProject: map[liquid.ProjectUUID]liquid.ProjectCommitmentChangeset{
 			dbProject.UUID: {
 				ProjectMetadata: datamodel.LiquidProjectMetadataFromDBProject(*dbProject, *dbDomain),
 				ByResource: map[liquid.ResourceName]liquid.ResourceCommitmentChangeset{
-					loc.ResourceName: {
+					path.ResourceName: {
 						TotalConfirmedBefore: totalConfirmed,
 						TotalConfirmedAfter:  totalConfirmedAfter,
 						// TODO: change when introducing "guaranteed" commitments
@@ -1155,7 +1149,7 @@ func (p *v1Provider) DeleteProjectCommitment(w http.ResponseWriter, r *http.Requ
 			},
 		},
 	}
-	_, err = datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, loc, service, resources, p.DB)
+	_, err = datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, service, resources, p.DB)
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
@@ -1261,11 +1255,11 @@ func (p *v1Provider) StartCommitmentTransfer(w http.ResponseWriter, r *http.Requ
 	}
 
 	var (
-		loc            core.AZResourceLocation
+		path           db.AZResourcePath
 		totalConfirmed uint64
 	)
 	err = p.DB.QueryRow(findAZResourceLocationByIDQuery, dbCommitment.AZResourceID, dbProject.ID).
-		Scan(&loc.ServiceType, &loc.ResourceName, &loc.AvailabilityZone, &totalConfirmed)
+		Scan(&path, &totalConfirmed)
 	if errors.Is(err, sql.ErrNoRows) {
 		// defense in depth: this should not happen because all the relevant tables are connected by FK constraints
 		http.Error(w, "no route to this commitment", http.StatusNotFound)
@@ -1274,9 +1268,9 @@ func (p *v1Provider) StartCommitmentTransfer(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	service, _ := p.Cluster.SIC.GetServiceForLoc(loc)
-	resources, _ := p.Cluster.SIC.GetResourcesForType(loc.ServiceType)
-	resource, rExists := p.Cluster.SIC.GetResourceForLoc(loc)
+	service, _ := p.Cluster.SIC.GetServiceForType(path.ServiceType)
+	resources, _ := p.Cluster.SIC.GetResourcesForType(path.ServiceType)
+	resource, rExists := resources[path.ResourceName]
 	if !rExists { // checking the deepest level is enough
 		http.Error(w, "service not found", http.StatusNotFound)
 		return
@@ -1300,13 +1294,13 @@ func (p *v1Provider) StartCommitmentTransfer(w http.ResponseWriter, r *http.Requ
 
 	// if not split, the ccr is just used for audit logging
 	ccr := liquid.CommitmentChangeRequest{
-		AZ:          loc.AvailabilityZone,
+		AZ:          path.AvailabilityZone,
 		InfoVersion: service.LiquidVersion,
 		ByProject: map[liquid.ProjectUUID]liquid.ProjectCommitmentChangeset{
 			dbProject.UUID: {
 				ProjectMetadata: datamodel.LiquidProjectMetadataFromDBProject(*dbProject, *dbDomain),
 				ByResource: map[liquid.ResourceName]liquid.ResourceCommitmentChangeset{
-					loc.ResourceName: {
+					path.ResourceName: {
 						TotalConfirmedBefore: totalConfirmed,
 						TotalConfirmedAfter:  totalConfirmed,
 						// TODO: change when introducing "guaranteed" commitments
@@ -1320,7 +1314,7 @@ func (p *v1Provider) StartCommitmentTransfer(w http.ResponseWriter, r *http.Requ
 	cac := map[liquid.CommitmentUUID]audit.CommitmentAttributeChangeset{}
 
 	if req.Amount == dbCommitment.Amount || req.TransferStatus == limesresources.CommitmentTransferStatusNone {
-		rcr := ccr.ByProject[dbProject.UUID].ByResource[loc.ResourceName]
+		rcr := ccr.ByProject[dbProject.UUID].ByResource[path.ResourceName]
 		rcr.Commitments = []liquid.Commitment{
 			// unchanged
 			{
@@ -1332,7 +1326,7 @@ func (p *v1Provider) StartCommitmentTransfer(w http.ResponseWriter, r *http.Requ
 				ExpiresAt: dbCommitment.ExpiresAt,
 			},
 		}
-		ccr.ByProject[dbProject.UUID].ByResource[loc.ResourceName] = rcr
+		ccr.ByProject[dbProject.UUID].ByResource[path.ResourceName] = rcr
 		cac[dbCommitment.UUID] = audit.CommitmentAttributeChangeset{
 			OldTransferStatus: dbCommitment.TransferStatus,
 			NewTransferStatus: req.TransferStatus,
@@ -1370,7 +1364,7 @@ func (p *v1Provider) StartCommitmentTransfer(w http.ResponseWriter, r *http.Requ
 			return
 		}
 
-		rcr := ccr.ByProject[dbProject.UUID].ByResource[loc.ResourceName]
+		rcr := ccr.ByProject[dbProject.UUID].ByResource[path.ResourceName]
 		rcr.Commitments = []liquid.Commitment{
 			// old
 			{
@@ -1399,13 +1393,13 @@ func (p *v1Provider) StartCommitmentTransfer(w http.ResponseWriter, r *http.Requ
 				ExpiresAt: remainingCommitment.ExpiresAt,
 			},
 		}
-		ccr.ByProject[dbProject.UUID].ByResource[loc.ResourceName] = rcr
+		ccr.ByProject[dbProject.UUID].ByResource[path.ResourceName] = rcr
 		cac[transferCommitment.UUID] = audit.CommitmentAttributeChangeset{
 			OldTransferStatus: limesresources.CommitmentTransferStatusNone,
 			NewTransferStatus: req.TransferStatus,
 		}
 
-		_, err = datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, loc, service, resources, tx)
+		_, err = datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, service, resources, tx)
 		if respondwith.ObfuscatedErrorText(w, err) {
 			return
 		}
@@ -1435,7 +1429,7 @@ func (p *v1Provider) StartCommitmentTransfer(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	c := datamodel.ConvertCommitmentToDisplayForm(dbCommitment, loc.AvailabilityZone, p.Cluster.BehaviorForResourceLocation(loc).IdentityInV1API, datamodel.CanDeleteCommitment(token, dbCommitment, p.timeNow), resource.Unit)
+	c := datamodel.ConvertCommitmentToDisplayForm(dbCommitment, path.AvailabilityZone, p.Cluster.BehaviorForResourcePath(path.Resource()).IdentityInV1API, datamodel.CanDeleteCommitment(token, dbCommitment, p.timeNow), resource.Unit)
 
 	auditEvents := audit.CommitmentEventTarget{
 		CommitmentChangeRequest:       ccr,
@@ -1502,11 +1496,11 @@ func (p *v1Provider) GetCommitmentByTransferToken(w http.ResponseWriter, r *http
 	}
 
 	var (
-		loc            core.AZResourceLocation
+		path           db.AZResourcePath
 		totalConfirmed uint64
 	)
 	err = p.DB.QueryRow(findAZResourceLocationByIDQuery, dbCommitment.AZResourceID, dbCommitment.ProjectID).
-		Scan(&loc.ServiceType, &loc.ResourceName, &loc.AvailabilityZone, &totalConfirmed)
+		Scan(&path, &totalConfirmed)
 	if errors.Is(err, sql.ErrNoRows) {
 		// defense in depth: this should not happen because all the relevant tables are connected by FK constraints
 		http.Error(w, "location data not found.", http.StatusNotFound)
@@ -1515,13 +1509,13 @@ func (p *v1Provider) GetCommitmentByTransferToken(w http.ResponseWriter, r *http
 		return
 	}
 
-	resource, rExists := p.Cluster.SIC.GetResourceForLoc(loc)
+	resource, rExists := p.Cluster.SIC.GetResourceForPath(path.Resource())
 	if !rExists {
 		http.Error(w, "service not found", http.StatusNotFound)
 		return
 	}
 
-	c := datamodel.ConvertCommitmentToDisplayForm(dbCommitment, loc.AvailabilityZone, p.Cluster.BehaviorForResourceLocation(loc).IdentityInV1API, datamodel.CanDeleteCommitment(token, dbCommitment, p.timeNow), resource.Unit)
+	c := datamodel.ConvertCommitmentToDisplayForm(dbCommitment, path.AvailabilityZone, p.Cluster.BehaviorForResourcePath(path.Resource()).IdentityInV1API, datamodel.CanDeleteCommitment(token, dbCommitment, p.timeNow), resource.Unit)
 	respondwith.JSON(w, http.StatusAccepted, map[string]any{"commitment": c})
 }
 
@@ -1562,11 +1556,11 @@ func (p *v1Provider) TransferCommitment(w http.ResponseWriter, r *http.Request) 
 	}
 
 	var (
-		loc                  core.AZResourceLocation
+		path                 db.AZResourcePath
 		sourceTotalConfirmed uint64
 	)
 	err = p.DB.QueryRow(findAZResourceLocationByIDQuery, dbCommitment.AZResourceID, dbCommitment.ProjectID).
-		Scan(&loc.ServiceType, &loc.ResourceName, &loc.AvailabilityZone, &sourceTotalConfirmed)
+		Scan(&path, &sourceTotalConfirmed)
 
 	if errors.Is(err, sql.ErrNoRows) {
 		// defense in depth: this should not happen because all the relevant tables are connected by FK constraints
@@ -1576,9 +1570,9 @@ func (p *v1Provider) TransferCommitment(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	service, _ := p.Cluster.SIC.GetServiceForLoc(loc)
-	resources, _ := p.Cluster.SIC.GetResourcesForType(loc.ServiceType)
-	resource, rExists := p.Cluster.SIC.GetResourceForLoc(loc)
+	service, _ := p.Cluster.SIC.GetServiceForType(path.ServiceType)
+	resources, _ := p.Cluster.SIC.GetResourcesForType(path.ServiceType)
+	resource, rExists := resources[path.ResourceName]
 	if !rExists { // checking the deepest level is enough
 		http.Error(w, "service not found", http.StatusNotFound)
 		return
@@ -1602,13 +1596,13 @@ func (p *v1Provider) TransferCommitment(w http.ResponseWriter, r *http.Request) 
 		resourceAllowsCommitments bool
 		targetTotalConfirmed      uint64
 	)
-	err = p.DB.QueryRow(findAZResourceIDByLocationQuery, targetProject.ID, loc.ServiceType, loc.ResourceName, loc.AvailabilityZone).
+	err = p.DB.QueryRow(findAZResourceIDByLocationQuery, targetProject.ID, path).
 		Scan(&azResourceID, &resourceAllowsCommitments, &targetTotalConfirmed)
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
 	if !resourceAllowsCommitments {
-		msg := fmt.Sprintf("resource %s/%s is not enabled in the target project", loc.ServiceType, loc.ResourceName)
+		msg := fmt.Sprintf("resource %s is not enabled in the target project", path.Resource().String())
 		http.Error(w, msg, http.StatusUnprocessableEntity)
 		return
 	}
@@ -1636,13 +1630,13 @@ func (p *v1Provider) TransferCommitment(w http.ResponseWriter, r *http.Request) 
 		},
 	}
 	ccr := liquid.CommitmentChangeRequest{
-		AZ:          loc.AvailabilityZone,
+		AZ:          path.AvailabilityZone,
 		InfoVersion: service.LiquidVersion,
 		ByProject: map[liquid.ProjectUUID]liquid.ProjectCommitmentChangeset{
 			sourceProject.UUID: {
 				ProjectMetadata: datamodel.LiquidProjectMetadataFromDBProject(sourceProject, sourceDomain),
 				ByResource: map[liquid.ResourceName]liquid.ResourceCommitmentChangeset{
-					loc.ResourceName: {
+					path.ResourceName: {
 						TotalConfirmedBefore: sourceTotalConfirmed,
 						TotalConfirmedAfter:  sourceTotalConfirmedAfter,
 						// TODO: change when introducing "guaranteed" commitments
@@ -1664,7 +1658,7 @@ func (p *v1Provider) TransferCommitment(w http.ResponseWriter, r *http.Request) 
 			targetProject.UUID: {
 				ProjectMetadata: datamodel.LiquidProjectMetadataFromDBProject(*targetProject, *targetDomain),
 				ByResource: map[liquid.ResourceName]liquid.ResourceCommitmentChangeset{
-					loc.ResourceName: {
+					path.ResourceName: {
 						TotalConfirmedBefore: targetTotalConfirmed,
 						TotalConfirmedAfter:  targetTotalConfirmedAfter,
 						// TODO: change when introducing "guaranteed" commitments
@@ -1685,7 +1679,7 @@ func (p *v1Provider) TransferCommitment(w http.ResponseWriter, r *http.Request) 
 			},
 		},
 	}
-	commitmentChangeResponse, err := datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, loc, service, resources, tx)
+	commitmentChangeResponse, err := datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, service, resources, tx)
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
@@ -1708,7 +1702,7 @@ func (p *v1Provider) TransferCommitment(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	c := datamodel.ConvertCommitmentToDisplayForm(dbCommitment, loc.AvailabilityZone, p.Cluster.BehaviorForResourceLocation(loc).IdentityInV1API, datamodel.CanDeleteCommitment(token, dbCommitment, p.timeNow), resource.Unit)
+	c := datamodel.ConvertCommitmentToDisplayForm(dbCommitment, path.AvailabilityZone, p.Cluster.BehaviorForResourcePath(path.Resource()).IdentityInV1API, datamodel.CanDeleteCommitment(token, dbCommitment, p.timeNow), resource.Unit)
 
 	auditEvents := audit.CommitmentEventTarget{
 		CommitmentChangeRequest:       ccr,
@@ -1837,11 +1831,11 @@ func (p *v1Provider) ConvertCommitment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var (
-		sourceLoc            core.AZResourceLocation
+		sourcePath           db.AZResourcePath
 		sourceTotalConfirmed uint64
 	)
 	err = p.DB.QueryRow(findAZResourceLocationByIDQuery, dbCommitment.AZResourceID, dbProject.ID).
-		Scan(&sourceLoc.ServiceType, &sourceLoc.ResourceName, &sourceLoc.AvailabilityZone, &sourceTotalConfirmed)
+		Scan(&sourcePath, &sourceTotalConfirmed)
 	if errors.Is(err, sql.ErrNoRows) {
 		// defense in depth: this should not happen because all the relevant tables are connected by FK constraints
 		http.Error(w, "no route to this commitment", http.StatusNotFound)
@@ -1849,11 +1843,11 @@ func (p *v1Provider) ConvertCommitment(w http.ResponseWriter, r *http.Request) {
 	} else if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
-	sourceBehavior := p.Cluster.CommitmentBehaviorForResource(sourceLoc.ServiceType, sourceLoc.ResourceName).ForDomain(dbDomain.Name)
+	sourceBehavior := p.Cluster.CommitmentBehaviorForResourcePath(sourcePath.Resource()).ForDomain(dbDomain.Name)
 	resources := p.Cluster.SIC.GetResources()
-	sourceService, sExists := p.Cluster.SIC.GetServiceForType(sourceLoc.ServiceType)
+	sourceService, sExists := p.Cluster.SIC.GetServiceForType(sourcePath.ServiceType)
 	if !sExists {
-		msg := fmt.Sprintf("no such service and/or resource: %s/%s", sourceLoc.ServiceType, sourceLoc.ResourceName)
+		msg := "no such service and/or resource: " + sourcePath.Resource().String()
 		http.Error(w, msg, http.StatusUnprocessableEntity)
 		return
 	}
@@ -1878,8 +1872,13 @@ func (p *v1Provider) ConvertCommitment(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, msg, http.StatusUnprocessableEntity)
 		return
 	}
-	targetBehavior := p.Cluster.CommitmentBehaviorForResource(targetServiceType, targetResourceName).ForDomain(dbDomain.Name)
-	if sourceLoc.ResourceName == targetResourceName && sourceLoc.ServiceType == targetServiceType {
+	targetPath := db.AZResourcePath{
+		ServiceType:      targetServiceType,
+		ResourceName:     targetResourceName,
+		AvailabilityZone: sourcePath.AvailabilityZone,
+	}
+	targetBehavior := p.Cluster.CommitmentBehaviorForResourcePath(targetPath.Resource()).ForDomain(dbDomain.Name)
+	if sourcePath.ResourceName == targetResourceName && sourcePath.ServiceType == targetServiceType {
 		http.Error(w, "conversion attempt to the same resource.", http.StatusConflict)
 		return
 	}
@@ -1925,7 +1924,7 @@ func (p *v1Provider) ConvertCommitment(w http.ResponseWriter, r *http.Request) {
 		resourceAllowsCommitments bool
 		targetTotalConfirmed      uint64
 	)
-	err = p.DB.QueryRow(findAZResourceIDByLocationQuery, dbProject.ID, targetServiceType, targetResourceName, sourceLoc.AvailabilityZone).
+	err = p.DB.QueryRow(findAZResourceIDByLocationQuery, dbProject.ID, targetPath).
 		Scan(&targetAZResourceID, &resourceAllowsCommitments, &targetTotalConfirmed)
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
@@ -1944,11 +1943,6 @@ func (p *v1Provider) ConvertCommitment(w http.ResponseWriter, r *http.Request) {
 	if dbCommitment.TransferStatus != limesresources.CommitmentTransferStatusNone {
 		http.Error(w, "commitments in transfer cannot be converted", http.StatusUnprocessableEntity)
 		return
-	}
-	targetLoc := core.AZResourceLocation{
-		ServiceType:      sourceLoc.ServiceType,
-		ResourceName:     targetResourceName,
-		AvailabilityZone: sourceLoc.AvailabilityZone,
 	}
 	remainingAmount := dbCommitment.Amount - req.SourceAmount
 	var remainingCommitment db.ProjectCommitment
@@ -1992,13 +1986,13 @@ func (p *v1Provider) ConvertCommitment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ccr := liquid.CommitmentChangeRequest{
-		AZ:          sourceLoc.AvailabilityZone,
+		AZ:          sourcePath.AvailabilityZone,
 		InfoVersion: sourceService.LiquidVersion,
 		ByProject: map[liquid.ProjectUUID]liquid.ProjectCommitmentChangeset{
 			dbProject.UUID: {
 				ProjectMetadata: datamodel.LiquidProjectMetadataFromDBProject(*dbProject, *dbDomain),
 				ByResource: map[liquid.ResourceName]liquid.ResourceCommitmentChangeset{
-					sourceLoc.ResourceName: {
+					sourcePath.ResourceName: {
 						TotalConfirmedBefore: sourceTotalConfirmed,
 						TotalConfirmedAfter:  sourceTotalConfirmedAfter,
 						// TODO: change when introducing "guaranteed" commitments
@@ -2006,7 +2000,7 @@ func (p *v1Provider) ConvertCommitment(w http.ResponseWriter, r *http.Request) {
 						TotalGuaranteedAfter:  0,
 						Commitments:           sourceCommitments,
 					},
-					targetLoc.ResourceName: {
+					targetPath.ResourceName: {
 						TotalConfirmedBefore: targetTotalConfirmed,
 						TotalConfirmedAfter:  targetTotalConfirmedAfter,
 						// TODO: change when introducing "guaranteed" commitments
@@ -2027,7 +2021,7 @@ func (p *v1Provider) ConvertCommitment(w http.ResponseWriter, r *http.Request) {
 			},
 		},
 	}
-	commitmentChangeResponse, err := datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, sourceLoc, sourceService, resources[sourceLoc.ServiceType], tx)
+	commitmentChangeResponse, err := datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, sourceService, resources[sourcePath.ServiceType], tx)
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
@@ -2082,7 +2076,7 @@ func (p *v1Provider) ConvertCommitment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	c := datamodel.ConvertCommitmentToDisplayForm(convertedCommitment, targetLoc.AvailabilityZone, p.Cluster.BehaviorForResourceLocation(targetLoc).IdentityInV1API, datamodel.CanDeleteCommitment(token, convertedCommitment, p.timeNow), resources[targetLoc.ServiceType][targetLoc.ResourceName].Unit)
+	c := datamodel.ConvertCommitmentToDisplayForm(convertedCommitment, targetPath.AvailabilityZone, p.Cluster.BehaviorForResourcePath(targetPath.Resource()).IdentityInV1API, datamodel.CanDeleteCommitment(token, convertedCommitment, p.timeNow), resources[targetPath.ServiceType][targetPath.ResourceName].Unit)
 
 	auditEvents := audit.CommitmentEventTarget{
 		CommitmentChangeRequest: ccr,
@@ -2149,11 +2143,11 @@ func (p *v1Provider) UpdateCommitmentDuration(w http.ResponseWriter, r *http.Req
 	}
 
 	var (
-		loc            core.AZResourceLocation
+		path           db.AZResourcePath
 		totalConfirmed uint64
 	)
 	err = p.DB.QueryRow(findAZResourceLocationByIDQuery, dbCommitment.AZResourceID, dbProject.ID).
-		Scan(&loc.ServiceType, &loc.ResourceName, &loc.AvailabilityZone, &totalConfirmed)
+		Scan(&path, &totalConfirmed)
 	if errors.Is(err, sql.ErrNoRows) {
 		// defense in depth: this should not happen because all the relevant tables are connected by FK constraints
 		http.Error(w, "no route to this commitment", http.StatusNotFound)
@@ -2161,7 +2155,7 @@ func (p *v1Provider) UpdateCommitmentDuration(w http.ResponseWriter, r *http.Req
 	} else if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
-	behavior := p.Cluster.CommitmentBehaviorForResource(loc.ServiceType, loc.ResourceName).ForDomain(dbDomain.Name)
+	behavior := p.Cluster.CommitmentBehaviorForResourcePath(path.Resource()).ForDomain(dbDomain.Name)
 	if !slices.Contains(behavior.Durations, req.Duration) {
 		msg := fmt.Sprintf("provided duration: %s does not match the config %v", req.Duration, behavior.Durations)
 		http.Error(w, msg, http.StatusUnprocessableEntity)
@@ -2175,9 +2169,9 @@ func (p *v1Provider) UpdateCommitmentDuration(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	service, _ := p.Cluster.SIC.GetServiceForLoc(loc)
-	resources, _ := p.Cluster.SIC.GetResourcesForType(loc.ServiceType)
-	resource, rExists := p.Cluster.SIC.GetResourceForLoc(loc)
+	service, _ := p.Cluster.SIC.GetServiceForType(path.ServiceType)
+	resources, _ := p.Cluster.SIC.GetResourcesForType(path.ServiceType)
+	resource, rExists := resources[path.ResourceName]
 	if !rExists { // checking the deepest level is enough
 		http.Error(w, "service not found", http.StatusNotFound)
 		return
@@ -2185,13 +2179,13 @@ func (p *v1Provider) UpdateCommitmentDuration(w http.ResponseWriter, r *http.Req
 
 	// might only reject in the remote-case, locally we accept extensions as limes does not know future capacity
 	ccr := liquid.CommitmentChangeRequest{
-		AZ:          loc.AvailabilityZone,
+		AZ:          path.AvailabilityZone,
 		InfoVersion: service.LiquidVersion,
 		ByProject: map[liquid.ProjectUUID]liquid.ProjectCommitmentChangeset{
 			dbProject.UUID: {
 				ProjectMetadata: datamodel.LiquidProjectMetadataFromDBProject(*dbProject, *dbDomain),
 				ByResource: map[liquid.ResourceName]liquid.ResourceCommitmentChangeset{
-					loc.ResourceName: {
+					path.ResourceName: {
 						TotalConfirmedBefore: totalConfirmed,
 						TotalConfirmedAfter:  totalConfirmed,
 						// TODO: change when introducing "guaranteed" commitments
@@ -2213,7 +2207,7 @@ func (p *v1Provider) UpdateCommitmentDuration(w http.ResponseWriter, r *http.Req
 			},
 		},
 	}
-	commitmentChangeResponse, err := datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, loc, service, resources, p.DB)
+	commitmentChangeResponse, err := datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, service, resources, p.DB)
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
@@ -2230,7 +2224,7 @@ func (p *v1Provider) UpdateCommitmentDuration(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	c := datamodel.ConvertCommitmentToDisplayForm(dbCommitment, loc.AvailabilityZone, p.Cluster.BehaviorForResourceLocation(loc).IdentityInV1API, datamodel.CanDeleteCommitment(token, dbCommitment, p.timeNow), resource.Unit)
+	c := datamodel.ConvertCommitmentToDisplayForm(dbCommitment, path.AvailabilityZone, p.Cluster.BehaviorForResourcePath(path.Resource()).IdentityInV1API, datamodel.CanDeleteCommitment(token, dbCommitment, p.timeNow), resource.Unit)
 
 	auditEvents := audit.CommitmentEventTarget{
 		CommitmentChangeRequest: ccr,

--- a/internal/api/commitment_test.go
+++ b/internal/api/commitment_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/sapcc/go-bits/easypg"
 	"github.com/sapcc/go-bits/must"
 
-	"github.com/sapcc/limes/internal/core"
 	"github.com/sapcc/limes/internal/datamodel"
 	"github.com/sapcc/limes/internal/db"
 	"github.com/sapcc/limes/internal/test"
@@ -769,12 +768,7 @@ func TestCommitmentLifecycleWithImmediateConfirmation(t *testing.T) {
 			},
 		},
 	}
-	loc := core.AZResourceLocation{
-		ServiceType:      "first",
-		ResourceName:     "capacity",
-		AvailabilityZone: "az-one",
-	}
-	dbResult := must.ReturnT(datamodel.CanAcceptCommitmentChangeRequest(commitmentChangeRequest, loc, s.Cluster, s.DB))(t)
+	dbResult := must.ReturnT(datamodel.CanAcceptCommitmentChangeRequest(commitmentChangeRequest, "first", s.Cluster, s.DB))(t)
 	assert.Equal(t, dbResult, true)
 
 	oldassert.HTTPRequest{
@@ -791,7 +785,7 @@ func TestCommitmentLifecycleWithImmediateConfirmation(t *testing.T) {
 	capacityResourceCommitmentChangeset.Commitments[0].UUID = test.GenerateDummyCommitmentUUID(3)
 	capacityResourceCommitmentChangeset.TotalConfirmedAfter = maxCommittableCapacity + 1
 	commitmentChangeRequest.ByProject["uuid-for-berlin"].ByResource["capacity"] = capacityResourceCommitmentChangeset
-	dbResult = must.ReturnT(datamodel.CanAcceptCommitmentChangeRequest(commitmentChangeRequest, loc, s.Cluster, s.DB))(t)
+	dbResult = must.ReturnT(datamodel.CanAcceptCommitmentChangeRequest(commitmentChangeRequest, "first", s.Cluster, s.DB))(t)
 	assert.Equal(t, dbResult, false)
 	s.LiquidClients["first"].CommitmentChangeResponse.Set(liquid.CommitmentChangeResponse{RejectionReason: "not enough capacity available"})
 
@@ -810,7 +804,7 @@ func TestCommitmentLifecycleWithImmediateConfirmation(t *testing.T) {
 	capacityResourceCommitmentChangeset.TotalConfirmedAfter = committedCapacity
 	commitmentChangeRequest.ByProject["uuid-for-berlin"].ByResource["capacity"] = capacityResourceCommitmentChangeset
 	commitmentChangeRequest.DryRun = false
-	dbResult = must.ReturnT(datamodel.CanAcceptCommitmentChangeRequest(commitmentChangeRequest, loc, s.Cluster, s.DB))(t)
+	dbResult = must.ReturnT(datamodel.CanAcceptCommitmentChangeRequest(commitmentChangeRequest, "first", s.Cluster, s.DB))(t)
 	assert.Equal(t, dbResult, true)
 	s.LiquidClients["first"].CommitmentChangeResponse.Set(liquid.CommitmentChangeResponse{})
 
@@ -830,7 +824,7 @@ func TestCommitmentLifecycleWithImmediateConfirmation(t *testing.T) {
 	capacityResourceCommitmentChangeset.TotalConfirmedAfter = maxCommittableCapacity
 	commitmentChangeRequest.ByProject["uuid-for-berlin"].ByResource["capacity"] = capacityResourceCommitmentChangeset
 	commitmentChangeRequest.DryRun = true
-	dbResult = must.ReturnT(datamodel.CanAcceptCommitmentChangeRequest(commitmentChangeRequest, loc, s.Cluster, s.DB))(t)
+	dbResult = must.ReturnT(datamodel.CanAcceptCommitmentChangeRequest(commitmentChangeRequest, "first", s.Cluster, s.DB))(t)
 	assert.Equal(t, dbResult, true)
 
 	oldassert.HTTPRequest{
@@ -846,7 +840,7 @@ func TestCommitmentLifecycleWithImmediateConfirmation(t *testing.T) {
 	capacityResourceCommitmentChangeset.Commitments[0].UUID = "00000000-0000-0000-0000-000000000006"
 	capacityResourceCommitmentChangeset.TotalConfirmedAfter = maxCommittableCapacity + 1
 	commitmentChangeRequest.ByProject["uuid-for-berlin"].ByResource["capacity"] = capacityResourceCommitmentChangeset
-	dbResult = must.ReturnT(datamodel.CanAcceptCommitmentChangeRequest(commitmentChangeRequest, loc, s.Cluster, s.DB))(t)
+	dbResult = must.ReturnT(datamodel.CanAcceptCommitmentChangeRequest(commitmentChangeRequest, "first", s.Cluster, s.DB))(t)
 	assert.Equal(t, dbResult, false)
 	s.LiquidClients["first"].CommitmentChangeResponse.Set(liquid.CommitmentChangeResponse{RejectionReason: "not enough capacity available"})
 
@@ -868,7 +862,7 @@ func TestCommitmentLifecycleWithImmediateConfirmation(t *testing.T) {
 	capacityResourceCommitmentChangeset.TotalConfirmedBefore = 0
 	capacityResourceCommitmentChangeset.TotalConfirmedAfter = maxCommittableCapacity
 	commitmentChangeRequest.ByProject["uuid-for-berlin"].ByResource["capacity"] = capacityResourceCommitmentChangeset
-	dbResult = must.ReturnT(datamodel.CanAcceptCommitmentChangeRequest(commitmentChangeRequest, loc, s.Cluster, s.DB))(t)
+	dbResult = must.ReturnT(datamodel.CanAcceptCommitmentChangeRequest(commitmentChangeRequest, "first", s.Cluster, s.DB))(t)
 	assert.Equal(t, dbResult, true)
 	s.LiquidClients["first"].CommitmentChangeResponse.Set(liquid.CommitmentChangeResponse{})
 
@@ -2024,12 +2018,7 @@ func Test_TransferCommitmentForbiddenByCapacityCheck(t *testing.T) {
 			},
 		},
 	}
-	loc := core.AZResourceLocation{
-		ServiceType:      "second",
-		ResourceName:     "capacity",
-		AvailabilityZone: "az-one",
-	}
-	dbResult := must.ReturnT(datamodel.CanAcceptCommitmentChangeRequest(commitmentChangeRequest, loc, s.Cluster, s.DB))(t)
+	dbResult := must.ReturnT(datamodel.CanAcceptCommitmentChangeRequest(commitmentChangeRequest, "second", s.Cluster, s.DB))(t)
 	assert.Equal(t, dbResult, false)
 	s.LiquidClients["second"].CommitmentChangeResponse.Set(liquid.CommitmentChangeResponse{RejectionReason: "not enough committable capacity on the receiving side"})
 
@@ -2227,12 +2216,7 @@ func Test_ConvertCommitments(t *testing.T) {
 			},
 		},
 	}
-	loc := core.AZResourceLocation{
-		ServiceType:      "fourth",
-		ResourceName:     "capacity_a",
-		AvailabilityZone: "az-one",
-	}
-	dbResult := must.ReturnT(datamodel.CanAcceptCommitmentChangeRequest(commitmentChangeRequest, loc, s.Cluster, s.DB))(t)
+	dbResult := must.ReturnT(datamodel.CanAcceptCommitmentChangeRequest(commitmentChangeRequest, "fourth", s.Cluster, s.DB))(t)
 	assert.Equal(t, dbResult, false)
 	s.LiquidClients["fourth"].CommitmentChangeResponse.Set(liquid.CommitmentChangeResponse{RejectionReason: "liquid says: not enough capacity!"})
 
@@ -2269,7 +2253,7 @@ func Test_ConvertCommitments(t *testing.T) {
 	capacityACommitmentChangeset.Commitments[0].UUID = test.GenerateDummyCommitmentUUID(3)
 	commitmentChangeRequest.ByProject["uuid-for-berlin"].ByResource["capacity_b"] = capacityBCommitmentChangeset
 	commitmentChangeRequest.ByProject["uuid-for-berlin"].ByResource["capacity_a"] = capacityACommitmentChangeset
-	dbResult = must.ReturnT(datamodel.CanAcceptCommitmentChangeRequest(commitmentChangeRequest, loc, s.Cluster, s.DB))(t)
+	dbResult = must.ReturnT(datamodel.CanAcceptCommitmentChangeRequest(commitmentChangeRequest, "fourth", s.Cluster, s.DB))(t)
 	assert.Equal(t, dbResult, true)
 	s.LiquidClients["fourth"].CommitmentChangeResponse.Set(liquid.CommitmentChangeResponse{})
 
@@ -2358,7 +2342,7 @@ func Test_ConvertCommitments(t *testing.T) {
 	}
 	commitmentChangeRequest.ByProject["uuid-for-berlin"].ByResource["capacity_a"] = capacityACommitmentChangeset
 	commitmentChangeRequest.ByProject["uuid-for-berlin"].ByResource["capacity_b"] = capacityBCommitmentChangeset
-	dbResult = must.ReturnT(datamodel.CanAcceptCommitmentChangeRequest(commitmentChangeRequest, loc, s.Cluster, s.DB))(t)
+	dbResult = must.ReturnT(datamodel.CanAcceptCommitmentChangeRequest(commitmentChangeRequest, "fourth", s.Cluster, s.DB))(t)
 	assert.Equal(t, dbResult, true)
 
 	oldassert.HTTPRequest{

--- a/internal/api/mail.go
+++ b/internal/api/mail.go
@@ -74,7 +74,7 @@ func (p *v1Provider) RenderMailTemplate(w http.ResponseWriter, r *http.Request) 
 		"transferred_commitments": mailConfig.Templates.TransferredCommitments,
 	}
 
-	dummyResource := core.AZResourceLocation{
+	dummyResource := core.AZResourceLocationV1{
 		ServiceType:      "foo-service",
 		ResourceName:     "bar-resource",
 		AvailabilityZone: "eu-de-1a",

--- a/internal/collector/capacity_scrape.go
+++ b/internal/collector/capacity_scrape.go
@@ -258,8 +258,7 @@ func (c *Collector) processCapacityScrapeTask(ctx context.Context, task capacity
 	// for all resources thus updated, sync commitment status with reality
 	for _, res := range resources {
 		now := c.MeasureTime()
-		path := db.ResourcePath{ServiceType: service.Type, ResourceName: res.Name}
-		_, err = c.DB.Exec(updateProjectCommitmentStatusForResourceQuery, path.String(), now)
+		_, err = c.DB.Exec(updateProjectCommitmentStatusForResourceQuery, res.Path, now)
 		if err != nil {
 			return fmt.Errorf("while updating project_commitments.status for %s/%s: %w", service.Type, res.Name, err)
 		}
@@ -267,7 +266,7 @@ func (c *Collector) processCapacityScrapeTask(ctx context.Context, task capacity
 
 	// for all resources thus updated, try to confirm pending commitments
 	for _, resource := range resources {
-		err := c.confirmPendingCommitmentsIfNecessary(ctx, service, resource)
+		err := c.confirmPendingCommitmentsIfNecessary(ctx, resource)
 		if err != nil {
 			return err
 		}
@@ -305,8 +304,8 @@ func (c *Collector) scrapeLiquidCapacity(ctx context.Context, connection *core.L
 	return capacityData, serializedMetrics, nil
 }
 
-func (c *Collector) confirmPendingCommitmentsIfNecessary(ctx context.Context, service db.Service, resource db.Resource) error {
-	behavior := c.Cluster.CommitmentBehaviorForResource(service.Type, resource.Name).ForCluster()
+func (c *Collector) confirmPendingCommitmentsIfNecessary(ctx context.Context, resource db.Resource) error {
+	behavior := c.Cluster.CommitmentBehaviorForResourcePath(resource.Path).ForCluster()
 	now := c.MeasureTime()
 
 	// do not run ConfirmPendingCommitments if commitments are not enabled (or not live yet) for this resource
@@ -327,18 +326,14 @@ func (c *Collector) confirmPendingCommitmentsIfNecessary(ctx context.Context, se
 	}
 	var auditevents []audittools.Event
 	for _, az := range committableAZs {
-		loc := core.AZResourceLocation{
-			ServiceType:      service.Type,
-			ResourceName:     resource.Name,
-			AvailabilityZone: az,
-		}
+		path := resource.Path.InAZ(az)
 		auditContext := audit.Context{
 			UserIdentity: audit.CollectorUserInfo{
 				TaskName: "capacity-scrape",
 			},
 			Request: audit.CollectorDummyRequest,
 		}
-		azAuditEvents, err := datamodel.ConfirmPendingCommitments(ctx, loc, c.Cluster, tx, now, c.GenerateProjectCommitmentUUID, c.GenerateTransferToken, auditContext)
+		azAuditEvents, err := datamodel.ConfirmPendingCommitments(ctx, path, c.Cluster, tx, now, c.GenerateProjectCommitmentUUID, c.GenerateTransferToken, auditContext)
 		if err != nil {
 			return err
 		}

--- a/internal/collector/expiring_commitments.go
+++ b/internal/collector/expiring_commitments.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/lib/pq"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/sapcc/go-api-declarations/liquid"
 	"github.com/sapcc/go-bits/jobloop"
 	"github.com/sapcc/go-bits/sqlext"
 
@@ -47,13 +46,11 @@ var (
 		 WHERE expires_at <= $1 AND status = {{liquid.CommitmentStatusConfirmed}} AND renew_context_json IS NULL AND NOT notified_for_expiration
 	`))
 	locateExpiringCommitmentsQuery = sqlext.SimplifyWhitespace(`
-		SELECT pc.project_id, s.type, r.name, azr.az, pc.id
-		  FROM services s
-		  JOIN resources r ON r.service_id = s.id
-		  JOIN az_resources azr ON azr.resource_id = r.id
+		SELECT pc.project_id, azr.path, pc.id
+		  FROM az_resources azr
 		  JOIN project_commitments pc ON pc.az_resource_id = azr.id
 		WHERE pc.id = ANY($1)
-		ORDER BY s.type, r.name, azr.az ASC, pc.amount DESC
+		ORDER BY azr.path ASC, pc.amount DESC
 	`)
 	updateCommitmentAsNotifiedQuery = `UPDATE project_commitments SET notified_for_expiration = TRUE, updated_at = $1 WHERE id = ANY($2)`
 )
@@ -104,19 +101,24 @@ func (c *Collector) processExpiringCommitmentTask(ctx context.Context, commitmen
 		var (
 			pid  db.ProjectID
 			cid  db.ProjectCommitmentID
-			info core.CommitmentNotification
+			path db.AZResourcePath
 		)
-		err := rows.Scan(&pid, &info.Resource.ServiceType, &info.Resource.ResourceName, &info.Resource.AvailabilityZone, &cid)
+		err := rows.Scan(&pid, &path, &cid)
 		if err != nil {
 			return err
 		}
 
-		apiIdentity := c.Cluster.BehaviorForResource(info.Resource.ServiceType, info.Resource.ResourceName).IdentityInV1API
-		info.Resource.ServiceType = db.ServiceType(apiIdentity.ServiceType)
-		info.Resource.ResourceName = liquid.ResourceName(apiIdentity.Name)
-		info.Commitment = longTermCommitmentsByID[cid]
-		info.DateString = info.Commitment.ExpiresAt.Format(time.DateOnly)
-		notifications[pid] = append(notifications[pid], info)
+		apiIdentity := c.Cluster.BehaviorForResourcePath(path.Resource()).IdentityInV1API
+		commitment := longTermCommitmentsByID[cid]
+		notifications[pid] = append(notifications[pid], core.CommitmentNotification{
+			Resource: core.AZResourceLocationV1{
+				ServiceType:      apiIdentity.ServiceType,
+				ResourceName:     apiIdentity.Name,
+				AvailabilityZone: path.AvailabilityZone,
+			},
+			Commitment: commitment,
+			DateString: commitment.ExpiresAt.Format(time.DateOnly),
+		})
 		return nil
 	})
 	if err != nil {

--- a/internal/core/cluster.go
+++ b/internal/core/cluster.go
@@ -162,6 +162,11 @@ func (c *Cluster) CommitmentBehaviorForResource(serviceType db.ServiceType, reso
 	return c.Config.Liquids[serviceType].CommitmentBehaviorPerResource.Pick(resourceName).UnwrapOr(CommitmentBehavior{})
 }
 
+// CommitmentBehaviorForResourcePath is a shorthand for CommitmentBehaviorForResource using a [db.ResourcePath].
+func (c *Cluster) CommitmentBehaviorForResourcePath(path db.ResourcePath) CommitmentBehavior {
+	return c.CommitmentBehaviorForResource(path.ServiceType, path.ResourceName)
+}
+
 // BehaviorForResource returns the ResourceBehavior for the given resource in the given service.
 func (c *Cluster) BehaviorForResource(serviceType db.ServiceType, resourceName liquid.ResourceName) ResourceBehavior {
 	// default behavior
@@ -184,9 +189,9 @@ func (c *Cluster) BehaviorForResource(serviceType db.ServiceType, resourceName l
 	return result
 }
 
-// BehaviorForResourceLocation is a shorthand for BehaviorForResource using an AZResourceLocation.
-func (c *Cluster) BehaviorForResourceLocation(loc AZResourceLocation) ResourceBehavior {
-	return c.BehaviorForResource(loc.ServiceType, loc.ResourceName)
+// BehaviorForResourcePath is a shorthand for BehaviorForResource using a [db.ResourcePath].
+func (c *Cluster) BehaviorForResourcePath(path db.ResourcePath) ResourceBehavior {
+	return c.BehaviorForResource(path.ServiceType, path.ResourceName)
 }
 
 // BehaviorForRate returns the RateBehavior for the given rate in

--- a/internal/core/mail.go
+++ b/internal/core/mail.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/sapcc/go-api-declarations/limes"
-	"github.com/sapcc/go-api-declarations/liquid"
+	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
 
 	"github.com/sapcc/limes/internal/db"
 )
@@ -23,30 +23,18 @@ type CommitmentGroupNotification struct {
 	Commitments []CommitmentNotification
 }
 
-// AZResourceLocation is a tuple identifying an AZ resource within a project.
-type AZResourceLocation struct {
-	ServiceType      db.ServiceType
-	ResourceName     liquid.ResourceName
+// AZResourceLocationV1 is a tuple identifying an AZ resource within a project, using v1 names for services and resources.
+type AZResourceLocationV1 struct {
+	ServiceType      limes.ServiceType
+	ResourceName     limesresources.ResourceName
 	AvailabilityZone limes.AvailabilityZone
-}
-
-// ScopeString returns a human-readable string representation of this AZ resource location.
-// Format: "<service_type>/<resource_name> in <availability_zone>"
-func (a AZResourceLocation) ScopeString() string {
-	return fmt.Sprintf("%s/%s in %s", a.ServiceType, a.ResourceName, a.AvailabilityZone)
-}
-
-// ShortScopeString returns a compact string representation of this AZ resource location.
-// Format: "<service_type>/<resource_name>/<availability_zone>"
-func (a AZResourceLocation) ShortScopeString() string {
-	return fmt.Sprintf("%s/%s/%s", a.ServiceType, a.ResourceName, a.AvailabilityZone)
 }
 
 // CommitmentNotification appears in type CommitmentGroupNotification.
 type CommitmentNotification struct {
 	Commitment     db.ProjectCommitment
 	DateString     string
-	Resource       AZResourceLocation
+	Resource       AZResourceLocationV1
 	LeftoverAmount uint64
 }
 

--- a/internal/core/mail.go
+++ b/internal/core/mail.go
@@ -25,6 +25,7 @@ type CommitmentGroupNotification struct {
 
 // AZResourceLocationV1 is a tuple identifying an AZ resource within a project, using v1 names for services and resources.
 type AZResourceLocationV1 struct {
+	// TODO: replace this struct with db.AZResourcePath when the v2 API enters GA
 	ServiceType      limes.ServiceType
 	ResourceName     limesresources.ResourceName
 	AvailabilityZone limes.AvailabilityZone

--- a/internal/core/service_info_cache.go
+++ b/internal/core/service_info_cache.go
@@ -290,11 +290,6 @@ func (s *ServiceInfoCache) GetServiceForType(serviceType db.ServiceType) (db.Ser
 	return val, ok
 }
 
-// GetServiceForLoc returns the cached service for the serviceType of loc.
-func (s *ServiceInfoCache) GetServiceForLoc(loc AZResourceLocation) (db.Service, bool) {
-	return s.GetServiceForType(loc.ServiceType)
-}
-
 // HasServiceForType checks whether the given service exists.
 func (s *ServiceInfoCache) HasServiceForType(serviceType db.ServiceType) bool {
 	s.dataMutex.RLock()
@@ -326,9 +321,9 @@ func (s *ServiceInfoCache) GetResourceForTypeName(serviceType db.ServiceType, re
 	return val, ok
 }
 
-// GetResourceForLoc returns the cached resource for the serviceType and resourceName of loc.
-func (s *ServiceInfoCache) GetResourceForLoc(loc AZResourceLocation) (db.Resource, bool) {
-	return s.GetResourceForTypeName(loc.ServiceType, loc.ResourceName)
+// GetResourceForPath returns the cached resource for the given path.
+func (s *ServiceInfoCache) GetResourceForPath(path db.ResourcePath) (db.Resource, bool) {
+	return s.GetResourceForTypeName(path.ServiceType, path.ResourceName)
 }
 
 // GetAZResources returns all cached AZ resources, indexed by service type, resource name, and availability zone.
@@ -364,9 +359,9 @@ func (s *ServiceInfoCache) GetAZResourceForTypeNameAZ(serviceType db.ServiceType
 	return val, ok
 }
 
-// GetAZResourceForLoc returns the cached AZ resource for this location.
-func (s *ServiceInfoCache) GetAZResourceForLoc(loc AZResourceLocation) (db.AZResource, bool) {
-	return s.GetAZResourceForTypeNameAZ(loc.ServiceType, loc.ResourceName, loc.AvailabilityZone)
+// GetAZResourceForPath returns the cached AZ resource for the given path.
+func (s *ServiceInfoCache) GetAZResourceForPath(path db.AZResourcePath) (db.AZResource, bool) {
+	return s.GetAZResourceForTypeNameAZ(path.ServiceType, path.ResourceName, path.AvailabilityZone)
 }
 
 // GetRates returns all cached rates, indexed by service type and rate name.

--- a/internal/datamodel/commitment.go
+++ b/internal/datamodel/commitment.go
@@ -130,7 +130,7 @@ func ConvertCommitmentToDisplayForm(c db.ProjectCommitment, az limes.Availabilit
 // preloaded - but does not have to. In case the LiquidConnection is not filled,
 // a LiquidClient is instantiated on the fly to perform the operation remotely. It utilizes a given
 // ServiceInfo so that no double retrieval is necessary caused by operations to assemble the liquid.CommitmentChange.
-func DelegateChangeCommitments(ctx context.Context, cluster *core.Cluster, req liquid.CommitmentChangeRequest, loc core.AZResourceLocation, service db.Service, resources core.ResourcesByName, dbi db.Interface) (result liquid.CommitmentChangeResponse, err error) {
+func DelegateChangeCommitments(ctx context.Context, cluster *core.Cluster, req liquid.CommitmentChangeRequest, service db.Service, resources core.ResourcesByName, dbi db.Interface) (result liquid.CommitmentChangeResponse, err error) {
 	localCommitmentChanges := liquid.CommitmentChangeRequest{
 		DryRun:      req.DryRun,
 		AZ:          req.AZ,
@@ -191,16 +191,16 @@ func DelegateChangeCommitments(ctx context.Context, cluster *core.Cluster, req l
 		var liquidClient core.LiquidClient
 		if len(cluster.LiquidConnections) == 0 {
 			// find the right ServiceType
-			liquidClient, err = cluster.LiquidClientFactory(loc.ServiceType)
+			liquidClient, err = cluster.LiquidClientFactory(service.Type)
 			if err != nil {
 				return result, err
 			}
 		} else {
-			liquidClient = cluster.LiquidConnections[loc.ServiceType].LiquidClient
+			liquidClient = cluster.LiquidConnections[service.Type].LiquidClient
 		}
 		commitmentChangeResponse, err := liquidClient.ChangeCommitments(ctx, remoteCommitmentChanges)
 		if err != nil {
-			return result, fmt.Errorf("failed to retrieve liquid ChangeCommitment response for service %s: %w", loc.ServiceType, err)
+			return result, fmt.Errorf("failed to retrieve liquid ChangeCommitment response for service %s: %w", service.Type, err)
 		}
 		if commitmentChangeResponse.RejectionReason != "" {
 			return commitmentChangeResponse, nil
@@ -209,7 +209,7 @@ func DelegateChangeCommitments(ctx context.Context, cluster *core.Cluster, req l
 
 	// check local
 	if len(localCommitmentChanges.ByProject) != 0 {
-		canAcceptLocally, err := CanAcceptCommitmentChangeRequest(localCommitmentChanges, loc, cluster, dbi)
+		canAcceptLocally, err := CanAcceptCommitmentChangeRequest(localCommitmentChanges, service.Type, cluster, dbi)
 		if err != nil {
 			return result, fmt.Errorf("failed to check local ChangeCommitment: %w", err)
 		}

--- a/internal/datamodel/confirm_project_commitments.go
+++ b/internal/datamodel/confirm_project_commitments.go
@@ -122,7 +122,7 @@ func ConfirmPendingCommitments(ctx context.Context, path db.AZResourcePath, clus
 	var confirmableCommitments []db.ProjectCommitment
 	_, err = dbi.Select(&confirmableCommitments, getConfirmableCommitmentsQuery, path)
 	if err != nil {
-		return nil, fmt.Errorf("while enumerating confirmable commitments for %s: %w", path.String(), err)
+		return nil, fmt.Errorf("while enumerating confirmable commitments for %s: %w", path, err)
 	}
 
 	// optimization: do not do more loading, if we do not have anything to confirm
@@ -144,11 +144,11 @@ func ConfirmPendingCommitments(ctx context.Context, path db.AZResourcePath, clus
 	}
 	affectedProjectsByID, err := db.BuildIndexOfDBResult(dbi, func(p db.Project) db.ProjectID { return p.ID }, `SELECT * FROM projects WHERE id = ANY($1)`, pq.Array(slices.Collect(maps.Keys(affectedProjectIDs))))
 	if err != nil {
-		return nil, fmt.Errorf("while loading affected projects for %s: %w", path.String(), err)
+		return nil, fmt.Errorf("while loading affected projects for %s: %w", path, err)
 	}
 	affectedDomainsByID, err := db.BuildIndexOfDBResult(dbi, func(d db.Domain) db.DomainID { return d.ID }, `SELECT * FROM domains WHERE id IN (SELECT domain_id FROM projects WHERE id = ANY($1))`, pq.Array(slices.Collect(maps.Keys(affectedProjectIDs))))
 	if err != nil {
-		return nil, fmt.Errorf("while loading affected domains for %s: %w", path.String(), err)
+		return nil, fmt.Errorf("while loading affected domains for %s: %w", path, err)
 	}
 
 	// load mail templates
@@ -195,7 +195,7 @@ func ConfirmPendingCommitments(ctx context.Context, path db.AZResourcePath, clus
 		cc.UpdatedAt = now
 		_, err = dbi.Update(&cc)
 		if err != nil {
-			return nil, fmt.Errorf("while confirming commitment ID=%d for %s: %w", cc.ID, path.String(), err)
+			return nil, fmt.Errorf("while confirming commitment ID=%d for %s: %w", cc.ID, path, err)
 		}
 		transferableCommitmentCache.ConfirmTransferableCommitmentIfExists(cc.ID, now)
 		confirmedCommitmentsByProjectID[cc.ProjectID] = append(confirmedCommitmentsByProjectID[cc.ProjectID], &cc)

--- a/internal/datamodel/confirm_project_commitments.go
+++ b/internal/datamodel/confirm_project_commitments.go
@@ -68,6 +68,7 @@ func CanAcceptCommitmentChangeRequest(req liquid.CommitmentChangeRequest, servic
 	}
 
 	for resourceName := range distinctResources {
+		path := db.ResourcePath{ServiceType: serviceType, ResourceName: resourceName}
 		additions := map[db.ProjectID]uint64{}
 		subtractions := map[db.ProjectID]uint64{}
 		additionSum := uint64(0)
@@ -101,10 +102,8 @@ func CanAcceptCommitmentChangeRequest(req liquid.CommitmentChangeRequest, servic
 		stats := statsByAZ[req.AZ]
 
 		behavior := cluster.CommitmentBehaviorForResource(serviceType, resourceName)
-		logg.Debug("checking additions in %s/%s: overall amount %d",
-			serviceType, resourceName, additionSum)
-		logg.Debug("checking subtractions in %s/%s: overall amount %d",
-			serviceType, resourceName, subtractionSum)
+		logg.Debug("checking additions in %s: overall amount %d", path, additionSum)
+		logg.Debug("checking subtractions in %s: overall amount %d", path, subtractionSum)
 		result := stats.CanAcceptCommitmentChanges(additions, subtractions, behavior)
 		if !result {
 			return false, nil
@@ -256,7 +255,6 @@ func generateConfirmationMails(mailTemplate Option[core.MailTemplate], dbi db.In
 		n.Commitments = append(n.Commitments, core.CommitmentNotification{
 			Commitment: *c,
 			DateString: confirmedAt.Format(time.DateOnly),
-			// TODO: we actually don't want to have api-named props in AZResourceLocation. Replace the template and the code simultaneously.
 			Resource: core.AZResourceLocationV1{
 				ServiceType:      apiIdentity.ServiceType,
 				ResourceName:     apiIdentity.Name,

--- a/internal/datamodel/confirm_project_commitments.go
+++ b/internal/datamodel/confirm_project_commitments.go
@@ -39,11 +39,9 @@ type commitmentTransferLeftover struct {
 // The final `BY pc.id` ordering ensures deterministic behavior in tests.
 var getConfirmableCommitmentsQuery = sqlext.SimplifyWhitespace(db.ExpandEnumPlaceholders(`
 		SELECT pc.*
-		  FROM services s
-		  JOIN resources r ON r.service_id = s.id
-		  JOIN az_resources azr ON azr.resource_id = r.id
+		  FROM az_resources azr
 		  JOIN project_commitments pc ON pc.az_resource_id = azr.id
-		 WHERE s.type = $1 AND r.name = $2 AND azr.az = $3 AND pc.status = {{liquid.CommitmentStatusPending}}
+		 WHERE azr.path = $1 AND pc.status = {{liquid.CommitmentStatusPending}}
 		 ORDER BY pc.created_at ASC, pc.confirm_by ASC, pc.id ASC
 	`))
 
@@ -52,7 +50,7 @@ const ConsumeAction cadf.Action = "consume"
 
 // CanAcceptCommitmentChangeRequest returns whether the requested moves and creations
 // within the liquid.CommitmentChangeRequest can be done from capacity perspective.
-func CanAcceptCommitmentChangeRequest(req liquid.CommitmentChangeRequest, loc core.AZResourceLocation, cluster *core.Cluster, dbi db.Interface) (bool, error) {
+func CanAcceptCommitmentChangeRequest(req liquid.CommitmentChangeRequest, serviceType db.ServiceType, cluster *core.Cluster, dbi db.Interface) (bool, error) {
 	var distinctResources = make(map[liquid.ResourceName]struct{})
 	for _, projectCommitmentChangeset := range req.ByProject {
 		for resourceName := range projectCommitmentChangeset.ByResource {
@@ -96,17 +94,17 @@ func CanAcceptCommitmentChangeRequest(req liquid.CommitmentChangeRequest, loc co
 		if len(additions) == 0 {
 			continue
 		}
-		statsByAZ, err := collectAZAllocationStats(loc.ServiceType, resourceName, Some(req.AZ), cluster, dbi)
+		statsByAZ, err := collectAZAllocationStats(serviceType, resourceName, Some(req.AZ), cluster, dbi)
 		if err != nil {
 			return false, err
 		}
 		stats := statsByAZ[req.AZ]
 
-		behavior := cluster.CommitmentBehaviorForResource(loc.ServiceType, resourceName)
-		logg.Debug("checking additions in %s: overall amount %d",
-			loc.ShortScopeString(), resourceName, additionSum)
-		logg.Debug("checking subtractions in %s: overall amount %d",
-			loc.ShortScopeString(), resourceName, subtractionSum)
+		behavior := cluster.CommitmentBehaviorForResource(serviceType, resourceName)
+		logg.Debug("checking additions in %s/%s: overall amount %d",
+			serviceType, resourceName, additionSum)
+		logg.Debug("checking subtractions in %s/%s: overall amount %d",
+			serviceType, resourceName, subtractionSum)
 		result := stats.CanAcceptCommitmentChanges(additions, subtractions, behavior)
 		if !result {
 			return false, nil
@@ -119,13 +117,12 @@ func CanAcceptCommitmentChangeRequest(req liquid.CommitmentChangeRequest, loc co
 // could be confirmed, in chronological creation order, and confirms as many of
 // them as possible given the currently available capacity. Simultaneously, it
 // releases transferable commitments that can be used to satisfy the pending ones.
-func ConfirmPendingCommitments(ctx context.Context, loc core.AZResourceLocation, cluster *core.Cluster, dbi db.Interface, now time.Time, generateProjectCommitmentUUID func() liquid.CommitmentUUID, generateTransferToken func() string, auditContext audit.Context) (auditEvents []audittools.Event, err error) {
+func ConfirmPendingCommitments(ctx context.Context, path db.AZResourcePath, cluster *core.Cluster, dbi db.Interface, now time.Time, generateProjectCommitmentUUID func() liquid.CommitmentUUID, generateTransferToken func() string, auditContext audit.Context) (auditEvents []audittools.Event, err error) {
 	// load confirmable commitments
 	var confirmableCommitments []db.ProjectCommitment
-	queryArgs := []any{loc.ServiceType, loc.ResourceName, loc.AvailabilityZone}
-	_, err = dbi.Select(&confirmableCommitments, getConfirmableCommitmentsQuery, queryArgs...)
+	_, err = dbi.Select(&confirmableCommitments, getConfirmableCommitmentsQuery, path)
 	if err != nil {
-		return nil, fmt.Errorf("while enumerating confirmable commitments for %s: %w", loc.ScopeString(), err)
+		return nil, fmt.Errorf("while enumerating confirmable commitments for %s: %w", path.String(), err)
 	}
 
 	// optimization: do not do more loading, if we do not have anything to confirm
@@ -134,10 +131,10 @@ func ConfirmPendingCommitments(ctx context.Context, loc core.AZResourceLocation,
 	}
 
 	// load service info (used to generate liquid.ProjectMetadata)
-	service, sExists := cluster.SIC.GetServiceForLoc(loc)
-	resources, _ := cluster.SIC.GetResourcesForType(loc.ServiceType)
+	service, sExists := cluster.SIC.GetServiceForType(path.ServiceType)
+	resources, _ := cluster.SIC.GetResourcesForType(path.ServiceType)
 	if !sExists {
-		return nil, fmt.Errorf("service/resource not found when trying to confirm commitments for %s", loc.ServiceType)
+		return nil, fmt.Errorf("service/resource not found when trying to confirm commitments for %s", path.ServiceType)
 	}
 
 	// load affected projects and domains
@@ -147,11 +144,11 @@ func ConfirmPendingCommitments(ctx context.Context, loc core.AZResourceLocation,
 	}
 	affectedProjectsByID, err := db.BuildIndexOfDBResult(dbi, func(p db.Project) db.ProjectID { return p.ID }, `SELECT * FROM projects WHERE id = ANY($1)`, pq.Array(slices.Collect(maps.Keys(affectedProjectIDs))))
 	if err != nil {
-		return nil, fmt.Errorf("while loading affected projects for %s: %w", loc.ScopeString(), err)
+		return nil, fmt.Errorf("while loading affected projects for %s: %w", path.String(), err)
 	}
 	affectedDomainsByID, err := db.BuildIndexOfDBResult(dbi, func(d db.Domain) db.DomainID { return d.ID }, `SELECT * FROM domains WHERE id IN (SELECT domain_id FROM projects WHERE id = ANY($1))`, pq.Array(slices.Collect(maps.Keys(affectedProjectIDs))))
 	if err != nil {
-		return nil, fmt.Errorf("while loading affected domains for %s: %w", loc.ScopeString(), err)
+		return nil, fmt.Errorf("while loading affected domains for %s: %w", path.String(), err)
 	}
 
 	// load mail templates
@@ -163,7 +160,7 @@ func ConfirmPendingCommitments(ctx context.Context, loc core.AZResourceLocation,
 	}
 
 	// initiate cache of transferable commitments
-	transferableCommitmentCache, err := NewTransferableCommitmentCache(dbi, cluster, service, resources, loc, now, generateProjectCommitmentUUID, generateTransferToken, transferTemplate)
+	transferableCommitmentCache, err := NewTransferableCommitmentCache(dbi, cluster, service, resources, path, now, generateProjectCommitmentUUID, generateTransferToken, transferTemplate)
 	if err != nil {
 		return nil, err
 	}
@@ -198,14 +195,14 @@ func ConfirmPendingCommitments(ctx context.Context, loc core.AZResourceLocation,
 		cc.UpdatedAt = now
 		_, err = dbi.Update(&cc)
 		if err != nil {
-			return nil, fmt.Errorf("while confirming commitment ID=%d for %s: %w", cc.ID, loc.ScopeString(), err)
+			return nil, fmt.Errorf("while confirming commitment ID=%d for %s: %w", cc.ID, path.String(), err)
 		}
 		transferableCommitmentCache.ConfirmTransferableCommitmentIfExists(cc.ID, now)
 		confirmedCommitmentsByProjectID[cc.ProjectID] = append(confirmedCommitmentsByProjectID[cc.ProjectID], &cc)
 	}
 
 	// generate mail notifications for commitment transfers
-	apiIdentity := cluster.BehaviorForResource(loc.ServiceType, loc.ResourceName).IdentityInV1API
+	apiIdentity := cluster.BehaviorForResourcePath(path.Resource()).IdentityInV1API
 	err = transferableCommitmentCache.GenerateTransferMails(apiIdentity)
 	if err != nil {
 		return nil, err
@@ -226,7 +223,7 @@ func ConfirmPendingCommitments(ctx context.Context, loc core.AZResourceLocation,
 
 		affectedProject := affectedProjectsByID[projectID]
 		affectedDomain := affectedDomainsByID[affectedProject.DomainID]
-		err = generateConfirmationMails(confirmationTemplate, dbi, loc, apiIdentity, affectedProject, affectedDomain, confirmedCommitments, now)
+		err = generateConfirmationMails(confirmationTemplate, dbi, path, apiIdentity, affectedProject, affectedDomain, confirmedCommitments, now)
 		if err != nil {
 			return nil, err
 		}
@@ -235,7 +232,7 @@ func ConfirmPendingCommitments(ctx context.Context, loc core.AZResourceLocation,
 	return auditEvents, nil
 }
 
-func generateConfirmationMails(mailTemplate Option[core.MailTemplate], dbi db.Interface, loc core.AZResourceLocation, apiIdentity core.ResourceRef, project db.Project, domain db.Domain, confirmedCommitments []*db.ProjectCommitment, now time.Time) error {
+func generateConfirmationMails(mailTemplate Option[core.MailTemplate], dbi db.Interface, path db.AZResourcePath, apiIdentity core.ResourceRef, project db.Project, domain db.Domain, confirmedCommitments []*db.ProjectCommitment, now time.Time) error {
 	// The system can be configured to not send mails (e.g. for test systems).
 	tpl, tplExists := mailTemplate.Unpack()
 	if !tplExists {
@@ -260,10 +257,10 @@ func generateConfirmationMails(mailTemplate Option[core.MailTemplate], dbi db.In
 			Commitment: *c,
 			DateString: confirmedAt.Format(time.DateOnly),
 			// TODO: we actually don't want to have api-named props in AZResourceLocation. Replace the template and the code simultaneously.
-			Resource: core.AZResourceLocation{
-				ServiceType:      db.ServiceType(apiIdentity.ServiceType),
-				ResourceName:     liquid.ResourceName(apiIdentity.Name),
-				AvailabilityZone: loc.AvailabilityZone,
+			Resource: core.AZResourceLocationV1{
+				ServiceType:      apiIdentity.ServiceType,
+				ResourceName:     apiIdentity.Name,
+				AvailabilityZone: path.AvailabilityZone,
 			},
 		})
 	}

--- a/internal/datamodel/consume_transferable_commitments.go
+++ b/internal/datamodel/consume_transferable_commitments.go
@@ -86,7 +86,7 @@ type TransferableCommitmentCache struct {
 func NewTransferableCommitmentCache(dbi db.Interface, cluster *core.Cluster, service db.Service, resources core.ResourcesByName, path db.AZResourcePath, now time.Time, generateProjectCommitmentUUID func() liquid.CommitmentUUID, generateTransferToken func() string, mailTemplate Option[core.MailTemplate]) (t TransferableCommitmentCache, err error) {
 	_, err = dbi.Select(&t.transferableCommitments, getTransferableCommitmentsQuery, path)
 	if err != nil {
-		return t, fmt.Errorf("while enumerating transferable commitments for %s: %w", path.String(), err)
+		return t, fmt.Errorf("while enumerating transferable commitments for %s: %w", path, err)
 	}
 	t.transferableCommitmentsByID = make(map[db.ProjectCommitmentID]*db.ProjectCommitment, len(t.transferableCommitments))
 	affectedProjectIDs := make(map[db.ProjectID]struct{})
@@ -99,7 +99,7 @@ func NewTransferableCommitmentCache(dbi db.Interface, cluster *core.Cluster, ser
 	// project and domain structures
 	t.affectedProjectsByID, err = db.BuildIndexOfDBResult(dbi, func(p db.Project) db.ProjectID { return p.ID }, `SELECT * from projects WHERE id = ANY($1)`, pq.Array(slices.Collect(maps.Keys(affectedProjectIDs))))
 	if err != nil {
-		return t, fmt.Errorf("while loading projects with transferable commitments for %s: %w", path.String(), err)
+		return t, fmt.Errorf("while loading projects with transferable commitments for %s: %w", path, err)
 	}
 	t.affectedProjectsByUUID = make(map[liquid.ProjectUUID]db.Project)
 	for _, project := range t.affectedProjectsByID {
@@ -107,7 +107,7 @@ func NewTransferableCommitmentCache(dbi db.Interface, cluster *core.Cluster, ser
 	}
 	t.affectedDomainsByID, err = db.BuildIndexOfDBResult(dbi, func(d db.Domain) db.DomainID { return d.ID }, `SELECT * from domains WHERE id IN (SELECT domain_id FROM projects WHERE id = ANY($1))`, pq.Array(slices.Collect(maps.Keys(affectedProjectIDs))))
 	if err != nil {
-		return t, fmt.Errorf("while loading domains with projects with transferable commitments for %s: %w", path.String(), err)
+		return t, fmt.Errorf("while loading domains with projects with transferable commitments for %s: %w", path, err)
 	}
 
 	// prep audit event storage
@@ -133,7 +133,7 @@ func NewTransferableCommitmentCache(dbi db.Interface, cluster *core.Cluster, ser
 	t.liquidHandlesCommitments = resource.HandlesCommitments
 	statsByAZ, err := collectAZAllocationStats(path.ServiceType, path.ResourceName, Some(path.AvailabilityZone), cluster, dbi)
 	if err != nil {
-		return t, fmt.Errorf("while collecting AZ stats for %s: %w", path.String(), err)
+		return t, fmt.Errorf("while collecting AZ stats for %s: %w", path, err)
 	}
 	t.stats = statsByAZ[path.AvailabilityZone]
 
@@ -302,7 +302,7 @@ func (t *TransferableCommitmentCache) CanConfirmWithTransfers(ctx context.Contex
 
 	// check that the ccr is accepted
 	logg.Debug("checking CanConfirmWithTransfers in %s: commitmentID = %d, projectID = %d, overall amount = %d, missing amount = %d",
-		t.path.String(), c.ID, c.ProjectID, c.Amount, c.Amount-overallTransferredAmount)
+		t.path, c.ID, c.ProjectID, c.Amount, c.Amount-overallTransferredAmount)
 	result, err = t.delegateChangeCommitmentsWithShortcut(ctx, ccr)
 	if err != nil {
 		return result, err
@@ -538,7 +538,7 @@ func (t *TransferableCommitmentCache) delegateChangeCommitmentsWithShortcut(ctx 
 		result = commitmentChangeResponse
 	}
 	if result.RejectionReason != "" {
-		logg.Info("commitment not accepted for %s: %s", t.path.String(), result.RejectionReason)
+		logg.Info("commitment not accepted for %s: %s", t.path, result.RejectionReason)
 	}
 	return result, nil
 }

--- a/internal/datamodel/consume_transferable_commitments.go
+++ b/internal/datamodel/consume_transferable_commitments.go
@@ -35,11 +35,9 @@ import (
 // very small due to the atomicity of the API operation.
 var getTransferableCommitmentsQuery = sqlext.SimplifyWhitespace(db.ExpandEnumPlaceholders(`
 		SELECT pc.*
-		FROM services s
-		JOIN resources r ON r.service_id = s.id
-		JOIN az_resources azr ON azr.resource_id = r.id
+		FROM az_resources azr
 		JOIN project_commitments pc ON pc.az_resource_id = azr.id
-		WHERE s.type = $1 AND r.name = $2 AND azr.az = $3
+		WHERE azr.path = $1
 			AND pc.transfer_status = {{limesresources.CommitmentTransferStatusPublic}}
 			AND pc.status NOT IN ({{liquid.CommitmentStatusSuperseded}}, {{liquid.CommitmentStatusExpired}}, {{util.CommitmentStatusDeleted}})
 		ORDER BY pc.transfer_started_at ASC, pc.created_at ASC, pc.id ASC
@@ -73,7 +71,7 @@ type TransferableCommitmentCache struct {
 	cluster                       *core.Cluster
 	service                       db.Service
 	resources                     core.ResourcesByName
-	loc                           core.AZResourceLocation
+	path                          db.AZResourcePath
 	now                           time.Time
 	generateProjectCommitmentUUID func() liquid.CommitmentUUID
 	generateTransferToken         func() string
@@ -85,11 +83,10 @@ type TransferableCommitmentCache struct {
 }
 
 // NewTransferableCommitmentCache builds a TransferableCommitmentCache and fills it.
-func NewTransferableCommitmentCache(dbi db.Interface, cluster *core.Cluster, service db.Service, resources core.ResourcesByName, loc core.AZResourceLocation, now time.Time, generateProjectCommitmentUUID func() liquid.CommitmentUUID, generateTransferToken func() string, mailTemplate Option[core.MailTemplate]) (t TransferableCommitmentCache, err error) {
-	queryArgs := []any{loc.ServiceType, loc.ResourceName, loc.AvailabilityZone}
-	_, err = dbi.Select(&t.transferableCommitments, getTransferableCommitmentsQuery, queryArgs...)
+func NewTransferableCommitmentCache(dbi db.Interface, cluster *core.Cluster, service db.Service, resources core.ResourcesByName, path db.AZResourcePath, now time.Time, generateProjectCommitmentUUID func() liquid.CommitmentUUID, generateTransferToken func() string, mailTemplate Option[core.MailTemplate]) (t TransferableCommitmentCache, err error) {
+	_, err = dbi.Select(&t.transferableCommitments, getTransferableCommitmentsQuery, path)
 	if err != nil {
-		return t, fmt.Errorf("while enumerating transferable commitments for %s: %w", loc.ScopeString(), err)
+		return t, fmt.Errorf("while enumerating transferable commitments for %s: %w", path.String(), err)
 	}
 	t.transferableCommitmentsByID = make(map[db.ProjectCommitmentID]*db.ProjectCommitment, len(t.transferableCommitments))
 	affectedProjectIDs := make(map[db.ProjectID]struct{})
@@ -102,7 +99,7 @@ func NewTransferableCommitmentCache(dbi db.Interface, cluster *core.Cluster, ser
 	// project and domain structures
 	t.affectedProjectsByID, err = db.BuildIndexOfDBResult(dbi, func(p db.Project) db.ProjectID { return p.ID }, `SELECT * from projects WHERE id = ANY($1)`, pq.Array(slices.Collect(maps.Keys(affectedProjectIDs))))
 	if err != nil {
-		return t, fmt.Errorf("while loading projects with transferable commitments for %s: %w", loc.ScopeString(), err)
+		return t, fmt.Errorf("while loading projects with transferable commitments for %s: %w", path.String(), err)
 	}
 	t.affectedProjectsByUUID = make(map[liquid.ProjectUUID]db.Project)
 	for _, project := range t.affectedProjectsByID {
@@ -110,7 +107,7 @@ func NewTransferableCommitmentCache(dbi db.Interface, cluster *core.Cluster, ser
 	}
 	t.affectedDomainsByID, err = db.BuildIndexOfDBResult(dbi, func(d db.Domain) db.DomainID { return d.ID }, `SELECT * from domains WHERE id IN (SELECT domain_id FROM projects WHERE id = ANY($1))`, pq.Array(slices.Collect(maps.Keys(affectedProjectIDs))))
 	if err != nil {
-		return t, fmt.Errorf("while loading domains with projects with transferable commitments for %s: %w", loc.ScopeString(), err)
+		return t, fmt.Errorf("while loading domains with projects with transferable commitments for %s: %w", path.String(), err)
 	}
 
 	// prep audit event storage
@@ -121,24 +118,24 @@ func NewTransferableCommitmentCache(dbi db.Interface, cluster *core.Cluster, ser
 	t.cluster = cluster
 	t.service = service
 	t.resources = resources
-	t.loc = loc
+	t.path = path
 	t.now = now
 	t.generateProjectCommitmentUUID = generateProjectCommitmentUUID
 	t.generateTransferToken = generateTransferToken
 	t.mailTemplate = mailTemplate
 
-	resource, ok := resources[loc.ResourceName]
+	resource, ok := resources[path.ResourceName]
 	if !ok {
-		return t, fmt.Errorf("resource %s not found in provided resources", loc.ResourceName)
+		return t, fmt.Errorf("resource %s not found in provided resources", path.ResourceName)
 	}
 
 	// determine whether liquid handles commitments for this resource
 	t.liquidHandlesCommitments = resource.HandlesCommitments
-	statsByAZ, err := collectAZAllocationStats(loc.ServiceType, loc.ResourceName, Some(loc.AvailabilityZone), cluster, dbi)
+	statsByAZ, err := collectAZAllocationStats(path.ServiceType, path.ResourceName, Some(path.AvailabilityZone), cluster, dbi)
 	if err != nil {
-		return t, fmt.Errorf("while collecting AZ stats for %s: %w", loc.ScopeString(), err)
+		return t, fmt.Errorf("while collecting AZ stats for %s: %w", path.String(), err)
 	}
-	t.stats = statsByAZ[loc.AvailabilityZone]
+	t.stats = statsByAZ[path.AvailabilityZone]
 
 	return t, nil
 }
@@ -174,13 +171,13 @@ func (t *TransferableCommitmentCache) CanConfirmWithTransfers(ctx context.Contex
 	}
 	ccr := liquid.CommitmentChangeRequest{
 		DryRun:      dryRun,
-		AZ:          t.loc.AvailabilityZone,
+		AZ:          t.path.AvailabilityZone,
 		InfoVersion: t.service.LiquidVersion,
 		ByProject: map[liquid.ProjectUUID]liquid.ProjectCommitmentChangeset{
 			project.UUID: {
 				ProjectMetadata: LiquidProjectMetadataFromDBProject(project, domain),
 				ByResource: map[liquid.ResourceName]liquid.ResourceCommitmentChangeset{
-					t.loc.ResourceName: {
+					t.path.ResourceName: {
 						TotalConfirmedBefore: t.stats.ProjectStats[c.ProjectID].Committed,
 						TotalConfirmedAfter:  t.stats.ProjectStats[c.ProjectID].Committed + c.Amount,
 						// TODO: change when introducing "guaranteed" commitments
@@ -244,7 +241,7 @@ func (t *TransferableCommitmentCache) CanConfirmWithTransfers(ctx context.Contex
 			ccr.ByProject[tcProject.UUID] = liquid.ProjectCommitmentChangeset{
 				ProjectMetadata: LiquidProjectMetadataFromDBProject(tcProject, tcDomain),
 				ByResource: map[liquid.ResourceName]liquid.ResourceCommitmentChangeset{
-					t.loc.ResourceName: {
+					t.path.ResourceName: {
 						TotalConfirmedBefore: t.stats.ProjectStats[tc.ProjectID].Committed,
 						TotalConfirmedAfter:  t.stats.ProjectStats[tc.ProjectID].Committed, // will be adjusted below based on how much is consumed
 						// TODO: change when introducing "guaranteed" commitments
@@ -254,7 +251,7 @@ func (t *TransferableCommitmentCache) CanConfirmWithTransfers(ctx context.Contex
 				},
 			}
 		}
-		rcc := ccr.ByProject[tcProject.UUID].ByResource[t.loc.ResourceName]
+		rcc := ccr.ByProject[tcProject.UUID].ByResource[t.path.ResourceName]
 
 		// modify CCR/ CAC structures
 		amountToConsume := c.Amount - overallTransferredAmount
@@ -296,7 +293,7 @@ func (t *TransferableCommitmentCache) CanConfirmWithTransfers(ctx context.Contex
 		if tc.Status == liquid.CommitmentStatusConfirmed {
 			rcc.TotalConfirmedAfter -= lastConsumedAmount
 		}
-		ccr.ByProject[tcProject.UUID].ByResource[t.loc.ResourceName] = rcc
+		ccr.ByProject[tcProject.UUID].ByResource[t.path.ResourceName] = rcc
 		cacs[tc.UUID] = audit.CommitmentAttributeChangeset{
 			OldTransferStatus: tc.TransferStatus,
 			NewTransferStatus: limesresources.CommitmentTransferStatusNone,
@@ -305,7 +302,7 @@ func (t *TransferableCommitmentCache) CanConfirmWithTransfers(ctx context.Contex
 
 	// check that the ccr is accepted
 	logg.Debug("checking CanConfirmWithTransfers in %s: commitmentID = %d, projectID = %d, overall amount = %d, missing amount = %d",
-		t.loc.ShortScopeString(), c.ID, c.ProjectID, c.Amount, c.Amount-overallTransferredAmount)
+		t.path.String(), c.ID, c.ProjectID, c.Amount, c.Amount-overallTransferredAmount)
 	result, err = t.delegateChangeCommitmentsWithShortcut(ctx, ccr)
 	if err != nil {
 		return result, err
@@ -450,10 +447,10 @@ func (t *TransferableCommitmentCache) GenerateTransferMails(apiIdentity core.Res
 			n.Commitments = append(n.Commitments, core.CommitmentNotification{
 				Commitment: *c,
 				DateString: supersededAt.Format(time.DateOnly),
-				Resource: core.AZResourceLocation{
-					ServiceType:      db.ServiceType(apiIdentity.ServiceType),
-					ResourceName:     liquid.ResourceName(apiIdentity.Name),
-					AvailabilityZone: t.loc.AvailabilityZone,
+				Resource: core.AZResourceLocationV1{
+					ServiceType:      apiIdentity.ServiceType,
+					ResourceName:     apiIdentity.Name,
+					AvailabilityZone: t.path.AvailabilityZone,
 				},
 				LeftoverAmount: leftover.Amount,
 			})
@@ -513,11 +510,11 @@ func (t *TransferableCommitmentCache) delegateChangeCommitmentsWithShortcut(ctx 
 	case !ccr.RequiresConfirmation():
 		result = liquid.CommitmentChangeResponse{}
 	case !t.liquidHandlesCommitments:
-		behavior := t.cluster.CommitmentBehaviorForResource(t.loc.ServiceType, t.loc.ResourceName)
+		behavior := t.cluster.CommitmentBehaviorForResourcePath(t.path.Resource())
 		additions := make(map[db.ProjectID]uint64)
 		subtractions := make(map[db.ProjectID]uint64)
 		for projectUUID, pcc := range ccr.ByProject {
-			rcc := pcc.ByResource[t.loc.ResourceName]
+			rcc := pcc.ByResource[t.path.ResourceName]
 			affectedProject := t.affectedProjectsByUUID[projectUUID]
 			if rcc.TotalConfirmedAfter > rcc.TotalConfirmedBefore {
 				additions[affectedProject.ID] = rcc.TotalConfirmedAfter - rcc.TotalConfirmedBefore
@@ -534,14 +531,14 @@ func (t *TransferableCommitmentCache) delegateChangeCommitmentsWithShortcut(ctx 
 			}
 		}
 	default:
-		commitmentChangeResponse, err := DelegateChangeCommitments(ctx, t.cluster, ccr, t.loc, t.service, t.resources, t.dbi)
+		commitmentChangeResponse, err := DelegateChangeCommitments(ctx, t.cluster, ccr, t.service, t.resources, t.dbi)
 		if err != nil {
 			return result, err
 		}
 		result = commitmentChangeResponse
 	}
 	if result.RejectionReason != "" {
-		logg.Info("commitment not accepted for %s: %s", t.loc.ShortScopeString(), result.RejectionReason)
+		logg.Info("commitment not accepted for %s: %s", t.path.String(), result.RejectionReason)
 	}
 	return result, nil
 }
@@ -549,7 +546,7 @@ func (t *TransferableCommitmentCache) delegateChangeCommitmentsWithShortcut(ctx 
 // updateStats modifies the local stats according to the given CCR.
 func (t *TransferableCommitmentCache) updateStats(ccr liquid.CommitmentChangeRequest) {
 	for projectUUID, pcc := range ccr.ByProject {
-		rcc := pcc.ByResource[t.loc.ResourceName]
+		rcc := pcc.ByResource[t.path.ResourceName]
 		affectedProject := t.affectedProjectsByUUID[projectUUID]
 		projectStats := t.stats.ProjectStats[affectedProject.ID]
 		if rcc.TotalConfirmedAfter != rcc.TotalConfirmedBefore {

--- a/internal/db/refs.go
+++ b/internal/db/refs.go
@@ -36,6 +36,11 @@ type ResourcePath struct {
 	ResourceName liquid.ResourceName
 }
 
+// InAZ builds an [AZResourcePath] below this ResourcePath.
+func (r ResourcePath) InAZ(az liquid.AvailabilityZone) AZResourcePath {
+	return AZResourcePath{r.ServiceType, r.ResourceName, az}
+}
+
 // String implements the [fmt.Stringer] interface.
 func (r ResourcePath) String() string {
 	return string(r.ServiceType) + "/" + string(r.ResourceName)
@@ -72,6 +77,11 @@ type AZResourcePath struct {
 	ServiceType      ServiceType
 	ResourceName     liquid.ResourceName
 	AvailabilityZone liquid.AvailabilityZone
+}
+
+// Resource extracts the [ResourcePath] portion of this AZResourcePath.
+func (r AZResourcePath) Resource() ResourcePath {
+	return ResourcePath{r.ServiceType, r.ResourceName}
 }
 
 // String implements the [fmt.Stringer] interface.


### PR DESCRIPTION
From the "Xyrill wanted to implement new stuff and ended up doing a refactor instead" department.

Both types do nearly the same thing. Historically, `core.AZResourceLocation` has existed for longer and was pervasive throughout commitment handling code. But `db.AZResourcePath` is a better fit because it implements SQL marshaling and thus is more convenient to use in queries. While replacing `core.AZResourceLocation` with `db.AZResourcePath`, I also rewrote several queries to use `az_resources.path` where I saw that it simplifies the join structure.

The one usecase where `core.AZResourceLocation` remains (with a changed name) is for email notifications, where having a separate type is warranted because those currently use the v1 API names.