### PR TITLE
implement POST /resources/v2/commitments/new

### DIFF
--- a/docs/example-policy.json
+++ b/docs/example-policy.json
@@ -30,6 +30,7 @@
     "v2:meta:no_error_obfuscation": "rule:cluster_admin",
 
     "v2:project:info": "rule:project_viewer",
+    "v2:project:commitment_create": "rule:project_editor",
 
     "v2:domain:info": "rule:domain_viewer",
 

--- a/internal/api/api_v2/commitment_create.go
+++ b/internal/api/api_v2/commitment_create.go
@@ -160,6 +160,7 @@ func (p *v2Provider) handlePostNewCommitment(r *http.Request, token *gopherpolic
 			}
 		} else {
 			ccr := liquid.CommitmentChangeRequest{
+				DryRun:      req.DryRun,
 				AZ:          path.AvailabilityZone,
 				InfoVersion: must.BeOK(sis.GetServiceForType(path.ServiceType)).LiquidVersion,
 				ByProject: map[liquid.ProjectUUID]liquid.ProjectCommitmentChangeset{

--- a/internal/api/api_v2/commitment_create.go
+++ b/internal/api/api_v2/commitment_create.go
@@ -1,0 +1,257 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package api_v2
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/go-gorp/gorp/v3"
+	"github.com/sapcc/go-api-declarations/cadf"
+	"github.com/sapcc/go-api-declarations/liquid"
+	"github.com/sapcc/go-bits/audittools"
+	"github.com/sapcc/go-bits/gopherpolicy"
+	"github.com/sapcc/go-bits/httpapi"
+	"github.com/sapcc/go-bits/logg"
+	"github.com/sapcc/go-bits/must"
+	"github.com/sapcc/go-bits/respondwith"
+	"github.com/sapcc/go-bits/sqlext"
+	. "go.xyrillian.de/gg/option"
+	"go.xyrillian.de/gg/options"
+
+	resourcesv2 "github.com/sapcc/limes/internal/apideclarations/apiv2/resources"
+	"github.com/sapcc/limes/internal/audit"
+	"github.com/sapcc/limes/internal/core"
+	"github.com/sapcc/limes/internal/datamodel"
+	"github.com/sapcc/limes/internal/db"
+	"github.com/sapcc/limes/internal/util"
+)
+
+func (p *v2Provider) handlePostNewCommitment(r *http.Request, token *gopherpolicy.Token) (resourcesv2.Commitment, error) {
+	httpapi.IdentifyEndpoint(r, "/resources/v2/commitments/new")
+	var (
+		none resourcesv2.Commitment // used on error return paths only
+		ctx  = r.Context()
+		sis  = p.Cluster.SIC.GetSnapshot()
+	)
+
+	// parse request
+	req, err := parseRequestBodyAs[resourcesv2.CommitmentRequest](r)
+	if err != nil {
+		return none, err
+	}
+	path := db.AZResourcePath{
+		ServiceType:      req.ServiceType,
+		ResourceName:     req.ResourceName,
+		AvailabilityZone: req.AvailabilityZone,
+	}
+	attrs := commitmentStatusAttributes{
+		Status:          req.Status,
+		ConfirmBy:       options.Map(req.ConfirmBy, util.FromUnixEncodedTime),
+		NotifyOnConfirm: req.NotifyOnConfirm,
+	}
+	now := p.timeNow()
+
+	// validate request contents
+	dbDomain, dbProject, err := p.checkProjectAccess(token, req.ProjectUUID, "v2:project:commitment_create")
+	if err != nil {
+		return none, err
+	}
+	azResource, behavior, err := p.validateCommittability(path, dbDomain, dbProject, req.Duration, sis)
+	if err != nil {
+		return none, err
+	}
+	if req.Amount == 0 {
+		return none, respondwith.CustomStatus(http.StatusUnprocessableEntity, errEmptyAmount)
+	}
+	err = p.validateStatusAttributesOnNewCommitment(attrs, behavior, now)
+	if err != nil {
+		return none, err
+	}
+
+	// prepare commitment and commitment request
+	creationContextJSON, err := json.Marshal(db.CommitmentWorkflowContext{Reason: db.CommitmentReasonCreate})
+	if err != nil {
+		return none, err
+	}
+	c := db.ProjectCommitment{
+		UUID:                datamodel.GenerateProjectCommitmentUUID(),
+		AZResourceID:        azResource.ID,
+		ProjectID:           dbProject.ID,
+		Amount:              req.Amount,
+		Duration:            req.Duration,
+		CreatedAt:           now,
+		UpdatedAt:           now,
+		CreatorUUID:         token.UserUUID(),
+		CreatorName:         fmt.Sprintf("%s@%s", token.UserName(), token.UserDomainName()),
+		ConfirmBy:           None[time.Time](), // may be set below
+		ConfirmedAt:         None[time.Time](), // may be set below
+		ExpiresAt:           req.Duration.AddTo(attrs.ConfirmBy.UnwrapOr(now)),
+		CreationContextJSON: json.RawMessage(creationContextJSON),
+		Status:              req.Status,
+		NotifyOnConfirm:     req.NotifyOnConfirm,
+	}
+	switch c.Status {
+	case liquid.CommitmentStatusConfirmed:
+		// special case: need to insert this with a different status initially;
+		// otherwise TransferableCommitmentCache will count it as an existing
+		// confirmed commitment when gathering stats (will change this later)
+		c.Status = liquid.CommitmentStatusPending
+	case liquid.CommitmentStatusPending:
+		c.ConfirmBy = Some(now)
+	default:
+		c.ConfirmBy = attrs.ConfirmBy
+	}
+
+	// using a transaction because we need to insert the commitment first to get
+	// its ID (for use in the SupersedeContext of consumed commitments),
+	// but we need to be able to revert this insertion if the CommitmentChangeRequest is rejected
+	var auditEvents []audittools.Event
+	err = withinTransactionThatMayBeADryRun(p.DB, req.DryRun, func(tx db.Interface) error {
+		stats, err := getCommitmentStats(tx, dbProject.ID, azResource.ID)
+		if err != nil {
+			return err
+		}
+
+		err = tx.Insert(&c)
+		if err != nil {
+			return err
+		}
+
+		var (
+			auditContext = audit.Context{UserIdentity: token, Request: r}
+		)
+
+		// creation of confirmed commitments requires a special codepath because we might be consuming other commitments
+		if req.Status == liquid.CommitmentStatusConfirmed {
+			mailTemplate := None[core.MailTemplate]()
+			if mailConfig, exists := p.Cluster.Config.MailNotifications.Unpack(); exists && !req.DryRun {
+				mailTemplate = Some(mailConfig.Templates.TransferredCommitments)
+			}
+			tcc, err := datamodel.NewTransferableCommitmentCache(tx, p.Cluster, sis, path, now, datamodel.GenerateProjectCommitmentUUID, datamodel.GenerateTransferToken, mailTemplate)
+			if err != nil {
+				return err
+			}
+			resp, err := tcc.CanConfirmWithTransfers(ctx, c, dbProject, dbDomain, true, req.DryRun, auditContext, cadf.CreateAction)
+			if err != nil {
+				return err
+			}
+			err = analyzeCommitmentChangeResponse(resp)
+			if err != nil {
+				return err
+			}
+			if !req.DryRun {
+				auditEvents = append(auditEvents, tcc.RetrieveAuditEvents()...)
+			}
+			err = tcc.GenerateTransferMails(p.Cluster.BehaviorForResourcePath(path.Resource()).IdentityInV1API)
+			if err != nil {
+				return err
+			}
+
+			// update status (as mentioned before, we had to insert this as "pending" initially to avoid confusing the TCC)
+			c.Status = liquid.CommitmentStatusConfirmed
+			c.ConfirmedAt = Some(now)
+			_, err = tx.Update(&c)
+			if err != nil {
+				return err
+			}
+		} else {
+			ccr := liquid.CommitmentChangeRequest{
+				AZ:          path.AvailabilityZone,
+				InfoVersion: must.BeOK(sis.GetServiceForType(path.ServiceType)).LiquidVersion,
+				ByProject: map[liquid.ProjectUUID]liquid.ProjectCommitmentChangeset{
+					dbProject.UUID: {
+						ProjectMetadata: datamodel.LiquidProjectMetadataFromDBProject(dbProject, dbDomain),
+						ByResource: map[liquid.ResourceName]liquid.ResourceCommitmentChangeset{
+							path.ResourceName: {
+								TotalConfirmedBefore:  stats.TotalConfirmed,
+								TotalConfirmedAfter:   stats.TotalConfirmed,
+								TotalGuaranteedBefore: stats.TotalGuaranteed,
+								TotalGuaranteedAfter:  stats.TotalGuaranteed, // TODO: change when introducing "guaranteed" commitments
+								Commitments: []liquid.Commitment{
+									{
+										UUID:      c.UUID,
+										OldStatus: None[liquid.CommitmentStatus](),
+										NewStatus: Some(c.Status),
+										Amount:    c.Amount,
+										ConfirmBy: c.ConfirmBy,
+										ExpiresAt: c.ExpiresAt,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			resp, err := datamodel.DelegateChangeCommitments(ctx, p.Cluster, ccr, sis, path.ServiceType, tx)
+			if err != nil {
+				return err
+			}
+			if ccr.RequiresConfirmation() {
+				err = analyzeCommitmentChangeResponse(resp)
+				if err != nil {
+					return err
+				}
+			}
+
+			if !req.DryRun {
+				auditEvents = append(auditEvents, audit.CommitmentEventTarget{
+					CommitmentChangeRequest: ccr,
+				}.ReplicateForAllProjectsWithDefaults(audittools.Event{
+					Time:       now,
+					Request:    r,
+					User:       token,
+					ReasonCode: http.StatusCreated,
+					Action:     cadf.CreateAction,
+				})...)
+			}
+		}
+
+		return nil
+	}) // `tx` is committed here
+	if err != nil {
+		return none, err
+	}
+	if !req.DryRun {
+		for _, event := range auditEvents {
+			p.auditor.Record(event)
+		}
+	}
+
+	// trigger a capacity scrape in order to ApplyComputedProjectQuota based on the new commitment
+	if c.Status == liquid.CommitmentStatusConfirmed && !req.DryRun {
+		_, err := p.DB.Exec(`UPDATE services SET next_scrape_at = $1 WHERE type = $2`, now, path.ServiceType)
+		if err != nil {
+			logg.Error("could not trigger a new capacity scrape after creating commitment %s: %s", c.UUID, err.Error())
+		}
+	}
+
+	canBeDeleted := datamodel.CanDeleteCommitment(token, c, p.timeNow)
+	result := convertCommitmentToDisplayForm(c, path, dbProject, canBeDeleted)
+	if req.DryRun {
+		result.UUID = "00000000-0000-0000-0000-000000000000"
+	}
+	return result, nil
+}
+
+// withinTransactionThatMayBeADryRun starts a transaction such that the type system helps enforce that a dry run is not accidentally committed:
+// Within `action`, `tx` is only a generic interface handle that does not allow calling `tx.Commit()` directly.
+func withinTransactionThatMayBeADryRun(dbm *gorp.DbMap, dryRun bool, action func(tx db.Interface) error) error {
+	tx, err := dbm.Begin()
+	if err != nil {
+		return err
+	}
+	defer sqlext.RollbackUnlessCommitted(tx)
+	err = action(tx)
+	if err != nil {
+		return err
+	}
+	if dryRun {
+		return tx.Rollback()
+	} else {
+		return tx.Commit()
+	}
+}

--- a/internal/api/api_v2/commitment_create.go
+++ b/internal/api/api_v2/commitment_create.go
@@ -110,7 +110,7 @@ func (p *v2Provider) handlePostNewCommitment(r *http.Request, token *gopherpolic
 	// its ID (for use in the SupersedeContext of consumed commitments),
 	// but we need to be able to revert this insertion if the CommitmentChangeRequest is rejected
 	var auditEvents []audittools.Event
-	err = withinTransactionThatMayBeADryRun(p.DB, req.DryRun, func(tx db.Interface) error {
+	err = withinDryRunnableTx(p.DB, req.DryRun, func(tx db.Interface) error {
 		stats, err := getCommitmentStats(tx, dbProject.ID, azResource.ID)
 		if err != nil {
 			return err
@@ -238,9 +238,9 @@ func (p *v2Provider) handlePostNewCommitment(r *http.Request, token *gopherpolic
 	return result, nil
 }
 
-// withinTransactionThatMayBeADryRun starts a transaction such that the type system helps enforce that a dry run is not accidentally committed:
+// withinDryRunnableTx starts a transaction such that the type system helps enforce that a dry run is not accidentally committed:
 // Within `action`, `tx` is only a generic interface handle that does not allow calling `tx.Commit()` directly.
-func withinTransactionThatMayBeADryRun(dbm *gorp.DbMap, dryRun bool, action func(tx db.Interface) error) error {
+func withinDryRunnableTx(dbm *gorp.DbMap, dryRun bool, action func(tx db.Interface) error) error {
 	tx, err := dbm.Begin()
 	if err != nil {
 		return err

--- a/internal/api/api_v2/commitment_create_test.go
+++ b/internal/api/api_v2/commitment_create_test.go
@@ -79,12 +79,12 @@ const commitmentCreateConfigJSON = `{
 }`
 
 // Helper function for a successful commitment creation. This always tests the dry-run first, and then does the actual creation.
-func createCommitmentAndExpectSuccess(t *testing.T, s test.Setup, tr *easypg.Tracker, ccrAcceptedByLiquid bool, request map[string]any, expected jsonmatch.Object, getTarget func() cadf.Resource) {
+func createCommitmentAndExpectSuccess(t *testing.T, s test.Setup, tr *easypg.Tracker, liquidHandlesCommitments bool, request map[string]any, expected jsonmatch.Object, getTarget func() cadf.Resource) {
 	t.Helper()
 	ctx := t.Context()
 	mockLiquid := s.LiquidClients[db.ServiceType(request["service_type"].(string))]
 
-	if ccrAcceptedByLiquid {
+	if liquidHandlesCommitments {
 		// explicitly clear LastCommitmentChangeRequest, so we can detect if the dry-run incorrectly writes into it
 		mockLiquid.LastCommitmentChangeRequest = liquid.CommitmentChangeRequest{}
 	}
@@ -99,7 +99,7 @@ func createCommitmentAndExpectSuccess(t *testing.T, s test.Setup, tr *easypg.Tra
 
 	s.Auditor.ExpectEvents(t, nil...)
 	tr.DBChanges().AssertEmpty()
-	if ccrAcceptedByLiquid {
+	if liquidHandlesCommitments {
 		// if there was a CCR, then it must have been a dry-run
 		if !reflect.DeepEqual(mockLiquid.LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{}) {
 			assert.Equal(t, mockLiquid.LastCommitmentChangeRequest.DryRun, true)
@@ -119,7 +119,7 @@ func createCommitmentAndExpectSuccess(t *testing.T, s test.Setup, tr *easypg.Tra
 		Target:      target,
 	})
 
-	if ccrAcceptedByLiquid {
+	if liquidHandlesCommitments {
 		// check that the mock liquid saw the correct CommitmentChangeRequest
 		// (the same as inside the audit event payload)
 		actualCCR := must.Return(json.Marshal(mockLiquid.LastCommitmentChangeRequest))
@@ -576,7 +576,7 @@ func TestCommitmentCreateValidationErrors(t *testing.T) {
 	}
 
 	// invalid presence/absence of confirm_by for chosen state
-	for _, status := range []string{"planned"} {
+	for _, status := range []string{"planned"} { // TODO: add "guaranteed" here
 		createCommitmentAndExpectError(t, s, tr, map[string]any{
 			"amount":            1,
 			"duration":          "1 hour",

--- a/internal/api/api_v2/commitment_create_test.go
+++ b/internal/api/api_v2/commitment_create_test.go
@@ -1,0 +1,745 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package api_v2_test
+
+import (
+	"encoding/json"
+	"maps"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/sapcc/go-api-declarations/cadf"
+	"github.com/sapcc/go-api-declarations/liquid"
+	"github.com/sapcc/go-bits/easypg"
+	"github.com/sapcc/go-bits/httptest"
+	"github.com/sapcc/go-bits/must"
+	"go.xyrillian.de/gg/jsonmatch"
+	. "go.xyrillian.de/gg/option"
+
+	"github.com/sapcc/limes/internal/db"
+	"github.com/sapcc/limes/internal/test"
+)
+
+const commitmentCreateConfigJSON = `{
+	"availability_zones": ["az-one", "az-two"],
+	"discovery": {
+		"method": "static",
+		"static_config": {
+			"domains": [
+				{"name": "germany", "id": "uuid-for-germany"},
+				{"name": "france", "id": "uuid-for-france"}
+			],
+			"projects": {
+				"uuid-for-germany": [
+					{"name": "berlin", "id": "uuid-for-berlin", "parent_id": "uuid-for-germany"},
+					{"name": "dresden", "id": "uuid-for-dresden", "parent_id": "uuid-for-berlin"}
+				],
+				"uuid-for-france": [
+					{"name": "paris", "id": "uuid-for-paris", "parent_id": "uuid-for-france"}
+				]
+			}
+		}
+	},
+	"areas": { "first": { "display_name": "First" }, "second": { "display_name": "Second" }},
+	"liquids": {
+		"first": {
+			"area": "first",
+			"commitment_behavior_per_resource": [
+				{
+					"key": "capacity",
+					"value": {
+						"durations_per_domain": [{"key": ".*", "value": ["1 hour", "2 hours"]}]
+					}
+				},
+				{
+					"key": "things",
+					"value": {
+						"durations_per_domain": [{"key": ".*", "value": ["1 hour", "2 hours"]}],
+						"min_confirm_date": "1970-01-08T00:00:00Z" // one week after start of mock.Clock
+					}
+				}
+			]
+		},
+		"second": {
+			"area": "second"
+		}
+	},
+	"mail_notifications": {
+		// Mail templates are configured solely to prove that API use does not generate mail notifications.
+		"templates": {
+			"confirmed_commitments":   { "subject": "Confirmed!",   "body": "Hello" },
+			"expiring_commitments":    { "subject": "Expiring!",    "body": "Hello" },
+			"transferred_commitments": { "subject": "Transferred!", "body": "Hello" }
+		}
+	}
+}`
+
+// Helper function for a successful commitment creation. This always tests the dry-run first, and then does the actual creation.
+func createCommitmentAndExpectSuccess(t *testing.T, s test.Setup, tr *easypg.Tracker, ccrAcceptedByLiquid bool, request map[string]any, expected jsonmatch.Object, getTarget func() cadf.Resource) {
+	t.Helper()
+	ctx := t.Context()
+
+	// check that the dry-run request succeeds, without causing any side effects in the DB or audit trail
+	dryrunRequest := maps.Clone(request)
+	dryrunRequest["dry_run"] = true
+	dryrunExpected := maps.Clone(expected)
+	dryrunExpected["uuid"] = jsonmatch.Irrelevant()
+	s.Handler.RespondTo(ctx, "POST /resources/v2/commitments/new", httptest.WithJSONBody(dryrunRequest)).
+		ExpectJSON(t, http.StatusCreated, dryrunExpected)
+	s.Auditor.ExpectEvents(t, nil...)
+	tr.DBChanges().AssertEmpty()
+
+	// after creating the commitment, we expect to see an audit event
+	// (the DB effect is not checked here; the caller will take care of that afterwards)
+	s.Handler.RespondTo(ctx, "POST /resources/v2/commitments/new", httptest.WithJSONBody(request)).
+		ExpectJSON(t, http.StatusCreated, expected)
+	target := getTarget() // this is a callback because we need to wait for ExpectJSON() to capture the UUID in expected["uuid"] first
+	s.Auditor.ExpectEvents(t, cadf.Event{
+		Action:      "create",
+		Outcome:     "success",
+		Reason:      cadf.Reason{ReasonType: "HTTP", ReasonCode: "201"},
+		RequestPath: "/resources/v2/commitments/new",
+		Target:      target,
+	})
+
+	if ccrAcceptedByLiquid {
+		// check that the mock liquid saw the correct CommitmentChangeRequest
+		// (the same as inside the audit event payload)
+		mockLiquid := s.LiquidClients[db.ServiceType(request["service_type"].(string))]
+		actualCCR := must.Return(json.Marshal(mockLiquid.LastCommitmentChangeRequest))
+		var expectedCCR jsonmatch.Object
+		must.SucceedT(t, json.Unmarshal([]byte(target.Attachments[0].Content.(string)), &expectedCCR))
+		for _, diff := range expectedCCR.DiffAgainst(actualCCR) {
+			t.Error("in MockLiquid.LastCommitmentChangeRequest: " + diff.String())
+		}
+	}
+}
+
+// Helper function for a failed commitment creation. This tests that the dry-run and the actual run fail in the same way.
+func createCommitmentAndExpectError(t *testing.T, s test.Setup, tr *easypg.Tracker, request map[string]any, expect func(r httptest.Response)) {
+	t.Helper()
+	ctx := t.Context()
+
+	dryrunRequest := maps.Clone(request)
+	dryrunRequest["dry_run"] = true
+
+	s.Handler.RespondTo(ctx, "POST /resources/v2/commitments/new", httptest.WithJSONBody(dryrunRequest)).Expect(expect)
+	s.Handler.RespondTo(ctx, "POST /resources/v2/commitments/new", httptest.WithJSONBody(request)).Expect(expect)
+	tr.DBChanges().AssertEmpty() // since both requests failed
+}
+
+func TestCommitmentCreateBasic(t *testing.T) {
+	// run this test twice, once with commitments managed by Limes, and once managed by the liquid
+	for _, manager := range []string{"limes", "liquid"} {
+		t.Run("managedby="+manager, func(t *testing.T) {
+			srvInfoFirst := test.DefaultLiquidServiceInfo("First")
+			srvInfoSecond := test.DefaultLiquidServiceInfo("Second")
+			if manager == "liquid" {
+				for resName, resInfo := range srvInfoFirst.Resources {
+					resInfo.HandlesCommitments = true
+					srvInfoFirst.Resources[resName] = resInfo
+				}
+				for resName, resInfo := range srvInfoSecond.Resources {
+					resInfo.HandlesCommitments = true
+					srvInfoSecond.Resources[resName] = resInfo
+				}
+			}
+
+			s := test.NewSetup(t,
+				test.WithConfig(commitmentCreateConfigJSON),
+				test.WithMockLiquidClient("first", srvInfoFirst),
+				test.WithPersistedServiceInfo("first", srvInfoFirst),
+				test.WithMockLiquidClient("second", srvInfoSecond),
+				test.WithPersistedServiceInfo("second", srvInfoSecond),
+				test.WithInitialDiscovery,
+				test.WithEmptyResourceRecordsAsNeeded,
+			)
+			s.Clock.StepBy(time.Hour) // to detect later that services.next_scrape_at was moved to NOW() after adding a confirmed commitment
+
+			tr, tr0 := easypg.NewTracker(t, s.DB.Db)
+			tr0.Ignore()
+
+			// it is always possible to create "pending" commitments, regardless of capacity
+			var uuid1 string
+			createCommitmentAndExpectSuccess(t, s, tr, manager == "liquid", map[string]any{
+				"amount":            1,
+				"duration":          "1 hour",
+				"project_id":        "uuid-for-berlin",
+				"service_type":      "first",
+				"resource_name":     "capacity",
+				"availability_zone": "az-one",
+				"status":            "pending",
+			}, jsonmatch.Object{
+				"uuid":              jsonmatch.CaptureField(&uuid1),
+				"amount":            1,
+				"duration":          "1 hour",
+				"project_id":        "uuid-for-berlin",
+				"service_type":      "first",
+				"resource_name":     "capacity",
+				"availability_zone": "az-one",
+				"status":            "pending",
+				"created_at":        s.Clock.Now().Unix(),
+				"creator_uuid":      "uuid-for-alice",
+				"creator_name":      "alice@Default",
+				"can_be_deleted":    true,
+				"confirm_by":        s.Clock.Now().Unix(),
+				"expires_at":        s.Clock.Now().Add(1 * time.Hour).Unix(),
+				"updated_at":        s.Clock.Now().Unix(),
+			}, func() cadf.Resource {
+				return cadf.Resource{
+					TypeURI:     "service/resources/commitment",
+					ID:          uuid1,
+					DomainID:    "uuid-for-germany",
+					DomainName:  "germany",
+					ProjectID:   "uuid-for-berlin",
+					ProjectName: "berlin",
+					Attachments: []cadf.Attachment{must.Return(cadf.NewJSONAttachment("payload", map[string]any{
+						"az":          "az-one",
+						"dryRun":      false,
+						"infoVersion": 1,
+						"byProject": map[string]map[string]any{
+							"uuid-for-berlin": {
+								"byResource": map[string]map[string]any{
+									"capacity": {
+										"totalConfirmedBefore":  0,
+										"totalConfirmedAfter":   0,
+										"totalGuaranteedBefore": 0,
+										"totalGuaranteedAfter":  0,
+										"commitments": []map[string]any{{
+											"amount":    1,
+											"confirmBy": s.Clock.Now().UTC().Format(time.RFC3339),
+											"expiresAt": s.Clock.Now().Add(1 * time.Hour).UTC().Format(time.RFC3339),
+											"newStatus": "pending",
+											"oldStatus": nil,
+											"uuid":      uuid1,
+										}},
+									},
+								},
+							},
+						},
+					}))},
+				}
+			})
+			tr.DBChanges().AssertEqualf(`
+			INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, status, amount, duration, created_at, creator_uuid, creator_name, confirm_by, expires_at, creation_context_json, updated_at) VALUES (2, '%[1]s', 1, 2, 'pending', 1, '1 hour', %[2]d, 'uuid-for-alice', 'alice@Default', %[2]d, %[3]d, '{"reason": "create"}', %[2]d);
+		`,
+				uuid1,
+				s.Clock.Now().Unix(),
+				s.Clock.Now().Add(1*time.Hour).Unix(),
+			)
+
+			// same for "planned" commitments; these are also allowed for resources with a min_confirm_date in the future
+			const oneDay time.Duration = 24 * time.Hour
+			var uuid2 string
+			createCommitmentAndExpectSuccess(t, s, tr, manager == "liquid", map[string]any{
+				"amount":            2,
+				"duration":          "1 hour",
+				"project_id":        "uuid-for-berlin",
+				"service_type":      "first",
+				"resource_name":     "things",
+				"availability_zone": "any",
+				"status":            "planned",
+				"confirm_by":        s.Clock.Now().Add(10 * oneDay).Unix(),
+			}, jsonmatch.Object{
+				"uuid":              jsonmatch.CaptureField(&uuid2),
+				"amount":            2,
+				"duration":          "1 hour",
+				"project_id":        "uuid-for-berlin",
+				"service_type":      "first",
+				"resource_name":     "things",
+				"availability_zone": "any",
+				"status":            "planned",
+				"created_at":        s.Clock.Now().Unix(),
+				"creator_uuid":      "uuid-for-alice",
+				"creator_name":      "alice@Default",
+				"can_be_deleted":    true,
+				"confirm_by":        s.Clock.Now().Add(10 * oneDay).Unix(),
+				"expires_at":        s.Clock.Now().Add(10*oneDay + 1*time.Hour).Unix(),
+				"updated_at":        s.Clock.Now().Unix(),
+			}, func() cadf.Resource {
+				return cadf.Resource{
+					TypeURI:     "service/resources/commitment",
+					ID:          uuid2,
+					DomainID:    "uuid-for-germany",
+					DomainName:  "germany",
+					ProjectID:   "uuid-for-berlin",
+					ProjectName: "berlin",
+					Attachments: []cadf.Attachment{must.Return(cadf.NewJSONAttachment("payload", map[string]any{
+						"az":          "any",
+						"dryRun":      false,
+						"infoVersion": 1,
+						"byProject": map[string]map[string]any{
+							"uuid-for-berlin": {
+								"byResource": map[string]map[string]any{
+									"things": {
+										"totalConfirmedBefore":  0,
+										"totalConfirmedAfter":   0,
+										"totalGuaranteedBefore": 0,
+										"totalGuaranteedAfter":  0,
+										"commitments": []map[string]any{{
+											"amount":    2,
+											"confirmBy": s.Clock.Now().Add(10 * oneDay).UTC().Format(time.RFC3339),
+											"expiresAt": s.Clock.Now().Add(10*oneDay + 1*time.Hour).UTC().Format(time.RFC3339),
+											"newStatus": "planned",
+											"oldStatus": nil,
+											"uuid":      uuid2,
+										}},
+									},
+								},
+							},
+						},
+					}))},
+				}
+			})
+			tr.DBChanges().AssertEqualf(`
+			INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, status, amount, duration, created_at, creator_uuid, creator_name, confirm_by, expires_at, creation_context_json, updated_at) VALUES (4, '%[1]s', 1, 6, 'planned', 2, '1 hour', %[2]d, 'uuid-for-alice', 'alice@Default', %[3]d, %[4]d, '{"reason": "create"}', %[2]d);
+		`,
+				uuid2,
+				s.Clock.Now().Unix(),
+				s.Clock.Now().Add(10*oneDay).Unix(),
+				s.Clock.Now().Add(10*oneDay+1*time.Hour).Unix(),
+			)
+
+			// "confirmed" commitments require capacity to be present
+			firstCapacityAZTwoID := s.GetAZResourceID("first", "capacity", "az-two")
+			firstCapacityTotalID := s.GetAZResourceID("first", "capacity", "total")
+			s.MustDBExec("UPDATE az_resources SET raw_capacity = $1 WHERE id IN ($2, $3)", 100, firstCapacityAZTwoID, firstCapacityTotalID)
+			tr.DBChanges().Ignore()
+
+			var uuid3 string
+			createCommitmentAndExpectSuccess(t, s, tr, manager == "liquid", map[string]any{
+				"amount":            3,
+				"duration":          "1 hour",
+				"project_id":        "uuid-for-berlin",
+				"service_type":      "first",
+				"resource_name":     "capacity",
+				"availability_zone": "az-two",
+				"status":            "confirmed",
+			}, jsonmatch.Object{
+				"uuid":              jsonmatch.CaptureField(&uuid3),
+				"amount":            3,
+				"duration":          "1 hour",
+				"project_id":        "uuid-for-berlin",
+				"service_type":      "first",
+				"resource_name":     "capacity",
+				"availability_zone": "az-two",
+				"status":            "confirmed",
+				"created_at":        s.Clock.Now().Unix(),
+				"creator_uuid":      "uuid-for-alice",
+				"creator_name":      "alice@Default",
+				"can_be_deleted":    true,
+				"confirmed_at":      s.Clock.Now().Unix(),
+				"expires_at":        s.Clock.Now().Add(1 * time.Hour).Unix(),
+				"updated_at":        s.Clock.Now().Unix(),
+			}, func() cadf.Resource {
+				return cadf.Resource{
+					TypeURI:     "service/resources/commitment",
+					ID:          uuid3,
+					DomainID:    "uuid-for-germany",
+					DomainName:  "germany",
+					ProjectID:   "uuid-for-berlin",
+					ProjectName: "berlin",
+					Attachments: []cadf.Attachment{must.Return(cadf.NewJSONAttachment("payload", map[string]any{
+						"az":          "az-two",
+						"dryRun":      false,
+						"infoVersion": 1,
+						"byProject": map[string]map[string]any{
+							"uuid-for-berlin": {
+								"byResource": map[string]map[string]any{
+									"capacity": {
+										"totalConfirmedBefore":  0,
+										"totalConfirmedAfter":   3,
+										"totalGuaranteedBefore": 0,
+										"totalGuaranteedAfter":  0,
+										"commitments": []map[string]any{{
+											"amount":    3,
+											"expiresAt": s.Clock.Now().Add(1 * time.Hour).UTC().Format(time.RFC3339),
+											"newStatus": "confirmed",
+											"oldStatus": nil,
+											"uuid":      uuid3,
+										}},
+									},
+								},
+							},
+						},
+					}))},
+				}
+			})
+			tr.DBChanges().AssertEqualf(`
+			INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, status, amount, duration, created_at, creator_uuid, creator_name, confirmed_at, expires_at, creation_context_json, updated_at) VALUES (6, '%[1]s', 1, 3, 'confirmed', 3, '1 hour', %[2]d, 'uuid-for-alice', 'alice@Default', %[2]d, %[3]d, '{"reason": "create"}', %[2]d);
+			UPDATE services SET next_scrape_at = %[2]d WHERE id = 1 AND type = 'first' AND liquid_version = 1;
+		`,
+				uuid3,
+				s.Clock.Now().Unix(),
+				s.Clock.Now().Add(1*time.Hour).Unix(),
+			)
+		})
+	}
+}
+
+func TestCommitmentCreateValidationErrors(t *testing.T) {
+	s := test.NewSetup(t,
+		test.WithConfig(commitmentCreateConfigJSON),
+		test.WithPersistedServiceInfo("first", test.DefaultLiquidServiceInfo("First")),
+		test.WithPersistedServiceInfo("second", test.DefaultLiquidServiceInfo("Second")),
+		test.WithInitialDiscovery,
+		test.WithEmptyResourceRecordsAsNeeded,
+	)
+
+	tr, tr0 := easypg.NewTracker(t, s.DB.Db)
+	tr0.Ignore()
+
+	s.TokenValidator.Enforcer.AllowCommitmentCreate = false
+	createCommitmentAndExpectError(t, s, tr, map[string]any{
+		"amount":            1,
+		"duration":          "1 hour",
+		"project_id":        "uuid-for-berlin",
+		"service_type":      "first",
+		"resource_name":     "capacity",
+		"availability_zone": "az-one",
+		"status":            "pending",
+	}, func(r httptest.Response) {
+		r.ExpectText(t, http.StatusForbidden, "Forbidden\n")
+	})
+	s.TokenValidator.Enforcer.AllowCommitmentCreate = true
+
+	// no such project/service/resource/AZ
+	createCommitmentAndExpectError(t, s, tr, map[string]any{
+		"amount":            1,
+		"duration":          "1 hour",
+		"project_id":        "uuid-for-chemnitz",
+		"service_type":      "nonexistent",
+		"resource_name":     "capacity",
+		"availability_zone": "az-one",
+		"status":            "pending",
+	}, func(r httptest.Response) {
+		r.ExpectText(t, http.StatusNotFound, "no such project (UUID = uuid-for-chemnitz)\n")
+	})
+	createCommitmentAndExpectError(t, s, tr, map[string]any{
+		"amount":            1,
+		"duration":          "1 hour",
+		"project_id":        "uuid-for-berlin",
+		"service_type":      "nonexistent",
+		"resource_name":     "capacity",
+		"availability_zone": "az-one",
+		"status":            "pending",
+	}, func(r httptest.Response) {
+		r.ExpectText(t, http.StatusNotFound, "no such service\n")
+	})
+	createCommitmentAndExpectError(t, s, tr, map[string]any{
+		"amount":            1,
+		"duration":          "1 hour",
+		"project_id":        "uuid-for-berlin",
+		"service_type":      "first",
+		"resource_name":     "nonexistent",
+		"availability_zone": "az-one",
+		"status":            "pending",
+	}, func(r httptest.Response) {
+		r.ExpectText(t, http.StatusNotFound, "no such resource\n")
+	})
+	for _, az := range []string{"az-three", "unknown", ""} {
+		createCommitmentAndExpectError(t, s, tr, map[string]any{
+			"amount":            1,
+			"duration":          "1 hour",
+			"project_id":        "uuid-for-berlin",
+			"service_type":      "first",
+			"resource_name":     "capacity",
+			"availability_zone": az,
+			"status":            "pending",
+		}, func(r httptest.Response) {
+			r.ExpectText(t, http.StatusNotFound, "no such availability zone\n")
+		})
+	}
+
+	// invalid AZ choice for resource
+	createCommitmentAndExpectError(t, s, tr, map[string]any{
+		"amount":            1,
+		"duration":          "1 hour",
+		"project_id":        "uuid-for-berlin",
+		"service_type":      "first",
+		"resource_name":     "things", // FlatTopology!
+		"availability_zone": "az-one",
+		"status":            "pending",
+	}, func(r httptest.Response) {
+		r.ExpectText(t, http.StatusUnprocessableEntity, "resource does not accept AZ-aware commitments, so the AZ must be set to \"any\"\n")
+	})
+	createCommitmentAndExpectError(t, s, tr, map[string]any{
+		"amount":            1,
+		"duration":          "1 hour",
+		"project_id":        "uuid-for-berlin",
+		"service_type":      "first",
+		"resource_name":     "capacity", // AZAwareTopology!
+		"availability_zone": "any",
+		"status":            "pending",
+	}, func(r httptest.Response) {
+		r.ExpectText(t, http.StatusUnprocessableEntity, "resource is AZ-aware, so the AZ may not be set to \"any\"\n")
+	})
+
+	// resource is forbidden
+	berlinID := s.GetProjectID("berlin")
+	firstCapacityID := s.GetResourceID("first", "capacity")
+	s.MustDBExec(`UPDATE project_resources SET forbidden = $1 WHERE project_id = $2 AND resource_id = $3`, true, berlinID, firstCapacityID)
+	tr.DBChanges().Ignore()
+	createCommitmentAndExpectError(t, s, tr, map[string]any{
+		"amount":            1,
+		"duration":          "1 hour",
+		"project_id":        "uuid-for-berlin",
+		"service_type":      "first",
+		"resource_name":     "capacity",
+		"availability_zone": "az-one",
+		"status":            "pending",
+	}, func(r httptest.Response) {
+		r.ExpectText(t, http.StatusUnprocessableEntity, "resource is not enabled in this project\n")
+	})
+	s.MustDBExec(`UPDATE project_resources SET forbidden = $1 WHERE project_id = $2 AND resource_id = $3`, false, berlinID, firstCapacityID)
+	tr.DBChanges().Ignore()
+
+	// resource does not allow commitments
+	createCommitmentAndExpectError(t, s, tr, map[string]any{
+		"amount":            1,
+		"duration":          "1 hour",
+		"project_id":        "uuid-for-berlin",
+		"service_type":      "second",
+		"resource_name":     "capacity",
+		"availability_zone": "az-one",
+		"status":            "pending",
+	}, func(r httptest.Response) {
+		r.ExpectText(t, http.StatusUnprocessableEntity, "commitments are not enabled for this resource\n")
+	})
+
+	// invalid choice of amount
+	createCommitmentAndExpectError(t, s, tr, map[string]any{
+		"amount":            -42,
+		"duration":          "1 hour",
+		"project_id":        "uuid-for-berlin",
+		"service_type":      "first",
+		"resource_name":     "capacity",
+		"availability_zone": "az-one",
+		"status":            "confirmed",
+	}, func(r httptest.Response) {
+		r.ExpectText(t, http.StatusBadRequest, "request body is not valid JSON: json: cannot unmarshal number -42 into Go struct field CommitmentRequest.amount of type uint64\n")
+	})
+	createCommitmentAndExpectError(t, s, tr, map[string]any{
+		"amount":            0,
+		"duration":          "1 hour",
+		"project_id":        "uuid-for-berlin",
+		"service_type":      "first",
+		"resource_name":     "capacity",
+		"availability_zone": "az-one",
+		"status":            "confirmed",
+	}, func(r httptest.Response) {
+		r.ExpectText(t, http.StatusUnprocessableEntity, "amount of committed resource must be greater than zero\n")
+	})
+
+	// invalid choice of duration
+	createCommitmentAndExpectError(t, s, tr, map[string]any{
+		"amount":            1,
+		"duration":          "3 hours",
+		"project_id":        "uuid-for-berlin",
+		"service_type":      "first",
+		"resource_name":     "capacity",
+		"availability_zone": "az-one",
+		"status":            "pending",
+	}, func(r httptest.Response) {
+		r.ExpectText(t, http.StatusUnprocessableEntity, "unacceptable commitment duration for this resource; acceptable values: [\"1 hour\",\"2 hours\"]\n")
+	})
+
+	// invalid choice of status
+	for _, status := range []string{"guaranteed", "active", "superseded", "expired", "deleted", "unknown"} {
+		createCommitmentAndExpectError(t, s, tr, map[string]any{
+			"amount":            1,
+			"duration":          "1 hour",
+			"project_id":        "uuid-for-berlin",
+			"service_type":      "first",
+			"resource_name":     "capacity",
+			"availability_zone": "az-one",
+			"status":            status,
+		}, func(r httptest.Response) {
+			r.ExpectText(t, http.StatusUnprocessableEntity, "initial commitment status value is invalid\n")
+		})
+	}
+
+	// invalid presence/absence of confirm_by for chosen state
+	for _, status := range []string{"planned"} {
+		createCommitmentAndExpectError(t, s, tr, map[string]any{
+			"amount":            1,
+			"duration":          "1 hour",
+			"project_id":        "uuid-for-berlin",
+			"service_type":      "first",
+			"resource_name":     "capacity",
+			"availability_zone": "az-one",
+			"status":            status,
+		}, func(r httptest.Response) {
+			r.ExpectText(t, http.StatusUnprocessableEntity, "confirm_by must be set for the requested initial commitment status\n")
+		})
+	}
+	for _, status := range []string{"pending", "confirmed"} {
+		createCommitmentAndExpectError(t, s, tr, map[string]any{
+			"amount":            1,
+			"duration":          "1 hour",
+			"project_id":        "uuid-for-berlin",
+			"service_type":      "first",
+			"resource_name":     "capacity",
+			"availability_zone": "az-one",
+			"status":            status,
+			"confirm_by":        s.Clock.Now().Add(1 * time.Hour).Unix(),
+		}, func(r httptest.Response) {
+			r.ExpectText(t, http.StatusUnprocessableEntity, "confirm_by may not be set for the requested initial commitment status\n")
+		})
+	}
+
+	// invalid choice of confirm_by
+	s.Clock.StepBy(2 * time.Hour)
+	createCommitmentAndExpectError(t, s, tr, map[string]any{
+		"amount":            1,
+		"duration":          "1 hour",
+		"project_id":        "uuid-for-berlin",
+		"service_type":      "first",
+		"resource_name":     "capacity",
+		"availability_zone": "az-one",
+		"status":            "planned",
+		"confirm_by":        s.Clock.Now().Add(-1 * time.Hour).Unix(),
+	}, func(r httptest.Response) {
+		r.ExpectText(t, http.StatusUnprocessableEntity, "confirm_by may not be set in the past\n")
+	})
+
+	// invalid choice of confirm_by: "things" has min_confirm_date = "1970-01-08T00:00:00Z",
+	// which is one week after the current time on the mock clock
+	createCommitmentAndExpectError(t, s, tr, map[string]any{
+		"amount":            1,
+		"duration":          "1 hour",
+		"project_id":        "uuid-for-berlin",
+		"service_type":      "first",
+		"resource_name":     "things",
+		"availability_zone": "any",
+		"status":            "pending", // i.e. confirm_by defaults to NOW()
+	}, func(r httptest.Response) {
+		r.ExpectText(t, http.StatusUnprocessableEntity, "this commitment needs a `confirm_by` timestamp at or after 1970-01-08T00:00:00Z\n")
+	})
+	createCommitmentAndExpectError(t, s, tr, map[string]any{
+		"amount":            1,
+		"duration":          "1 hour",
+		"project_id":        "uuid-for-berlin",
+		"service_type":      "first",
+		"resource_name":     "things",
+		"availability_zone": "any",
+		"status":            "planned",
+		"confirm_by":        s.Clock.Now().Add(1 * time.Hour).Unix(),
+	}, func(r httptest.Response) {
+		r.ExpectText(t, http.StatusUnprocessableEntity, "this commitment needs a `confirm_by` timestamp at or after 1970-01-08T00:00:00Z\n")
+	})
+
+	// invalid choice of notify_on_confirm
+	createCommitmentAndExpectError(t, s, tr, map[string]any{
+		"amount":            1,
+		"duration":          "1 hour",
+		"project_id":        "uuid-for-berlin",
+		"service_type":      "first",
+		"resource_name":     "capacity",
+		"availability_zone": "az-one",
+		"status":            "confirmed",
+		"notify_on_confirm": true,
+	}, func(r httptest.Response) {
+		r.ExpectText(t, http.StatusUnprocessableEntity, "notify_on_confirm may not be set for commitments with immediate confirmation\n")
+	})
+}
+
+func TestCommitmentCreateRejectedByLiquid(t *testing.T) {
+	srvInfoFirst := test.DefaultLiquidServiceInfo("First")
+	for resName, resInfo := range srvInfoFirst.Resources {
+		resInfo.HandlesCommitments = true
+		srvInfoFirst.Resources[resName] = resInfo
+	}
+
+	ctx := t.Context()
+	s := test.NewSetup(t,
+		test.WithConfig(commitmentCreateConfigJSON),
+		test.WithMockLiquidClient("first", srvInfoFirst),
+		test.WithPersistedServiceInfo("first", srvInfoFirst),
+		test.WithPersistedServiceInfo("second", test.DefaultLiquidServiceInfo("Second")),
+		test.WithInitialDiscovery,
+		test.WithEmptyResourceRecordsAsNeeded,
+	)
+
+	// test rejection by liquid without RetryAt
+	mockLiquid := s.LiquidClients["first"]
+	mockLiquid.CommitmentChangeResponse.Set(liquid.CommitmentChangeResponse{
+		RejectionReason: "datacenter is not accepting new commitments at this time (reason: on fire)",
+	})
+	s.Handler.RespondTo(ctx, "POST /resources/v2/commitments/new", httptest.WithJSONBody(map[string]any{
+		"amount":            1,
+		"duration":          "1 hour",
+		"project_id":        "uuid-for-berlin",
+		"service_type":      "first",
+		"resource_name":     "capacity",
+		"availability_zone": "az-two",
+		"status":            "confirmed",
+	})).
+		ExpectHeader(t, "Retry-After", ""). // not set
+		ExpectText(t, http.StatusConflict, "datacenter is not accepting new commitments at this time (reason: on fire)\n")
+
+	// test rejection by liquid with RetryAt
+	mockLiquid.CommitmentChangeResponse.Set(liquid.CommitmentChangeResponse{
+		RejectionReason: "could not purchase new capacity, Sammy bought it all",
+		RetryAt:         Some(s.Clock.Now().Add(1 * time.Hour)),
+	})
+	s.Handler.RespondTo(ctx, "POST /resources/v2/commitments/new", httptest.WithJSONBody(map[string]any{
+		"amount":            1,
+		"duration":          "1 hour",
+		"project_id":        "uuid-for-berlin",
+		"service_type":      "first",
+		"resource_name":     "capacity",
+		"availability_zone": "az-one",
+		"status":            "confirmed",
+	})).
+		ExpectHeader(t, "Retry-After", s.Clock.Now().Add(1*time.Hour).Format(time.RFC1123)).
+		ExpectText(t, http.StatusConflict, "could not purchase new capacity, Sammy bought it all\n")
+}
+
+func TestCommitmentCreateRejectedByLimes(t *testing.T) {
+	ctx := t.Context()
+	s := test.NewSetup(t,
+		test.WithConfig(commitmentCreateConfigJSON),
+		test.WithPersistedServiceInfo("first", test.DefaultLiquidServiceInfo("First")),
+		test.WithPersistedServiceInfo("second", test.DefaultLiquidServiceInfo("Second")),
+		test.WithInitialDiscovery,
+		test.WithEmptyResourceRecordsAsNeeded,
+	)
+	// set up some capacity in first/capacity, and allocate some of it with commitments and usage
+	firstCapacityID := s.GetResourceID("first", "capacity")
+	for az, capacity := range map[liquid.AvailabilityZone]uint64{
+		"az-one": 20,
+		"az-two": 30,
+		"total":  50,
+	} {
+		s.MustDBExec(`UPDATE az_resources SET raw_capacity = $1 WHERE az = $2 AND resource_id = $3`,
+			capacity, az, firstCapacityID)
+	}
+	dresdenID := s.GetProjectID("dresden")
+	firstCapacityOneID := s.GetAZResourceID("first", "capacity", "az-one")
+	s.MustDBExec(`UPDATE project_az_resources SET usage = $1 WHERE project_id = $2 AND az_resource_id = $3`,
+		10, dresdenID, firstCapacityOneID)
+	s.Handler.RespondTo(ctx, "POST /resources/v2/commitments/new", httptest.WithJSONBody(map[string]any{
+		"amount":            5,
+		"duration":          "1 hour",
+		"project_id":        "uuid-for-berlin",
+		"service_type":      "first",
+		"resource_name":     "capacity",
+		"availability_zone": "az-one",
+		"status":            "confirmed",
+	})).ExpectStatus(t, http.StatusCreated)
+
+	// test rejection by Limes: on 20 capacity, we have 10 used by dresden
+	// and 5 committed by berlin, so this additional commitment does not fit
+	s.Handler.RespondTo(ctx, "POST /resources/v2/commitments/new", httptest.WithJSONBody(map[string]any{
+		"amount":            15,
+		"duration":          "1 hour",
+		"project_id":        "uuid-for-berlin",
+		"service_type":      "first",
+		"resource_name":     "capacity",
+		"availability_zone": "az-one",
+		"status":            "confirmed",
+	})).ExpectText(t, http.StatusConflict, "not enough capacity!\n")
+}

--- a/internal/api/api_v2/commitment_create_test.go
+++ b/internal/api/api_v2/commitment_create_test.go
@@ -7,11 +7,13 @@ import (
 	"encoding/json"
 	"maps"
 	"net/http"
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/sapcc/go-api-declarations/cadf"
 	"github.com/sapcc/go-api-declarations/liquid"
+	"github.com/sapcc/go-bits/assert"
 	"github.com/sapcc/go-bits/easypg"
 	"github.com/sapcc/go-bits/httptest"
 	"github.com/sapcc/go-bits/must"
@@ -80,6 +82,12 @@ const commitmentCreateConfigJSON = `{
 func createCommitmentAndExpectSuccess(t *testing.T, s test.Setup, tr *easypg.Tracker, ccrAcceptedByLiquid bool, request map[string]any, expected jsonmatch.Object, getTarget func() cadf.Resource) {
 	t.Helper()
 	ctx := t.Context()
+	mockLiquid := s.LiquidClients[db.ServiceType(request["service_type"].(string))]
+
+	if ccrAcceptedByLiquid {
+		// explicitly clear LastCommitmentChangeRequest, so we can detect if the dry-run incorrectly writes into it
+		mockLiquid.LastCommitmentChangeRequest = liquid.CommitmentChangeRequest{}
+	}
 
 	// check that the dry-run request succeeds, without causing any side effects in the DB or audit trail
 	dryrunRequest := maps.Clone(request)
@@ -88,8 +96,15 @@ func createCommitmentAndExpectSuccess(t *testing.T, s test.Setup, tr *easypg.Tra
 	dryrunExpected["uuid"] = jsonmatch.Irrelevant()
 	s.Handler.RespondTo(ctx, "POST /resources/v2/commitments/new", httptest.WithJSONBody(dryrunRequest)).
 		ExpectJSON(t, http.StatusCreated, dryrunExpected)
+
 	s.Auditor.ExpectEvents(t, nil...)
 	tr.DBChanges().AssertEmpty()
+	if ccrAcceptedByLiquid {
+		// if there was a CCR, then it must have been a dry-run
+		if !reflect.DeepEqual(mockLiquid.LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{}) {
+			assert.Equal(t, mockLiquid.LastCommitmentChangeRequest.DryRun, true)
+		}
+	}
 
 	// after creating the commitment, we expect to see an audit event
 	// (the DB effect is not checked here; the caller will take care of that afterwards)
@@ -107,7 +122,6 @@ func createCommitmentAndExpectSuccess(t *testing.T, s test.Setup, tr *easypg.Tra
 	if ccrAcceptedByLiquid {
 		// check that the mock liquid saw the correct CommitmentChangeRequest
 		// (the same as inside the audit event payload)
-		mockLiquid := s.LiquidClients[db.ServiceType(request["service_type"].(string))]
 		actualCCR := must.Return(json.Marshal(mockLiquid.LastCommitmentChangeRequest))
 		var expectedCCR jsonmatch.Object
 		must.SucceedT(t, json.Unmarshal([]byte(target.Attachments[0].Content.(string)), &expectedCCR))

--- a/internal/api/api_v2/commitment_helpers.go
+++ b/internal/api/api_v2/commitment_helpers.go
@@ -28,7 +28,7 @@ import (
 )
 
 var (
-	errAZMayNotBeAny             = errors.New(`resource is AZ-aware, so the AZ may not be set to "any"`)
+	errAZMustNotBeAny            = errors.New(`resource is AZ-aware, so the AZ may not be set to "any"`)
 	errAZMustBeAny               = errors.New(`resource does not accept AZ-aware commitments, so the AZ must be set to "any"`)
 	errCommitmentsDisabled       = errors.New("commitments are not enabled for this resource")
 	errConfirmByInPast           = errors.New("confirm_by may not be set in the past")
@@ -113,7 +113,7 @@ func (p *v2Provider) validateCommittability(path db.AZResourcePath, dbDomain db.
 		}
 	} else {
 		if path.AvailabilityZone == limes.AvailabilityZoneAny {
-			err = respondwith.CustomStatus(http.StatusUnprocessableEntity, errAZMayNotBeAny)
+			err = respondwith.CustomStatus(http.StatusUnprocessableEntity, errAZMustNotBeAny)
 			return
 		}
 		if !slices.Contains(p.Cluster.Config.AvailabilityZones, path.AvailabilityZone) {

--- a/internal/api/api_v2/commitment_helpers.go
+++ b/internal/api/api_v2/commitment_helpers.go
@@ -1,0 +1,209 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package api_v2
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"slices"
+	"time"
+
+	"github.com/sapcc/go-api-declarations/limes"
+	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
+	"github.com/sapcc/go-api-declarations/liquid"
+	"github.com/sapcc/go-bits/must"
+	"github.com/sapcc/go-bits/respondwith"
+	"github.com/sapcc/go-bits/sqlext"
+	"go.xyrillian.de/gg/is"
+	. "go.xyrillian.de/gg/option"
+	"go.xyrillian.de/gg/options"
+
+	resourcesv2 "github.com/sapcc/limes/internal/apideclarations/apiv2/resources"
+	"github.com/sapcc/limes/internal/core"
+	"github.com/sapcc/limes/internal/db"
+	"github.com/sapcc/limes/internal/util"
+)
+
+var (
+	errAZMayNotBeAny             = errors.New(`resource is AZ-aware, so the AZ may not be set to "any"`)
+	errAZMustBeAny               = errors.New(`resource does not accept AZ-aware commitments, so the AZ must be set to "any"`)
+	errCommitmentsDisabled       = errors.New("commitments are not enabled for this resource")
+	errConfirmByInPast           = errors.New("confirm_by may not be set in the past")
+	errConfirmByMissing          = errors.New("confirm_by must be set for the requested initial commitment status")
+	errConfirmByNotAllowed       = errors.New("confirm_by may not be set for the requested initial commitment status")
+	errEmptyAmount               = errors.New("amount of committed resource must be greater than zero")
+	errInvalidInitialStatus      = errors.New("initial commitment status value is invalid")
+	errNoSuchAZ                  = errors.New("no such availability zone")
+	errNoSuchResource            = errors.New("no such resource")
+	errNoSuchService             = errors.New("no such service")
+	errNotifyOnConfirmNotAllowed = errors.New("notify_on_confirm may not be set for commitments with immediate confirmation")
+	errResourceForbidden         = errors.New("resource is not enabled in this project")
+)
+
+func convertCommitmentToDisplayForm(c db.ProjectCommitment, path db.AZResourcePath, project db.Project, canBeDeleted bool) resourcesv2.Commitment {
+	return resourcesv2.Commitment{
+		UUID:             c.UUID,
+		Amount:           c.Amount,
+		Duration:         c.Duration,
+		ProjectUUID:      project.UUID,
+		ServiceType:      path.ServiceType,
+		ResourceName:     path.ResourceName,
+		AvailabilityZone: path.AvailabilityZone,
+		Status:           c.Status,
+		TransferStatus:   c.TransferStatus,
+		TransferToken:    c.TransferToken,
+		CreatedAt:        limes.UnixEncodedTime{Time: c.CreatedAt},
+		UpdatedAt:        limes.UnixEncodedTime{Time: c.UpdatedAt},
+		CreatorUUID:      c.CreatorUUID,
+		CreatorName:      c.CreatorName,
+		CanBeDeleted:     canBeDeleted,
+		ConfirmBy:        options.Map(c.ConfirmBy, util.IntoUnixEncodedTime),
+		ConfirmedAt:      options.Map(c.ConfirmedAt, util.IntoUnixEncodedTime),
+		ExpiresAt:        limes.UnixEncodedTime{Time: c.ExpiresAt},
+		NotifyOnConfirm:  c.NotifyOnConfirm,
+		WasRenewed:       c.RenewContextJSON.IsSome(),
+	}
+}
+
+// validateCommittability checks that the AZ resource identified by `path`:
+//   - exists in the given project scope, and
+//   - allows commitments of the specified duration.
+func (p *v2Provider) validateCommittability(path db.AZResourcePath, dbDomain db.Domain, dbProject db.Project, duration limesresources.CommitmentDuration, sis core.ServiceInfoSnapshot) (_ db.AZResource, _ core.ScopedCommitmentBehavior, err error) {
+	_, ok := sis.GetServiceForType(path.ServiceType)
+	if !ok {
+		err = respondwith.CustomStatus(http.StatusNotFound, errNoSuchService)
+		return
+	}
+	resource, ok := sis.GetResourceForPath(path.Resource())
+	if !ok {
+		err = respondwith.CustomStatus(http.StatusNotFound, errNoSuchResource)
+		return
+	}
+
+	var forbidden bool
+	err = p.DB.QueryRow(`SELECT forbidden FROM project_resources WHERE project_id = $1 AND resource_id = $2`,
+		dbProject.ID, resource.ID).Scan(&forbidden)
+	if err != nil {
+		return
+	}
+	if forbidden {
+		err = respondwith.CustomStatus(http.StatusUnprocessableEntity, errResourceForbidden)
+		return
+	}
+
+	behavior := p.Cluster.CommitmentBehaviorForResourcePath(path.Resource()).ForDomain(dbDomain.Name)
+	if len(behavior.Durations) == 0 {
+		err = respondwith.CustomStatus(http.StatusUnprocessableEntity, errCommitmentsDisabled)
+		return
+	}
+	if !slices.Contains(behavior.Durations, duration) {
+		buf := must.Return(json.Marshal(behavior.Durations)) // panic on error is acceptable here, marshals should never fail
+		msg := "unacceptable commitment duration for this resource; acceptable values: " + string(buf)
+		err = respondwith.CustomStatus(http.StatusUnprocessableEntity, errors.New(msg))
+		return
+	}
+
+	if resource.Topology == liquid.FlatTopology {
+		if path.AvailabilityZone != limes.AvailabilityZoneAny {
+			err = respondwith.CustomStatus(http.StatusUnprocessableEntity, errAZMustBeAny)
+			return
+		}
+	} else {
+		if path.AvailabilityZone == limes.AvailabilityZoneAny {
+			err = respondwith.CustomStatus(http.StatusUnprocessableEntity, errAZMayNotBeAny)
+			return
+		}
+		if !slices.Contains(p.Cluster.Config.AvailabilityZones, path.AvailabilityZone) {
+			err = respondwith.CustomStatus(http.StatusNotFound, errNoSuchAZ)
+			return
+		}
+	}
+
+	// If we did this load earlier, we could only report a generic error like
+	// "something about this service/resource/AZ combo is not right", instead of
+	// the more specific errors we produced above.
+	//
+	// With all the previous validations having succeeded, it should not be
+	// possible to fail this load, so errors are considered server errors here.
+	azResource, ok := sis.GetAZResourceForPath(path)
+	if !ok {
+		err = fmt.Errorf("could not find az_resources entry for path = %q in ServiceInfoCache", path.String())
+		return
+	}
+
+	return azResource, behavior, nil
+}
+
+type commitmentStatusAttributes struct {
+	Status          liquid.CommitmentStatus
+	ConfirmBy       Option[time.Time]
+	NotifyOnConfirm bool
+}
+
+// validateStatusAttributesOnNewCommitment validates the Status, ConfirmBy and
+// NotifyOnConfirm fields of a CommitmentRequest.
+func (p *v2Provider) validateStatusAttributesOnNewCommitment(attrs commitmentStatusAttributes, behavior core.ScopedCommitmentBehavior, now time.Time) error {
+	switch attrs.Status {
+	case liquid.CommitmentStatusPlanned: // TODO: add "guaranteed" here when adding support for it
+		if attrs.ConfirmBy.IsNone() {
+			return respondwith.CustomStatus(http.StatusUnprocessableEntity, errConfirmByMissing)
+		}
+	case liquid.CommitmentStatusPending, liquid.CommitmentStatusConfirmed:
+		if attrs.ConfirmBy.IsSome() {
+			return respondwith.CustomStatus(http.StatusUnprocessableEntity, errConfirmByNotAllowed)
+		}
+	default:
+		return respondwith.CustomStatus(http.StatusUnprocessableEntity, errInvalidInitialStatus)
+	}
+
+	if attrs.ConfirmBy.IsSomeAnd(is.Before(now)) {
+		return respondwith.CustomStatus(http.StatusUnprocessableEntity, errConfirmByInPast)
+	}
+	if msg := behavior.CanConfirmCommitmentsAt(attrs.ConfirmBy.UnwrapOr(now)); msg != "" {
+		return respondwith.CustomStatus(http.StatusUnprocessableEntity, errors.New(msg))
+	}
+
+	if attrs.NotifyOnConfirm && attrs.Status == liquid.CommitmentStatusConfirmed {
+		return respondwith.CustomStatus(http.StatusUnprocessableEntity, errNotifyOnConfirmNotAllowed)
+	}
+
+	return nil
+}
+
+// pazrCommitmentStats contains statistics about existing commitments in a specific ProjectAZResource (pazr) scope.
+type pazrCommitmentStats struct {
+	TotalConfirmed  uint64
+	TotalGuaranteed uint64
+}
+
+var pazrCommitmentStatsQuery = sqlext.SimplifyWhitespace(db.ExpandEnumPlaceholders(`
+	SELECT COALESCE(SUM(amount) FILTER (WHERE status = {{liquid.CommitmentStatusConfirmed}}), 0) AS total_confirmed,
+	       COALESCE(SUM(amount) FILTER (WHERE status = {{liquid.CommitmentStatusGuaranteed}}), 0) AS total_guaranteed
+	  FROM project_commitments
+	 WHERE project_id = $1 AND az_resource_id = $2
+`))
+
+// getCommitmentStats collects statistics about existing commitments in a specific ProjectAZResource (pazr) scope.
+func getCommitmentStats(dbi db.Interface, projectID db.ProjectID, azResourceID db.AZResourceID) (stats pazrCommitmentStats, err error) {
+	err = dbi.QueryRow(pazrCommitmentStatsQuery, projectID, azResourceID).
+		Scan(&stats.TotalConfirmed, &stats.TotalGuaranteed)
+	return
+}
+
+// analyzeCommitmentChangeResponse converts a CommitmentChangeResponse into an API error unless the response is positive.
+func analyzeCommitmentChangeResponse(resp liquid.CommitmentChangeResponse) error {
+	if resp.RejectionReason == "" {
+		return nil
+	}
+	err := errors.New(resp.RejectionReason)
+	if retryAt, exists := resp.RetryAt.Unpack(); exists {
+		return respondwith.CustomStatus(http.StatusConflict, err,
+			respondwith.CustomHeader("Retry-After", retryAt.Format(time.RFC1123)),
+		)
+	} else {
+		return respondwith.CustomStatus(http.StatusConflict, err)
+	}
+}

--- a/internal/api/api_v2/core.go
+++ b/internal/api/api_v2/core.go
@@ -4,10 +4,13 @@
 package api_v2
 
 import (
+	"bytes"
 	"cmp"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 
@@ -44,6 +47,7 @@ func (p *v2Provider) AddTo(r *mux.Router) {
 	tv := p.tokenValidator
 	r.Methods("GET").Path("/resources/v2/info").HandlerFunc(handlerFunc(http.StatusOK, tv, p.handleGetResourcesInfo))
 	r.Methods("GET").Path("/rates/v2/info").HandlerFunc(handlerFunc(http.StatusOK, tv, p.handleGetRatesInfo))
+	r.Methods("POST").Path("/resources/v2/commitments/new").HandlerFunc(handlerFunc(http.StatusCreated, tv, p.handlePostNewCommitment))
 }
 
 // Wrapper for request handlers that enforces a structure,
@@ -89,9 +93,38 @@ func handlerFunc[T any](successCode int, tv gopherpolicy.Validator, action func(
 	}
 }
 
+// parseRequestBodyAs unmarshals a JSON-encoded request body.
+func parseRequestBodyAs[T any](r *http.Request) (T, error) {
+	var result T
+
+	// To guard against complexity attacks using extremely large request bodies,
+	// we never read more than 8 KiB. There are no request types in the v2 API
+	// that could ever require more than that.
+	const maxRequestSize = 8192
+	buf, err := io.ReadAll(io.LimitReader(r.Body, maxRequestSize))
+	if err != nil {
+		return result, fmt.Errorf("while reading request body: %w", err)
+	}
+	if len(buf) == maxRequestSize {
+		// looks like we could have read more if we wanted to
+		err = errors.New("request body too large")
+		return result, respondwith.CustomStatus(http.StatusRequestEntityTooLarge, err)
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(buf))
+	dec.DisallowUnknownFields()
+	err = dec.Decode(&result)
+	if err != nil {
+		err = respondwith.CustomStatus(http.StatusBadRequest,
+			fmt.Errorf("request body is not valid JSON: %w", err),
+		)
+	}
+	return result, err
+}
+
 // checkProjectAccess authenticates and authorizes a project-scoped request using the given policy rule.
 // On success, returns the database records for the project scope, its containing domain and the authenticated token.
-func (p *v2Provider) checkProjectAccess(t *gopherpolicy.Token, projectUUID, policyRule string) (_ db.Domain, _ db.Project, err error) { //nolint:unused // TODO: remove this nolint once it is used
+func (p *v2Provider) checkProjectAccess(t *gopherpolicy.Token, projectUUID, policyRule string) (_ db.Domain, _ db.Project, err error) {
 	// NOTE: This method is written in a way that obfuscates "domain not found"
 	// errors to users without successful authorization (including by timing side-channel).
 

--- a/internal/api/api_v2/core.go
+++ b/internal/api/api_v2/core.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/go-gorp/gorp/v3"
 	"github.com/gorilla/mux"
+	"github.com/sapcc/go-api-declarations/liquid"
 	"github.com/sapcc/go-bits/audittools"
 	"github.com/sapcc/go-bits/gopherpolicy"
 	"github.com/sapcc/go-bits/httpapi"
@@ -95,6 +96,7 @@ func handlerFunc[T any](successCode int, tv gopherpolicy.Validator, action func(
 
 // parseRequestBodyAs unmarshals a JSON-encoded request body.
 func parseRequestBodyAs[T any](r *http.Request) (T, error) {
+	// TODO: With how clever this function is now, it probably should be in go-bits.
 	var result T
 
 	// To guard against complexity attacks using extremely large request bodies,
@@ -115,16 +117,30 @@ func parseRequestBodyAs[T any](r *http.Request) (T, error) {
 	dec.DisallowUnknownFields()
 	err = dec.Decode(&result)
 	if err != nil {
-		err = respondwith.CustomStatus(http.StatusBadRequest,
+		return result, respondwith.CustomStatus(http.StatusBadRequest,
 			fmt.Errorf("request body is not valid JSON: %w", err),
 		)
 	}
-	return result, err
+
+	// Decoder.Decode() only reads until the end of a JSON payload, which may be before the end of `buf`;
+	// complain if there is anything of substance after the JSON payload (e.g. another JSON payload)
+	remainder, err := io.ReadAll(dec.Buffered())
+	if err != nil {
+		// defense in depth: reading from a buffer should never fail
+		return result, fmt.Errorf("unexpected error when checking buffer remains in parseRequestBodyAs: %w", err)
+	}
+	if len(bytes.TrimSpace(remainder)) > 0 {
+		return result, respondwith.CustomStatus(http.StatusBadRequest,
+			fmt.Errorf("request body contains %d unexpected bytes after the JSON payload", len(remainder)),
+		)
+	}
+
+	return result, nil
 }
 
 // checkProjectAccess authenticates and authorizes a project-scoped request using the given policy rule.
 // On success, returns the database records for the project scope, its containing domain and the authenticated token.
-func (p *v2Provider) checkProjectAccess(t *gopherpolicy.Token, projectUUID, policyRule string) (_ db.Domain, _ db.Project, err error) {
+func (p *v2Provider) checkProjectAccess(t *gopherpolicy.Token, projectUUID liquid.ProjectUUID, policyRule string) (_ db.Domain, _ db.Project, err error) {
 	// NOTE: This method is written in a way that obfuscates "domain not found"
 	// errors to users without successful authorization (including by timing side-channel).
 
@@ -138,7 +154,7 @@ func (p *v2Provider) checkProjectAccess(t *gopherpolicy.Token, projectUUID, poli
 	case err == nil:
 		t.Context.Request = map[string]string{
 			"domain_id":  domain.UUID,
-			"project_id": projectUUID,
+			"project_id": string(projectUUID),
 		}
 		err = t.Enforce(policyRule)
 		if err != nil {
@@ -147,7 +163,7 @@ func (p *v2Provider) checkProjectAccess(t *gopherpolicy.Token, projectUUID, poli
 	case errors.Is(err, sql.ErrNoRows):
 		t.Context.Request = map[string]string{
 			"domain_id":  "unknown",
-			"project_id": projectUUID,
+			"project_id": string(projectUUID),
 		}
 		err = t.Enforce(policyRule)
 		if err == nil {

--- a/internal/api/api_v2/core_test.go
+++ b/internal/api/api_v2/core_test.go
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package api_v2_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/sapcc/go-bits/httptest"
+
+	"github.com/sapcc/limes/internal/test"
+)
+
+func TestRequestBodyParsing(t *testing.T) {
+	// the actual test setup is kind of irrelevant; we just do a minimal setup based
+	// on the commitment-create tests since we are using that endpoint for this test
+	ctx := t.Context()
+	s := test.NewSetup(t,
+		test.WithConfig(commitmentCreateConfigJSON),
+		test.WithPersistedServiceInfo("first", test.DefaultLiquidServiceInfo("First")),
+		test.WithInitialDiscovery,
+		test.WithEmptyResourceRecordsAsNeeded,
+	)
+
+	// overlong request body
+	s.Handler.RespondTo(ctx, "POST /resources/v2/commitments/new",
+		httptest.WithHeader("Content-Type", "application/json"),
+		httptest.WithBody(strings.NewReader(
+			fmt.Sprintf(`{"service_type":"%s"}`, strings.Repeat("a", 10000)),
+		)),
+	).ExpectText(t, http.StatusRequestEntityTooLarge, "request body too large\n")
+
+	// request body that is not a JSON payload
+	s.Handler.RespondTo(ctx, "POST /resources/v2/commitments/new",
+		httptest.WithHeader("Content-Type", "application/json"),
+		httptest.WithBody(strings.NewReader("I need more quota kthxbye")),
+	).ExpectText(t, http.StatusBadRequest, "request body is not valid JSON: invalid character 'I' looking for beginning of value\n")
+
+	// multiple JSON payloads in request body
+	s.Handler.RespondTo(ctx, "POST /resources/v2/commitments/new",
+		httptest.WithHeader("Content-Type", "application/json"),
+		httptest.WithBody(strings.NewReader(`{"service_type":"first"}{"service_type":"second"}`)),
+	).ExpectText(t, http.StatusBadRequest, "request body contains 25 unexpected bytes after the JSON payload\n")
+}

--- a/internal/api/commitment_test.go
+++ b/internal/api/commitment_test.go
@@ -978,7 +978,7 @@ func TestAutomaticCommitmentTransfer(t *testing.T) {
 		INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, status, amount, duration, created_at, creator_uuid, creator_name, confirmed_at, expires_at, superseded_at, creation_context_json, supersede_context_json, updated_at) VALUES (2, '00000000-0000-0000-0000-000000000002', 2, 2, 'superseded', 3, '1 hour', %[1]d, 'dummy', 'dummy', %[1]d, %[2]d, %[1]d, '{}', '{"reason": "consume", "related_ids": [3], "related_uuids": ["00000000-0000-0000-0000-000000000003"]}', %[1]d);
 		INSERT INTO project_commitments (id, uuid, project_id, az_resource_id, status, amount, duration, created_at, creator_uuid, creator_name, confirmed_at, expires_at, creation_context_json, updated_at) VALUES (3, '00000000-0000-0000-0000-000000000003', 1, 2, 'confirmed', 6, '2 hours', %[1]d, 'uuid-for-alice', 'alice@Default', %[1]d, %[3]d, '{"reason": "create"}', %[1]d);
 		UPDATE services SET next_scrape_at = %[1]d WHERE id = 1 AND type = 'first' AND liquid_version = 1;
-    `, s.Clock.Now().Unix(), s.Clock.Now().Add(time.Hour).Unix(), s.Clock.Now().Add(2*time.Hour).Unix())
+	`, s.Clock.Now().Unix(), s.Clock.Now().Add(time.Hour).Unix(), s.Clock.Now().Add(2*time.Hour).Unix())
 
 	// we are now at sum(max(committed, usage)) = 10 and capacity for this resource is 10
 	// all projects have a usage of 2

--- a/internal/apideclarations/apiv2/doc.go
+++ b/internal/apideclarations/apiv2/doc.go
@@ -57,6 +57,15 @@
 //
 // TODO: fill when implemented
 //
+// # Endpoint: POST /resources/v2/commitments/new
+//
+// Creates a new commitment (or performs a dry run of a commitment creation request).
+//
+//   - The request body payload must be of type [resourcesv2.CommitmentRequest].
+//   - On success, status code 201 (Created) will be returned, including for dry runs.
+//   - On success, the response body payload will be of type [resourcesv2.Commitment].
+//   - Errors caused by insufficient committable capacity will be marked with status code 409 (Conflict) and might have a Retry-After header.
+//
 // # Endpoint: GET /rates/v2/info
 //
 // Returns information about the cluster's rates, potentially limited to those rates that are accessible within the authenticated scope:

--- a/internal/apideclarations/apiv2/resources/commitment.go
+++ b/internal/apideclarations/apiv2/resources/commitment.go
@@ -57,7 +57,7 @@ type Commitment struct {
 // See documentation on [Commitment] for the semantics of all fields.
 // Documentation on this type's fields only mentions specifics related to the commitment creation process.
 type CommitmentRequest struct {
-	// DryRun can be set to true to avoid any side effects.
+	// DryRun can be set to true to avoid any side effects: No data will be saved in the system.
 	// The response from a dry run will be identical to if a commitment had actually been created,
 	// except that the UUID will be set to a dummy value.
 	DryRun bool   `json:"dry_run"`
@@ -74,11 +74,11 @@ type CommitmentRequest struct {
 	//   - liquid.CommitmentStatusPlanned
 	//   - liquid.CommitmentStatusPending
 	//   - liquid.CommitmentStatusConfirmed
-	//   - liquid.CommitmentStatusGuaranteed
+	//   - liquid.CommitmentStatusGuaranteed (TODO: coming soon)
 	Status liquid.CommitmentStatus `json:"status"`
 	// ConfirmBy must be set for statuses "planned" and "guaranteed", and may not be set otherwise.
 	// Commitments created in status "pending" will have a ConfirmBy value equal to the current time.
 	ConfirmBy Option[limes.UnixEncodedTime] `json:"confirm_by,omitzero"`
 	// NotifyOnConfirm may not be set for commitments that are created in status "confirmed".
-	NotifyOnConfirm bool `json:"notify_on_confirm,omitempty"` // may not be set for "confirmed"
+	NotifyOnConfirm bool `json:"notify_on_confirm,omitempty"`
 }

--- a/internal/apideclarations/apiv2/resources/commitment.go
+++ b/internal/apideclarations/apiv2/resources/commitment.go
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcesv2
+
+import (
+	"github.com/sapcc/go-api-declarations/limes"
+	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
+	"github.com/sapcc/go-api-declarations/liquid"
+	. "go.xyrillian.de/gg/option"
+
+	"github.com/sapcc/limes/internal/db"
+)
+
+// Commitment is the response payload format for GET /v2/commitments/:uuid and several endpoints that create or modify commitments.
+type Commitment struct {
+	UUID liquid.CommitmentUUID `json:"uuid"`
+	// Amount refers to the amount of resource that is committed, in terms of the unit of the committed resource.
+	Amount   uint64                            `json:"amount"`
+	Duration limesresources.CommitmentDuration `json:"duration"`
+
+	ProjectUUID      liquid.ProjectUUID     `json:"project_id"`
+	ServiceType      db.ServiceType         `json:"service_type"`
+	ResourceName     liquid.ResourceName    `json:"resource_name"`
+	AvailabilityZone limes.AvailabilityZone `json:"availability_zone"`
+
+	Status liquid.CommitmentStatus `json:"status"`
+	// TransferStatus and TransferToken are only shown while the commitment is marked for transfer.
+	TransferStatus limesresources.CommitmentTransferStatus `json:"transfer_status,omitempty"`
+	TransferToken  Option[string]                          `json:"transfer_token,omitzero"`
+
+	CreatedAt limes.UnixEncodedTime `json:"created_at"`
+	// CreatorUUID and CreatorName identify the user who created this commitment.
+	// CreatorName is in the format `fmt.Sprintf("%s@%s", userName, userDomainName)`and intended for informational displays only.
+	CreatorUUID string `json:"creator_uuid,omitempty"`
+	CreatorName string `json:"creator_name,omitempty"`
+	// CanBeDeleted will be true if the commitment can be deleted by the same user who saw this object in response to a GET query.
+	CanBeDeleted bool `json:"can_be_deleted,omitempty"`
+	// ConfirmBy is unset if and only if the commitment was created in status "confirmed".
+	ConfirmBy Option[limes.UnixEncodedTime] `json:"confirm_by,omitzero"`
+	// ConfirmedAt is only filled after the commitment was confirmed.
+	ConfirmedAt Option[limes.UnixEncodedTime] `json:"confirmed_at,omitzero"`
+	ExpiresAt   limes.UnixEncodedTime         `json:"expires_at"`
+	// UpdatedAt is updated at least every time any field of this type changes.
+	UpdatedAt limes.UnixEncodedTime `json:"updated_at"`
+
+	// NotifyOnConfirm can only be set if ConfirmBy is filled.
+	// If true, a mail notification will be set to the project owners when the commitment is confirmed.
+	NotifyOnConfirm bool `json:"notify_on_confirm,omitempty"`
+	// WasRenewed indicates whether this commitment has been renewed.
+	// This means that a new commitment was created that will be confirmed when this commitment is set to expire.
+	WasRenewed bool `json:"was_renewed,omitempty"`
+}
+
+// CommitmentRequest is the request payload format for POST /v2/commitments/new.
+//
+// See documentation on [Commitment] for the semantics of all fields.
+// Documentation on this type's fields only mentions specifics related to the commitment creation process.
+type CommitmentRequest struct {
+	// DryRun can be set to true to avoid any side effects.
+	// The response from a dry run will be identical to if a commitment had actually been created,
+	// except that the UUID will be set to a dummy value.
+	DryRun bool   `json:"dry_run"`
+	Amount uint64 `json:"amount"`
+	// Duration must be one of the values that appear in the resource's [ResourceInfoReport].
+	Duration limesresources.CommitmentDuration `json:"duration"`
+
+	ProjectUUID      string                 `json:"project_id"`
+	ServiceType      db.ServiceType         `json:"service_type"`
+	ResourceName     liquid.ResourceName    `json:"resource_name"`
+	AvailabilityZone limes.AvailabilityZone `json:"availability_zone"`
+
+	// Status must be one of:
+	//   - liquid.CommitmentStatusPlanned
+	//   - liquid.CommitmentStatusPending
+	//   - liquid.CommitmentStatusConfirmed
+	//   - liquid.CommitmentStatusGuaranteed
+	Status liquid.CommitmentStatus `json:"status"`
+	// ConfirmBy must be set for statuses "planned" and "guaranteed", and may not be set otherwise.
+	// Commitments created in status "pending" will have a ConfirmBy value equal to the current time.
+	ConfirmBy Option[limes.UnixEncodedTime] `json:"confirm_by,omitzero"`
+	// NotifyOnConfirm may not be set for commitments that are created in status "confirmed".
+	NotifyOnConfirm bool `json:"notify_on_confirm,omitempty"` // may not be set for "confirmed"
+}

--- a/internal/apideclarations/apiv2/resources/commitment.go
+++ b/internal/apideclarations/apiv2/resources/commitment.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sapcc/limes/internal/db"
 )
 
-// Commitment is the response payload format for GET /v2/commitments/:uuid and several endpoints that create or modify commitments.
+// Commitment is the response payload format for GET /resources/v2/commitments/:uuid and several endpoints that create or modify commitments.
 type Commitment struct {
 	UUID liquid.CommitmentUUID `json:"uuid"`
 	// Amount refers to the amount of resource that is committed, in terms of the unit of the committed resource.
@@ -52,7 +52,7 @@ type Commitment struct {
 	WasRenewed bool `json:"was_renewed,omitempty"`
 }
 
-// CommitmentRequest is the request payload format for POST /v2/commitments/new.
+// CommitmentRequest is the request payload format for POST /resources/v2/commitments/new.
 //
 // See documentation on [Commitment] for the semantics of all fields.
 // Documentation on this type's fields only mentions specifics related to the commitment creation process.
@@ -65,7 +65,7 @@ type CommitmentRequest struct {
 	// Duration must be one of the values that appear in the resource's [ResourceInfoReport].
 	Duration limesresources.CommitmentDuration `json:"duration"`
 
-	ProjectUUID      string                 `json:"project_id"`
+	ProjectUUID      liquid.ProjectUUID     `json:"project_id"`
 	ServiceType      db.ServiceType         `json:"service_type"`
 	ResourceName     liquid.ResourceName    `json:"resource_name"`
 	AvailabilityZone limes.AvailabilityZone `json:"availability_zone"`

--- a/internal/test/mock_enforcer.go
+++ b/internal/test/mock_enforcer.go
@@ -21,7 +21,8 @@ type PolicyEnforcer struct {
 	AllowEditMaxQuota bool
 	AllowUncommit     bool
 	// flags by v2 action
-	AllowInfo bool
+	AllowInfo             bool
+	AllowCommitmentCreate bool
 	// match by request attribute
 	RejectServiceType string
 }
@@ -69,6 +70,8 @@ func (e *PolicyEnforcer) allowAction(action string) bool {
 		return e.AllowUncommit
 	case "info":
 		return e.AllowInfo
+	case "commitment_create":
+		return e.AllowCommitmentCreate
 	case "block_commitments":
 		return false
 	default:

--- a/internal/test/setup.go
+++ b/internal/test/setup.go
@@ -266,7 +266,8 @@ func NewSetup(t *testing.T, opts ...SetupOption) Setup {
 		AllowEditMaxQuota: true,
 		AllowUncommit:     true,
 		// v2 actions
-		AllowInfo: true,
+		AllowInfo:             true,
+		AllowCommitmentCreate: true,
 	}
 	s.mockUserIdentity = map[string]string{
 		"user_id":             "uuid-for-alice",


### PR DESCRIPTION
This has _some_ preparations for status "guaranteed" in it, but I decided to reject this status for now because handling it properly will require changes to `package datamodel` that I want to avoid within this epic.