### PR TITLE
introduce ServiceInfoSnapshot

### DIFF
--- a/internal/api/api_v2/info.go
+++ b/internal/api/api_v2/info.go
@@ -86,12 +86,13 @@ func (p *v2Provider) handleGetResourcesInfo(r *http.Request, token *gopherpolicy
 	report := resourcesv2.InfoReport{
 		Areas: make(map[string]resourcesv2.AreaInfoReport),
 	}
-	services := p.Cluster.SIC.GetServices()
-	resources := p.Cluster.SIC.GetResources()
-	categories := p.Cluster.SIC.GetCategories()
+	sis := p.Cluster.SIC.GetSnapshot()
+	services := sis.GetServices()
+	categories := sis.GetCategories()
 
 	for _, serviceType := range slices.Sorted(maps.Keys(services)) {
 		service := services[serviceType]
+		resources, _ := sis.GetResourcesForType(serviceType) // can have no resources
 		// skip non-allowed resources for this user, if any
 		allowedResources, serviceTypeOK := allowedResourcesByService[serviceType]
 		if !serviceTypeOK {
@@ -122,8 +123,8 @@ func (p *v2Provider) handleGetResourcesInfo(r *http.Request, token *gopherpolicy
 		}
 		serviceReport := report.Areas[area].Services[serviceType]
 
-		for _, resourceName := range slices.Sorted(maps.Keys(resources[serviceType])) {
-			resource := resources[serviceType][resourceName]
+		for _, resourceName := range slices.Sorted(maps.Keys(resources)) {
+			resource := resources[resourceName]
 			// skip non-allowed resources for this user, if any
 			if !slices.Contains(allowedResources, resourceName) {
 				continue
@@ -175,12 +176,13 @@ func (p *v2Provider) handleGetRatesInfo(r *http.Request, token *gopherpolicy.Tok
 	report := ratesv2.InfoReport{
 		Areas: make(map[string]ratesv2.AreaInfoReport),
 	}
-	services := p.Cluster.SIC.GetServices()
-	rates := p.Cluster.SIC.GetRates()
-	categories := p.Cluster.SIC.GetCategories()
+	sis := p.Cluster.SIC.GetSnapshot()
+	services := sis.GetServices()
+	categories := sis.GetCategories()
 
 	for _, serviceType := range slices.Sorted(maps.Keys(services)) {
 		service := services[serviceType]
+		rates, _ := sis.GetRatesForType(serviceType) // can have no rates
 		config := p.Cluster.Config.Liquids[serviceType]
 		area := config.Area
 		// defense in depth: config should be in sync with serviceInfo
@@ -206,8 +208,8 @@ func (p *v2Provider) handleGetRatesInfo(r *http.Request, token *gopherpolicy.Tok
 		}
 		serviceReport := report.Areas[area].Services[serviceType]
 
-		for _, rateName := range slices.Sorted(maps.Keys(rates[serviceType])) {
-			rate := rates[serviceType][rateName]
+		for _, rateName := range slices.Sorted(maps.Keys(rates)) {
+			rate := rates[rateName]
 			rir := ratesv2.RateInfoReport{
 				DisplayName: rate.DisplayName,
 				Topology:    rate.Topology,

--- a/internal/api/clusters.go
+++ b/internal/api/clusters.go
@@ -24,9 +24,9 @@ func (p *v1Provider) GetCluster(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	showBasic := !token.Check("cluster:show")
-	resources := p.Cluster.SIC.GetResources()
+	sis := p.Cluster.SIC.GetSnapshot()
 
-	filter := reports.ReadFilter(r, p.Cluster, resources)
+	filter := reports.ReadFilter(r, p.Cluster, sis)
 	p.recordReportSpecificity("cluster_show", filter)
 	if showBasic {
 		filter.IsSubcapacityAllowed = func(serviceType db.ServiceType, resourceName liquid.ResourceName) bool {
@@ -38,7 +38,7 @@ func (p *v1Provider) GetCluster(w http.ResponseWriter, r *http.Request) {
 
 	var cluster *limesresources.ClusterReport
 	err := db.RunOLAPQueries(p.DB, func(tx *gorp.Transaction) (err error) {
-		cluster, err = reports.GetClusterResources(p.Cluster, p.timeNow(), p.DB, filter, resources)
+		cluster, err = reports.GetClusterResources(p.Cluster, p.timeNow(), p.DB, filter, sis)
 		return err
 	})
 	if respondwith.ObfuscatedErrorText(w, err) {

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -223,7 +223,7 @@ func (p *v1Provider) GetPublicCommitments(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	resource, rExists := sis.GetResourceForTypeName(dbServiceType, dbResourceName)
+	resource, rExists := sis.GetResourceForPath(db.ResourcePath{ServiceType: dbServiceType, ResourceName: dbResourceName})
 	// this check is defense in depth (when a name mapping was found, the resource must be found too)
 	if !rExists {
 		msg := fmt.Sprintf("could not load underlying resource: %q", resource.Path)
@@ -329,6 +329,11 @@ func (p *v1Provider) parseAndValidateCommitmentRequest(w http.ResponseWriter, r 
 		http.Error(w, msg, http.StatusUnprocessableEntity)
 		return nil, nil, nil, filteredSIS
 	}
+	path := db.AZResourcePath{
+		ServiceType:      dbServiceType,
+		ResourceName:     dbResourceName,
+		AvailabilityZone: req.AvailabilityZone,
+	}
 	filteredSIS = sis.Filter(core.ServiceInfoFilter{ServiceType: Some(dbServiceType), ResourceName: Some(dbResourceName)})
 
 	behavior := p.Cluster.CommitmentBehaviorForResource(dbServiceType, dbResourceName).ForDomain(dbDomain.Name)
@@ -336,7 +341,7 @@ func (p *v1Provider) parseAndValidateCommitmentRequest(w http.ResponseWriter, r 
 		http.Error(w, "commitments are not enabled for this resource", http.StatusUnprocessableEntity)
 		return nil, nil, nil, filteredSIS
 	}
-	resource := must.BeOK(filteredSIS.GetResourceForTypeName(dbServiceType, dbResourceName))
+	resource := must.BeOK(filteredSIS.GetResourceForPath(path.Resource()))
 	if resource.Topology == liquid.FlatTopology {
 		if req.AvailabilityZone != limes.AvailabilityZoneAny {
 			http.Error(w, `resource does not accept AZ-aware commitments, so the AZ must be set to "any"`, http.StatusUnprocessableEntity)
@@ -359,11 +364,6 @@ func (p *v1Provider) parseAndValidateCommitmentRequest(w http.ResponseWriter, r 
 		return nil, nil, nil, filteredSIS
 	}
 
-	path := db.AZResourcePath{
-		ServiceType:      dbServiceType,
-		ResourceName:     dbResourceName,
-		AvailabilityZone: req.AvailabilityZone,
-	}
 	// when the name mapping succeeded, service and resource must be found
 	return &req, &path, &behavior, filteredSIS
 }
@@ -1756,7 +1756,7 @@ func (p *v1Provider) GetCommitmentConversions(w http.ResponseWriter, r *http.Req
 		http.Error(w, msg, http.StatusUnprocessableEntity)
 		return
 	}
-	sourceResource, rExists := sis.GetResourceForTypeName(sourceServiceType, sourceResourceName)
+	sourceResource, rExists := sis.GetResourceForPath(db.ResourcePath{ServiceType: sourceServiceType, ResourceName: sourceResourceName})
 	if !rExists {
 		http.Error(w, "service not found", http.StatusNotFound)
 		return

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -310,7 +310,7 @@ func (p *v1Provider) GetPublicCommitments(w http.ResponseWriter, r *http.Request
 // parseAndValidateCommitmentRequest parses and validates the request body for a commitment creation or confirmation.
 // This function in its current form should only be used if the serviceInfo is not necessary to be used outside
 // of this validation to avoid unnecessary database queries.
-func (p *v1Provider) parseAndValidateCommitmentRequest(w http.ResponseWriter, r *http.Request, dbDomain db.Domain) (_ *limesresources.CommitmentRequest, _ *db.AZResourcePath, _ *core.ScopedCommitmentBehavior, filteredSIS *core.FilteredServiceInfoSnapshot) {
+func (p *v1Provider) parseAndValidateCommitmentRequest(w http.ResponseWriter, r *http.Request, dbDomain db.Domain) (_ *limesresources.CommitmentRequest, _ *db.AZResourcePath, _ *core.ScopedCommitmentBehavior, filteredSIS core.FilteredServiceInfoSnapshot) {
 	// parse request
 	var parseTarget struct {
 		Request limesresources.CommitmentRequest `json:"commitment"`

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -731,7 +731,7 @@ func (p *v1Provider) MergeProjectCommitments(w http.ResponseWriter, r *http.Requ
 	sis := p.Cluster.SIC.GetSnapshot()
 	resource, rExists := sis.GetResourceForPath(path.Resource())
 	if !rExists { // checking the deepest level is enough
-		http.Error(w, "service not found", http.StatusNotFound)
+		http.Error(w, "service or resource not found", http.StatusNotFound)
 		return
 	}
 	service := must.BeOK(sis.GetServiceForType(path.ServiceType))
@@ -949,7 +949,7 @@ func (p *v1Provider) RenewProjectCommitments(w http.ResponseWriter, r *http.Requ
 	sis := p.Cluster.SIC.GetSnapshot()
 	resource, rExists := sis.GetResourceForPath(path.Resource())
 	if !rExists { // checking the deepest level is enough
-		http.Error(w, "service not found", http.StatusNotFound)
+		http.Error(w, "service or resource not found", http.StatusNotFound)
 		return
 	}
 	service := must.BeOK(sis.GetServiceForType(path.ServiceType))
@@ -1101,7 +1101,7 @@ func (p *v1Provider) DeleteProjectCommitment(w http.ResponseWriter, r *http.Requ
 	sis := p.Cluster.SIC.GetSnapshot()
 	_, rExists := sis.GetResourceForPath(path.Resource())
 	if !rExists { // checking the deepest level is enough
-		http.Error(w, "service not found", http.StatusNotFound)
+		http.Error(w, "service or resource not found", http.StatusNotFound)
 		return
 	}
 	service := must.BeOK(sis.GetServiceForType(path.ServiceType))
@@ -1273,7 +1273,7 @@ func (p *v1Provider) StartCommitmentTransfer(w http.ResponseWriter, r *http.Requ
 	sis := p.Cluster.SIC.GetSnapshot()
 	resource, rExists := sis.GetResourceForPath(path.Resource())
 	if !rExists { // checking the deepest level is enough
-		http.Error(w, "service not found", http.StatusNotFound)
+		http.Error(w, "service or resource not found", http.StatusNotFound)
 		return
 	}
 	service := must.BeOK(sis.GetServiceForType(path.ServiceType))
@@ -1513,7 +1513,7 @@ func (p *v1Provider) GetCommitmentByTransferToken(w http.ResponseWriter, r *http
 
 	resource, rExists := p.Cluster.SIC.GetSnapshot().GetResourceForPath(path.Resource())
 	if !rExists {
-		http.Error(w, "service not found", http.StatusNotFound)
+		http.Error(w, "service or resource not found", http.StatusNotFound)
 		return
 	}
 
@@ -1575,7 +1575,7 @@ func (p *v1Provider) TransferCommitment(w http.ResponseWriter, r *http.Request) 
 	sis := p.Cluster.SIC.GetSnapshot()
 	resource, rExists := sis.GetResourceForPath(path.Resource())
 	if !rExists { // checking the deepest level is enough
-		http.Error(w, "service not found", http.StatusNotFound)
+		http.Error(w, "service or resource not found", http.StatusNotFound)
 		return
 	}
 	service := must.BeOK(sis.GetServiceForType(path.ServiceType))
@@ -1757,7 +1757,7 @@ func (p *v1Provider) GetCommitmentConversions(w http.ResponseWriter, r *http.Req
 	}
 	sourceResource, rExists := sis.GetResourceForPath(db.ResourcePath{ServiceType: sourceServiceType, ResourceName: sourceResourceName})
 	if !rExists {
-		http.Error(w, "service not found", http.StatusNotFound)
+		http.Error(w, "service or resource not found", http.StatusNotFound)
 		return
 	}
 	sourceBehavior := forTokenScope(p.Cluster.CommitmentBehaviorForResource(sourceServiceType, sourceResourceName))
@@ -1849,9 +1849,9 @@ func (p *v1Provider) ConvertCommitment(w http.ResponseWriter, r *http.Request) {
 	sourceBehavior := p.Cluster.CommitmentBehaviorForResourcePath(sourcePath.Resource()).ForDomain(dbDomain.Name)
 
 	sis := p.Cluster.SIC.GetSnapshot()
-	sourceService, rExists := sis.GetServiceForType(sourcePath.ServiceType)
-	if !rExists { // checking the deepest level is enough
-		http.Error(w, "service not found", http.StatusNotFound)
+	sourceService, sExists := sis.GetServiceForType(sourcePath.ServiceType)
+	if !sExists {
+		http.Error(w, "service or resource not found", http.StatusNotFound)
 		return
 	}
 
@@ -2175,8 +2175,8 @@ func (p *v1Provider) UpdateCommitmentDuration(w http.ResponseWriter, r *http.Req
 
 	sis := p.Cluster.SIC.GetSnapshot()
 	resource, rExists := sis.GetResourceForPath(path.Resource())
-	if !rExists { // checking the deepest level is enough
-		http.Error(w, "service not found", http.StatusNotFound)
+	if !rExists {
+		http.Error(w, "service or resource not found", http.StatusNotFound)
 		return
 	}
 	service := must.BeOK(sis.GetServiceForType(path.ServiceType))

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -121,10 +121,10 @@ func (p *v1Provider) GetProjectCommitments(w http.ResponseWriter, r *http.Reques
 	if dbProject == nil {
 		return
 	}
-	resources := p.Cluster.SIC.GetResources()
+	sis := p.Cluster.SIC.GetSnapshot()
 
 	// enumerate project AZ resources
-	filter := reports.ReadFilter(r, p.Cluster, resources)
+	filter := reports.ReadFilter(r, p.Cluster, sis)
 	queryStr, joinArgs := filter.PrepareQuery(getAZResourceLocationsQuery)
 	whereStr, whereArgs := db.BuildSimpleWhereClause(map[string]any{"pazr.project_id": dbProject.ID}, len(joinArgs))
 	azResourcePathsByID := make(map[db.AZResourceID]db.AZResourcePath)
@@ -157,7 +157,7 @@ func (p *v1Provider) GetProjectCommitments(w http.ResponseWriter, r *http.Reques
 	result := make([]limesresources.Commitment, 0, len(dbCommitments))
 	for _, c := range dbCommitments {
 		path, pExists := azResourcePathsByID[c.AZResourceID]
-		resource, rExists := resources[path.ServiceType][path.ResourceName]
+		resource, rExists := sis.GetResourceForPath(path.Resource())
 		if !pExists || !rExists {
 			// defense in depth (the DB should not change that much between the 2 queries and the state of SIC)
 			continue
@@ -214,8 +214,8 @@ func (p *v1Provider) GetPublicCommitments(w http.ResponseWriter, r *http.Request
 	}
 	requestedResourceName := limesresources.ResourceName(query.Get("resource"))
 
-	resources := p.Cluster.SIC.GetResources()
-	nm := core.BuildResourceNameMapping(p.Cluster, resources)
+	sis := p.Cluster.SIC.GetSnapshot()
+	nm := core.BuildResourceNameMapping(p.Cluster, sis)
 	dbServiceType, dbResourceName, ok := nm.MapFromV1API(requestedServiceType, requestedResourceName)
 	if !ok {
 		msg := fmt.Sprintf("no such service and/or resource: %q", fmt.Sprintf("%s/%s", requestedServiceType, requestedResourceName))
@@ -223,7 +223,7 @@ func (p *v1Provider) GetPublicCommitments(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	resource, rExists := resources[dbServiceType][dbResourceName]
+	resource, rExists := sis.GetResourceForTypeName(dbServiceType, dbResourceName)
 	// this check is defense in depth (when a name mapping was found, the resource must be found too)
 	if !rExists {
 		msg := fmt.Sprintf("could not load underlying resource: %q", resource.Path)
@@ -310,52 +310,53 @@ func (p *v1Provider) GetPublicCommitments(w http.ResponseWriter, r *http.Request
 // parseAndValidateCommitmentRequest parses and validates the request body for a commitment creation or confirmation.
 // This function in its current form should only be used if the serviceInfo is not necessary to be used outside
 // of this validation to avoid unnecessary database queries.
-func (p *v1Provider) parseAndValidateCommitmentRequest(w http.ResponseWriter, r *http.Request, dbDomain db.Domain) (_ *limesresources.CommitmentRequest, _ *db.AZResourcePath, _ *core.ScopedCommitmentBehavior, service db.Service, resources core.ResourcesByName) {
+func (p *v1Provider) parseAndValidateCommitmentRequest(w http.ResponseWriter, r *http.Request, dbDomain db.Domain) (_ *limesresources.CommitmentRequest, _ *db.AZResourcePath, _ *core.ScopedCommitmentBehavior, filteredSIS *core.FilteredServiceInfoSnapshot) {
 	// parse request
 	var parseTarget struct {
 		Request limesresources.CommitmentRequest `json:"commitment"`
 	}
 	if !RequireJSON(w, r, &parseTarget) {
-		return nil, nil, nil, service, resources
+		return nil, nil, nil, filteredSIS
 	}
 	req := parseTarget.Request
 
 	// validate request
-	services := p.Cluster.SIC.GetServices()
-	allResources := p.Cluster.SIC.GetResources()
-	nm := core.BuildResourceNameMapping(p.Cluster, allResources)
+	sis := p.Cluster.SIC.GetSnapshot()
+	nm := core.BuildResourceNameMapping(p.Cluster, sis)
 	dbServiceType, dbResourceName, ok := nm.MapFromV1API(req.ServiceType, req.ResourceName)
 	if !ok {
 		msg := fmt.Sprintf("no such service and/or resource: %s/%s", req.ServiceType, req.ResourceName)
 		http.Error(w, msg, http.StatusUnprocessableEntity)
-		return nil, nil, nil, service, resources
+		return nil, nil, nil, filteredSIS
 	}
+	filteredSIS = sis.Filter(core.ServiceInfoFilter{ServiceType: Some(dbServiceType), ResourceName: Some(dbResourceName)})
 
 	behavior := p.Cluster.CommitmentBehaviorForResource(dbServiceType, dbResourceName).ForDomain(dbDomain.Name)
 	if len(behavior.Durations) == 0 {
 		http.Error(w, "commitments are not enabled for this resource", http.StatusUnprocessableEntity)
-		return nil, nil, nil, service, resources
+		return nil, nil, nil, filteredSIS
 	}
-	if allResources[dbServiceType][dbResourceName].Topology == liquid.FlatTopology {
+	resource := must.BeOK(filteredSIS.GetResourceForTypeName(dbServiceType, dbResourceName))
+	if resource.Topology == liquid.FlatTopology {
 		if req.AvailabilityZone != limes.AvailabilityZoneAny {
 			http.Error(w, `resource does not accept AZ-aware commitments, so the AZ must be set to "any"`, http.StatusUnprocessableEntity)
-			return nil, nil, nil, service, resources
+			return nil, nil, nil, filteredSIS
 		}
 	} else {
 		if !slices.Contains(p.Cluster.Config.AvailabilityZones, req.AvailabilityZone) {
 			http.Error(w, "no such availability zone", http.StatusUnprocessableEntity)
-			return nil, nil, nil, service, resources
+			return nil, nil, nil, filteredSIS
 		}
 	}
 	if !slices.Contains(behavior.Durations, req.Duration) {
 		buf := must.Return(json.Marshal(behavior.Durations)) // panic on error is acceptable here, marshals should never fail
 		msg := "unacceptable commitment duration for this resource, acceptable values: " + string(buf)
 		http.Error(w, msg, http.StatusUnprocessableEntity)
-		return nil, nil, nil, service, resources
+		return nil, nil, nil, filteredSIS
 	}
 	if req.Amount == 0 {
 		http.Error(w, "amount of committed resource must be greater than zero", http.StatusUnprocessableEntity)
-		return nil, nil, nil, service, resources
+		return nil, nil, nil, filteredSIS
 	}
 
 	path := db.AZResourcePath{
@@ -364,7 +365,7 @@ func (p *v1Provider) parseAndValidateCommitmentRequest(w http.ResponseWriter, r 
 		AvailabilityZone: req.AvailabilityZone,
 	}
 	// when the name mapping succeeded, service and resource must be found
-	return &req, &path, &behavior, services[dbServiceType], allResources[dbServiceType]
+	return &req, &path, &behavior, filteredSIS
 }
 
 // CanConfirmNewProjectCommitment handles POST /v1/domains/:domain_id/projects/:project_id/commitments/can-confirm.
@@ -382,7 +383,7 @@ func (p *v1Provider) CanConfirmNewProjectCommitment(w http.ResponseWriter, r *ht
 	if dbProject == nil {
 		return
 	}
-	req, path, behavior, service, resources := p.parseAndValidateCommitmentRequest(w, r, *dbDomain)
+	req, path, behavior, filteredSIS := p.parseAndValidateCommitmentRequest(w, r, *dbDomain)
 	if req == nil {
 		return
 	}
@@ -437,7 +438,7 @@ func (p *v1Provider) CanConfirmNewProjectCommitment(w http.ResponseWriter, r *ht
 
 	// check for committable capacity via the transferableCommitmentCache
 	// it automatically does the delegation to liquid if required
-	transferableCommitmentCache, err := datamodel.NewTransferableCommitmentCache(p.DB, p.Cluster, service, resources, *path, now, p.generateProjectCommitmentUUID, p.generateTransferToken, None[core.MailTemplate]())
+	transferableCommitmentCache, err := datamodel.NewTransferableCommitmentCache(p.DB, p.Cluster, filteredSIS, *path, now, p.generateProjectCommitmentUUID, p.generateTransferToken, None[core.MailTemplate]())
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
@@ -464,10 +465,11 @@ func (p *v1Provider) CreateProjectCommitment(w http.ResponseWriter, r *http.Requ
 	if dbProject == nil {
 		return
 	}
-	req, path, behavior, service, resources := p.parseAndValidateCommitmentRequest(w, r, *dbDomain)
+	req, path, behavior, filteredSIS := p.parseAndValidateCommitmentRequest(w, r, *dbDomain)
 	if req == nil {
 		return
 	}
+	service := must.BeOK(filteredSIS.GetFilteredService())
 
 	var (
 		azResourceID              db.AZResourceID
@@ -547,7 +549,7 @@ func (p *v1Provider) CreateProjectCommitment(w http.ResponseWriter, r *http.Requ
 		if mailConfig, exists := p.Cluster.Config.MailNotifications.Unpack(); exists {
 			mailTemplate = Some(mailConfig.Templates.TransferredCommitments)
 		}
-		transferableCommitmentCache, err := datamodel.NewTransferableCommitmentCache(tx, p.Cluster, service, resources, *path, now, p.generateProjectCommitmentUUID, p.generateTransferToken, mailTemplate)
+		transferableCommitmentCache, err := datamodel.NewTransferableCommitmentCache(tx, p.Cluster, filteredSIS, *path, now, p.generateProjectCommitmentUUID, p.generateTransferToken, mailTemplate)
 		if respondwith.ObfuscatedErrorText(w, err) {
 			return
 		}
@@ -603,7 +605,7 @@ func (p *v1Provider) CreateProjectCommitment(w http.ResponseWriter, r *http.Requ
 				},
 			},
 		}
-		commitmentChangeResponse, err := datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, service, resources, tx)
+		commitmentChangeResponse, err := datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, filteredSIS, service.Type, tx)
 		if respondwith.ObfuscatedErrorText(w, err) {
 			return
 		}
@@ -648,7 +650,7 @@ func (p *v1Provider) CreateProjectCommitment(w http.ResponseWriter, r *http.Requ
 	}
 
 	// render response
-	commitment := datamodel.ConvertCommitmentToDisplayForm(dbCommitment, path.AvailabilityZone, p.Cluster.BehaviorForResourcePath(path.Resource()).IdentityInV1API, datamodel.CanDeleteCommitment(token, dbCommitment, p.timeNow), resources[path.ResourceName].Unit)
+	commitment := datamodel.ConvertCommitmentToDisplayForm(dbCommitment, path.AvailabilityZone, p.Cluster.BehaviorForResourcePath(path.Resource()).IdentityInV1API, datamodel.CanDeleteCommitment(token, dbCommitment, p.timeNow), must.BeOK(filteredSIS.GetResourceForPath(path.Resource())).Unit)
 	respondwith.JSON(w, http.StatusCreated, map[string]any{"commitment": commitment})
 }
 
@@ -727,13 +729,13 @@ func (p *v1Provider) MergeProjectCommitments(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	service, _ := p.Cluster.SIC.GetServiceForType(path.ServiceType)
-	resources, _ := p.Cluster.SIC.GetResourcesForType(path.ServiceType)
-	resource, rExists := resources[path.ResourceName]
+	filteredSIS := p.Cluster.SIC.GetSnapshot().Filter(core.ServiceInfoFilter{ServiceType: Some(path.ServiceType)})
+	resource, rExists := filteredSIS.GetResourceForPath(path.Resource())
 	if !rExists { // checking the deepest level is enough
 		http.Error(w, "service not found", http.StatusNotFound)
 		return
 	}
+	service := must.BeOK(filteredSIS.GetServiceForType(path.ServiceType))
 
 	// Start transaction for creating new commitment and marking merged commitments as superseded
 	tx, err := p.DB.Begin()
@@ -847,7 +849,7 @@ func (p *v1Provider) MergeProjectCommitments(w http.ResponseWriter, r *http.Requ
 			},
 		},
 	}
-	_, err = datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, service, resources, tx)
+	_, err = datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, filteredSIS, service.Type, tx)
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
@@ -945,13 +947,13 @@ func (p *v1Provider) RenewProjectCommitments(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	service, _ := p.Cluster.SIC.GetServiceForType(path.ServiceType)
-	resources, _ := p.Cluster.SIC.GetResourcesForType(path.ServiceType)
-	resource, rExists := resources[path.ResourceName]
+	filteredSIS := p.Cluster.SIC.GetSnapshot().Filter(core.ServiceInfoFilter{ServiceType: Some(path.ServiceType)})
+	resource, rExists := filteredSIS.GetResourceForPath(path.Resource())
 	if !rExists { // checking the deepest level is enough
 		http.Error(w, "service not found", http.StatusNotFound)
 		return
 	}
+	service := must.BeOK(filteredSIS.GetServiceForType(path.ServiceType))
 
 	creationContext := db.CommitmentWorkflowContext{
 		Reason:                 db.CommitmentReasonRenew,
@@ -1029,7 +1031,7 @@ func (p *v1Provider) RenewProjectCommitments(w http.ResponseWriter, r *http.Requ
 			},
 		},
 	}
-	_, err = datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, service, resources, tx)
+	_, err = datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, filteredSIS, service.Type, tx)
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
@@ -1097,12 +1099,13 @@ func (p *v1Provider) DeleteProjectCommitment(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	service, sExists := p.Cluster.SIC.GetServiceForType(path.ServiceType)
-	resources, _ := p.Cluster.SIC.GetResourcesForType(path.ServiceType)
-	if !sExists {
+	filteredSIS := p.Cluster.SIC.GetSnapshot().Filter(core.ServiceInfoFilter{ServiceType: Some(path.ServiceType)})
+	_, rExists := filteredSIS.GetResourceForPath(path.Resource())
+	if !rExists { // checking the deepest level is enough
 		http.Error(w, "service not found", http.StatusNotFound)
 		return
 	}
+	service := must.BeOK(filteredSIS.GetServiceForType(path.ServiceType))
 
 	// ignore expired, superseded or soft-deleted commitments
 	if slices.Contains([]liquid.CommitmentStatus{liquid.CommitmentStatusExpired, liquid.CommitmentStatusSuperseded, util.CommitmentStatusDeleted}, dbCommitment.Status) {
@@ -1149,7 +1152,7 @@ func (p *v1Provider) DeleteProjectCommitment(w http.ResponseWriter, r *http.Requ
 			},
 		},
 	}
-	_, err = datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, service, resources, p.DB)
+	_, err = datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, filteredSIS, service.Type, p.DB)
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
@@ -1268,13 +1271,13 @@ func (p *v1Provider) StartCommitmentTransfer(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	service, _ := p.Cluster.SIC.GetServiceForType(path.ServiceType)
-	resources, _ := p.Cluster.SIC.GetResourcesForType(path.ServiceType)
-	resource, rExists := resources[path.ResourceName]
+	filteredSIS := p.Cluster.SIC.GetSnapshot().Filter(core.ServiceInfoFilter{ServiceType: Some(path.ServiceType)})
+	resource, rExists := filteredSIS.GetResourceForPath(path.Resource())
 	if !rExists { // checking the deepest level is enough
 		http.Error(w, "service not found", http.StatusNotFound)
 		return
 	}
+	service := must.BeOK(filteredSIS.GetServiceForType(path.ServiceType))
 
 	// when moving into CommitmentTransferStatusNone, the token is cleared;
 	// otherwise a new token is generated and filled in for the transfer
@@ -1399,7 +1402,7 @@ func (p *v1Provider) StartCommitmentTransfer(w http.ResponseWriter, r *http.Requ
 			NewTransferStatus: req.TransferStatus,
 		}
 
-		_, err = datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, service, resources, tx)
+		_, err = datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, filteredSIS, service.Type, tx)
 		if respondwith.ObfuscatedErrorText(w, err) {
 			return
 		}
@@ -1509,7 +1512,7 @@ func (p *v1Provider) GetCommitmentByTransferToken(w http.ResponseWriter, r *http
 		return
 	}
 
-	resource, rExists := p.Cluster.SIC.GetResourceForPath(path.Resource())
+	resource, rExists := p.Cluster.SIC.GetSnapshot().GetResourceForPath(path.Resource())
 	if !rExists {
 		http.Error(w, "service not found", http.StatusNotFound)
 		return
@@ -1570,13 +1573,13 @@ func (p *v1Provider) TransferCommitment(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	service, _ := p.Cluster.SIC.GetServiceForType(path.ServiceType)
-	resources, _ := p.Cluster.SIC.GetResourcesForType(path.ServiceType)
-	resource, rExists := resources[path.ResourceName]
+	filteredSIS := p.Cluster.SIC.GetSnapshot().Filter(core.ServiceInfoFilter{ServiceType: Some(path.ServiceType)})
+	resource, rExists := filteredSIS.GetResourceForPath(path.Resource())
 	if !rExists { // checking the deepest level is enough
 		http.Error(w, "service not found", http.StatusNotFound)
 		return
 	}
+	service := must.BeOK(filteredSIS.GetServiceForType(path.ServiceType))
 
 	// get old project additionally
 	var sourceProject db.Project
@@ -1679,7 +1682,7 @@ func (p *v1Provider) TransferCommitment(w http.ResponseWriter, r *http.Request) 
 			},
 		},
 	}
-	commitmentChangeResponse, err := datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, service, resources, tx)
+	commitmentChangeResponse, err := datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, filteredSIS, service.Type, tx)
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
@@ -1742,8 +1745,8 @@ func (p *v1Provider) GetCommitmentConversions(w http.ResponseWriter, r *http.Req
 	// validate request
 	vars := mux.Vars(r)
 
-	resources := p.Cluster.SIC.GetResources()
-	nm := core.BuildResourceNameMapping(p.Cluster, resources)
+	sis := p.Cluster.SIC.GetSnapshot()
+	nm := core.BuildResourceNameMapping(p.Cluster, sis)
 	sourceServiceType, sourceResourceName, exists := nm.MapFromV1API(
 		limes.ServiceType(vars["service_type"]),
 		limesresources.ResourceName(vars["resource_name"]),
@@ -1753,7 +1756,7 @@ func (p *v1Provider) GetCommitmentConversions(w http.ResponseWriter, r *http.Req
 		http.Error(w, msg, http.StatusUnprocessableEntity)
 		return
 	}
-	sourceResource, rExists := p.Cluster.SIC.GetResourceForTypeName(sourceServiceType, sourceResourceName)
+	sourceResource, rExists := sis.GetResourceForTypeName(sourceServiceType, sourceResourceName)
 	if !rExists {
 		http.Error(w, "service not found", http.StatusNotFound)
 		return
@@ -1763,8 +1766,9 @@ func (p *v1Provider) GetCommitmentConversions(w http.ResponseWriter, r *http.Req
 	// enumerate possible conversions
 	conversions := make([]limesresources.CommitmentConversionRule, 0)
 	if sourceBehavior.ConversionRule.IsSome() {
-		for _, targetServiceType := range slices.Sorted(maps.Keys(resources)) {
-			for targetResourceName, targetResource := range resources[targetServiceType] {
+		for _, targetServiceType := range slices.Sorted(maps.Keys(sis.GetResources())) {
+			resources, _ := sis.GetResourcesForType(targetServiceType) // can have no resources
+			for targetResourceName, targetResource := range resources {
 				if sourceServiceType == targetServiceType && sourceResourceName == targetResourceName {
 					continue
 				}
@@ -1844,11 +1848,12 @@ func (p *v1Provider) ConvertCommitment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	sourceBehavior := p.Cluster.CommitmentBehaviorForResourcePath(sourcePath.Resource()).ForDomain(dbDomain.Name)
-	resources := p.Cluster.SIC.GetResources()
-	sourceService, sExists := p.Cluster.SIC.GetServiceForType(sourcePath.ServiceType)
-	if !sExists {
-		msg := "no such service and/or resource: " + sourcePath.Resource().String()
-		http.Error(w, msg, http.StatusUnprocessableEntity)
+
+	sis := p.Cluster.SIC.GetSnapshot()
+	filteredSIS := sis.Filter(core.ServiceInfoFilter{ServiceType: Some(sourcePath.ServiceType)})
+	sourceService, rExists := filteredSIS.GetServiceForType(sourcePath.ServiceType)
+	if !rExists { // checking the deepest level is enough
+		http.Error(w, "service not found", http.StatusNotFound)
 		return
 	}
 
@@ -1865,7 +1870,7 @@ func (p *v1Provider) ConvertCommitment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	req := parseTarget.Request
-	nm := core.BuildResourceNameMapping(p.Cluster, resources)
+	nm := core.BuildResourceNameMapping(p.Cluster, sis)
 	targetServiceType, targetResourceName, exists := nm.MapFromV1API(req.TargetService, req.TargetResource)
 	if !exists {
 		msg := fmt.Sprintf("no such service and/or resource: %s/%s", req.TargetService, req.TargetResource)
@@ -2021,7 +2026,7 @@ func (p *v1Provider) ConvertCommitment(w http.ResponseWriter, r *http.Request) {
 			},
 		},
 	}
-	commitmentChangeResponse, err := datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, sourceService, resources[sourcePath.ServiceType], tx)
+	commitmentChangeResponse, err := datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, filteredSIS, sourceService.Type, tx)
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
@@ -2076,7 +2081,8 @@ func (p *v1Provider) ConvertCommitment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	c := datamodel.ConvertCommitmentToDisplayForm(convertedCommitment, targetPath.AvailabilityZone, p.Cluster.BehaviorForResourcePath(targetPath.Resource()).IdentityInV1API, datamodel.CanDeleteCommitment(token, convertedCommitment, p.timeNow), resources[targetPath.ServiceType][targetPath.ResourceName].Unit)
+	targetResource := must.BeOK(sis.GetResourceForPath(targetPath.Resource()))
+	c := datamodel.ConvertCommitmentToDisplayForm(convertedCommitment, targetPath.AvailabilityZone, p.Cluster.BehaviorForResourcePath(targetPath.Resource()).IdentityInV1API, datamodel.CanDeleteCommitment(token, convertedCommitment, p.timeNow), targetResource.Unit)
 
 	auditEvents := audit.CommitmentEventTarget{
 		CommitmentChangeRequest: ccr,
@@ -2169,13 +2175,13 @@ func (p *v1Provider) UpdateCommitmentDuration(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	service, _ := p.Cluster.SIC.GetServiceForType(path.ServiceType)
-	resources, _ := p.Cluster.SIC.GetResourcesForType(path.ServiceType)
-	resource, rExists := resources[path.ResourceName]
+	filteredSIS := p.Cluster.SIC.GetSnapshot().Filter(core.ServiceInfoFilter{ServiceType: Some(path.ServiceType)})
+	resource, rExists := filteredSIS.GetResourceForPath(path.Resource())
 	if !rExists { // checking the deepest level is enough
 		http.Error(w, "service not found", http.StatusNotFound)
 		return
 	}
+	service := must.BeOK(filteredSIS.GetServiceForType(path.ServiceType))
 
 	// might only reject in the remote-case, locally we accept extensions as limes does not know future capacity
 	ccr := liquid.CommitmentChangeRequest{
@@ -2207,7 +2213,7 @@ func (p *v1Provider) UpdateCommitmentDuration(w http.ResponseWriter, r *http.Req
 			},
 		},
 	}
-	commitmentChangeResponse, err := datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, service, resources, p.DB)
+	commitmentChangeResponse, err := datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, filteredSIS, service.Type, p.DB)
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -310,62 +310,61 @@ func (p *v1Provider) GetPublicCommitments(w http.ResponseWriter, r *http.Request
 // parseAndValidateCommitmentRequest parses and validates the request body for a commitment creation or confirmation.
 // This function in its current form should only be used if the serviceInfo is not necessary to be used outside
 // of this validation to avoid unnecessary database queries.
-func (p *v1Provider) parseAndValidateCommitmentRequest(w http.ResponseWriter, r *http.Request, dbDomain db.Domain) (_ *limesresources.CommitmentRequest, _ *db.AZResourcePath, _ *core.ScopedCommitmentBehavior, filteredSIS core.FilteredServiceInfoSnapshot) {
+func (p *v1Provider) parseAndValidateCommitmentRequest(w http.ResponseWriter, r *http.Request, dbDomain db.Domain) (_ *limesresources.CommitmentRequest, _ *db.AZResourcePath, _ *core.ScopedCommitmentBehavior, sis core.ServiceInfoSnapshot) {
 	// parse request
 	var parseTarget struct {
 		Request limesresources.CommitmentRequest `json:"commitment"`
 	}
 	if !RequireJSON(w, r, &parseTarget) {
-		return nil, nil, nil, filteredSIS
+		return nil, nil, nil, sis
 	}
 	req := parseTarget.Request
 
 	// validate request
-	sis := p.Cluster.SIC.GetSnapshot()
+	sis = p.Cluster.SIC.GetSnapshot()
 	nm := core.BuildResourceNameMapping(p.Cluster, sis)
 	dbServiceType, dbResourceName, ok := nm.MapFromV1API(req.ServiceType, req.ResourceName)
 	if !ok {
 		msg := fmt.Sprintf("no such service and/or resource: %s/%s", req.ServiceType, req.ResourceName)
 		http.Error(w, msg, http.StatusUnprocessableEntity)
-		return nil, nil, nil, filteredSIS
+		return nil, nil, nil, sis
 	}
 	path := db.AZResourcePath{
 		ServiceType:      dbServiceType,
 		ResourceName:     dbResourceName,
 		AvailabilityZone: req.AvailabilityZone,
 	}
-	filteredSIS = sis.Filter(core.ServiceInfoFilter{ServiceType: Some(dbServiceType), ResourceName: Some(dbResourceName)})
 
 	behavior := p.Cluster.CommitmentBehaviorForResource(dbServiceType, dbResourceName).ForDomain(dbDomain.Name)
 	if len(behavior.Durations) == 0 {
 		http.Error(w, "commitments are not enabled for this resource", http.StatusUnprocessableEntity)
-		return nil, nil, nil, filteredSIS
+		return nil, nil, nil, sis
 	}
-	resource := must.BeOK(filteredSIS.GetResourceForPath(path.Resource()))
+	resource := must.BeOK(sis.GetResourceForPath(path.Resource()))
 	if resource.Topology == liquid.FlatTopology {
 		if req.AvailabilityZone != limes.AvailabilityZoneAny {
 			http.Error(w, `resource does not accept AZ-aware commitments, so the AZ must be set to "any"`, http.StatusUnprocessableEntity)
-			return nil, nil, nil, filteredSIS
+			return nil, nil, nil, sis
 		}
 	} else {
 		if !slices.Contains(p.Cluster.Config.AvailabilityZones, req.AvailabilityZone) {
 			http.Error(w, "no such availability zone", http.StatusUnprocessableEntity)
-			return nil, nil, nil, filteredSIS
+			return nil, nil, nil, sis
 		}
 	}
 	if !slices.Contains(behavior.Durations, req.Duration) {
 		buf := must.Return(json.Marshal(behavior.Durations)) // panic on error is acceptable here, marshals should never fail
 		msg := "unacceptable commitment duration for this resource, acceptable values: " + string(buf)
 		http.Error(w, msg, http.StatusUnprocessableEntity)
-		return nil, nil, nil, filteredSIS
+		return nil, nil, nil, sis
 	}
 	if req.Amount == 0 {
 		http.Error(w, "amount of committed resource must be greater than zero", http.StatusUnprocessableEntity)
-		return nil, nil, nil, filteredSIS
+		return nil, nil, nil, sis
 	}
 
 	// when the name mapping succeeded, service and resource must be found
-	return &req, &path, &behavior, filteredSIS
+	return &req, &path, &behavior, sis
 }
 
 // CanConfirmNewProjectCommitment handles POST /v1/domains/:domain_id/projects/:project_id/commitments/can-confirm.
@@ -465,11 +464,11 @@ func (p *v1Provider) CreateProjectCommitment(w http.ResponseWriter, r *http.Requ
 	if dbProject == nil {
 		return
 	}
-	req, path, behavior, filteredSIS := p.parseAndValidateCommitmentRequest(w, r, *dbDomain)
+	req, path, behavior, sis := p.parseAndValidateCommitmentRequest(w, r, *dbDomain)
 	if req == nil {
 		return
 	}
-	service := must.BeOK(filteredSIS.GetFilteredService())
+	service := must.BeOK(sis.GetServiceForType(path.ServiceType))
 
 	var (
 		azResourceID              db.AZResourceID
@@ -549,7 +548,7 @@ func (p *v1Provider) CreateProjectCommitment(w http.ResponseWriter, r *http.Requ
 		if mailConfig, exists := p.Cluster.Config.MailNotifications.Unpack(); exists {
 			mailTemplate = Some(mailConfig.Templates.TransferredCommitments)
 		}
-		transferableCommitmentCache, err := datamodel.NewTransferableCommitmentCache(tx, p.Cluster, filteredSIS, *path, now, p.generateProjectCommitmentUUID, p.generateTransferToken, mailTemplate)
+		transferableCommitmentCache, err := datamodel.NewTransferableCommitmentCache(tx, p.Cluster, sis, *path, now, p.generateProjectCommitmentUUID, p.generateTransferToken, mailTemplate)
 		if respondwith.ObfuscatedErrorText(w, err) {
 			return
 		}
@@ -605,7 +604,7 @@ func (p *v1Provider) CreateProjectCommitment(w http.ResponseWriter, r *http.Requ
 				},
 			},
 		}
-		commitmentChangeResponse, err := datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, filteredSIS, service.Type, tx)
+		commitmentChangeResponse, err := datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, sis, service.Type, tx)
 		if respondwith.ObfuscatedErrorText(w, err) {
 			return
 		}
@@ -650,7 +649,7 @@ func (p *v1Provider) CreateProjectCommitment(w http.ResponseWriter, r *http.Requ
 	}
 
 	// render response
-	commitment := datamodel.ConvertCommitmentToDisplayForm(dbCommitment, path.AvailabilityZone, p.Cluster.BehaviorForResourcePath(path.Resource()).IdentityInV1API, datamodel.CanDeleteCommitment(token, dbCommitment, p.timeNow), must.BeOK(filteredSIS.GetResourceForPath(path.Resource())).Unit)
+	commitment := datamodel.ConvertCommitmentToDisplayForm(dbCommitment, path.AvailabilityZone, p.Cluster.BehaviorForResourcePath(path.Resource()).IdentityInV1API, datamodel.CanDeleteCommitment(token, dbCommitment, p.timeNow), must.BeOK(sis.GetResourceForPath(path.Resource())).Unit)
 	respondwith.JSON(w, http.StatusCreated, map[string]any{"commitment": commitment})
 }
 
@@ -729,13 +728,13 @@ func (p *v1Provider) MergeProjectCommitments(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	filteredSIS := p.Cluster.SIC.GetSnapshot().Filter(core.ServiceInfoFilter{ServiceType: Some(path.ServiceType)})
-	resource, rExists := filteredSIS.GetResourceForPath(path.Resource())
+	sis := p.Cluster.SIC.GetSnapshot()
+	resource, rExists := sis.GetResourceForPath(path.Resource())
 	if !rExists { // checking the deepest level is enough
 		http.Error(w, "service not found", http.StatusNotFound)
 		return
 	}
-	service := must.BeOK(filteredSIS.GetServiceForType(path.ServiceType))
+	service := must.BeOK(sis.GetServiceForType(path.ServiceType))
 
 	// Start transaction for creating new commitment and marking merged commitments as superseded
 	tx, err := p.DB.Begin()
@@ -849,7 +848,7 @@ func (p *v1Provider) MergeProjectCommitments(w http.ResponseWriter, r *http.Requ
 			},
 		},
 	}
-	_, err = datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, filteredSIS, service.Type, tx)
+	_, err = datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, sis, service.Type, tx)
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
@@ -947,13 +946,13 @@ func (p *v1Provider) RenewProjectCommitments(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	filteredSIS := p.Cluster.SIC.GetSnapshot().Filter(core.ServiceInfoFilter{ServiceType: Some(path.ServiceType)})
-	resource, rExists := filteredSIS.GetResourceForPath(path.Resource())
+	sis := p.Cluster.SIC.GetSnapshot()
+	resource, rExists := sis.GetResourceForPath(path.Resource())
 	if !rExists { // checking the deepest level is enough
 		http.Error(w, "service not found", http.StatusNotFound)
 		return
 	}
-	service := must.BeOK(filteredSIS.GetServiceForType(path.ServiceType))
+	service := must.BeOK(sis.GetServiceForType(path.ServiceType))
 
 	creationContext := db.CommitmentWorkflowContext{
 		Reason:                 db.CommitmentReasonRenew,
@@ -1031,7 +1030,7 @@ func (p *v1Provider) RenewProjectCommitments(w http.ResponseWriter, r *http.Requ
 			},
 		},
 	}
-	_, err = datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, filteredSIS, service.Type, tx)
+	_, err = datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, sis, service.Type, tx)
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
@@ -1099,13 +1098,13 @@ func (p *v1Provider) DeleteProjectCommitment(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	filteredSIS := p.Cluster.SIC.GetSnapshot().Filter(core.ServiceInfoFilter{ServiceType: Some(path.ServiceType)})
-	_, rExists := filteredSIS.GetResourceForPath(path.Resource())
+	sis := p.Cluster.SIC.GetSnapshot()
+	_, rExists := sis.GetResourceForPath(path.Resource())
 	if !rExists { // checking the deepest level is enough
 		http.Error(w, "service not found", http.StatusNotFound)
 		return
 	}
-	service := must.BeOK(filteredSIS.GetServiceForType(path.ServiceType))
+	service := must.BeOK(sis.GetServiceForType(path.ServiceType))
 
 	// ignore expired, superseded or soft-deleted commitments
 	if slices.Contains([]liquid.CommitmentStatus{liquid.CommitmentStatusExpired, liquid.CommitmentStatusSuperseded, util.CommitmentStatusDeleted}, dbCommitment.Status) {
@@ -1152,7 +1151,7 @@ func (p *v1Provider) DeleteProjectCommitment(w http.ResponseWriter, r *http.Requ
 			},
 		},
 	}
-	_, err = datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, filteredSIS, service.Type, p.DB)
+	_, err = datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, sis, service.Type, p.DB)
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
@@ -1271,13 +1270,13 @@ func (p *v1Provider) StartCommitmentTransfer(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	filteredSIS := p.Cluster.SIC.GetSnapshot().Filter(core.ServiceInfoFilter{ServiceType: Some(path.ServiceType)})
-	resource, rExists := filteredSIS.GetResourceForPath(path.Resource())
+	sis := p.Cluster.SIC.GetSnapshot()
+	resource, rExists := sis.GetResourceForPath(path.Resource())
 	if !rExists { // checking the deepest level is enough
 		http.Error(w, "service not found", http.StatusNotFound)
 		return
 	}
-	service := must.BeOK(filteredSIS.GetServiceForType(path.ServiceType))
+	service := must.BeOK(sis.GetServiceForType(path.ServiceType))
 
 	// when moving into CommitmentTransferStatusNone, the token is cleared;
 	// otherwise a new token is generated and filled in for the transfer
@@ -1402,7 +1401,7 @@ func (p *v1Provider) StartCommitmentTransfer(w http.ResponseWriter, r *http.Requ
 			NewTransferStatus: req.TransferStatus,
 		}
 
-		_, err = datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, filteredSIS, service.Type, tx)
+		_, err = datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, sis, service.Type, tx)
 		if respondwith.ObfuscatedErrorText(w, err) {
 			return
 		}
@@ -1573,13 +1572,13 @@ func (p *v1Provider) TransferCommitment(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	filteredSIS := p.Cluster.SIC.GetSnapshot().Filter(core.ServiceInfoFilter{ServiceType: Some(path.ServiceType)})
-	resource, rExists := filteredSIS.GetResourceForPath(path.Resource())
+	sis := p.Cluster.SIC.GetSnapshot()
+	resource, rExists := sis.GetResourceForPath(path.Resource())
 	if !rExists { // checking the deepest level is enough
 		http.Error(w, "service not found", http.StatusNotFound)
 		return
 	}
-	service := must.BeOK(filteredSIS.GetServiceForType(path.ServiceType))
+	service := must.BeOK(sis.GetServiceForType(path.ServiceType))
 
 	// get old project additionally
 	var sourceProject db.Project
@@ -1682,7 +1681,7 @@ func (p *v1Provider) TransferCommitment(w http.ResponseWriter, r *http.Request) 
 			},
 		},
 	}
-	commitmentChangeResponse, err := datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, filteredSIS, service.Type, tx)
+	commitmentChangeResponse, err := datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, sis, service.Type, tx)
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
@@ -1850,8 +1849,7 @@ func (p *v1Provider) ConvertCommitment(w http.ResponseWriter, r *http.Request) {
 	sourceBehavior := p.Cluster.CommitmentBehaviorForResourcePath(sourcePath.Resource()).ForDomain(dbDomain.Name)
 
 	sis := p.Cluster.SIC.GetSnapshot()
-	filteredSIS := sis.Filter(core.ServiceInfoFilter{ServiceType: Some(sourcePath.ServiceType)})
-	sourceService, rExists := filteredSIS.GetServiceForType(sourcePath.ServiceType)
+	sourceService, rExists := sis.GetServiceForType(sourcePath.ServiceType)
 	if !rExists { // checking the deepest level is enough
 		http.Error(w, "service not found", http.StatusNotFound)
 		return
@@ -2026,7 +2024,7 @@ func (p *v1Provider) ConvertCommitment(w http.ResponseWriter, r *http.Request) {
 			},
 		},
 	}
-	commitmentChangeResponse, err := datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, filteredSIS, sourceService.Type, tx)
+	commitmentChangeResponse, err := datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, sis, sourceService.Type, tx)
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
@@ -2175,13 +2173,13 @@ func (p *v1Provider) UpdateCommitmentDuration(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	filteredSIS := p.Cluster.SIC.GetSnapshot().Filter(core.ServiceInfoFilter{ServiceType: Some(path.ServiceType)})
-	resource, rExists := filteredSIS.GetResourceForPath(path.Resource())
+	sis := p.Cluster.SIC.GetSnapshot()
+	resource, rExists := sis.GetResourceForPath(path.Resource())
 	if !rExists { // checking the deepest level is enough
 		http.Error(w, "service not found", http.StatusNotFound)
 		return
 	}
-	service := must.BeOK(filteredSIS.GetServiceForType(path.ServiceType))
+	service := must.BeOK(sis.GetServiceForType(path.ServiceType))
 
 	// might only reject in the remote-case, locally we accept extensions as limes does not know future capacity
 	ccr := liquid.CommitmentChangeRequest{
@@ -2213,7 +2211,7 @@ func (p *v1Provider) UpdateCommitmentDuration(w http.ResponseWriter, r *http.Req
 			},
 		},
 	}
-	commitmentChangeResponse, err := datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, filteredSIS, service.Type, p.DB)
+	commitmentChangeResponse, err := datamodel.DelegateChangeCommitments(r.Context(), p.Cluster, ccr, sis, service.Type, p.DB)
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -224,8 +224,8 @@ func (p *v1Provider) FindProjectFromRequestIfExists(w http.ResponseWriter, r *ht
 }
 
 // GetDomainReport is a convenience wrapper around reports.GetDomains() for getting a single domain report.
-func GetDomainReport(cluster *core.Cluster, dbDomain db.Domain, now time.Time, dbi db.Interface, filter reports.Filter, resources core.ResourcesByNameType) (*limesresources.DomainReport, error) {
-	domainReports, err := reports.GetDomains(cluster, &dbDomain.ID, now, dbi, filter, resources)
+func GetDomainReport(cluster *core.Cluster, dbDomain db.Domain, now time.Time, dbi db.Interface, filter reports.Filter, sis *core.ServiceInfoSnapshot) (*limesresources.DomainReport, error) {
+	domainReports, err := reports.GetDomains(cluster, &dbDomain.ID, now, dbi, filter, sis)
 	if err != nil {
 		return nil, err
 	}
@@ -236,9 +236,9 @@ func GetDomainReport(cluster *core.Cluster, dbDomain db.Domain, now time.Time, d
 }
 
 // GetProjectResourceReport is a convenience wrapper around reports.GetProjectResources() for getting a single project resource report.
-func GetProjectResourceReport(cluster *core.Cluster, dbDomain db.Domain, dbProject db.Project, now time.Time, dbi db.Interface, filter reports.Filter, resources core.ResourcesByNameType) (*limesresources.ProjectReport, error) {
+func GetProjectResourceReport(cluster *core.Cluster, dbDomain db.Domain, dbProject db.Project, now time.Time, dbi db.Interface, filter reports.Filter, sis *core.ServiceInfoSnapshot) (*limesresources.ProjectReport, error) {
 	var result *limesresources.ProjectReport
-	err := reports.GetProjectResources(cluster, dbDomain, &dbProject, now, dbi, filter, resources, func(r *limesresources.ProjectReport) error {
+	err := reports.GetProjectResources(cluster, dbDomain, &dbProject, now, dbi, filter, sis, func(r *limesresources.ProjectReport) error {
 		result = r
 		return nil
 	})
@@ -252,9 +252,9 @@ func GetProjectResourceReport(cluster *core.Cluster, dbDomain db.Domain, dbProje
 }
 
 // GetProjectRateReport is a convenience wrapper around reports.GetProjectRates() for getting a single project rate report.
-func GetProjectRateReport(cluster *core.Cluster, dbDomain db.Domain, dbProject db.Project, dbi db.Interface, filter reports.Filter, rates core.RatesByNameType) (*limesrates.ProjectReport, error) {
+func GetProjectRateReport(cluster *core.Cluster, dbDomain db.Domain, dbProject db.Project, dbi db.Interface, filter reports.Filter, sis *core.ServiceInfoSnapshot) (*limesrates.ProjectReport, error) {
 	var result *limesrates.ProjectReport
-	err := reports.GetProjectRates(cluster, dbDomain, &dbProject, dbi, filter, rates, func(r *limesrates.ProjectReport) error {
+	err := reports.GetProjectRates(cluster, dbDomain, &dbProject, dbi, filter, sis, func(r *limesrates.ProjectReport) error {
 		result = r
 		return nil
 	})

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -224,7 +224,7 @@ func (p *v1Provider) FindProjectFromRequestIfExists(w http.ResponseWriter, r *ht
 }
 
 // GetDomainReport is a convenience wrapper around reports.GetDomains() for getting a single domain report.
-func GetDomainReport(cluster *core.Cluster, dbDomain db.Domain, now time.Time, dbi db.Interface, filter reports.Filter, sis *core.ServiceInfoSnapshot) (*limesresources.DomainReport, error) {
+func GetDomainReport(cluster *core.Cluster, dbDomain db.Domain, now time.Time, dbi db.Interface, filter reports.Filter, sis core.ServiceInfoSnapshot) (*limesresources.DomainReport, error) {
 	domainReports, err := reports.GetDomains(cluster, &dbDomain.ID, now, dbi, filter, sis)
 	if err != nil {
 		return nil, err
@@ -236,7 +236,7 @@ func GetDomainReport(cluster *core.Cluster, dbDomain db.Domain, now time.Time, d
 }
 
 // GetProjectResourceReport is a convenience wrapper around reports.GetProjectResources() for getting a single project resource report.
-func GetProjectResourceReport(cluster *core.Cluster, dbDomain db.Domain, dbProject db.Project, now time.Time, dbi db.Interface, filter reports.Filter, sis *core.ServiceInfoSnapshot) (*limesresources.ProjectReport, error) {
+func GetProjectResourceReport(cluster *core.Cluster, dbDomain db.Domain, dbProject db.Project, now time.Time, dbi db.Interface, filter reports.Filter, sis core.ServiceInfoSnapshot) (*limesresources.ProjectReport, error) {
 	var result *limesresources.ProjectReport
 	err := reports.GetProjectResources(cluster, dbDomain, &dbProject, now, dbi, filter, sis, func(r *limesresources.ProjectReport) error {
 		result = r
@@ -252,7 +252,7 @@ func GetProjectResourceReport(cluster *core.Cluster, dbDomain db.Domain, dbProje
 }
 
 // GetProjectRateReport is a convenience wrapper around reports.GetProjectRates() for getting a single project rate report.
-func GetProjectRateReport(cluster *core.Cluster, dbDomain db.Domain, dbProject db.Project, dbi db.Interface, filter reports.Filter, sis *core.ServiceInfoSnapshot) (*limesrates.ProjectReport, error) {
+func GetProjectRateReport(cluster *core.Cluster, dbDomain db.Domain, dbProject db.Project, dbi db.Interface, filter reports.Filter, sis core.ServiceInfoSnapshot) (*limesrates.ProjectReport, error) {
 	var result *limesrates.ProjectReport
 	err := reports.GetProjectRates(cluster, dbDomain, &dbProject, dbi, filter, sis, func(r *limesrates.ProjectReport) error {
 		result = r

--- a/internal/api/domains.go
+++ b/internal/api/domains.go
@@ -23,10 +23,10 @@ func (p *v1Provider) ListDomains(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// missing services/ resources will lead to empty filter --> empty report
-	resources := p.Cluster.SIC.GetResources()
-	filter := reports.ReadFilter(r, p.Cluster, resources)
+	sis := p.Cluster.SIC.GetSnapshot()
+	filter := reports.ReadFilter(r, p.Cluster, sis)
 	p.recordReportSpecificity("domain_list", filter)
-	domains, err := reports.GetDomains(p.Cluster, nil, p.timeNow(), p.DB, filter, resources)
+	domains, err := reports.GetDomains(p.Cluster, nil, p.timeNow(), p.DB, filter, sis)
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
@@ -46,11 +46,11 @@ func (p *v1Provider) GetDomain(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resources := p.Cluster.SIC.GetResources()
+	sis := p.Cluster.SIC.GetSnapshot()
 
-	filter := reports.ReadFilter(r, p.Cluster, resources)
+	filter := reports.ReadFilter(r, p.Cluster, sis)
 	p.recordReportSpecificity("domain_show", filter)
-	domain, err := GetDomainReport(p.Cluster, *dbDomain, p.timeNow(), p.DB, filter, resources)
+	domain, err := GetDomainReport(p.Cluster, *dbDomain, p.timeNow(), p.DB, filter, sis)
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -20,9 +20,9 @@ func (p *v1Provider) ListScrapeErrors(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resources := p.Cluster.SIC.GetResources()
+	sis := p.Cluster.SIC.GetSnapshot()
 
-	scrapeErrors, err := reports.GetScrapeErrors(p.DB, reports.ReadFilter(r, p.Cluster, resources))
+	scrapeErrors, err := reports.GetScrapeErrors(p.DB, reports.ReadFilter(r, p.Cluster, sis))
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}

--- a/internal/api/inconsistencies.go
+++ b/internal/api/inconsistencies.go
@@ -20,9 +20,9 @@ func (p *v1Provider) ListInconsistencies(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	resources := p.Cluster.SIC.GetResources()
+	sis := p.Cluster.SIC.GetSnapshot()
 
-	inconsistencies, err := reports.GetInconsistencies(p.Cluster, p.DB, reports.ReadFilter(r, p.Cluster, resources), resources)
+	inconsistencies, err := reports.GetInconsistencies(p.Cluster, p.DB, reports.ReadFilter(r, p.Cluster, sis), sis)
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}

--- a/internal/api/liquid.go
+++ b/internal/api/liquid.go
@@ -15,6 +15,8 @@ import (
 	"github.com/sapcc/limes/internal/core"
 	"github.com/sapcc/limes/internal/datamodel"
 	"github.com/sapcc/limes/internal/db"
+
+	. "go.xyrillian.de/gg/option"
 )
 
 // GetServiceCapacityRequest handles GET /admin/liquid/service-capacity-request?service_type=:type.
@@ -31,14 +33,14 @@ func (p *v1Provider) GetServiceCapacityRequest(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	resources, ok := p.Cluster.SIC.GetResourcesForType(serviceType)
-	if !ok {
+	filteredSIS := p.Cluster.SIC.GetSnapshot().Filter(core.ServiceInfoFilter{ServiceType: Some(serviceType)})
+	if len(filteredSIS.GetServices()) == 0 {
 		http.Error(w, "unknown service type", http.StatusBadRequest)
 		return
 	}
 
 	backchannel := datamodel.NewCapacityScrapeBackchannel(p.Cluster, p.DB)
-	serviceCapacityRequest, err := core.BuildServiceCapacityRequest(backchannel, p.Cluster.Config.AvailabilityZones, serviceType, resources)
+	serviceCapacityRequest, err := core.BuildServiceCapacityRequest(backchannel, p.Cluster.Config.AvailabilityZones, filteredSIS)
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}

--- a/internal/api/liquid.go
+++ b/internal/api/liquid.go
@@ -15,8 +15,6 @@ import (
 	"github.com/sapcc/limes/internal/core"
 	"github.com/sapcc/limes/internal/datamodel"
 	"github.com/sapcc/limes/internal/db"
-
-	. "go.xyrillian.de/gg/option"
 )
 
 // GetServiceCapacityRequest handles GET /admin/liquid/service-capacity-request?service_type=:type.
@@ -33,14 +31,15 @@ func (p *v1Provider) GetServiceCapacityRequest(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	filteredSIS := p.Cluster.SIC.GetSnapshot().Filter(core.ServiceInfoFilter{ServiceType: Some(serviceType)})
-	if len(filteredSIS.GetServices()) == 0 {
+	sis := p.Cluster.SIC.GetSnapshot()
+	_, ok := sis.GetServiceForType(serviceType)
+	if !ok {
 		http.Error(w, "unknown service type", http.StatusBadRequest)
 		return
 	}
 
 	backchannel := datamodel.NewCapacityScrapeBackchannel(p.Cluster, p.DB)
-	serviceCapacityRequest, err := core.BuildServiceCapacityRequest(backchannel, p.Cluster.Config.AvailabilityZones, filteredSIS)
+	serviceCapacityRequest, err := core.BuildServiceCapacityRequest(backchannel, p.Cluster.Config.AvailabilityZones, sis, serviceType)
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -215,7 +215,7 @@ func (p *v1Provider) PutProjectMaxQuota(w http.ResponseWriter, r *http.Request) 
 				return
 			}
 			// when found in the name mapping, the resource exists
-			resource, _ := sis.GetResourceForTypeName(dbServiceType, dbResourceName)
+			resource, _ := sis.GetResourceForPath(db.ResourcePath{ServiceType: dbServiceType, ResourceName: dbResourceName})
 
 			if requested[dbServiceType] == nil {
 				requested[dbServiceType] = make(map[liquid.ResourceName]*audit.MaxQuotaChange)
@@ -361,7 +361,7 @@ func (p *v1Provider) PutQuotaAutogrowth(w http.ResponseWriter, r *http.Request) 
 				return
 			}
 			// when found in the name mapping, the resource exists
-			resource, _ := sis.GetResourceForTypeName(dbServiceType, dbResourceName)
+			resource, _ := sis.GetResourceForPath(db.ResourcePath{ServiceType: dbServiceType, ResourceName: dbResourceName})
 
 			forbidAutogrowth, isSome := resRequest.ForbidAutogrowth.Unpack()
 			if !isSome {

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -5,6 +5,7 @@ package api
 
 import (
 	"fmt"
+	"maps"
 	"net/http"
 	"slices"
 
@@ -46,12 +47,12 @@ func (p *v1Provider) ListProjects(w http.ResponseWriter, r *http.Request) {
 	// projects runs as large as 160 MiB for the pure JSON.)
 	p.listProjectsMutex.Lock()
 	defer p.listProjectsMutex.Unlock()
-	resources := p.Cluster.SIC.GetResources()
+	sis := p.Cluster.SIC.GetSnapshot()
 
-	filter := reports.ReadFilter(r, p.Cluster, resources)
+	filter := reports.ReadFilter(r, p.Cluster, sis)
 	p.recordReportSpecificity("project_list", filter)
 	stream := NewJSONListStream[*limesresources.ProjectReport](w, r, "projects")
-	stream.FinalizeDocument(reports.GetProjectResources(p.Cluster, *dbDomain, nil, p.timeNow(), p.DB, filter, resources, stream.WriteItem))
+	stream.FinalizeDocument(reports.GetProjectResources(p.Cluster, *dbDomain, nil, p.timeNow(), p.DB, filter, sis, stream.WriteItem))
 }
 
 // GetProject handles GET /v1/domains/:domain_id/projects/:project_id.
@@ -69,11 +70,11 @@ func (p *v1Provider) GetProject(w http.ResponseWriter, r *http.Request) {
 	if dbProject == nil {
 		return
 	}
-	resources := p.Cluster.SIC.GetResources()
+	sis := p.Cluster.SIC.GetSnapshot()
 
-	filter := reports.ReadFilter(r, p.Cluster, resources)
+	filter := reports.ReadFilter(r, p.Cluster, sis)
 	p.recordReportSpecificity("project_show", filter)
-	project, err := GetProjectResourceReport(p.Cluster, *dbDomain, *dbProject, p.timeNow(), p.DB, filter, resources)
+	project, err := GetProjectResourceReport(p.Cluster, *dbDomain, *dbProject, p.timeNow(), p.DB, filter, sis)
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
@@ -200,10 +201,10 @@ func (p *v1Provider) PutProjectMaxQuota(w http.ResponseWriter, r *http.Request) 
 	if !RequireJSON(w, r, &parseTarget) {
 		return
 	}
-	resources := p.Cluster.SIC.GetResources()
+	sis := p.Cluster.SIC.GetSnapshot()
 
 	// validate request
-	nm := core.BuildResourceNameMapping(p.Cluster, resources)
+	nm := core.BuildResourceNameMapping(p.Cluster, sis)
 	requested := make(map[db.ServiceType]map[liquid.ResourceName]*audit.MaxQuotaChange)
 	for _, srvRequest := range parseTarget.Project.Services {
 		for _, resRequest := range srvRequest.Resources {
@@ -213,6 +214,8 @@ func (p *v1Provider) PutProjectMaxQuota(w http.ResponseWriter, r *http.Request) 
 				http.Error(w, msg, http.StatusUnprocessableEntity)
 				return
 			}
+			// when found in the name mapping, the resource exists
+			resource, _ := sis.GetResourceForTypeName(dbServiceType, dbResourceName)
 
 			if requested[dbServiceType] == nil {
 				requested[dbServiceType] = make(map[liquid.ResourceName]*audit.MaxQuotaChange)
@@ -220,7 +223,6 @@ func (p *v1Provider) PutProjectMaxQuota(w http.ResponseWriter, r *http.Request) 
 			if resRequest.MaxQuota == nil {
 				requested[dbServiceType][dbResourceName] = &audit.MaxQuotaChange{NewValue: None[uint64]()}
 			} else {
-				resource := resources[dbServiceType][dbResourceName]
 				if !resource.HasQuota {
 					msg := fmt.Sprintf("resource %s/%s does not track quota", dbServiceType, dbResourceName)
 					http.Error(w, msg, http.StatusUnprocessableEntity)
@@ -255,19 +257,15 @@ func (p *v1Provider) PutProjectMaxQuota(w http.ResponseWriter, r *http.Request) 
 	}
 	defer sqlext.RollbackUnlessCommitted(tx)
 
-	var services []db.Service
-	_, err = tx.Select(&services,
-		`SELECT s.* FROM services s JOIN project_services ps ON ps.service_id = s.id and ps.project_id = $1 ORDER BY s.type`, dbProject.ID)
-	if respondwith.ObfuscatedErrorText(w, err) {
-		return
-	}
-
-	for _, srv := range services {
-		requestedInService, exists := requested[srv.Type]
+	for _, serviceType := range slices.Sorted(maps.Keys(sis.GetServices())) {
+		service, _ := sis.GetServiceForType(serviceType)
+		requestedInService, exists := requested[service.Type]
 		if !exists {
 			continue
 		}
 
+		// when we got here, we can be sure the service exists
+		filteredSIS := sis.Filter(core.ServiceInfoFilter{ServiceType: Some(serviceType)})
 		err := datamodel.ProjectResourceUpdate{
 			UpdateResource: func(res *db.ProjectResource, resName liquid.ResourceName) error {
 				requestedChange := requestedInService[resName]
@@ -278,7 +276,7 @@ func (p *v1Provider) PutProjectMaxQuota(w http.ResponseWriter, r *http.Request) 
 				}
 				return nil
 			},
-		}.Run(tx, *dbProject, srv, resources[srv.Type])
+		}.Run(tx, *dbProject, filteredSIS)
 		if respondwith.ObfuscatedErrorText(w, err) {
 			return
 		}
@@ -349,10 +347,10 @@ func (p *v1Provider) PutQuotaAutogrowth(w http.ResponseWriter, r *http.Request) 
 	if !RequireJSON(w, r, &parseTarget) {
 		return
 	}
-	resources := p.Cluster.SIC.GetResources()
+	sis := p.Cluster.SIC.GetSnapshot()
 
 	// validate request
-	nm := core.BuildResourceNameMapping(p.Cluster, resources)
+	nm := core.BuildResourceNameMapping(p.Cluster, sis)
 	requested := make(map[db.ServiceType]map[liquid.ResourceName]*audit.AutogrowthChange)
 	for _, srvRequest := range parseTarget.Project.Services {
 		for _, resRequest := range srvRequest.Resources {
@@ -362,6 +360,8 @@ func (p *v1Provider) PutQuotaAutogrowth(w http.ResponseWriter, r *http.Request) 
 				http.Error(w, msg, http.StatusUnprocessableEntity)
 				return
 			}
+			// when found in the name mapping, the resource exists
+			resource, _ := sis.GetResourceForTypeName(dbServiceType, dbResourceName)
 
 			forbidAutogrowth, isSome := resRequest.ForbidAutogrowth.Unpack()
 			if !isSome {
@@ -370,8 +370,6 @@ func (p *v1Provider) PutQuotaAutogrowth(w http.ResponseWriter, r *http.Request) 
 				return
 			}
 
-			// we ignore when a resource can't be found in the app layer yet, it will default to return
-			resource := resources[dbServiceType][dbResourceName]
 			if !resource.HasQuota {
 				msg := fmt.Sprintf("resource %s/%s does not track quota", dbServiceType, dbResourceName)
 				http.Error(w, msg, http.StatusUnprocessableEntity)
@@ -400,21 +398,15 @@ func (p *v1Provider) PutQuotaAutogrowth(w http.ResponseWriter, r *http.Request) 
 	}
 	defer sqlext.RollbackUnlessCommitted(tx)
 
-	var services []db.Service
-	_, err = tx.Select(&services,
-		`SELECT s.* FROM services s JOIN project_services ps ON ps.service_id = s.id and ps.project_id = $1 ORDER BY s.type`, dbProject.ID)
-	if respondwith.ErrorText(w, err) {
-		return
-	}
-
-	for _, srv := range services {
-		requestedInService, exists := requested[srv.Type]
+	for _, serviceType := range slices.Sorted(maps.Keys(sis.GetServices())) {
+		service, _ := sis.GetServiceForType(serviceType)
+		requestedInService, exists := requested[service.Type]
 		if !exists {
 			continue
 		}
 
 		// when we got here, we can be sure the service exists
-		filteredResources := resources[srv.Type]
+		filteredSIS := sis.Filter(core.ServiceInfoFilter{ServiceType: Some(serviceType)})
 		err := datamodel.ProjectResourceUpdate{
 			UpdateResource: func(res *db.ProjectResource, resName liquid.ResourceName) error {
 				requestedChange := requestedInService[resName]
@@ -424,7 +416,7 @@ func (p *v1Provider) PutQuotaAutogrowth(w http.ResponseWriter, r *http.Request) 
 				}
 				return nil
 			},
-		}.Run(tx, *dbProject, srv, filteredResources)
+		}.Run(tx, *dbProject, filteredSIS)
 		if respondwith.ErrorText(w, err) {
 			return
 		}

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -265,7 +265,6 @@ func (p *v1Provider) PutProjectMaxQuota(w http.ResponseWriter, r *http.Request) 
 		}
 
 		// when we got here, we can be sure the service exists
-		filteredSIS := sis.Filter(core.ServiceInfoFilter{ServiceType: Some(serviceType)})
 		err := datamodel.ProjectResourceUpdate{
 			UpdateResource: func(res *db.ProjectResource, resName liquid.ResourceName) error {
 				requestedChange := requestedInService[resName]
@@ -276,7 +275,7 @@ func (p *v1Provider) PutProjectMaxQuota(w http.ResponseWriter, r *http.Request) 
 				}
 				return nil
 			},
-		}.Run(tx, *dbProject, filteredSIS)
+		}.Run(tx, *dbProject, sis, serviceType)
 		if respondwith.ObfuscatedErrorText(w, err) {
 			return
 		}
@@ -406,7 +405,6 @@ func (p *v1Provider) PutQuotaAutogrowth(w http.ResponseWriter, r *http.Request) 
 		}
 
 		// when we got here, we can be sure the service exists
-		filteredSIS := sis.Filter(core.ServiceInfoFilter{ServiceType: Some(serviceType)})
 		err := datamodel.ProjectResourceUpdate{
 			UpdateResource: func(res *db.ProjectResource, resName liquid.ResourceName) error {
 				requestedChange := requestedInService[resName]
@@ -416,7 +414,7 @@ func (p *v1Provider) PutQuotaAutogrowth(w http.ResponseWriter, r *http.Request) 
 				}
 				return nil
 			},
-		}.Run(tx, *dbProject, filteredSIS)
+		}.Run(tx, *dbProject, sis, serviceType)
 		if respondwith.ErrorText(w, err) {
 			return
 		}

--- a/internal/api/rate_updater.go
+++ b/internal/api/rate_updater.go
@@ -61,14 +61,14 @@ type RateValidationError struct {
 // Results are collected into u.Requests. The return value is only set for unexpected
 // errors, not for validation errors.
 func (u *RateLimitUpdater) ValidateInput(input limesrates.RateRequest, dbi db.Interface) error {
-	rates := u.Cluster.SIC.GetRates()
+	sis := u.Cluster.SIC.GetSnapshot()
 
-	projectReport, err := GetProjectRateReport(u.Cluster, *u.Domain, *u.Project, dbi, reports.Filter{}, rates)
+	projectReport, err := GetProjectRateReport(u.Cluster, *u.Domain, *u.Project, dbi, reports.Filter{}, sis)
 	if err != nil {
 		return err
 	}
 
-	nm := core.BuildRateNameMapping(u.Cluster, rates)
+	nm := core.BuildRateNameMapping(u.Cluster, sis)
 	u.Requests = make(map[db.ServiceType]map[liquid.RateName]RateLimitRequest)
 
 	// Go through all services and validate the requested rate limits.

--- a/internal/api/rates.go
+++ b/internal/api/rates.go
@@ -33,10 +33,9 @@ func (p *v1Provider) GetClusterRates(w http.ResponseWriter, r *http.Request) {
 
 	// TODO: We only use the serviceType-part of the filter here, otherwise this would
 	// not work for rates. Would be better to use a dedicated filter for that which is fed with "rates".
-	resources := p.Cluster.SIC.GetResources()
-	rates := p.Cluster.SIC.GetRates()
+	sis := p.Cluster.SIC.GetSnapshot()
 
-	cluster, err := reports.GetClusterRates(p.Cluster, p.DB, reports.ReadFilter(r, p.Cluster, resources), rates)
+	cluster, err := reports.GetClusterRates(p.Cluster, p.DB, reports.ReadFilter(r, p.Cluster, sis), sis)
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
@@ -62,12 +61,11 @@ func (p *v1Provider) ListProjectRates(w http.ResponseWriter, r *http.Request) {
 
 	// TODO: We only use the serviceType-part of the filter here, otherwise this would
 	// not work for rates. Would be better to use a dedicated filter for that which is fed with "rates".
-	resources := p.Cluster.SIC.GetResources()
-	rates := p.Cluster.SIC.GetRates()
+	sis := p.Cluster.SIC.GetSnapshot()
 
-	filter := reports.ReadFilter(r, p.Cluster, resources)
+	filter := reports.ReadFilter(r, p.Cluster, sis)
 	stream := NewJSONListStream[*limesrates.ProjectReport](w, r, "projects")
-	stream.FinalizeDocument(reports.GetProjectRates(p.Cluster, *dbDomain, nil, p.DB, filter, rates, stream.WriteItem))
+	stream.FinalizeDocument(reports.GetProjectRates(p.Cluster, *dbDomain, nil, p.DB, filter, sis, stream.WriteItem))
 }
 
 // GetProjectRates handles GET /rates/v1/domains/:domain_id/projects/:project_id.
@@ -93,10 +91,9 @@ func (p *v1Provider) GetProjectRates(w http.ResponseWriter, r *http.Request) {
 
 	// TODO: We only use the serviceType-part of the filter here, otherwise this would
 	// not work for rates. Would be better to use a dedicated filter for that which is fed with "rates".
-	resources := p.Cluster.SIC.GetResources()
-	rates := p.Cluster.SIC.GetRates()
+	sis := p.Cluster.SIC.GetSnapshot()
 
-	project, err := GetProjectRateReport(p.Cluster, *dbDomain, *dbProject, p.DB, reports.ReadFilter(r, p.Cluster, resources), rates)
+	project, err := GetProjectRateReport(p.Cluster, *dbDomain, *dbProject, p.DB, reports.ReadFilter(r, p.Cluster, sis), sis)
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}

--- a/internal/collector/capacity_scrape.go
+++ b/internal/collector/capacity_scrape.go
@@ -126,7 +126,7 @@ func (c *Collector) discoverCapacityScrapeTask(_ context.Context, _ prometheus.L
 	}
 	// if the above check succeeded, this should never fail because the SIC is updated after the
 	// LiquidConnection is initialized.
-	_, ok = c.Cluster.SIC.GetServiceForType(task.ServiceType)
+	_, ok = c.Cluster.SIC.GetSnapshot().GetServiceForType(task.ServiceType)
 	if !ok {
 		return task, fmt.Errorf("no data found in ServiceInfoCache for type %s", task.ServiceType)
 	}
@@ -147,7 +147,7 @@ func (c *Collector) processCapacityScrapeTask(ctx context.Context, task capacity
 	connection := c.Cluster.LiquidConnections[serviceType]
 	if connection == nil {
 		task.Timing.FinishedAt = c.MeasureTimeAtEnd()
-		service, _ := c.Cluster.SIC.GetServiceForType(serviceType)
+		service, _ := c.Cluster.SIC.GetSnapshot().GetServiceForType(serviceType)
 		service.NextScrapeAt = task.Timing.FinishedAt.Add(c.AddJitter(capacityScrapeInterval))
 		_, err := c.DB.Update(&service)
 		if err != nil {
@@ -158,15 +158,14 @@ func (c *Collector) processCapacityScrapeTask(ctx context.Context, task capacity
 	}
 
 	// scrape capacity data
-	capacityData, serializedMetrics, err := c.scrapeLiquidCapacity(ctx, connection)
+	capacityData, serializedMetrics, sis, err := c.scrapeLiquidCapacity(ctx, connection)
 
-	// IMPORTANT: service may have been updated, only load it here
-	service, sExists := c.Cluster.SIC.GetServiceForType(serviceType)
-	resources, _ := c.Cluster.SIC.GetResourcesForType(serviceType)
-	azResources, _ := c.Cluster.SIC.GetAZResourcesForType(serviceType)
+	service, sExists := sis.GetServiceForType(serviceType)
 	if !sExists { // defense in depth: when we get here, the scrape was successful, so the service should be up to date
 		return fmt.Errorf("no data found in ServiceInfoCache for type %s", connection.ServiceType)
 	}
+	resources, _ := sis.GetResourcesForType(serviceType)     // might have no resources
+	azResources, _ := sis.GetAZResourcesForType(serviceType) // might have no az_resources
 
 	task.Timing.FinishedAt = c.MeasureTimeAtEnd()
 	if err == nil {
@@ -284,24 +283,24 @@ func (c *Collector) processCapacityScrapeTask(ctx context.Context, task capacity
 	return nil
 }
 
-func (c *Collector) scrapeLiquidCapacity(ctx context.Context, connection *core.LiquidConnection) (capacityData liquid.ServiceCapacityReport, serializedMetrics []byte, err error) {
-	capacityData, err = connection.ScrapeCapacity(ctx, datamodel.NewCapacityScrapeBackchannel(c.Cluster, c.DB), c.Cluster.Config.AvailabilityZones)
+func (c *Collector) scrapeLiquidCapacity(ctx context.Context, connection *core.LiquidConnection) (capacityData liquid.ServiceCapacityReport, serializedMetrics []byte, sis *core.ServiceInfoSnapshot, err error) {
+	capacityData, sis, err = connection.ScrapeCapacity(ctx, datamodel.NewCapacityScrapeBackchannel(c.Cluster, c.DB), c.Cluster.Config.AvailabilityZones)
 	if err != nil {
-		return liquid.ServiceCapacityReport{}, nil, err
+		return liquid.ServiceCapacityReport{}, nil, sis, err
 	}
-	service, sExists := c.Cluster.SIC.GetServiceForType(connection.ServiceType)
-	if !sExists { // defense in depth: when we get here, the scrape was successful, so the service should be up to date
-		return capacityData, nil, fmt.Errorf("no data found in ServiceInfoCache for type %s", connection.ServiceType)
+	service, sExists := sis.GetServiceForType(connection.ServiceType)
+	if !sExists { // defense in depth: this snapshot is taken immediately after saving the ServiceInfo
+		return capacityData, nil, sis, fmt.Errorf("no data found in ServiceInfoCache for type %s", connection.ServiceType)
 	}
 	capacityMetricFamilies, err := util.JSONToAny[map[liquid.MetricName]liquid.MetricFamilyInfo](service.CapacityMetricFamiliesJSON, "capacity_metric_families")
 	if err != nil {
-		return liquid.ServiceCapacityReport{}, nil, err
+		return liquid.ServiceCapacityReport{}, nil, sis, err
 	}
 	serializedMetrics, err = liquidSerializeMetrics(capacityMetricFamilies, capacityData.Metrics)
 	if err != nil {
-		return liquid.ServiceCapacityReport{}, nil, err
+		return liquid.ServiceCapacityReport{}, nil, sis, err
 	}
-	return capacityData, serializedMetrics, nil
+	return capacityData, serializedMetrics, sis, nil
 }
 
 func (c *Collector) confirmPendingCommitmentsIfNecessary(ctx context.Context, resource db.Resource) error {

--- a/internal/collector/capacity_scrape.go
+++ b/internal/collector/capacity_scrape.go
@@ -283,7 +283,7 @@ func (c *Collector) processCapacityScrapeTask(ctx context.Context, task capacity
 	return nil
 }
 
-func (c *Collector) scrapeLiquidCapacity(ctx context.Context, connection *core.LiquidConnection) (capacityData liquid.ServiceCapacityReport, serializedMetrics []byte, sis *core.ServiceInfoSnapshot, err error) {
+func (c *Collector) scrapeLiquidCapacity(ctx context.Context, connection *core.LiquidConnection) (capacityData liquid.ServiceCapacityReport, serializedMetrics []byte, sis core.ServiceInfoSnapshot, err error) {
 	capacityData, sis, err = connection.ScrapeCapacity(ctx, datamodel.NewCapacityScrapeBackchannel(c.Cluster, c.DB), c.Cluster.Config.AvailabilityZones)
 	if err != nil {
 		return liquid.ServiceCapacityReport{}, nil, sis, err

--- a/internal/collector/metrics.go
+++ b/internal/collector/metrics.go
@@ -99,7 +99,7 @@ func (c *AggregateMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 			return err
 		}
 
-		resources, _ := c.Cluster.SIC.GetResourcesForType(serviceType) // we can ignore "ok" because the len matters
+		resources, _ := c.Cluster.SIC.GetSnapshot().GetResourcesForType(serviceType) // we can ignore "ok" because the len matters
 		if len(resources) > 0 {
 			ch <- prometheus.MustNewConstMetric(
 				minScrapedAtDesc,
@@ -156,7 +156,7 @@ type CapacityCollectionMetricsInstance struct {
 // Describe implements the prometheus.Collector interface.
 func (c *CapacityCollectionMetricsCollector) Describe(ch chan<- *prometheus.Desc) {
 	capacityCollectionMetricsOkGauge.Describe(ch)
-	for _, service := range c.Cluster.SIC.GetServices() {
+	for _, service := range c.Cluster.SIC.GetSnapshot().GetServices() {
 		capacityMetricFamilies, err := util.JSONToAny[map[liquid.MetricName]liquid.MetricFamilyInfo](service.CapacityMetricFamiliesJSON, "capacity_metric_families")
 		if err != nil {
 			ch <- prometheus.NewInvalidDesc(fmt.Errorf("error describing capacity_metric_families for %s: %w", service.Type, err))
@@ -200,7 +200,7 @@ func (c *CapacityCollectionMetricsCollector) Collect(ch chan<- prometheus.Metric
 
 func (c *CapacityCollectionMetricsCollector) collectOneCapacitor(ch chan<- prometheus.Metric, collectionMetricsOkDesc *prometheus.Desc, instance CapacityCollectionMetricsInstance) {
 	// we ignore when a resource can't be found in the app layer yet, it will appear with default value
-	service, _ := c.Cluster.SIC.GetServiceForType(instance.ServiceType)
+	service, _ := c.Cluster.SIC.GetSnapshot().GetServiceForType(instance.ServiceType)
 	successAsFloat := 1.0
 	capacityMetricFamilies, err := util.JSONToAny[map[liquid.MetricName]liquid.MetricFamilyInfo](service.CapacityMetricFamiliesJSON, "capacity_metric_families")
 	if err != nil {
@@ -254,7 +254,7 @@ type QuotaCollectionMetricsInstance struct {
 // Describe implements the prometheus.Collector interface.
 func (c *UsageCollectionMetricsCollector) Describe(ch chan<- *prometheus.Desc) {
 	usageCollectionMetricsOkGauge.Describe(ch)
-	for _, service := range c.Cluster.SIC.GetServices() {
+	for _, service := range c.Cluster.SIC.GetSnapshot().GetServices() {
 		usageMetricFamilies, err := util.JSONToAny[map[liquid.MetricName]liquid.MetricFamilyInfo](service.UsageMetricFamiliesJSON, "usage_metric_families")
 		if err != nil {
 			ch <- prometheus.NewInvalidDesc(fmt.Errorf("error describing usage_metric_families for %s: %w", service.Type, err))
@@ -304,7 +304,7 @@ func (c *UsageCollectionMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 
 func (c *UsageCollectionMetricsCollector) collectOneProjectService(ch chan<- prometheus.Metric, collectionMetricsOkDesc *prometheus.Desc, instance QuotaCollectionMetricsInstance) {
 	// we ignore when a resource can't be found in the app layer yet, it will appear with default value
-	service, _ := c.Cluster.SIC.GetServiceForType(instance.ServiceType)
+	service, _ := c.Cluster.SIC.GetSnapshot().GetServiceForType(instance.ServiceType)
 	successAsFloat := 1.0
 	usageMetricFamilies, err := util.JSONToAny[map[liquid.MetricName]liquid.MetricFamilyInfo](service.UsageMetricFamiliesJSON, "usage_metric_families")
 	if err != nil {
@@ -518,7 +518,7 @@ var projectRateMetricsQuery = sqlext.SimplifyWhitespace(`
 
 func (d *DataMetricsV1Reporter) collectMetrics() (*dataMetricSet, error) {
 	behaviorCache := newResourceAndRateBehaviorCache(d.Cluster)
-	resources := d.Cluster.SIC.GetResources()
+	resources := d.Cluster.SIC.GetSnapshot().GetResources()
 	result := make(map[string][]dataMetric)
 
 	// fetch values for cluster level

--- a/internal/collector/scrape.go
+++ b/internal/collector/scrape.go
@@ -217,22 +217,22 @@ func (c *Collector) recordScrapeError(task projectScrapeTask, serviceType db.Ser
 	return fmt.Errorf("during scrape of project %s/%s: %w", dbDomain.Name, dbProject.Name, task.Err)
 }
 
-func (c *Collector) scrapeLiquid(ctx context.Context, connection *core.LiquidConnection, project core.KeystoneProject, projectService db.ProjectService) (liquid.ServiceUsageReport, []byte, *core.ServiceInfoSnapshot, error) {
+func (c *Collector) scrapeLiquid(ctx context.Context, connection *core.LiquidConnection, project core.KeystoneProject, projectService db.ProjectService) (liquid.ServiceUsageReport, []byte, core.ServiceInfoSnapshot, error) {
 	report, sis, err := connection.Scrape(ctx, project, c.Cluster.Config.AvailabilityZones, projectService.SerializedScrapeState)
 	if err != nil {
-		return liquid.ServiceUsageReport{}, nil, &core.ServiceInfoSnapshot{}, err
+		return liquid.ServiceUsageReport{}, nil, core.ServiceInfoSnapshot{}, err
 	}
 	service, sExists := sis.GetServiceForType(connection.ServiceType)
 	if !sExists { // defense in depth: this snapshot is taken immediately after saving the ServiceInfo
-		return liquid.ServiceUsageReport{}, nil, &core.ServiceInfoSnapshot{}, fmt.Errorf("no data found in ServiceInfoCache for type %s", connection.ServiceType)
+		return liquid.ServiceUsageReport{}, nil, core.ServiceInfoSnapshot{}, fmt.Errorf("no data found in ServiceInfoCache for type %s", connection.ServiceType)
 	}
 	usageMetricFamilies, err := util.JSONToAny[map[liquid.MetricName]liquid.MetricFamilyInfo](service.UsageMetricFamiliesJSON, "usage_metric_families")
 	if err != nil {
-		return liquid.ServiceUsageReport{}, nil, &core.ServiceInfoSnapshot{}, err
+		return liquid.ServiceUsageReport{}, nil, core.ServiceInfoSnapshot{}, err
 	}
 	serializedMetrics, err := liquidSerializeMetrics(usageMetricFamilies, report.Metrics)
 	if err != nil {
-		return liquid.ServiceUsageReport{}, nil, &core.ServiceInfoSnapshot{}, err
+		return liquid.ServiceUsageReport{}, nil, core.ServiceInfoSnapshot{}, err
 	}
 	return report, serializedMetrics, sis, nil
 }
@@ -255,7 +255,7 @@ func extractRateData(report liquid.ServiceUsageReport) (result map[liquid.RateNa
 	return result, string(report.SerializedState)
 }
 
-func (c *Collector) writeResourceScrapeResult(task projectScrapeTask, serviceType db.ServiceType, dbProject db.Project, resourceData liquid.ServiceUsageReport, sis *core.ServiceInfoSnapshot) error {
+func (c *Collector) writeResourceScrapeResult(task projectScrapeTask, serviceType db.ServiceType, dbProject db.Project, resourceData liquid.ServiceUsageReport, sis core.ServiceInfoSnapshot) error {
 	filteredSIS := sis.Filter(core.ServiceInfoFilter{ServiceType: Some(serviceType)})
 	service, sExists := filteredSIS.GetServiceForType(serviceType)
 	resources, _ := filteredSIS.GetResourcesForType(serviceType)     // can have no resources
@@ -466,7 +466,7 @@ func (c *Collector) writeResourceScrapeResult(task projectScrapeTask, serviceTyp
 	return nil
 }
 
-func (c *Collector) writeRateScrapeResult(task projectScrapeTask, serviceType db.ServiceType, rateData map[liquid.RateName]*big.Int, sis *core.ServiceInfoSnapshot) error {
+func (c *Collector) writeRateScrapeResult(task projectScrapeTask, serviceType db.ServiceType, rateData map[liquid.RateName]*big.Int, sis core.ServiceInfoSnapshot) error {
 	projectService := task.ProjectService
 	service, sExists := sis.GetServiceForType(serviceType)
 	if !sExists { // defense in depth: this snapshot is taken immediately after saving the ServiceInfo
@@ -634,7 +634,7 @@ func (c *Collector) writeDummyResources(dbProject db.Project, serviceType db.Ser
 	return tx.Commit()
 }
 
-func enrichUsageReportTotals(value *liquid.ServiceUsageReport, filteredSIS *core.FilteredServiceInfoSnapshot) {
+func enrichUsageReportTotals(value *liquid.ServiceUsageReport, filteredSIS core.FilteredServiceInfoSnapshot) {
 	if value == nil || value.Resources == nil {
 		return
 	}

--- a/internal/collector/scrape.go
+++ b/internal/collector/scrape.go
@@ -265,7 +265,7 @@ func (c *Collector) writeResourceScrapeResult(task projectScrapeTask, serviceTyp
 	}
 
 	for resName, resData := range resourceData.Resources {
-		resource, rExists := filteredSIS.GetResourceForTypeName(serviceType, resName)
+		resource, rExists := filteredSIS.GetResourceForPath(db.ResourcePath{ServiceType: serviceType, ResourceName: resName})
 		if !rExists {
 			return fmt.Errorf("no data found in ServiceInfoCache for %s", db.ResourcePath{ServiceType: serviceType, ResourceName: resName})
 		}
@@ -315,7 +315,7 @@ func (c *Collector) writeResourceScrapeResult(task projectScrapeTask, serviceTyp
 	// we only need to ensure existence of project_resources - the values don't impact this operation
 	err = datamodel.ProjectResourceUpdate{
 		UpdateResource: func(res *db.ProjectResource, resName liquid.ResourceName) error {
-			resource, rExists := filteredSIS.GetResourceForTypeName(serviceType, resName)
+			resource, rExists := filteredSIS.GetResourceForPath(db.ResourcePath{ServiceType: serviceType, ResourceName: resName})
 			if !rExists {
 				return fmt.Errorf("no data found in ServiceInfoCache for %s", db.ResourcePath{ServiceType: serviceType, ResourceName: resName})
 			}
@@ -572,7 +572,7 @@ func (c *Collector) writeDummyResources(dbProject db.Project, serviceType db.Ser
 		UpdateResource: func(res *db.ProjectResource, resName liquid.ResourceName) error {
 			// until we know better, we will assume Forbidden = true to ensure that
 			// quota does not get distributed into projects that cannot accept it
-			resource, _ := filteredSIS.GetResourceForTypeName(serviceType, resName)
+			resource, _ := filteredSIS.GetResourceForPath(db.ResourcePath{ServiceType: serviceType, ResourceName: resName})
 			if resource.HasQuota {
 				res.Forbidden = true
 			}
@@ -646,7 +646,7 @@ func enrichUsageReportTotals(value *liquid.ServiceUsageReport, filteredSIS core.
 		}
 
 		// we use the values of resource which default to false
-		resource, _ := filteredSIS.GetResourceForTypeName(service.Type, resName)
+		resource, _ := filteredSIS.GetResourceForPath(db.ResourcePath{ServiceType: service.Type, ResourceName: resName})
 		var total liquid.AZResourceUsageReport
 		for _, azValue := range resValue.PerAZ {
 			total.Usage += azValue.Usage

--- a/internal/collector/scrape.go
+++ b/internal/collector/scrape.go
@@ -256,16 +256,15 @@ func extractRateData(report liquid.ServiceUsageReport) (result map[liquid.RateNa
 }
 
 func (c *Collector) writeResourceScrapeResult(task projectScrapeTask, serviceType db.ServiceType, dbProject db.Project, resourceData liquid.ServiceUsageReport, sis core.ServiceInfoSnapshot) error {
-	filteredSIS := sis.Filter(core.ServiceInfoFilter{ServiceType: Some(serviceType)})
-	service, sExists := filteredSIS.GetServiceForType(serviceType)
-	resources, _ := filteredSIS.GetResourcesForType(serviceType)     // can have no resources
-	azResources, _ := filteredSIS.GetAZResourcesForType(serviceType) // can have no az_resources
-	if !sExists {                                                    // defense in depth: this snapshot is taken immediately after saving the ServiceInfo
+	service, sExists := sis.GetServiceForType(serviceType)
+	resources, _ := sis.GetResourcesForType(serviceType)     // can have no resources
+	azResources, _ := sis.GetAZResourcesForType(serviceType) // can have no az_resources
+	if !sExists {                                            // defense in depth: this snapshot is taken immediately after saving the ServiceInfo
 		return fmt.Errorf("no data found in ServiceInfoCache for type %s", serviceType)
 	}
 
 	for resName, resData := range resourceData.Resources {
-		resource, rExists := filteredSIS.GetResourceForPath(db.ResourcePath{ServiceType: serviceType, ResourceName: resName})
+		resource, rExists := sis.GetResourceForPath(db.ResourcePath{ServiceType: serviceType, ResourceName: resName})
 		if !rExists {
 			return fmt.Errorf("no data found in ServiceInfoCache for %s", db.ResourcePath{ServiceType: serviceType, ResourceName: resName})
 		}
@@ -294,7 +293,7 @@ func (c *Collector) writeResourceScrapeResult(task projectScrapeTask, serviceTyp
 			}
 		}
 	}
-	enrichUsageReportTotals(&resourceData, filteredSIS)
+	enrichUsageReportTotals(&resourceData, sis, serviceType)
 
 	tx, err := c.DB.Begin()
 	if err != nil {
@@ -315,7 +314,7 @@ func (c *Collector) writeResourceScrapeResult(task projectScrapeTask, serviceTyp
 	// we only need to ensure existence of project_resources - the values don't impact this operation
 	err = datamodel.ProjectResourceUpdate{
 		UpdateResource: func(res *db.ProjectResource, resName liquid.ResourceName) error {
-			resource, rExists := filteredSIS.GetResourceForPath(db.ResourcePath{ServiceType: serviceType, ResourceName: resName})
+			resource, rExists := sis.GetResourceForPath(db.ResourcePath{ServiceType: serviceType, ResourceName: resName})
 			if !rExists {
 				return fmt.Errorf("no data found in ServiceInfoCache for %s", db.ResourcePath{ServiceType: serviceType, ResourceName: resName})
 			}
@@ -324,7 +323,7 @@ func (c *Collector) writeResourceScrapeResult(task projectScrapeTask, serviceTyp
 			}
 			return nil
 		},
-	}.Run(tx, dbProject, filteredSIS)
+	}.Run(tx, dbProject, sis, serviceType)
 	if err != nil {
 		return err
 	}
@@ -559,7 +558,6 @@ func (c *Collector) writeDummyResources(dbProject db.Project, serviceType db.Ser
 	}
 	defer sqlext.RollbackUnlessCommitted(tx)
 	sis := c.Cluster.SIC.GetSnapshot()
-	filteredSIS := sis.Filter(core.ServiceInfoFilter{ServiceType: Some(serviceType)})
 	service, sExists := sis.GetServiceForType(serviceType)
 	resources, _ := sis.GetResourcesForType(serviceType)     // can have no resources
 	azResources, _ := sis.GetAZResourcesForType(serviceType) // can have no az_resources
@@ -572,13 +570,13 @@ func (c *Collector) writeDummyResources(dbProject db.Project, serviceType db.Ser
 		UpdateResource: func(res *db.ProjectResource, resName liquid.ResourceName) error {
 			// until we know better, we will assume Forbidden = true to ensure that
 			// quota does not get distributed into projects that cannot accept it
-			resource, _ := filteredSIS.GetResourceForPath(db.ResourcePath{ServiceType: serviceType, ResourceName: resName})
+			resource, _ := sis.GetResourceForPath(db.ResourcePath{ServiceType: serviceType, ResourceName: resName})
 			if resource.HasQuota {
 				res.Forbidden = true
 			}
 			return nil
 		},
-	}.Run(tx, dbProject, filteredSIS)
+	}.Run(tx, dbProject, sis, serviceType)
 	if err != nil {
 		return err
 	}
@@ -634,11 +632,11 @@ func (c *Collector) writeDummyResources(dbProject db.Project, serviceType db.Ser
 	return tx.Commit()
 }
 
-func enrichUsageReportTotals(value *liquid.ServiceUsageReport, filteredSIS core.FilteredServiceInfoSnapshot) {
+func enrichUsageReportTotals(value *liquid.ServiceUsageReport, sis core.ServiceInfoSnapshot, serviceType db.ServiceType) {
 	if value == nil || value.Resources == nil {
 		return
 	}
-	service := must.BeOK(filteredSIS.GetFilteredService())
+	service := must.BeOK(sis.GetServiceForType(serviceType))
 
 	for resName, resValue := range value.Resources {
 		if len(resValue.PerAZ) == 0 {
@@ -646,7 +644,7 @@ func enrichUsageReportTotals(value *liquid.ServiceUsageReport, filteredSIS core.
 		}
 
 		// we use the values of resource which default to false
-		resource, _ := filteredSIS.GetResourceForPath(db.ResourcePath{ServiceType: service.Type, ResourceName: resName})
+		resource, _ := sis.GetResourceForPath(db.ResourcePath{ServiceType: service.Type, ResourceName: resName})
 		var total liquid.AZResourceUsageReport
 		for _, azValue := range resValue.PerAZ {
 			total.Usage += azValue.Usage

--- a/internal/collector/scrape.go
+++ b/internal/collector/scrape.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sapcc/go-bits/gophercloudext"
 	"github.com/sapcc/go-bits/jobloop"
 	"github.com/sapcc/go-bits/logg"
+	"github.com/sapcc/go-bits/must"
 	"github.com/sapcc/go-bits/sqlext"
 	. "go.xyrillian.de/gg/option"
 
@@ -117,7 +118,7 @@ func (c *Collector) discoverScrapeTask(_ context.Context, labels prometheus.Labe
 	}
 	// if the above check succeeded, this should never fail because the SIC is updated after the
 	// LiquidConnection is initialized.
-	_, ok = c.Cluster.SIC.GetServiceForType(serviceType)
+	_, ok = c.Cluster.SIC.GetSnapshot().GetServiceForType(serviceType)
 	if !ok {
 		return projectScrapeTask{}, fmt.Errorf("no data found in ServiceInfoCache for type %s", serviceType)
 	}
@@ -158,7 +159,7 @@ func (c *Collector) processScrapeTask(ctx context.Context, task projectScrapeTas
 	logg.Debug("scraping %s resources for %s/%s", serviceType, dbDomain.Name, dbProject.Name)
 
 	// perform scrape
-	report, serializedMetrics, err := c.scrapeLiquid(ctx, connection, project, projectService)
+	report, serializedMetrics, sis, err := c.scrapeLiquid(ctx, connection, project, projectService)
 	task.Timing.FinishedAt = c.MeasureTimeAtEnd()
 	if err != nil {
 		task.Err = gophercloudext.UnpackError(err)
@@ -169,13 +170,13 @@ func (c *Collector) processScrapeTask(ctx context.Context, task projectScrapeTas
 	// collect additional DB records (it is important to do this step after the
 	// scrape, because the scrape might observe a new ServiceInfo version)
 	// write resource results
-	err = c.writeResourceScrapeResult(task, serviceType, dbProject, report)
+	err = c.writeResourceScrapeResult(task, serviceType, dbProject, report, sis)
 	if err != nil {
 		return fmt.Errorf("while writing resource results into DB: %w", err)
 	}
 
 	// write rate results
-	err = c.writeRateScrapeResult(task, serviceType, rateData)
+	err = c.writeRateScrapeResult(task, serviceType, rateData, sis)
 	if err != nil {
 		return fmt.Errorf("while writing rate results into DB: %w", err)
 	}
@@ -216,24 +217,24 @@ func (c *Collector) recordScrapeError(task projectScrapeTask, serviceType db.Ser
 	return fmt.Errorf("during scrape of project %s/%s: %w", dbDomain.Name, dbProject.Name, task.Err)
 }
 
-func (c *Collector) scrapeLiquid(ctx context.Context, connection *core.LiquidConnection, project core.KeystoneProject, projectService db.ProjectService) (liquid.ServiceUsageReport, []byte, error) {
-	report, err := connection.Scrape(ctx, project, c.Cluster.Config.AvailabilityZones, projectService.SerializedScrapeState)
+func (c *Collector) scrapeLiquid(ctx context.Context, connection *core.LiquidConnection, project core.KeystoneProject, projectService db.ProjectService) (liquid.ServiceUsageReport, []byte, *core.ServiceInfoSnapshot, error) {
+	report, sis, err := connection.Scrape(ctx, project, c.Cluster.Config.AvailabilityZones, projectService.SerializedScrapeState)
 	if err != nil {
-		return liquid.ServiceUsageReport{}, nil, err
+		return liquid.ServiceUsageReport{}, nil, &core.ServiceInfoSnapshot{}, err
 	}
-	service, sExists := c.Cluster.SIC.GetServiceForType(connection.ServiceType)
-	if !sExists { // defense in depth: when we get here, the scrape was successful, so the service should be up to date
-		return liquid.ServiceUsageReport{}, nil, fmt.Errorf("no data found in ServiceInfoCache for type %s", connection.ServiceType)
+	service, sExists := sis.GetServiceForType(connection.ServiceType)
+	if !sExists { // defense in depth: this snapshot is taken immediately after saving the ServiceInfo
+		return liquid.ServiceUsageReport{}, nil, &core.ServiceInfoSnapshot{}, fmt.Errorf("no data found in ServiceInfoCache for type %s", connection.ServiceType)
 	}
 	usageMetricFamilies, err := util.JSONToAny[map[liquid.MetricName]liquid.MetricFamilyInfo](service.UsageMetricFamiliesJSON, "usage_metric_families")
 	if err != nil {
-		return liquid.ServiceUsageReport{}, nil, err
+		return liquid.ServiceUsageReport{}, nil, &core.ServiceInfoSnapshot{}, err
 	}
 	serializedMetrics, err := liquidSerializeMetrics(usageMetricFamilies, report.Metrics)
 	if err != nil {
-		return liquid.ServiceUsageReport{}, nil, err
+		return liquid.ServiceUsageReport{}, nil, &core.ServiceInfoSnapshot{}, err
 	}
-	return report, serializedMetrics, nil
+	return report, serializedMetrics, sis, nil
 }
 
 func extractRateData(report liquid.ServiceUsageReport) (result map[liquid.RateName]*big.Int, serializedState string) {
@@ -254,15 +255,20 @@ func extractRateData(report liquid.ServiceUsageReport) (result map[liquid.RateNa
 	return result, string(report.SerializedState)
 }
 
-func (c *Collector) writeResourceScrapeResult(task projectScrapeTask, serviceType db.ServiceType, dbProject db.Project, resourceData liquid.ServiceUsageReport) error {
-	service, sExists := c.Cluster.SIC.GetServiceForType(serviceType)
-	resources, _ := c.Cluster.SIC.GetResourcesForType(serviceType)
-	azResources, _ := c.Cluster.SIC.GetAZResourcesForType(serviceType)
-	if !sExists { // defense in depth: when we get here, the scrape was successful, so the service should be up to date
+func (c *Collector) writeResourceScrapeResult(task projectScrapeTask, serviceType db.ServiceType, dbProject db.Project, resourceData liquid.ServiceUsageReport, sis *core.ServiceInfoSnapshot) error {
+	filteredSIS := sis.Filter(core.ServiceInfoFilter{ServiceType: Some(serviceType)})
+	service, sExists := filteredSIS.GetServiceForType(serviceType)
+	resources, _ := filteredSIS.GetResourcesForType(serviceType)     // can have no resources
+	azResources, _ := filteredSIS.GetAZResourcesForType(serviceType) // can have no az_resources
+	if !sExists {                                                    // defense in depth: this snapshot is taken immediately after saving the ServiceInfo
 		return fmt.Errorf("no data found in ServiceInfoCache for type %s", serviceType)
 	}
+
 	for resName, resData := range resourceData.Resources {
-		resource := resources[resName]
+		resource, rExists := filteredSIS.GetResourceForTypeName(serviceType, resName)
+		if !rExists {
+			return fmt.Errorf("no data found in ServiceInfoCache for %s", db.ResourcePath{ServiceType: serviceType, ResourceName: resName})
+		}
 		if len(resData.PerAZ) == 0 {
 			// ensure that there is at least one ProjectAZResource for each ProjectResource
 			resData.PerAZ = liquid.InAnyAZ(liquid.AZResourceUsageReport{Usage: 0})
@@ -288,7 +294,7 @@ func (c *Collector) writeResourceScrapeResult(task projectScrapeTask, serviceTyp
 			}
 		}
 	}
-	enrichUsageReportTotals(&resourceData, resources)
+	enrichUsageReportTotals(&resourceData, filteredSIS)
 
 	tx, err := c.DB.Begin()
 	if err != nil {
@@ -309,13 +315,16 @@ func (c *Collector) writeResourceScrapeResult(task projectScrapeTask, serviceTyp
 	// we only need to ensure existence of project_resources - the values don't impact this operation
 	err = datamodel.ProjectResourceUpdate{
 		UpdateResource: func(res *db.ProjectResource, resName liquid.ResourceName) error {
-			resource := resources[resName]
+			resource, rExists := filteredSIS.GetResourceForTypeName(serviceType, resName)
+			if !rExists {
+				return fmt.Errorf("no data found in ServiceInfoCache for %s", db.ResourcePath{ServiceType: serviceType, ResourceName: resName})
+			}
 			if resource.HasQuota {
 				res.Forbidden = resourceData.Resources[resName].Forbidden
 			}
 			return nil
 		},
-	}.Run(tx, dbProject, service, resources)
+	}.Run(tx, dbProject, filteredSIS)
 	if err != nil {
 		return err
 	}
@@ -457,13 +466,13 @@ func (c *Collector) writeResourceScrapeResult(task projectScrapeTask, serviceTyp
 	return nil
 }
 
-func (c *Collector) writeRateScrapeResult(task projectScrapeTask, serviceType db.ServiceType, rateData map[liquid.RateName]*big.Int) error {
+func (c *Collector) writeRateScrapeResult(task projectScrapeTask, serviceType db.ServiceType, rateData map[liquid.RateName]*big.Int, sis *core.ServiceInfoSnapshot) error {
 	projectService := task.ProjectService
-	service, sExists := c.Cluster.SIC.GetServiceForType(serviceType)
-	rates, _ := c.Cluster.SIC.GetRatesForType(serviceType)
-	if !sExists { // defense in depth: when we get here, the scrape was successful, so the service should be up to date
+	service, sExists := sis.GetServiceForType(serviceType)
+	if !sExists { // defense in depth: this snapshot is taken immediately after saving the ServiceInfo
 		return fmt.Errorf("no data found in ServiceInfoCache for type %s", serviceType)
 	}
+	rates, _ := sis.GetRatesForType(serviceType) // can have no rates
 
 	tx, err := c.DB.Begin()
 	if err != nil {
@@ -549,10 +558,12 @@ func (c *Collector) writeDummyResources(dbProject db.Project, serviceType db.Ser
 		return err
 	}
 	defer sqlext.RollbackUnlessCommitted(tx)
-	service, sExists := c.Cluster.SIC.GetServiceForType(serviceType)
-	resources, _ := c.Cluster.SIC.GetResourcesForType(serviceType)
-	azResources, _ := c.Cluster.SIC.GetAZResourcesForType(serviceType)
-	if !sExists { // defense in depth: when we get here, the scrape never happened, so the sic must be up to date
+	sis := c.Cluster.SIC.GetSnapshot()
+	filteredSIS := sis.Filter(core.ServiceInfoFilter{ServiceType: Some(serviceType)})
+	service, sExists := sis.GetServiceForType(serviceType)
+	resources, _ := sis.GetResourcesForType(serviceType)     // can have no resources
+	azResources, _ := sis.GetAZResourcesForType(serviceType) // can have no az_resources
+	if !sExists {                                            // defense in depth: when we get here, the scrape never happened, so the sic must be up to date
 		return fmt.Errorf("no data found in ServiceInfoCache for type %s", serviceType)
 	}
 
@@ -561,13 +572,13 @@ func (c *Collector) writeDummyResources(dbProject db.Project, serviceType db.Ser
 		UpdateResource: func(res *db.ProjectResource, resName liquid.ResourceName) error {
 			// until we know better, we will assume Forbidden = true to ensure that
 			// quota does not get distributed into projects that cannot accept it
-			resource := resources[resName]
+			resource, _ := filteredSIS.GetResourceForTypeName(serviceType, resName)
 			if resource.HasQuota {
 				res.Forbidden = true
 			}
 			return nil
 		},
-	}.Run(tx, dbProject, service, resources)
+	}.Run(tx, dbProject, filteredSIS)
 	if err != nil {
 		return err
 	}
@@ -576,7 +587,7 @@ func (c *Collector) writeDummyResources(dbProject db.Project, serviceType db.Ser
 		resByAZ := azResources[resName]
 		resource := resources[resName]
 		for _, az := range slices.Sorted(maps.Keys(resByAZ)) {
-			azRes := resByAZ[az]
+			azResource := resByAZ[az]
 			if az == limes.AvailabilityZoneUnknown {
 				// we don't write dummy entries for unknown - this should just exist, when there is real usage
 				continue
@@ -592,7 +603,7 @@ func (c *Collector) writeDummyResources(dbProject db.Project, serviceType db.Ser
 			}
 			err := tx.Insert(&db.ProjectAZResource{
 				ProjectID:    dbProject.ID,
-				AZResourceID: azRes.ID,
+				AZResourceID: azResource.ID,
 				Usage:        0,
 				BackendQuota: backendQuota,
 				Quota:        quota,
@@ -623,17 +634,19 @@ func (c *Collector) writeDummyResources(dbProject db.Project, serviceType db.Ser
 	return tx.Commit()
 }
 
-func enrichUsageReportTotals(value *liquid.ServiceUsageReport, resources map[liquid.ResourceName]db.Resource) {
+func enrichUsageReportTotals(value *liquid.ServiceUsageReport, filteredSIS *core.FilteredServiceInfoSnapshot) {
 	if value == nil || value.Resources == nil {
 		return
 	}
+	service := must.BeOK(filteredSIS.GetFilteredService())
 
 	for resName, resValue := range value.Resources {
 		if len(resValue.PerAZ) == 0 {
 			continue
 		}
 
-		resource := resources[resName]
+		// we use the values of resource which default to false
+		resource, _ := filteredSIS.GetResourceForTypeName(service.Type, resName)
 		var total liquid.AZResourceUsageReport
 		for _, azValue := range resValue.PerAZ {
 			total.Usage += azValue.Usage

--- a/internal/collector/scrape_test.go
+++ b/internal/collector/scrape_test.go
@@ -521,7 +521,7 @@ func Test_ScrapeSuccess(t *testing.T) {
 	}}
 
 	// run ACPQ in order to be able to test how data metrics reporters handle project quota
-	val, ok := s.Cluster.SIC.GetResourcesForType("unittest")
+	val, ok := s.Cluster.SIC.GetSnapshot().GetResourcesForType("unittest")
 	assert.Equal(t, ok, true)
 	for _, resource := range val {
 		must.SucceedT(t, datamodel.ApplyComputedProjectQuota("unittest", resource, s.Cluster, s.Clock.Now()))

--- a/internal/collector/sync_quota_to_backend.go
+++ b/internal/collector/sync_quota_to_backend.go
@@ -118,7 +118,8 @@ func (c *Collector) performQuotaSync(ctx context.Context, srv db.ProjectService,
 		return fmt.Errorf("no quota connection registered for service type %s", serviceType)
 	}
 	startedAt := c.MeasureTime()
-	resources, ok := c.Cluster.SIC.GetResourcesForType(serviceType)
+
+	resources, ok := c.Cluster.SIC.GetSnapshot().GetResourcesForType(serviceType)
 	if !ok {
 		return fmt.Errorf("no data found in ServiceInfoCache for %s", serviceType)
 	}

--- a/internal/core/cluster.go
+++ b/internal/core/cluster.go
@@ -115,7 +115,7 @@ func (c *Cluster) Connect(ctx context.Context, provider *gophercloud.ProviderCli
 	}
 
 	// initialize SIC
-	c.SIC, err = NewServiceInfoCache(c.DB, dbURL)
+	c.SIC, err = NewServiceInfoCache(c.DB, c.Config, dbURL)
 	if err != nil {
 		errs.Addf("could not create service info cache: %w", err)
 		return errs

--- a/internal/core/liquid.go
+++ b/internal/core/liquid.go
@@ -85,7 +85,7 @@ func (l *LiquidConnection) Init(ctx context.Context, client LiquidClient, servic
 
 // compareServiceInfoVersions compares a report version of the ServiceInfo with the saved version
 // and triggers the update and persisting if necessary.
-func (l *LiquidConnection) compareServiceInfoVersions(ctx context.Context, infoVersion int64) (sis *ServiceInfoSnapshot, err error) {
+func (l *LiquidConnection) compareServiceInfoVersions(ctx context.Context, infoVersion int64) (sis ServiceInfoSnapshot, err error) {
 	sis = l.sic.GetSnapshot()
 	service, ok := sis.GetServiceForType(l.ServiceType)
 	if !ok {
@@ -146,7 +146,7 @@ func (l *LiquidConnection) retrieveServiceInfo(ctx context.Context) (result liqu
 // The `prevSerializedState` holds the `result.SerializedState` value from the previous call for the same project.
 // This state is persisted in the Limes DB between calls, and not otherwise interpreted by the core application in any way.
 // The liquid can use this field to carry state between Scrape() calls, esp. to detect and handle counter resets in the backend.
-func (l *LiquidConnection) Scrape(ctx context.Context, project KeystoneProject, allAZs []limes.AvailabilityZone, prevSerializedState string) (result liquid.ServiceUsageReport, sis *ServiceInfoSnapshot, err error) {
+func (l *LiquidConnection) Scrape(ctx context.Context, project KeystoneProject, allAZs []limes.AvailabilityZone, prevSerializedState string) (result liquid.ServiceUsageReport, sis ServiceInfoSnapshot, err error) {
 	sis = l.sic.GetSnapshot()
 	service, _ := sis.GetServiceForType(l.ServiceType) // we can ignore "ok" because we validated this before scraping
 	req := BuildServiceUsageRequest(project, allAZs, service.UsageReportNeedsProjectMetadata, prevSerializedState)
@@ -177,7 +177,7 @@ func (l *LiquidConnection) Scrape(ctx context.Context, project KeystoneProject, 
 // that this LiquidConnection is concerned with. The result is a two-dimensional map,
 // with the first key being the service type, and the second key being the
 // resource name.
-func (l *LiquidConnection) ScrapeCapacity(ctx context.Context, backchannel CapacityScrapeBackchannel, allAZs []limes.AvailabilityZone) (result liquid.ServiceCapacityReport, sis *ServiceInfoSnapshot, err error) {
+func (l *LiquidConnection) ScrapeCapacity(ctx context.Context, backchannel CapacityScrapeBackchannel, allAZs []limes.AvailabilityZone) (result liquid.ServiceCapacityReport, sis ServiceInfoSnapshot, err error) {
 	sis = l.sic.GetSnapshot()
 	filteredSIS := sis.Filter(ServiceInfoFilter{ServiceType: Some(l.ServiceType)}) // we validated the existence of the service before scraping
 	req, err := BuildServiceCapacityRequest(backchannel, allAZs, filteredSIS)
@@ -303,7 +303,7 @@ func prometheusScrapeOneResource(p PrometheusCapacityConfiguration, ctx context.
 // BuildServiceCapacityRequest generates the request body payload for querying the LIQUID API
 // endpoint /v1/report-capacity. In order to be reusable for exposing an API which prints the
 // request for admin purposes, it does not use the LiquidConnection as receiver type.
-func BuildServiceCapacityRequest(backchannel CapacityScrapeBackchannel, allAZs []limes.AvailabilityZone, filteredSIS *FilteredServiceInfoSnapshot) (liquid.ServiceCapacityRequest, error) {
+func BuildServiceCapacityRequest(backchannel CapacityScrapeBackchannel, allAZs []limes.AvailabilityZone, filteredSIS FilteredServiceInfoSnapshot) (liquid.ServiceCapacityRequest, error) {
 	service := must.BeOK(filteredSIS.GetFilteredService())        // when we get here, this is already validated
 	resources, _ := filteredSIS.GetResourcesForType(service.Type) // can have no resources
 	req := liquid.ServiceCapacityRequest{

--- a/internal/core/liquid.go
+++ b/internal/core/liquid.go
@@ -179,8 +179,7 @@ func (l *LiquidConnection) Scrape(ctx context.Context, project KeystoneProject, 
 // resource name.
 func (l *LiquidConnection) ScrapeCapacity(ctx context.Context, backchannel CapacityScrapeBackchannel, allAZs []limes.AvailabilityZone) (result liquid.ServiceCapacityReport, sis ServiceInfoSnapshot, err error) {
 	sis = l.sic.GetSnapshot()
-	filteredSIS := sis.Filter(ServiceInfoFilter{ServiceType: Some(l.ServiceType)}) // we validated the existence of the service before scraping
-	req, err := BuildServiceCapacityRequest(backchannel, allAZs, filteredSIS)
+	req, err := BuildServiceCapacityRequest(backchannel, allAZs, sis, l.ServiceType) // we validated the existence of the service before scraping
 	if err != nil {
 		return result, sis, err
 	}
@@ -303,9 +302,9 @@ func prometheusScrapeOneResource(p PrometheusCapacityConfiguration, ctx context.
 // BuildServiceCapacityRequest generates the request body payload for querying the LIQUID API
 // endpoint /v1/report-capacity. In order to be reusable for exposing an API which prints the
 // request for admin purposes, it does not use the LiquidConnection as receiver type.
-func BuildServiceCapacityRequest(backchannel CapacityScrapeBackchannel, allAZs []limes.AvailabilityZone, filteredSIS FilteredServiceInfoSnapshot) (liquid.ServiceCapacityRequest, error) {
-	service := must.BeOK(filteredSIS.GetFilteredService())        // when we get here, this is already validated
-	resources, _ := filteredSIS.GetResourcesForType(service.Type) // can have no resources
+func BuildServiceCapacityRequest(backchannel CapacityScrapeBackchannel, allAZs []limes.AvailabilityZone, sis ServiceInfoSnapshot, serviceType db.ServiceType) (liquid.ServiceCapacityRequest, error) {
+	service := must.BeOK(sis.GetServiceForType(serviceType)) // when we get here, this is already validated
+	resources, _ := sis.GetResourcesForType(service.Type)    // can have no resources
 	req := liquid.ServiceCapacityRequest{
 		AllAZs:           allAZs,
 		DemandByResource: make(map[liquid.ResourceName]liquid.ResourceDemand, len(resources)),

--- a/internal/core/liquid.go
+++ b/internal/core/liquid.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sapcc/go-api-declarations/liquid"
 	"github.com/sapcc/go-bits/liquidapi"
 	"github.com/sapcc/go-bits/logg"
+	"github.com/sapcc/go-bits/must"
 	"github.com/sapcc/go-bits/promquery"
 	. "go.xyrillian.de/gg/option"
 
@@ -84,37 +85,39 @@ func (l *LiquidConnection) Init(ctx context.Context, client LiquidClient, servic
 
 // compareServiceInfoVersions compares a report version of the ServiceInfo with the saved version
 // and triggers the update and persisting if necessary.
-func (l *LiquidConnection) compareServiceInfoVersions(ctx context.Context, infoVersion int64) (err error) {
-	service, ok := l.sic.GetServiceForType(l.ServiceType)
+func (l *LiquidConnection) compareServiceInfoVersions(ctx context.Context, infoVersion int64) (sis *ServiceInfoSnapshot, err error) {
+	sis = l.sic.GetSnapshot()
+	service, ok := sis.GetServiceForType(l.ServiceType)
 	if !ok {
 		service = db.Service{LiquidVersion: -1}
 	}
 	currentVersion := service.LiquidVersion
 	if infoVersion == currentVersion {
-		return nil
+		return sis, nil
 	}
 
 	logg.Info("ServiceInfo version for %s changed from %d to %d; reloading and persisting ServiceInfo.", l.ServiceType, currentVersion, infoVersion)
 	serviceInfo, err := l.retrieveServiceInfo(ctx)
 	if err != nil {
-		return err
+		return sis, err
 	}
 	// recheck to be sure, that there was no update between pulling the report and getting the ServiceInfo
 	newVersion := serviceInfo.Version
 	if infoVersion != newVersion {
-		return fmt.Errorf("ServiceInfo version mismatch for %s after update: GetResourcesInfo %d, report %d", l.ServiceType, newVersion, infoVersion)
+		return sis, fmt.Errorf("ServiceInfo version mismatch for %s after update: GetResourcesInfo %d, report %d", l.ServiceType, newVersion, infoVersion)
 	}
 	err = SaveServiceInfoToDB(l.ServiceType, serviceInfo, l.AvailabilityZones, l.RateLimits, l.timeNow(), l.DB)
 	if err != nil {
-		return fmt.Errorf("saving ServiceInfo: %w", err)
+		return sis, fmt.Errorf("saving ServiceInfo: %w", err)
 	}
 
 	// do reload of the SIC after successful database update
 	err = l.sic.InvalidateService(Some(l.ServiceType))
 	if err != nil {
-		return fmt.Errorf("invalidating ServiceInfoCache: %w", err)
+		return sis, fmt.Errorf("invalidating ServiceInfoCache: %w", err)
 	}
-	return nil
+	sis = l.sic.GetSnapshot()
+	return sis, nil
 }
 
 // retrieveServiceInfo queries the backend service for the latest ServiceInfo and validates it.
@@ -143,61 +146,63 @@ func (l *LiquidConnection) retrieveServiceInfo(ctx context.Context) (result liqu
 // The `prevSerializedState` holds the `result.SerializedState` value from the previous call for the same project.
 // This state is persisted in the Limes DB between calls, and not otherwise interpreted by the core application in any way.
 // The liquid can use this field to carry state between Scrape() calls, esp. to detect and handle counter resets in the backend.
-func (l *LiquidConnection) Scrape(ctx context.Context, project KeystoneProject, allAZs []limes.AvailabilityZone, prevSerializedState string) (result liquid.ServiceUsageReport, err error) {
-	service, _ := l.sic.GetServiceForType(l.ServiceType) // we can ignore "ok" because we validated this before scraping
+func (l *LiquidConnection) Scrape(ctx context.Context, project KeystoneProject, allAZs []limes.AvailabilityZone, prevSerializedState string) (result liquid.ServiceUsageReport, sis *ServiceInfoSnapshot, err error) {
+	sis = l.sic.GetSnapshot()
+	service, _ := sis.GetServiceForType(l.ServiceType) // we can ignore "ok" because we validated this before scraping
 	req := BuildServiceUsageRequest(project, allAZs, service.UsageReportNeedsProjectMetadata, prevSerializedState)
 	result, err = l.LiquidClient.GetUsageReport(ctx, string(project.UUID), req)
 	if err != nil {
-		return result, err
+		return result, sis, err
 	}
 
-	err = l.compareServiceInfoVersions(ctx, result.InfoVersion)
+	sis, err = l.compareServiceInfoVersions(ctx, result.InfoVersion)
 	if err != nil {
-		return result, err
+		return result, sis, err
 	}
 
 	serviceInfo, err := l.sic.GetServiceInfo(l.ServiceType)
 	if err != nil {
-		return result, err
+		return result, sis, err
 	}
 
 	err = liquid.ValidateUsageReport(result, req, serviceInfo)
 	if err != nil {
-		return result, err
+		return result, sis, err
 	}
 
-	return result, nil
+	return result, sis, nil
 }
 
 // ScrapeCapacity queries the backend service(s) for the capacities of the resources
 // that this LiquidConnection is concerned with. The result is a two-dimensional map,
 // with the first key being the service type, and the second key being the
 // resource name.
-func (l *LiquidConnection) ScrapeCapacity(ctx context.Context, backchannel CapacityScrapeBackchannel, allAZs []limes.AvailabilityZone) (result liquid.ServiceCapacityReport, err error) {
-	resources, _ := l.sic.GetResourcesForType(l.ServiceType) // we can ignore "ok" because we validated this before scraping
-	req, err := BuildServiceCapacityRequest(backchannel, allAZs, l.ServiceType, resources)
+func (l *LiquidConnection) ScrapeCapacity(ctx context.Context, backchannel CapacityScrapeBackchannel, allAZs []limes.AvailabilityZone) (result liquid.ServiceCapacityReport, sis *ServiceInfoSnapshot, err error) {
+	sis = l.sic.GetSnapshot()
+	filteredSIS := sis.Filter(ServiceInfoFilter{ServiceType: Some(l.ServiceType)}) // we validated the existence of the service before scraping
+	req, err := BuildServiceCapacityRequest(backchannel, allAZs, filteredSIS)
 	if err != nil {
-		return result, err
+		return result, sis, err
 	}
 
 	result, err = l.LiquidClient.GetCapacityReport(ctx, req)
 	if err != nil {
-		return result, err
+		return result, sis, err
 	}
 
-	err = l.compareServiceInfoVersions(ctx, result.InfoVersion)
+	sis, err = l.compareServiceInfoVersions(ctx, result.InfoVersion)
 	if err != nil {
-		return result, err
+		return result, sis, err
 	}
 
 	serviceInfo, err := l.sic.GetServiceInfo(l.ServiceType)
 	if err != nil {
-		return result, err
+		return result, sis, err
 	}
 
 	err = liquid.ValidateCapacityReport(result, req, serviceInfo)
 	if err != nil {
-		return result, err
+		return result, sis, err
 	}
 
 	// manual capacity collection
@@ -221,12 +226,12 @@ func (l *LiquidConnection) ScrapeCapacity(ctx context.Context, backchannel Capac
 		}
 		client, err := prometheusCapaConfig.APIConfig.Connect()
 		if err != nil {
-			return result, err
+			return result, sis, err
 		}
 		for resName, query := range prometheusCapaConfig.Queries {
 			azReports, err := prometheusScrapeOneResource(prometheusCapaConfig, ctx, client, query, allAZs)
 			if err != nil {
-				return result, fmt.Errorf("while scraping prometheus capacity %q/%q: %w", l.ServiceType, resName, err)
+				return result, sis, fmt.Errorf("while scraping prometheus capacity %q/%q: %w", l.ServiceType, resName, err)
 			}
 			result.Resources[resName] = &liquid.ResourceCapacityReport{
 				PerAZ: azReports,
@@ -234,7 +239,7 @@ func (l *LiquidConnection) ScrapeCapacity(ctx context.Context, backchannel Capac
 		}
 	}
 
-	return result, nil
+	return result, sis, nil
 }
 
 // prometheusScrapeOneResource retrieves capacity for one resource via a prometheus client.
@@ -298,7 +303,9 @@ func prometheusScrapeOneResource(p PrometheusCapacityConfiguration, ctx context.
 // BuildServiceCapacityRequest generates the request body payload for querying the LIQUID API
 // endpoint /v1/report-capacity. In order to be reusable for exposing an API which prints the
 // request for admin purposes, it does not use the LiquidConnection as receiver type.
-func BuildServiceCapacityRequest(backchannel CapacityScrapeBackchannel, allAZs []limes.AvailabilityZone, serviceType db.ServiceType, resources ResourcesByName) (liquid.ServiceCapacityRequest, error) {
+func BuildServiceCapacityRequest(backchannel CapacityScrapeBackchannel, allAZs []limes.AvailabilityZone, filteredSIS *FilteredServiceInfoSnapshot) (liquid.ServiceCapacityRequest, error) {
+	service := must.BeOK(filteredSIS.GetFilteredService())        // when we get here, this is already validated
+	resources, _ := filteredSIS.GetResourcesForType(service.Type) // can have no resources
 	req := liquid.ServiceCapacityRequest{
 		AllAZs:           allAZs,
 		DemandByResource: make(map[liquid.ResourceName]liquid.ResourceDemand, len(resources)),
@@ -312,9 +319,9 @@ func BuildServiceCapacityRequest(backchannel CapacityScrapeBackchannel, allAZs [
 		if !resource.NeedsResourceDemand {
 			continue
 		}
-		req.DemandByResource[resName], err = backchannel.GetResourceDemand(serviceType, resName)
+		req.DemandByResource[resName], err = backchannel.GetResourceDemand(service.Type, resName)
 		if err != nil {
-			return liquid.ServiceCapacityRequest{}, fmt.Errorf("while getting resource demand for %s/%s: %w", serviceType, resName, err)
+			return liquid.ServiceCapacityRequest{}, fmt.Errorf("while getting resource demand for %s/%s: %w", service.Type, resName, err)
 		}
 	}
 	return req, nil
@@ -338,7 +345,7 @@ func BuildServiceUsageRequest(project KeystoneProject, allAZs []limes.Availabili
 // given domain to the values specified here.
 func (l *LiquidConnection) SetQuota(ctx context.Context, project KeystoneProject, quotaReq map[liquid.ResourceName]liquid.ResourceQuotaRequest) error {
 	req := liquid.ServiceQuotaRequest{Resources: quotaReq}
-	service, ok := l.sic.GetServiceForType(l.ServiceType)
+	service, ok := l.sic.GetSnapshot().GetServiceForType(l.ServiceType)
 	if !ok {
 		return fmt.Errorf(`service for type "%s" not found`, l.ServiceType)
 	}

--- a/internal/core/name_mapping.go
+++ b/internal/core/name_mapping.go
@@ -37,12 +37,12 @@ type dbRateRef struct {
 }
 
 // BuildResourceNameMapping constructs a new ResourceNameMapping instance.
-func BuildResourceNameMapping(cluster *Cluster, resources ResourcesByNameType) ResourceNameMapping {
+func BuildResourceNameMapping(cluster *Cluster, sis *ServiceInfoSnapshot) ResourceNameMapping {
 	nm := ResourceNameMapping{
 		fromAPIToDB: make(map[ResourceRef]dbResourceRef),
 		fromDBToAPI: make(map[dbResourceRef]ResourceRef),
 	}
-	for dbServiceType, resByName := range resources {
+	for dbServiceType, resByName := range sis.GetResources() {
 		for dbResourceName := range resByName {
 			dbRef := dbResourceRef{dbServiceType, dbResourceName}
 			apiRef := cluster.BehaviorForResource(dbServiceType, dbResourceName).IdentityInV1API
@@ -54,13 +54,13 @@ func BuildResourceNameMapping(cluster *Cluster, resources ResourcesByNameType) R
 }
 
 // BuildRateNameMapping constructs a new RateNameMapping instance.
-func BuildRateNameMapping(cluster *Cluster, rates RatesByNameType) RateNameMapping {
+func BuildRateNameMapping(cluster *Cluster, sis *ServiceInfoSnapshot) RateNameMapping {
 	nm := RateNameMapping{
 		cluster:     cluster,
 		fromAPIToDB: make(map[RateRef]dbRateRef),
 		fromDBToAPI: make(map[dbRateRef]RateRef),
 	}
-	for dbServiceType, rateByName := range rates {
+	for dbServiceType, rateByName := range sis.GetRates() {
 		dbRateNames := make(map[liquid.RateName]struct{})
 		for dbRateName := range rateByName {
 			dbRateNames[dbRateName] = struct{}{}

--- a/internal/core/name_mapping.go
+++ b/internal/core/name_mapping.go
@@ -37,7 +37,7 @@ type dbRateRef struct {
 }
 
 // BuildResourceNameMapping constructs a new ResourceNameMapping instance.
-func BuildResourceNameMapping(cluster *Cluster, sis *ServiceInfoSnapshot) ResourceNameMapping {
+func BuildResourceNameMapping(cluster *Cluster, sis ServiceInfoSnapshot) ResourceNameMapping {
 	nm := ResourceNameMapping{
 		fromAPIToDB: make(map[ResourceRef]dbResourceRef),
 		fromDBToAPI: make(map[dbResourceRef]ResourceRef),
@@ -54,7 +54,7 @@ func BuildResourceNameMapping(cluster *Cluster, sis *ServiceInfoSnapshot) Resour
 }
 
 // BuildRateNameMapping constructs a new RateNameMapping instance.
-func BuildRateNameMapping(cluster *Cluster, sis *ServiceInfoSnapshot) RateNameMapping {
+func BuildRateNameMapping(cluster *Cluster, sis ServiceInfoSnapshot) RateNameMapping {
 	nm := RateNameMapping{
 		cluster:     cluster,
 		fromAPIToDB: make(map[RateRef]dbRateRef),

--- a/internal/core/service_info_cache.go
+++ b/internal/core/service_info_cache.go
@@ -23,33 +23,495 @@ import (
 	. "go.xyrillian.de/gg/option"
 )
 
+///////////////////////////////////////////////////////////////////////
+
+// ServiceInfoFilter is a set of possible attributes by which ServiceInfoSnapshot
+// can be filtered. Most of the time, these come directly or indirectly from an API
+// requests' scope, e.g. query filters or attributes of a processed commitment.
+type ServiceInfoFilter struct {
+	ServiceArea  Option[string]
+	ServiceType  Option[db.ServiceType]
+	Category     Option[liquid.CategoryName]
+	ResourceName Option[liquid.ResourceName]
+	RateName     Option[liquid.RateName]
+}
+
+///////////////////////////////////////////////////////////////////////
+
+// ServiceInfoReader defines shared methods for reading
+// filtered or unfiltered ServiceInfoSnapshots.
+type ServiceInfoReader interface {
+	// GetServices returns all services.
+	GetServices() ServicesByType
+	// GetServiceForType returns the service for the given service type.
+	GetServiceForType(serviceType db.ServiceType) (db.Service, bool)
+	// GetResources returns all resources
+	GetResources() ResourcesByNameType
+	// GetResourcesForType returns all resources for the given service type, keyed by resource name.
+	GetResourcesForType(serviceType db.ServiceType) (ResourcesByName, bool)
+	// GetResourceForTypeName returns the resource for the given service type and resource name.
+	GetResourceForTypeName(serviceType db.ServiceType, resourceName liquid.ResourceName) (db.Resource, bool)
+	// GetResourceForPath returns the resource for the given path.
+	GetResourceForPath(path db.ResourcePath) (db.Resource, bool)
+	// GetAZResources returns all AZ resources, indexed by service type, resource name, and availability zone.
+	GetAZResources() AZResourcesByAZNameType
+	// GetAZResourcesForType returns all AZ resources for the given service type, keyed by resource name and availability zone.
+	GetAZResourcesForType(serviceType db.ServiceType) (AZResourcesByAZName, bool)
+	// GetAZResourcesForTypeName returns all AZ resources for the given service type, resource name, keyed by availability zone.
+	GetAZResourcesForTypeName(serviceType db.ServiceType, resourceName liquid.ResourceName) (AZResourcesByAZ, bool)
+	// GetAZResourceForTypeNameAZ returns the AZ resource for the given service type, resource name, and availability zone.
+	GetAZResourceForTypeNameAZ(serviceType db.ServiceType, resourceName liquid.ResourceName, az limes.AvailabilityZone) (db.AZResource, bool)
+	// GetAZResourceForPath returns the AZ resource for the given path.
+	GetAZResourceForPath(path db.AZResourcePath) (db.AZResource, bool)
+	// GetRates returns all cached rates, indexed by service type and rate name.
+	GetRates() RatesByNameType
+	// GetRatesForType returns all rates, indexed by service type and rate name.
+	GetRatesForType(serviceType db.ServiceType) (RatesByName, bool)
+	// GetRateForTypeName returns the rate for the given service type and rate name.
+	GetRateForTypeName(serviceType db.ServiceType, rateName liquid.RateName) (db.Rate, bool)
+	// GetCategories returns all categories, indexed by category ID.
+	GetCategories() CategoriesByID
+	// GetCategoryForID returns the cached category for the given category ID.
+	GetCategoryForID(categoryID db.CategoryID) (db.Category, bool)
+}
+
+///////////////////////////////////////////////////////////////////////
+
+type (
+	// ServiceInfoSnapshot is the combined representation of db.Service, db.Resource
+	// db.AZResource, db.Rate and db.Category. We chose to provide this as only
+	// data structure and output of ServiceInfoCache mainly for 2 reasons:
+	// This ensures we get one consistent state from the ServiceInfoCache and
+	// not multiple outputs where the cache might have changed in between.
+	// Also, we can express filtering all entities by the same ServiceInfoFilter
+	// which makes application of the same filter to all entities easier.
+	// ServiceInfoSnapshot offers almost the same external method set for
+	// on-read access as FilteredServiceInfoSnapshot, they are defined by the
+	// ServiceInfoReader interface.
+	ServiceInfoSnapshot struct {
+		services    ServicesByType
+		resources   ResourcesByNameType
+		azResources AZResourcesByAZNameType
+		rates       RatesByNameType
+		categories  CategoriesByID
+		// necessary for constructing filters by area
+		areaMapping map[db.ServiceType]string
+	}
+	// ServicesByType are services, indexed by their service type.
+	ServicesByType map[db.ServiceType]db.Service
+	// ResourcesByNameType are resources, indexed by their name and type.
+	ResourcesByNameType map[db.ServiceType]ResourcesByName
+	// ResourcesByName are resources of a single service, indexed by their name.
+	ResourcesByName map[liquid.ResourceName]db.Resource
+	// AZResourcesByAZNameType are az_resources, indexed by their az, name and type.
+	AZResourcesByAZNameType map[db.ServiceType]AZResourcesByAZName
+	// AZResourcesByAZName are az_resources of a single service, indexed by their az and name.
+	AZResourcesByAZName map[liquid.ResourceName]AZResourcesByAZ
+	// AZResourcesByAZ are az_resources of a single service and resource, indexed by their az.
+	AZResourcesByAZ map[limes.AvailabilityZone]db.AZResource
+	// RatesByNameType are rates, indexed by their name and type.
+	RatesByNameType map[db.ServiceType]RatesByName
+	// RatesByName are rates of a single service, indexed by their name.
+	RatesByName map[liquid.RateName]db.Rate
+	// CategoriesByID are categories, indexed by their id.
+	CategoriesByID map[db.CategoryID]db.Category
+)
+
+// removeType removes all data of a given serviceType, making the cache ready
+// for populating this serviceType from scratch. Categories are always flushed
+// completely.
+func (s *ServiceInfoSnapshot) removeType(serviceType db.ServiceType) {
+	delete(s.services, serviceType)
+	delete(s.resources, serviceType)
+	delete(s.azResources, serviceType)
+	delete(s.rates, serviceType)
+	s.categories = make(map[db.CategoryID]db.Category)
+}
+
+// deepClone delivers a deep copy of the ServiceInfoSnapshot. This is used to
+// create a copy which can be altered without interfering with the original.
+// It shall only be used from ServiceInfoCache or when creating a
+// FilteredServiceInfoSnapshot.
+func (s *ServiceInfoSnapshot) deepClone() *ServiceInfoSnapshot {
+	result := &ServiceInfoSnapshot{
+		services:  maps.Clone(s.services),
+		resources: deepCloneMap(s.resources, maps.Clone),
+		azResources: deepCloneMap(s.azResources, func(inner AZResourcesByAZName) AZResourcesByAZName {
+			return deepCloneMap(inner, maps.Clone)
+		}),
+		rates:       deepCloneMap(s.rates, maps.Clone),
+		categories:  maps.Clone(s.categories),
+		areaMapping: s.areaMapping, // should never get modified
+	}
+	return result
+}
+
+// Filter applies the filter to the ServiceInfoSnapshot and produces an
+// eagerly filtered FilteredServiceInfoSnapshot.
+func (s *ServiceInfoSnapshot) Filter(filter ServiceInfoFilter) *FilteredServiceInfoSnapshot {
+	f := &FilteredServiceInfoSnapshot{
+		snapshot: s, // gets cloned by AddToFilter
+	}
+	return f.AddToFilter(filter)
+}
+
+// GetServices implements the [ServiceInfoReader] interface.
+func (s *ServiceInfoSnapshot) GetServices() ServicesByType {
+	return maps.Clone(s.services)
+}
+
+// GetServiceForType implements the [ServiceInfoReader] interface.
+func (s *ServiceInfoSnapshot) GetServiceForType(serviceType db.ServiceType) (db.Service, bool) {
+	val, ok := s.services[serviceType]
+	return val, ok
+}
+
+// GetResources implements the [ServiceInfoReader] interface.
+func (s *ServiceInfoSnapshot) GetResources() ResourcesByNameType {
+	return deepCloneMap(s.resources, maps.Clone)
+}
+
+// GetResourcesForType implements the [ServiceInfoReader] interface.
+func (s *ServiceInfoSnapshot) GetResourcesForType(serviceType db.ServiceType) (ResourcesByName, bool) {
+	val, ok := s.resources[serviceType]
+	return maps.Clone(val), ok
+}
+
+// GetResourceForTypeName implements the [ServiceInfoReader] interface.
+func (s *ServiceInfoSnapshot) GetResourceForTypeName(serviceType db.ServiceType, resourceName liquid.ResourceName) (db.Resource, bool) {
+	val, ok := s.resources[serviceType][resourceName]
+	return val, ok
+}
+
+// GetResourceForPath implements the [ServiceInfoReader] interface.
+func (s *ServiceInfoSnapshot) GetResourceForPath(path db.ResourcePath) (db.Resource, bool) {
+	return s.GetResourceForTypeName(path.ServiceType, path.ResourceName)
+}
+
+// GetAZResources implements the [ServiceInfoReader] interface.
+func (s *ServiceInfoSnapshot) GetAZResources() AZResourcesByAZNameType {
+	return deepCloneMap(s.azResources, func(inner AZResourcesByAZName) AZResourcesByAZName {
+		return deepCloneMap(inner, maps.Clone)
+	})
+}
+
+// GetAZResourcesForType implements the [ServiceInfoReader] interface.
+func (s *ServiceInfoSnapshot) GetAZResourcesForType(serviceType db.ServiceType) (AZResourcesByAZName, bool) {
+	val, ok := s.azResources[serviceType]
+	return deepCloneMap(val, maps.Clone), ok
+}
+
+// GetAZResourcesForTypeName implements the [ServiceInfoReader] interface.
+func (s *ServiceInfoSnapshot) GetAZResourcesForTypeName(serviceType db.ServiceType, resourceName liquid.ResourceName) (AZResourcesByAZ, bool) {
+	val, ok := s.azResources[serviceType][resourceName]
+	return maps.Clone(val), ok
+}
+
+// GetAZResourceForTypeNameAZ implements the [ServiceInfoReader] interface.
+func (s *ServiceInfoSnapshot) GetAZResourceForTypeNameAZ(serviceType db.ServiceType, resourceName liquid.ResourceName, az limes.AvailabilityZone) (db.AZResource, bool) {
+	val, ok := s.azResources[serviceType][resourceName][az]
+	return val, ok
+}
+
+// GetAZResourceForPath implements the [ServiceInfoReader] interface.
+func (s *ServiceInfoSnapshot) GetAZResourceForPath(path db.AZResourcePath) (db.AZResource, bool) {
+	return s.GetAZResourceForTypeNameAZ(path.ServiceType, path.ResourceName, path.AvailabilityZone)
+}
+
+// GetRates implements the [ServiceInfoReader] interface.
+func (s *ServiceInfoSnapshot) GetRates() RatesByNameType {
+	return deepCloneMap(s.rates, maps.Clone)
+}
+
+// GetRatesForType implements the [ServiceInfoReader] interface.
+func (s *ServiceInfoSnapshot) GetRatesForType(serviceType db.ServiceType) (RatesByName, bool) {
+	val, ok := s.rates[serviceType]
+	return maps.Clone(val), ok
+}
+
+// GetRateForTypeName implements the [ServiceInfoReader] interface.
+func (s *ServiceInfoSnapshot) GetRateForTypeName(serviceType db.ServiceType, rateName liquid.RateName) (db.Rate, bool) {
+	val, ok := s.rates[serviceType][rateName]
+	return val, ok
+}
+
+// GetCategories implements the [ServiceInfoReader] interface.
+func (s *ServiceInfoSnapshot) GetCategories() CategoriesByID {
+	return maps.Clone(s.categories)
+}
+
+// GetCategoryForID implements the [ServiceInfoReader] interface.
+func (s *ServiceInfoSnapshot) GetCategoryForID(categoryID db.CategoryID) (db.Category, bool) {
+	val, ok := s.categories[categoryID]
+	return val, ok
+}
+
+// newEmptyServiceInfoSnapshot() returns an empty ServiceInfoSnapshot with all
+// maps initialized on their first level.
+func newEmptyServiceInfoSnapshot(config ClusterConfiguration) ServiceInfoSnapshot {
+	areaMapping := make(map[db.ServiceType]string)
+	for serviceType, liquidConfiguration := range config.Liquids {
+		areaMapping[serviceType] = liquidConfiguration.Area
+	}
+	return ServiceInfoSnapshot{
+		services:    make(ServicesByType),
+		resources:   make(ResourcesByNameType),
+		azResources: make(AZResourcesByAZNameType),
+		rates:       make(RatesByNameType),
+		categories:  make(CategoriesByID),
+		areaMapping: areaMapping,
+	}
+}
+
+///////////////////////////////////////////////////////////////////////
+
+// FilteredServiceInfoSnapshot is a ServiceInfoSnapshot
+// filtered by the specification of the ServiceInfoFilter.
+// It offers the same method-set as ServiceInfoSnapshot.
+type FilteredServiceInfoSnapshot struct {
+	snapshot *ServiceInfoSnapshot
+	filter   ServiceInfoFilter
+}
+
+// GetFilter returns the current filter.
+func (f *FilteredServiceInfoSnapshot) GetFilter() ServiceInfoFilter {
+	return f.filter
+}
+
+// AddToFilter merges the given filter to the existing filter.
+// The filter can only become more specific.
+// If a property was already filtered before, the additional filter is
+// omitted.
+func (f *FilteredServiceInfoSnapshot) AddToFilter(filter ServiceInfoFilter) *FilteredServiceInfoSnapshot {
+	if serviceArea, ok := filter.ServiceArea.Unpack(); ok && f.filter.ServiceArea.IsNone() {
+		f.filter.ServiceArea = Some(serviceArea)
+	}
+	if serviceType, ok := filter.ServiceType.Unpack(); ok && f.filter.ServiceType.IsNone() {
+		f.filter.ServiceType = Some(serviceType)
+	}
+	if resourceCategory, ok := filter.Category.Unpack(); ok && f.filter.Category.IsNone() {
+		f.filter.Category = Some(resourceCategory)
+	}
+	if azResource, ok := filter.ResourceName.Unpack(); ok && f.filter.ResourceName.IsNone() {
+		f.filter.ResourceName = Some(azResource)
+	}
+
+	// filter services by area
+	newSnapshot := f.snapshot.deepClone()
+	if areaFilter, ok := f.filter.ServiceArea.Unpack(); ok {
+		for serviceType, area := range f.snapshot.areaMapping {
+			if area == areaFilter {
+				continue
+			}
+			delete(newSnapshot.services, serviceType)
+			delete(newSnapshot.resources, serviceType)
+			delete(newSnapshot.azResources, serviceType)
+			delete(newSnapshot.rates, serviceType)
+		}
+	}
+	// filter services by type
+	if typeFilter, ok := f.filter.ServiceType.Unpack(); ok {
+		for serviceType := range newSnapshot.services {
+			if typeFilter == serviceType {
+				continue
+			}
+			delete(newSnapshot.services, serviceType)
+			delete(newSnapshot.azResources, serviceType)
+			delete(newSnapshot.resources, serviceType)
+			delete(newSnapshot.rates, serviceType)
+		}
+	}
+	categoriesToRemove := make(map[db.CategoryID]struct{})
+	// find categories to remove
+	if categoryFilter, ok := f.filter.Category.Unpack(); ok {
+		for categoryID, info := range newSnapshot.categories {
+			if info.Name != categoryFilter {
+				delete(newSnapshot.categories, categoryID)
+				categoriesToRemove[categoryID] = struct{}{}
+			}
+		}
+	}
+	seenCategories := make(map[db.CategoryID]struct{})
+	resourceNameFilter, resourceFilterExists := f.filter.ResourceName.Unpack()
+	// filter resources/ az_resources by category or name
+	if len(categoriesToRemove) > 0 || resourceFilterExists {
+		for serviceType, resources := range newSnapshot.resources {
+			for resourceName, resource := range resources {
+				categoryID, cExists := resource.CategoryID.Unpack()
+				if _, removeCategory := categoriesToRemove[categoryID]; (cExists && removeCategory) || (resourceFilterExists && resourceName != resourceNameFilter) {
+					delete(newSnapshot.resources[serviceType], resourceName)
+					delete(newSnapshot.azResources[serviceType], resourceName)
+					if len(newSnapshot.resources[serviceType]) == 0 && len(newSnapshot.rates[serviceType]) == 0 {
+						delete(newSnapshot.services, serviceType)
+						delete(newSnapshot.resources, serviceType)
+						delete(newSnapshot.azResources, serviceType)
+						delete(newSnapshot.rates, serviceType)
+					}
+				} else {
+					seenCategories[categoryID] = struct{}{}
+				}
+			}
+		}
+	}
+	rateNameFilter, rateFilterExists := f.filter.RateName.Unpack()
+	// filter rates by category or name
+	if len(categoriesToRemove) > 0 || rateFilterExists {
+		for serviceType, rates := range newSnapshot.rates {
+			for rateName, rate := range rates {
+				categoryID, cExists := rate.CategoryID.Unpack()
+				if _, removeCategory := categoriesToRemove[categoryID]; (cExists && removeCategory) || (rateFilterExists && rateName != rateNameFilter) {
+					delete(newSnapshot.rates[serviceType], rateName)
+					if len(newSnapshot.resources[serviceType]) == 0 && len(newSnapshot.rates[serviceType]) == 0 {
+						delete(newSnapshot.services, serviceType)
+						delete(newSnapshot.resources, serviceType)
+						delete(newSnapshot.azResources, serviceType)
+						delete(newSnapshot.rates, serviceType)
+					}
+				} else {
+					seenCategories[categoryID] = struct{}{}
+				}
+			}
+		}
+	}
+
+	// if we filtered by rate or service name, we must thin out the categories
+	if resourceFilterExists || rateFilterExists {
+		for categoryID := range newSnapshot.categories {
+			if _, ok := seenCategories[categoryID]; !ok {
+				delete(newSnapshot.categories, categoryID)
+			}
+		}
+	}
+	f.snapshot = newSnapshot
+	return f
+}
+
+// GetFilteredService returns the service for the filtered type.
+// It is useful to access the service, when you know it was filtered.
+func (f *FilteredServiceInfoSnapshot) GetFilteredService() (db.Service, bool) {
+	serviceType, ok := f.filter.ServiceType.Unpack()
+	if !ok {
+		return db.Service{}, false
+	}
+	service, ok := f.snapshot.services[serviceType]
+	return service, ok
+}
+
+// GetFilteredResource returns the resource for the filtered type and name.
+// It is useful to access the resource, when you know it was filtered.
+func (f *FilteredServiceInfoSnapshot) GetFilteredResource() (db.Resource, bool) {
+	serviceType, ok := f.filter.ServiceType.Unpack()
+	if !ok {
+		return db.Resource{}, false
+	}
+	resourceName, ok := f.filter.ResourceName.Unpack()
+	if !ok {
+		return db.Resource{}, false
+	}
+	resource, ok := f.snapshot.resources[serviceType][resourceName]
+	return resource, ok
+}
+
+// GetFilteredRate returns the rate for the filtered type and name.
+// It is useful to access the rate, when you know it was filtered.
+func (f *FilteredServiceInfoSnapshot) GetFilteredRate() (db.Rate, bool) {
+	serviceType, ok := f.filter.ServiceType.Unpack()
+	if !ok {
+		return db.Rate{}, false
+	}
+	rateName, ok := f.filter.RateName.Unpack()
+	if !ok {
+		return db.Rate{}, false
+	}
+	rate, ok := f.snapshot.rates[serviceType][rateName]
+	return rate, ok
+}
+
+// GetServices implements the [ServiceInfoReader] interface.
+func (f *FilteredServiceInfoSnapshot) GetServices() ServicesByType {
+	return f.snapshot.GetServices()
+}
+
+// GetServiceForType implements the [ServiceInfoReader] interface.
+func (f *FilteredServiceInfoSnapshot) GetServiceForType(serviceType db.ServiceType) (db.Service, bool) {
+	return f.snapshot.GetServiceForType(serviceType)
+}
+
+// GetResources implements the [ServiceInfoReader] interface.
+func (f *FilteredServiceInfoSnapshot) GetResources() ResourcesByNameType {
+	return f.snapshot.GetResources()
+}
+
+// GetResourcesForType implements the [ServiceInfoReader] interface.
+func (f *FilteredServiceInfoSnapshot) GetResourcesForType(serviceType db.ServiceType) (ResourcesByName, bool) {
+	return f.snapshot.GetResourcesForType(serviceType)
+}
+
+// GetResourceForTypeName implements the [ServiceInfoReader] interface.
+func (f *FilteredServiceInfoSnapshot) GetResourceForTypeName(serviceType db.ServiceType, resourceName liquid.ResourceName) (db.Resource, bool) {
+	return f.snapshot.GetResourceForTypeName(serviceType, resourceName)
+}
+
+// GetResourceForPath implements the [ServiceInfoReader] interface.
+func (f *FilteredServiceInfoSnapshot) GetResourceForPath(path db.ResourcePath) (db.Resource, bool) {
+	return f.snapshot.GetResourceForPath(path)
+}
+
+// GetAZResources implements the [ServiceInfoReader] interface.
+func (f *FilteredServiceInfoSnapshot) GetAZResources() AZResourcesByAZNameType {
+	return f.snapshot.GetAZResources()
+}
+
+// GetAZResourcesForType implements the [ServiceInfoReader] interface.
+func (f *FilteredServiceInfoSnapshot) GetAZResourcesForType(serviceType db.ServiceType) (AZResourcesByAZName, bool) {
+	return f.snapshot.GetAZResourcesForType(serviceType)
+}
+
+// GetAZResourcesForTypeName implements the [ServiceInfoReader] interface.
+func (f *FilteredServiceInfoSnapshot) GetAZResourcesForTypeName(serviceType db.ServiceType, resourceName liquid.ResourceName) (AZResourcesByAZ, bool) {
+	return f.snapshot.GetAZResourcesForTypeName(serviceType, resourceName)
+}
+
+// GetAZResourceForTypeNameAZ implements the [ServiceInfoReader] interface.
+func (f *FilteredServiceInfoSnapshot) GetAZResourceForTypeNameAZ(serviceType db.ServiceType, resourceName liquid.ResourceName, az limes.AvailabilityZone) (db.AZResource, bool) {
+	return f.snapshot.GetAZResourceForTypeNameAZ(serviceType, resourceName, az)
+}
+
+// GetAZResourceForPath implements the [ServiceInfoReader] interface.
+func (f *FilteredServiceInfoSnapshot) GetAZResourceForPath(path db.AZResourcePath) (db.AZResource, bool) {
+	return f.snapshot.GetAZResourceForPath(path)
+}
+
+// GetRates implements the [ServiceInfoReader] interface.
+func (f *FilteredServiceInfoSnapshot) GetRates() RatesByNameType {
+	return f.snapshot.GetRates()
+}
+
+// GetRatesForType implements the [ServiceInfoReader] interface.
+func (f *FilteredServiceInfoSnapshot) GetRatesForType(serviceType db.ServiceType) (RatesByName, bool) {
+	return f.snapshot.GetRatesForType(serviceType)
+}
+
+// GetRateForTypeName implements the [ServiceInfoReader] interface.
+func (f *FilteredServiceInfoSnapshot) GetRateForTypeName(serviceType db.ServiceType, rateName liquid.RateName) (db.Rate, bool) {
+	return f.snapshot.GetRateForTypeName(serviceType, rateName)
+}
+
+// GetCategories implements the [ServiceInfoReader] interface.
+func (f *FilteredServiceInfoSnapshot) GetCategories() CategoriesByID {
+	return f.snapshot.GetCategories()
+}
+
+// GetCategoryForID implements the [ServiceInfoReader] interface.
+func (f *FilteredServiceInfoSnapshot) GetCategoryForID(categoryID db.CategoryID) (db.Category, bool) {
+	return f.snapshot.GetCategoryForID(categoryID)
+}
+
+///////////////////////////////////////////////////////////////////////
+
 // serviceNotifyChannel is the PostgreSQL NOTIFY channel name used to signal
 // that a service's data has changed and the cache should be invalidated.
 const serviceNotifyChannel = "limitas_service_update"
-
-// The following types are defined explicitly to aid using the return
-// types of functions of ServiceInfoCache as parameters of other functions.
-// Basically, they are the internal representation of liquid.ServiceInfo.
-type (
-	// ServicesByType are all services, indexed by their service type.
-	ServicesByType map[db.ServiceType]db.Service
-	// ResourcesByNameType are all resources, indexed by their name and type.
-	ResourcesByNameType map[db.ServiceType]ResourcesByName
-	// ResourcesByName are all resources of a single service, indexed by their name.
-	ResourcesByName map[liquid.ResourceName]db.Resource
-	// AZResourcesByAZNameType are all az_resources, indexed by their az, name and type.
-	AZResourcesByAZNameType map[db.ServiceType]AZResourcesByAZName
-	// AZResourcesByAZName are all az_resources of a single service, indexed by their az and name.
-	AZResourcesByAZName map[liquid.ResourceName]AZResourcesByAZ
-	// AZResourcesByAZ are all az_resources of a single service and resource, indexed by their az.
-	AZResourcesByAZ map[limes.AvailabilityZone]db.AZResource
-	// RatesByNameType are all rates, indexed by their name and type.
-	RatesByNameType map[db.ServiceType]RatesByName
-	// RatesByName are all rates of a single service, indexed by their name.
-	RatesByName map[liquid.RateName]db.Rate
-	// CategoriesByID are all categories, indexed by their id.
-	CategoriesByID map[db.CategoryID]db.Category
-)
 
 // ServiceInfoCache is the interface to the database to retrieve all data,
 // which was previously populated from the liquid.ServiceInfo. The principle
@@ -64,6 +526,8 @@ type ServiceInfoCache struct {
 	// state
 	DB       *gorp.DbMap
 	listener *pq.Listener
+	config   ClusterConfiguration
+	data     ServiceInfoSnapshot
 	// we use one mutex as all data is written together and reading is quick
 	dataMutex sync.RWMutex
 
@@ -73,25 +537,14 @@ type ServiceInfoCache struct {
 	// non-blocking so production code is unaffected when nobody reads.
 	OnInvalidate   <-chan struct{}
 	sendInvalidate chan<- struct{}
-
-	// data
-	servicesByType          ServicesByType
-	resourcesByNameType     ResourcesByNameType
-	azResourcesByAZNameType AZResourcesByAZNameType
-	ratesByNameType         RatesByNameType
-	categoriesByID          CategoriesByID
 }
 
 // NewServiceInfoCache generates a ServiceInfoCache and fills all services' data.
-func NewServiceInfoCache(dbm *gorp.DbMap, dbURL Option[url.URL]) (*ServiceInfoCache, error) {
+func NewServiceInfoCache(dbm *gorp.DbMap, config ClusterConfiguration, dbURL Option[url.URL]) (*ServiceInfoCache, error) {
 	sic := &ServiceInfoCache{
-		DB: dbm,
-
-		servicesByType:          make(ServicesByType),
-		resourcesByNameType:     make(ResourcesByNameType),
-		azResourcesByAZNameType: make(AZResourcesByAZNameType),
-		ratesByNameType:         make(RatesByNameType),
-		categoriesByID:          make(CategoriesByID),
+		DB:     dbm,
+		config: config,
+		data:   newEmptyServiceInfoSnapshot(config),
 	}
 
 	// populate all data from the DB on startup
@@ -177,18 +630,9 @@ func (s *ServiceInfoCache) InvalidateService(serviceType Option[db.ServiceType])
 	defer s.dataMutex.Unlock()
 
 	if st, ok := serviceType.Unpack(); ok {
-		delete(s.servicesByType, st)
-		delete(s.resourcesByNameType, st)
-		delete(s.azResourcesByAZNameType, st)
-		delete(s.ratesByNameType, st)
-
-		s.categoriesByID = make(CategoriesByID)
+		s.data.removeType(st)
 	} else {
-		s.servicesByType = make(ServicesByType)
-		s.resourcesByNameType = make(ResourcesByNameType)
-		s.azResourcesByAZNameType = make(AZResourcesByAZNameType)
-		s.ratesByNameType = make(RatesByNameType)
-		s.categoriesByID = make(CategoriesByID)
+		s.data = newEmptyServiceInfoSnapshot(s.config)
 	}
 
 	// now we fill the cache for the invalidated services again
@@ -196,7 +640,7 @@ func (s *ServiceInfoCache) InvalidateService(serviceType Option[db.ServiceType])
 	if err != nil {
 		return fmt.Errorf("while reading services for type(s) %v: %w", serviceType, err)
 	}
-	maps.Copy(s.servicesByType, servicesByType)
+	maps.Copy(s.data.services, servicesByType)
 
 	resourcesByPath, err := db.BuildIndexOfDBResult(
 		s.DB,
@@ -208,10 +652,10 @@ func (s *ServiceInfoCache) InvalidateService(serviceType Option[db.ServiceType])
 		return fmt.Errorf("while reading resources for type(s) %v: %w", serviceType, err)
 	}
 	for path, resource := range resourcesByPath {
-		if _, sExists := s.resourcesByNameType[path.ServiceType]; !sExists {
-			s.resourcesByNameType[path.ServiceType] = make(ResourcesByName)
+		if _, sExists := s.data.resources[path.ServiceType]; !sExists {
+			s.data.resources[path.ServiceType] = make(ResourcesByName)
 		}
-		s.resourcesByNameType[path.ServiceType][path.ResourceName] = resource
+		s.data.resources[path.ServiceType][path.ResourceName] = resource
 	}
 
 	azResourcesByPath, err := db.BuildIndexOfDBResult(
@@ -224,13 +668,13 @@ func (s *ServiceInfoCache) InvalidateService(serviceType Option[db.ServiceType])
 		return fmt.Errorf("while reading az_resources for type(s) %v: %w", serviceType, err)
 	}
 	for path, azResource := range azResourcesByPath {
-		if _, sExists := s.azResourcesByAZNameType[path.ServiceType]; !sExists {
-			s.azResourcesByAZNameType[path.ServiceType] = make(AZResourcesByAZName)
+		if _, sExists := s.data.azResources[path.ServiceType]; !sExists {
+			s.data.azResources[path.ServiceType] = make(AZResourcesByAZName)
 		}
-		if _, rExists := s.azResourcesByAZNameType[path.ServiceType][path.ResourceName]; !rExists {
-			s.azResourcesByAZNameType[path.ServiceType][path.ResourceName] = make(AZResourcesByAZ)
+		if _, rExists := s.data.azResources[path.ServiceType][path.ResourceName]; !rExists {
+			s.data.azResources[path.ServiceType][path.ResourceName] = make(AZResourcesByAZ)
 		}
-		s.azResourcesByAZNameType[path.ServiceType][path.ResourceName][path.AvailabilityZone] = azResource
+		s.data.azResources[path.ServiceType][path.ResourceName][path.AvailabilityZone] = azResource
 	}
 
 	ratesByPath, err := db.BuildIndexOfDBResult(
@@ -243,13 +687,13 @@ func (s *ServiceInfoCache) InvalidateService(serviceType Option[db.ServiceType])
 		return fmt.Errorf("while reading rates for type(s) %v: %w", serviceType, err)
 	}
 	for path, rate := range ratesByPath {
-		if _, rExists := s.ratesByNameType[path.ServiceType]; !rExists {
-			s.ratesByNameType[path.ServiceType] = make(RatesByName)
+		if _, rExists := s.data.rates[path.ServiceType]; !rExists {
+			s.data.rates[path.ServiceType] = make(RatesByName)
 		}
-		s.ratesByNameType[path.ServiceType][path.RateName] = rate
+		s.data.rates[path.ServiceType][path.RateName] = rate
 	}
 
-	s.categoriesByID, err = db.BuildIndexOfDBResult(
+	s.data.categories, err = db.BuildIndexOfDBResult(
 		s.DB,
 		func(c db.Category) db.CategoryID { return c.ID },
 		"SELECT * FROM categories",
@@ -260,146 +704,11 @@ func (s *ServiceInfoCache) InvalidateService(serviceType Option[db.ServiceType])
 	return nil
 }
 
-// deepCloneMap returns a deep copy of a map by cloning each value using the
-// provided cloneValue function. For leaf maps (where values are not maps),
-// pass maps.Clone directly. For nested maps, pass a function that itself
-// calls deepCloneMap to clone the next level.
-func deepCloneMap[M ~map[K]V, K comparable, V any](m M, cloneValue func(V) V) M {
-	if m == nil {
-		return nil
-	}
-	result := make(M, len(m))
-	for k, v := range m {
-		result[k] = cloneValue(v)
-	}
-	return result
-}
-
-// GetServices returns a map of all cached services keyed by their service type.
-func (s *ServiceInfoCache) GetServices() ServicesByType {
+// GetSnapshot returns a ServiceInfoSnapshot with the current data in the ServiceInfoCache.
+func (s *ServiceInfoCache) GetSnapshot() *ServiceInfoSnapshot {
 	s.dataMutex.RLock()
 	defer s.dataMutex.RUnlock()
-	return maps.Clone(s.servicesByType)
-}
-
-// GetServiceForType returns the cached service for the given service type.
-func (s *ServiceInfoCache) GetServiceForType(serviceType db.ServiceType) (db.Service, bool) {
-	s.dataMutex.RLock()
-	defer s.dataMutex.RUnlock()
-	val, ok := s.servicesByType[serviceType]
-	return val, ok
-}
-
-// HasServiceForType checks whether the given service exists.
-func (s *ServiceInfoCache) HasServiceForType(serviceType db.ServiceType) bool {
-	s.dataMutex.RLock()
-	defer s.dataMutex.RUnlock()
-	_, exists := s.servicesByType[serviceType]
-	return exists
-}
-
-// GetResources returns all cached resources, indexed by service type and resource name.
-func (s *ServiceInfoCache) GetResources() ResourcesByNameType {
-	s.dataMutex.RLock()
-	defer s.dataMutex.RUnlock()
-	return deepCloneMap(s.resourcesByNameType, maps.Clone)
-}
-
-// GetResourcesForType returns all cached resources for the given service type, keyed by resource name.
-func (s *ServiceInfoCache) GetResourcesForType(serviceType db.ServiceType) (ResourcesByName, bool) {
-	s.dataMutex.RLock()
-	defer s.dataMutex.RUnlock()
-	val, ok := s.resourcesByNameType[serviceType]
-	return val, ok
-}
-
-// GetResourceForTypeName returns the cached resource for the given service type and resource name.
-func (s *ServiceInfoCache) GetResourceForTypeName(serviceType db.ServiceType, resourceName liquid.ResourceName) (db.Resource, bool) {
-	s.dataMutex.RLock()
-	defer s.dataMutex.RUnlock()
-	val, ok := s.resourcesByNameType[serviceType][resourceName]
-	return val, ok
-}
-
-// GetResourceForPath returns the cached resource for the given path.
-func (s *ServiceInfoCache) GetResourceForPath(path db.ResourcePath) (db.Resource, bool) {
-	return s.GetResourceForTypeName(path.ServiceType, path.ResourceName)
-}
-
-// GetAZResources returns all cached AZ resources, indexed by service type, resource name, and availability zone.
-func (s *ServiceInfoCache) GetAZResources() AZResourcesByAZNameType {
-	s.dataMutex.RLock()
-	defer s.dataMutex.RUnlock()
-	return deepCloneMap(s.azResourcesByAZNameType, func(inner AZResourcesByAZName) AZResourcesByAZName {
-		return deepCloneMap(inner, maps.Clone)
-	})
-}
-
-// GetAZResourcesForType returns all cached AZ resources for the given service type, keyed by resource name and availability zone.
-func (s *ServiceInfoCache) GetAZResourcesForType(serviceType db.ServiceType) (AZResourcesByAZName, bool) {
-	s.dataMutex.RLock()
-	defer s.dataMutex.RUnlock()
-	val, ok := s.azResourcesByAZNameType[serviceType]
-	return deepCloneMap(val, maps.Clone), ok
-}
-
-// GetAZResourcesForTypeName returns all cached AZ resources for the given service type, resource name, keyed by availability zone.
-func (s *ServiceInfoCache) GetAZResourcesForTypeName(serviceType db.ServiceType, resourceName liquid.ResourceName) (AZResourcesByAZ, bool) {
-	s.dataMutex.RLock()
-	defer s.dataMutex.RUnlock()
-	val, ok := s.azResourcesByAZNameType[serviceType][resourceName]
-	return maps.Clone(val), ok
-}
-
-// GetAZResourceForTypeNameAZ returns the cached AZ resource for the given service type, resource name, and availability zone.
-func (s *ServiceInfoCache) GetAZResourceForTypeNameAZ(serviceType db.ServiceType, resourceName liquid.ResourceName, az limes.AvailabilityZone) (db.AZResource, bool) {
-	s.dataMutex.RLock()
-	defer s.dataMutex.RUnlock()
-	val, ok := s.azResourcesByAZNameType[serviceType][resourceName][az]
-	return val, ok
-}
-
-// GetAZResourceForPath returns the cached AZ resource for the given path.
-func (s *ServiceInfoCache) GetAZResourceForPath(path db.AZResourcePath) (db.AZResource, bool) {
-	return s.GetAZResourceForTypeNameAZ(path.ServiceType, path.ResourceName, path.AvailabilityZone)
-}
-
-// GetRates returns all cached rates, indexed by service type and rate name.
-func (s *ServiceInfoCache) GetRates() RatesByNameType {
-	s.dataMutex.RLock()
-	defer s.dataMutex.RUnlock()
-	return deepCloneMap(s.ratesByNameType, maps.Clone)
-}
-
-// GetRatesForType returns all cached rates, indexed by service type and rate name.
-func (s *ServiceInfoCache) GetRatesForType(serviceType db.ServiceType) (RatesByName, bool) {
-	s.dataMutex.RLock()
-	defer s.dataMutex.RUnlock()
-	val, ok := s.ratesByNameType[serviceType]
-	return maps.Clone(val), ok
-}
-
-// GetRateForTypeName returns the cached rate for the given service type and rate name.
-func (s *ServiceInfoCache) GetRateForTypeName(serviceType db.ServiceType, rateName liquid.RateName) (db.Rate, bool) {
-	s.dataMutex.RLock()
-	defer s.dataMutex.RUnlock()
-	val, ok := s.ratesByNameType[serviceType][rateName]
-	return val, ok
-}
-
-// GetCategories returns all cached categories, indexed by category ID.
-func (s *ServiceInfoCache) GetCategories() CategoriesByID {
-	s.dataMutex.RLock()
-	defer s.dataMutex.RUnlock()
-	return maps.Clone(s.categoriesByID)
-}
-
-// GetCategoryForID returns the cached category for the given category ID.
-func (s *ServiceInfoCache) GetCategoryForID(categoryID db.CategoryID) (db.Category, bool) {
-	s.dataMutex.RLock()
-	defer s.dataMutex.RUnlock()
-	val, ok := s.categoriesByID[categoryID]
-	return val, ok
+	return s.data.deepClone()
 }
 
 // GetServiceInfo should only be used when interacting with the liquid
@@ -409,10 +718,10 @@ func (s *ServiceInfoCache) GetServiceInfo(serviceType db.ServiceType) (info liqu
 	s.dataMutex.RLock()
 	defer s.dataMutex.RUnlock()
 	// we can assume the data is saved because of the call context
-	service := s.servicesByType[serviceType]
-	resources := s.resourcesByNameType[serviceType]
-	rates := s.ratesByNameType[serviceType]
-	categories := s.categoriesByID
+	service := s.data.services[serviceType]
+	resources := s.data.resources[serviceType]
+	rates := s.data.rates[serviceType]
+	categories := s.data.categories
 
 	capacityMetricFamilies, err := util.JSONToAny[map[liquid.MetricName]liquid.MetricFamilyInfo](service.CapacityMetricFamiliesJSON, "capacity_metric_families")
 	if err != nil {
@@ -480,23 +789,20 @@ func (s *ServiceInfoCache) GetServiceInfo(serviceType db.ServiceType) (info liqu
 	return info, nil
 }
 
-///////////////////////////////
-// utility functions on the results of the above functions
-///////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// Utility functions
 
-// HasResourceForTypeName checks whether the given service and resource exist.
-func (s *ServiceInfoCache) HasResourceForTypeName(serviceType db.ServiceType, resourceName liquid.ResourceName) bool {
-	s.dataMutex.RLock()
-	defer s.dataMutex.RUnlock()
-	_, exists := s.resourcesByNameType[serviceType][resourceName]
-	return exists
-}
-
-// HasUsageForRate checks whether the given service and resource exist and whether it has usage.
-func (r RatesByNameType) HasUsageForRate(serviceType db.ServiceType, rateName liquid.RateName) bool {
-	rate, exists := r[serviceType][rateName]
-	if !exists {
-		return false
+// deepCloneMap returns a deep copy of a map by cloning each value using the
+// provided cloneValue function. For leaf maps (where values are not maps),
+// pass maps.Clone directly. For nested maps, pass a function that itself
+// calls deepCloneMap to deepClone the next level.
+func deepCloneMap[M ~map[K]V, K comparable, V any](m M, cloneValue func(V) V) M {
+	if m == nil {
+		return nil
 	}
-	return rate.HasUsage
+	result := make(M, len(m))
+	for k, v := range m {
+		result[k] = cloneValue(v)
+	}
+	return result
 }

--- a/internal/core/service_info_cache.go
+++ b/internal/core/service_info_cache.go
@@ -25,7 +25,7 @@ import (
 
 ///////////////////////////////////////////////////////////////////////
 
-// ServiceInfoFilter is a set of possible attributes by which ServiceInfoSnapshot
+// ServiceInfoFilter is a set of possible attributes by which [ServiceInfoSnapshot]
 // can be filtered. Most of the time, these come directly or indirectly from an API
 // requests' scope, e.g. query filters or attributes of a processed commitment.
 type ServiceInfoFilter struct {
@@ -38,38 +38,45 @@ type ServiceInfoFilter struct {
 
 ///////////////////////////////////////////////////////////////////////
 
-// ServiceInfoReader defines shared methods for reading
-// filtered or unfiltered ServiceInfoSnapshots.
+// ServiceInfoReader defines shared methods for reading filtered or unfiltered ServiceInfoSnapshots.
+//
+// It is implemented by types [ServiceInfoSnapshot] and [FilteredServiceInfoSnapshot].
 type ServiceInfoReader interface {
 	// GetServices returns all services.
-	GetServices() ServicesByType
+	GetServices() map[db.ServiceType]db.Service
 	// GetServiceForType returns the service for the given service type.
 	GetServiceForType(serviceType db.ServiceType) (db.Service, bool)
-	// GetResources returns all resources
-	GetResources() ResourcesByNameType
-	// GetResourcesForType returns all resources for the given service type, keyed by resource name.
-	GetResourcesForType(serviceType db.ServiceType) (ResourcesByName, bool)
+	// GetResources returns all resources.
+	GetResources() map[db.ServiceType]map[liquid.ResourceName]db.Resource
+	// GetResourcesForType returns all resources for the given service type.
+	GetResourcesForType(serviceType db.ServiceType) (map[liquid.ResourceName]db.Resource, bool)
 	// GetResourceForPath returns the resource for the given path.
 	GetResourceForPath(path db.ResourcePath) (db.Resource, bool)
-	// GetAZResources returns all AZ resources, indexed by service type, resource name, and availability zone.
-	GetAZResources() AZResourcesByAZNameType
-	// GetAZResourcesForType returns all AZ resources for the given service type, keyed by resource name and availability zone.
-	GetAZResourcesForType(serviceType db.ServiceType) (AZResourcesByAZName, bool)
-	// GetAZResourcesForPath returns the AZ resource for the given ResourcePath.
-	GetAZResourcesForPath(path db.ResourcePath) (AZResourcesByAZ, bool)
+	// GetAZResources returns all AZ resources.
+	GetAZResources() map[db.ServiceType]map[liquid.ResourceName]map[limes.AvailabilityZone]db.AZResource
+	// GetAZResourcesForType returns all AZ resources for the given service type.
+	GetAZResourcesForType(serviceType db.ServiceType) (map[liquid.ResourceName]map[limes.AvailabilityZone]db.AZResource, bool)
+	// GetAZResourcesForPath returns all AZ resources for the given ResourcePath.
+	GetAZResourcesForPath(path db.ResourcePath) (map[limes.AvailabilityZone]db.AZResource, bool)
 	// GetAZResourceForPath returns the AZ resource for the given AZResourcePath.
 	GetAZResourceForPath(path db.AZResourcePath) (db.AZResource, bool)
-	// GetRates returns all cached rates, indexed by service type and rate name.
-	GetRates() RatesByNameType
-	// GetRatesForType returns all rates, indexed by service type and rate name.
-	GetRatesForType(serviceType db.ServiceType) (RatesByName, bool)
+	// GetRates returns all rates.
+	GetRates() map[db.ServiceType]map[liquid.RateName]db.Rate
+	// GetRatesForType returns all rates for the given service type.
+	GetRatesForType(serviceType db.ServiceType) (map[liquid.RateName]db.Rate, bool)
 	// GetRateForPath returns the rate for the given service type and rate name.
 	GetRateForPath(path db.RatePath) (db.Rate, bool)
-	// GetCategories returns all categories, indexed by category ID.
-	GetCategories() CategoriesByID
-	// GetCategoryForID returns the cached category for the given category ID.
+	// GetCategories returns all categories.
+	GetCategories() map[db.CategoryID]db.Category
+	// GetCategoryForID returns the category for the given ID.
 	GetCategoryForID(categoryID db.CategoryID) (db.Category, bool)
 }
+
+var (
+	// prove interface implementations
+	_ ServiceInfoReader = ServiceInfoSnapshot{}
+	_ ServiceInfoReader = FilteredServiceInfoSnapshot{}
+)
 
 ///////////////////////////////////////////////////////////////////////
 
@@ -85,32 +92,25 @@ type (
 	// on-read access as FilteredServiceInfoSnapshot, they are defined by the
 	// ServiceInfoReader interface.
 	ServiceInfoSnapshot struct {
-		services    ServicesByType
-		resources   ResourcesByNameType
-		azResources AZResourcesByAZNameType
-		rates       RatesByNameType
-		categories  CategoriesByID
+		services    servicesByType
+		resources   resourcesByNameType
+		azResources azResourcesByAZNameType
+		rates       ratesByNameType
+		categories  categoriesByID
 		// necessary for constructing filters by area
 		areaMapping map[db.ServiceType]string
 	}
-	// ServicesByType are services, indexed by their service type.
-	ServicesByType map[db.ServiceType]db.Service
-	// ResourcesByNameType are resources, indexed by their name and type.
-	ResourcesByNameType map[db.ServiceType]ResourcesByName
-	// ResourcesByName are resources of a single service, indexed by their name.
-	ResourcesByName map[liquid.ResourceName]db.Resource
-	// AZResourcesByAZNameType are az_resources, indexed by their az, name and type.
-	AZResourcesByAZNameType map[db.ServiceType]AZResourcesByAZName
-	// AZResourcesByAZName are az_resources of a single service, indexed by their az and name.
-	AZResourcesByAZName map[liquid.ResourceName]AZResourcesByAZ
-	// AZResourcesByAZ are az_resources of a single service and resource, indexed by their az.
-	AZResourcesByAZ map[limes.AvailabilityZone]db.AZResource
-	// RatesByNameType are rates, indexed by their name and type.
-	RatesByNameType map[db.ServiceType]RatesByName
-	// RatesByName are rates of a single service, indexed by their name.
-	RatesByName map[liquid.RateName]db.Rate
-	// CategoriesByID are categories, indexed by their id.
-	CategoriesByID map[db.CategoryID]db.Category
+
+	// shorthands for use within this file
+	servicesByType          = map[db.ServiceType]db.Service
+	resourcesByNameType     = map[db.ServiceType]resourcesByName
+	resourcesByName         = map[liquid.ResourceName]db.Resource
+	azResourcesByAZNameType = map[db.ServiceType]azResourcesByAZName
+	azResourcesByAZName     = map[liquid.ResourceName]azResourcesByAZ
+	azResourcesByAZ         = map[limes.AvailabilityZone]db.AZResource
+	ratesByNameType         = map[db.ServiceType]ratesByName
+	ratesByName             = map[liquid.RateName]db.Rate
+	categoriesByID          = map[db.CategoryID]db.Category
 )
 
 // removeDataForType removes all data of a given serviceType, making the cache ready
@@ -133,7 +133,7 @@ func (s ServiceInfoSnapshot) deepClone() ServiceInfoSnapshot {
 	return ServiceInfoSnapshot{
 		services:  maps.Clone(s.services),
 		resources: deepCloneMap(s.resources, maps.Clone),
-		azResources: deepCloneMap(s.azResources, func(inner AZResourcesByAZName) AZResourcesByAZName {
+		azResources: deepCloneMap(s.azResources, func(inner azResourcesByAZName) azResourcesByAZName {
 			return deepCloneMap(inner, maps.Clone)
 		}),
 		rates:       deepCloneMap(s.rates, maps.Clone),
@@ -262,7 +262,7 @@ func (s ServiceInfoSnapshot) Filter(filter ServiceInfoFilter) FilteredServiceInf
 }
 
 // GetServices implements the [ServiceInfoReader] interface.
-func (s ServiceInfoSnapshot) GetServices() ServicesByType {
+func (s ServiceInfoSnapshot) GetServices() servicesByType {
 	return maps.Clone(s.services)
 }
 
@@ -273,12 +273,12 @@ func (s ServiceInfoSnapshot) GetServiceForType(serviceType db.ServiceType) (db.S
 }
 
 // GetResources implements the [ServiceInfoReader] interface.
-func (s ServiceInfoSnapshot) GetResources() ResourcesByNameType {
+func (s ServiceInfoSnapshot) GetResources() resourcesByNameType {
 	return deepCloneMap(s.resources, maps.Clone)
 }
 
 // GetResourcesForType implements the [ServiceInfoReader] interface.
-func (s ServiceInfoSnapshot) GetResourcesForType(serviceType db.ServiceType) (ResourcesByName, bool) {
+func (s ServiceInfoSnapshot) GetResourcesForType(serviceType db.ServiceType) (resourcesByName, bool) {
 	val, ok := s.resources[serviceType]
 	return maps.Clone(val), ok
 }
@@ -290,20 +290,20 @@ func (s ServiceInfoSnapshot) GetResourceForPath(path db.ResourcePath) (db.Resour
 }
 
 // GetAZResources implements the [ServiceInfoReader] interface.
-func (s ServiceInfoSnapshot) GetAZResources() AZResourcesByAZNameType {
-	return deepCloneMap(s.azResources, func(inner AZResourcesByAZName) AZResourcesByAZName {
+func (s ServiceInfoSnapshot) GetAZResources() azResourcesByAZNameType {
+	return deepCloneMap(s.azResources, func(inner azResourcesByAZName) azResourcesByAZName {
 		return deepCloneMap(inner, maps.Clone)
 	})
 }
 
 // GetAZResourcesForType implements the [ServiceInfoReader] interface.
-func (s ServiceInfoSnapshot) GetAZResourcesForType(serviceType db.ServiceType) (AZResourcesByAZName, bool) {
+func (s ServiceInfoSnapshot) GetAZResourcesForType(serviceType db.ServiceType) (azResourcesByAZName, bool) {
 	val, ok := s.azResources[serviceType]
 	return deepCloneMap(val, maps.Clone), ok
 }
 
 // GetAZResourcesForPath implements the [ServiceInfoReader] interface.
-func (s ServiceInfoSnapshot) GetAZResourcesForPath(path db.ResourcePath) (AZResourcesByAZ, bool) {
+func (s ServiceInfoSnapshot) GetAZResourcesForPath(path db.ResourcePath) (azResourcesByAZ, bool) {
 	val, ok := s.azResources[path.ServiceType][path.ResourceName]
 	return maps.Clone(val), ok
 }
@@ -315,12 +315,12 @@ func (s ServiceInfoSnapshot) GetAZResourceForPath(path db.AZResourcePath) (db.AZ
 }
 
 // GetRates implements the [ServiceInfoReader] interface.
-func (s ServiceInfoSnapshot) GetRates() RatesByNameType {
+func (s ServiceInfoSnapshot) GetRates() ratesByNameType {
 	return deepCloneMap(s.rates, maps.Clone)
 }
 
 // GetRatesForType implements the [ServiceInfoReader] interface.
-func (s ServiceInfoSnapshot) GetRatesForType(serviceType db.ServiceType) (RatesByName, bool) {
+func (s ServiceInfoSnapshot) GetRatesForType(serviceType db.ServiceType) (ratesByName, bool) {
 	val, ok := s.rates[serviceType]
 	return maps.Clone(val), ok
 }
@@ -332,7 +332,7 @@ func (s ServiceInfoSnapshot) GetRateForPath(path db.RatePath) (db.Rate, bool) {
 }
 
 // GetCategories implements the [ServiceInfoReader] interface.
-func (s ServiceInfoSnapshot) GetCategories() CategoriesByID {
+func (s ServiceInfoSnapshot) GetCategories() categoriesByID {
 	return maps.Clone(s.categories)
 }
 
@@ -350,11 +350,11 @@ func newEmptyServiceInfoSnapshot(config ClusterConfiguration) ServiceInfoSnapsho
 		areaMapping[serviceType] = liquidConfiguration.Area
 	}
 	return ServiceInfoSnapshot{
-		services:    make(ServicesByType),
-		resources:   make(ResourcesByNameType),
-		azResources: make(AZResourcesByAZNameType),
-		rates:       make(RatesByNameType),
-		categories:  make(CategoriesByID),
+		services:    make(servicesByType),
+		resources:   make(resourcesByNameType),
+		azResources: make(azResourcesByAZNameType),
+		rates:       make(ratesByNameType),
+		categories:  make(categoriesByID),
 		areaMapping: areaMapping,
 	}
 }
@@ -411,7 +411,7 @@ func (f FilteredServiceInfoSnapshot) GetFilteredRate() (db.Rate, bool) {
 }
 
 // GetServices implements the [ServiceInfoReader] interface.
-func (f FilteredServiceInfoSnapshot) GetServices() ServicesByType {
+func (f FilteredServiceInfoSnapshot) GetServices() servicesByType {
 	return f.snapshot.GetServices()
 }
 
@@ -421,12 +421,12 @@ func (f FilteredServiceInfoSnapshot) GetServiceForType(serviceType db.ServiceTyp
 }
 
 // GetResources implements the [ServiceInfoReader] interface.
-func (f FilteredServiceInfoSnapshot) GetResources() ResourcesByNameType {
+func (f FilteredServiceInfoSnapshot) GetResources() resourcesByNameType {
 	return f.snapshot.GetResources()
 }
 
 // GetResourcesForType implements the [ServiceInfoReader] interface.
-func (f FilteredServiceInfoSnapshot) GetResourcesForType(serviceType db.ServiceType) (ResourcesByName, bool) {
+func (f FilteredServiceInfoSnapshot) GetResourcesForType(serviceType db.ServiceType) (resourcesByName, bool) {
 	return f.snapshot.GetResourcesForType(serviceType)
 }
 
@@ -436,17 +436,17 @@ func (f FilteredServiceInfoSnapshot) GetResourceForPath(path db.ResourcePath) (d
 }
 
 // GetAZResources implements the [ServiceInfoReader] interface.
-func (f FilteredServiceInfoSnapshot) GetAZResources() AZResourcesByAZNameType {
+func (f FilteredServiceInfoSnapshot) GetAZResources() azResourcesByAZNameType {
 	return f.snapshot.GetAZResources()
 }
 
 // GetAZResourcesForType implements the [ServiceInfoReader] interface.
-func (f FilteredServiceInfoSnapshot) GetAZResourcesForType(serviceType db.ServiceType) (AZResourcesByAZName, bool) {
+func (f FilteredServiceInfoSnapshot) GetAZResourcesForType(serviceType db.ServiceType) (azResourcesByAZName, bool) {
 	return f.snapshot.GetAZResourcesForType(serviceType)
 }
 
 // GetAZResourcesForPath implements the [ServiceInfoReader] interface.
-func (f FilteredServiceInfoSnapshot) GetAZResourcesForPath(path db.ResourcePath) (AZResourcesByAZ, bool) {
+func (f FilteredServiceInfoSnapshot) GetAZResourcesForPath(path db.ResourcePath) (azResourcesByAZ, bool) {
 	return f.snapshot.GetAZResourcesForPath(path)
 }
 
@@ -456,12 +456,12 @@ func (f FilteredServiceInfoSnapshot) GetAZResourceForPath(path db.AZResourcePath
 }
 
 // GetRates implements the [ServiceInfoReader] interface.
-func (f FilteredServiceInfoSnapshot) GetRates() RatesByNameType {
+func (f FilteredServiceInfoSnapshot) GetRates() ratesByNameType {
 	return f.snapshot.GetRates()
 }
 
 // GetRatesForType implements the [ServiceInfoReader] interface.
-func (f FilteredServiceInfoSnapshot) GetRatesForType(serviceType db.ServiceType) (RatesByName, bool) {
+func (f FilteredServiceInfoSnapshot) GetRatesForType(serviceType db.ServiceType) (ratesByName, bool) {
 	return f.snapshot.GetRatesForType(serviceType)
 }
 
@@ -471,7 +471,7 @@ func (f FilteredServiceInfoSnapshot) GetRateForPath(path db.RatePath) (db.Rate, 
 }
 
 // GetCategories implements the [ServiceInfoReader] interface.
-func (f FilteredServiceInfoSnapshot) GetCategories() CategoriesByID {
+func (f FilteredServiceInfoSnapshot) GetCategories() categoriesByID {
 	return f.snapshot.GetCategories()
 }
 
@@ -626,7 +626,7 @@ func (s *ServiceInfoCache) InvalidateService(serviceType Option[db.ServiceType])
 	}
 	for path, resource := range resourcesByPath {
 		if _, sExists := s.data.resources[path.ServiceType]; !sExists {
-			s.data.resources[path.ServiceType] = make(ResourcesByName)
+			s.data.resources[path.ServiceType] = make(resourcesByName)
 		}
 		s.data.resources[path.ServiceType][path.ResourceName] = resource
 	}
@@ -642,10 +642,10 @@ func (s *ServiceInfoCache) InvalidateService(serviceType Option[db.ServiceType])
 	}
 	for path, azResource := range azResourcesByPath {
 		if _, sExists := s.data.azResources[path.ServiceType]; !sExists {
-			s.data.azResources[path.ServiceType] = make(AZResourcesByAZName)
+			s.data.azResources[path.ServiceType] = make(azResourcesByAZName)
 		}
 		if _, rExists := s.data.azResources[path.ServiceType][path.ResourceName]; !rExists {
-			s.data.azResources[path.ServiceType][path.ResourceName] = make(AZResourcesByAZ)
+			s.data.azResources[path.ServiceType][path.ResourceName] = make(azResourcesByAZ)
 		}
 		s.data.azResources[path.ServiceType][path.ResourceName][path.AvailabilityZone] = azResource
 	}
@@ -661,7 +661,7 @@ func (s *ServiceInfoCache) InvalidateService(serviceType Option[db.ServiceType])
 	}
 	for path, rate := range ratesByPath {
 		if _, rExists := s.data.rates[path.ServiceType]; !rExists {
-			s.data.rates[path.ServiceType] = make(RatesByName)
+			s.data.rates[path.ServiceType] = make(ratesByName)
 		}
 		s.data.rates[path.ServiceType][path.RateName] = rate
 	}

--- a/internal/core/service_info_cache.go
+++ b/internal/core/service_info_cache.go
@@ -147,21 +147,7 @@ func (s ServiceInfoSnapshot) deepClone() ServiceInfoSnapshot {
 func (s ServiceInfoSnapshot) Filter(filter ServiceInfoFilter) FilteredServiceInfoSnapshot {
 	f := FilteredServiceInfoSnapshot{
 		snapshot: s.deepClone(),
-	}
-	if serviceArea, ok := filter.ServiceArea.Unpack(); ok {
-		f.filter.ServiceArea = Some(serviceArea)
-	}
-	if serviceType, ok := filter.ServiceType.Unpack(); ok {
-		f.filter.ServiceType = Some(serviceType)
-	}
-	if resourceCategory, ok := filter.Category.Unpack(); ok {
-		f.filter.Category = Some(resourceCategory)
-	}
-	if resourceName, ok := filter.ResourceName.Unpack(); ok {
-		f.filter.ResourceName = Some(resourceName)
-	}
-	if rateName, ok := filter.RateName.Unpack(); ok {
-		f.filter.RateName = Some(rateName)
+		filter:   filter,
 	}
 
 	// filter services by area

--- a/internal/core/service_info_cache.go
+++ b/internal/core/service_info_cache.go
@@ -292,8 +292,11 @@ func (f *FilteredServiceInfoSnapshot) AddToFilter(filter ServiceInfoFilter) *Fil
 	if resourceCategory, ok := filter.Category.Unpack(); ok && f.filter.Category.IsNone() {
 		f.filter.Category = Some(resourceCategory)
 	}
-	if azResource, ok := filter.ResourceName.Unpack(); ok && f.filter.ResourceName.IsNone() {
-		f.filter.ResourceName = Some(azResource)
+	if resourceName, ok := filter.ResourceName.Unpack(); ok && f.filter.ResourceName.IsNone() {
+		f.filter.ResourceName = Some(resourceName)
+	}
+	if rateName, ok := filter.RateName.Unpack(); ok && f.filter.RateName.IsNone() {
+		f.filter.RateName = Some(rateName)
 	}
 
 	// filter services by area
@@ -333,12 +336,16 @@ func (f *FilteredServiceInfoSnapshot) AddToFilter(filter ServiceInfoFilter) *Fil
 	}
 	seenCategories := make(map[db.CategoryID]struct{})
 	resourceNameFilter, resourceFilterExists := f.filter.ResourceName.Unpack()
+	categoryFilterExists := f.filter.Category.IsSome()
 	// filter resources/ az_resources by category or name
-	if len(categoriesToRemove) > 0 || resourceFilterExists {
+	if categoryFilterExists || resourceFilterExists {
 		for serviceType, resources := range newSnapshot.resources {
 			for resourceName, resource := range resources {
 				categoryID, cExists := resource.CategoryID.Unpack()
-				if _, removeCategory := categoriesToRemove[categoryID]; (cExists && removeCategory) || (resourceFilterExists && resourceName != resourceNameFilter) {
+				_, inRemoveSet := categoriesToRemove[categoryID]
+				shouldRemove := (resourceFilterExists && resourceName != resourceNameFilter) ||
+					(categoryFilterExists && (!cExists || inRemoveSet))
+				if shouldRemove {
 					delete(newSnapshot.resources[serviceType], resourceName)
 					delete(newSnapshot.azResources[serviceType], resourceName)
 					if len(newSnapshot.resources[serviceType]) == 0 && len(newSnapshot.rates[serviceType]) == 0 {
@@ -355,11 +362,14 @@ func (f *FilteredServiceInfoSnapshot) AddToFilter(filter ServiceInfoFilter) *Fil
 	}
 	rateNameFilter, rateFilterExists := f.filter.RateName.Unpack()
 	// filter rates by category or name
-	if len(categoriesToRemove) > 0 || rateFilterExists {
+	if categoryFilterExists || rateFilterExists {
 		for serviceType, rates := range newSnapshot.rates {
 			for rateName, rate := range rates {
 				categoryID, cExists := rate.CategoryID.Unpack()
-				if _, removeCategory := categoriesToRemove[categoryID]; (cExists && removeCategory) || (rateFilterExists && rateName != rateNameFilter) {
+				_, inRemoveSet := categoriesToRemove[categoryID]
+				shouldRemove := (rateFilterExists && rateName != rateNameFilter) ||
+					(categoryFilterExists && (!cExists || inRemoveSet))
+				if shouldRemove {
 					delete(newSnapshot.rates[serviceType], rateName)
 					if len(newSnapshot.resources[serviceType]) == 0 && len(newSnapshot.rates[serviceType]) == 0 {
 						delete(newSnapshot.services, serviceType)

--- a/internal/core/service_info_cache.go
+++ b/internal/core/service_info_cache.go
@@ -49,26 +49,22 @@ type ServiceInfoReader interface {
 	GetResources() ResourcesByNameType
 	// GetResourcesForType returns all resources for the given service type, keyed by resource name.
 	GetResourcesForType(serviceType db.ServiceType) (ResourcesByName, bool)
-	// GetResourceForTypeName returns the resource for the given service type and resource name.
-	GetResourceForTypeName(serviceType db.ServiceType, resourceName liquid.ResourceName) (db.Resource, bool)
 	// GetResourceForPath returns the resource for the given path.
 	GetResourceForPath(path db.ResourcePath) (db.Resource, bool)
 	// GetAZResources returns all AZ resources, indexed by service type, resource name, and availability zone.
 	GetAZResources() AZResourcesByAZNameType
 	// GetAZResourcesForType returns all AZ resources for the given service type, keyed by resource name and availability zone.
 	GetAZResourcesForType(serviceType db.ServiceType) (AZResourcesByAZName, bool)
-	// GetAZResourcesForTypeName returns all AZ resources for the given service type, resource name, keyed by availability zone.
-	GetAZResourcesForTypeName(serviceType db.ServiceType, resourceName liquid.ResourceName) (AZResourcesByAZ, bool)
-	// GetAZResourceForTypeNameAZ returns the AZ resource for the given service type, resource name, and availability zone.
-	GetAZResourceForTypeNameAZ(serviceType db.ServiceType, resourceName liquid.ResourceName, az limes.AvailabilityZone) (db.AZResource, bool)
-	// GetAZResourceForPath returns the AZ resource for the given path.
+	// GetAZResourcesForPath returns the AZ resource for the given ResourcePath.
+	GetAZResourcesForPath(path db.ResourcePath) (AZResourcesByAZ, bool)
+	// GetAZResourceForPath returns the AZ resource for the given AZResourcePath.
 	GetAZResourceForPath(path db.AZResourcePath) (db.AZResource, bool)
 	// GetRates returns all cached rates, indexed by service type and rate name.
 	GetRates() RatesByNameType
 	// GetRatesForType returns all rates, indexed by service type and rate name.
 	GetRatesForType(serviceType db.ServiceType) (RatesByName, bool)
-	// GetRateForTypeName returns the rate for the given service type and rate name.
-	GetRateForTypeName(serviceType db.ServiceType, rateName liquid.RateName) (db.Rate, bool)
+	// GetRateForPath returns the rate for the given service type and rate name.
+	GetRateForPath(path db.RatePath) (db.Rate, bool)
 	// GetCategories returns all categories, indexed by category ID.
 	GetCategories() CategoriesByID
 	// GetCategoryForID returns the cached category for the given category ID.
@@ -287,15 +283,10 @@ func (s ServiceInfoSnapshot) GetResourcesForType(serviceType db.ServiceType) (Re
 	return maps.Clone(val), ok
 }
 
-// GetResourceForTypeName implements the [ServiceInfoReader] interface.
-func (s ServiceInfoSnapshot) GetResourceForTypeName(serviceType db.ServiceType, resourceName liquid.ResourceName) (db.Resource, bool) {
-	val, ok := s.resources[serviceType][resourceName]
-	return val, ok
-}
-
 // GetResourceForPath implements the [ServiceInfoReader] interface.
 func (s ServiceInfoSnapshot) GetResourceForPath(path db.ResourcePath) (db.Resource, bool) {
-	return s.GetResourceForTypeName(path.ServiceType, path.ResourceName)
+	val, ok := s.resources[path.ServiceType][path.ResourceName]
+	return val, ok
 }
 
 // GetAZResources implements the [ServiceInfoReader] interface.
@@ -311,21 +302,16 @@ func (s ServiceInfoSnapshot) GetAZResourcesForType(serviceType db.ServiceType) (
 	return deepCloneMap(val, maps.Clone), ok
 }
 
-// GetAZResourcesForTypeName implements the [ServiceInfoReader] interface.
-func (s ServiceInfoSnapshot) GetAZResourcesForTypeName(serviceType db.ServiceType, resourceName liquid.ResourceName) (AZResourcesByAZ, bool) {
-	val, ok := s.azResources[serviceType][resourceName]
+// GetAZResourcesForPath implements the [ServiceInfoReader] interface.
+func (s ServiceInfoSnapshot) GetAZResourcesForPath(path db.ResourcePath) (AZResourcesByAZ, bool) {
+	val, ok := s.azResources[path.ServiceType][path.ResourceName]
 	return maps.Clone(val), ok
-}
-
-// GetAZResourceForTypeNameAZ implements the [ServiceInfoReader] interface.
-func (s ServiceInfoSnapshot) GetAZResourceForTypeNameAZ(serviceType db.ServiceType, resourceName liquid.ResourceName, az limes.AvailabilityZone) (db.AZResource, bool) {
-	val, ok := s.azResources[serviceType][resourceName][az]
-	return val, ok
 }
 
 // GetAZResourceForPath implements the [ServiceInfoReader] interface.
 func (s ServiceInfoSnapshot) GetAZResourceForPath(path db.AZResourcePath) (db.AZResource, bool) {
-	return s.GetAZResourceForTypeNameAZ(path.ServiceType, path.ResourceName, path.AvailabilityZone)
+	val, ok := s.azResources[path.ServiceType][path.ResourceName][path.AvailabilityZone]
+	return val, ok
 }
 
 // GetRates implements the [ServiceInfoReader] interface.
@@ -339,9 +325,9 @@ func (s ServiceInfoSnapshot) GetRatesForType(serviceType db.ServiceType) (RatesB
 	return maps.Clone(val), ok
 }
 
-// GetRateForTypeName implements the [ServiceInfoReader] interface.
-func (s ServiceInfoSnapshot) GetRateForTypeName(serviceType db.ServiceType, rateName liquid.RateName) (db.Rate, bool) {
-	val, ok := s.rates[serviceType][rateName]
+// GetRateForPath implements the [ServiceInfoReader] interface.
+func (s ServiceInfoSnapshot) GetRateForPath(path db.RatePath) (db.Rate, bool) {
+	val, ok := s.rates[path.ServiceType][path.RateName]
 	return val, ok
 }
 
@@ -444,11 +430,6 @@ func (f FilteredServiceInfoSnapshot) GetResourcesForType(serviceType db.ServiceT
 	return f.snapshot.GetResourcesForType(serviceType)
 }
 
-// GetResourceForTypeName implements the [ServiceInfoReader] interface.
-func (f FilteredServiceInfoSnapshot) GetResourceForTypeName(serviceType db.ServiceType, resourceName liquid.ResourceName) (db.Resource, bool) {
-	return f.snapshot.GetResourceForTypeName(serviceType, resourceName)
-}
-
 // GetResourceForPath implements the [ServiceInfoReader] interface.
 func (f FilteredServiceInfoSnapshot) GetResourceForPath(path db.ResourcePath) (db.Resource, bool) {
 	return f.snapshot.GetResourceForPath(path)
@@ -464,14 +445,9 @@ func (f FilteredServiceInfoSnapshot) GetAZResourcesForType(serviceType db.Servic
 	return f.snapshot.GetAZResourcesForType(serviceType)
 }
 
-// GetAZResourcesForTypeName implements the [ServiceInfoReader] interface.
-func (f FilteredServiceInfoSnapshot) GetAZResourcesForTypeName(serviceType db.ServiceType, resourceName liquid.ResourceName) (AZResourcesByAZ, bool) {
-	return f.snapshot.GetAZResourcesForTypeName(serviceType, resourceName)
-}
-
-// GetAZResourceForTypeNameAZ implements the [ServiceInfoReader] interface.
-func (f FilteredServiceInfoSnapshot) GetAZResourceForTypeNameAZ(serviceType db.ServiceType, resourceName liquid.ResourceName, az limes.AvailabilityZone) (db.AZResource, bool) {
-	return f.snapshot.GetAZResourceForTypeNameAZ(serviceType, resourceName, az)
+// GetAZResourcesForPath implements the [ServiceInfoReader] interface.
+func (f FilteredServiceInfoSnapshot) GetAZResourcesForPath(path db.ResourcePath) (AZResourcesByAZ, bool) {
+	return f.snapshot.GetAZResourcesForPath(path)
 }
 
 // GetAZResourceForPath implements the [ServiceInfoReader] interface.
@@ -489,9 +465,9 @@ func (f FilteredServiceInfoSnapshot) GetRatesForType(serviceType db.ServiceType)
 	return f.snapshot.GetRatesForType(serviceType)
 }
 
-// GetRateForTypeName implements the [ServiceInfoReader] interface.
-func (f FilteredServiceInfoSnapshot) GetRateForTypeName(serviceType db.ServiceType, rateName liquid.RateName) (db.Rate, bool) {
-	return f.snapshot.GetRateForTypeName(serviceType, rateName)
+// GetRateForPath implements the [ServiceInfoReader] interface.
+func (f FilteredServiceInfoSnapshot) GetRateForPath(path db.RatePath) (db.Rate, bool) {
+	return f.snapshot.GetRateForPath(path)
 }
 
 // GetCategories implements the [ServiceInfoReader] interface.

--- a/internal/core/service_info_cache.go
+++ b/internal/core/service_info_cache.go
@@ -117,23 +117,24 @@ type (
 	CategoriesByID map[db.CategoryID]db.Category
 )
 
-// removeType removes all data of a given serviceType, making the cache ready
+// removeDataForType removes all data of a given serviceType, making the cache ready
 // for populating this serviceType from scratch. Categories are always flushed
 // completely.
-func (s *ServiceInfoSnapshot) removeType(serviceType db.ServiceType) {
+func (s ServiceInfoSnapshot) removeDataForType(serviceType db.ServiceType) ServiceInfoSnapshot {
 	delete(s.services, serviceType)
 	delete(s.resources, serviceType)
 	delete(s.azResources, serviceType)
 	delete(s.rates, serviceType)
 	s.categories = make(map[db.CategoryID]db.Category)
+	return s
 }
 
 // deepClone delivers a deep copy of the ServiceInfoSnapshot. This is used to
 // create a copy which can be altered without interfering with the original.
 // It shall only be used from ServiceInfoCache or when creating a
 // FilteredServiceInfoSnapshot.
-func (s *ServiceInfoSnapshot) deepClone() *ServiceInfoSnapshot {
-	result := &ServiceInfoSnapshot{
+func (s ServiceInfoSnapshot) deepClone() ServiceInfoSnapshot {
+	return ServiceInfoSnapshot{
 		services:  maps.Clone(s.services),
 		resources: deepCloneMap(s.resources, maps.Clone),
 		azResources: deepCloneMap(s.azResources, func(inner AZResourcesByAZName) AZResourcesByAZName {
@@ -143,159 +144,27 @@ func (s *ServiceInfoSnapshot) deepClone() *ServiceInfoSnapshot {
 		categories:  maps.Clone(s.categories),
 		areaMapping: s.areaMapping, // should never get modified
 	}
-	return result
 }
 
 // Filter applies the filter to the ServiceInfoSnapshot and produces an
 // eagerly filtered FilteredServiceInfoSnapshot.
-func (s *ServiceInfoSnapshot) Filter(filter ServiceInfoFilter) *FilteredServiceInfoSnapshot {
-	f := &FilteredServiceInfoSnapshot{
-		snapshot: s, // gets cloned by AddToFilter
+func (s ServiceInfoSnapshot) Filter(filter ServiceInfoFilter) FilteredServiceInfoSnapshot {
+	f := FilteredServiceInfoSnapshot{
+		snapshot: s.deepClone(),
 	}
-	return f.AddToFilter(filter)
-}
-
-// GetServices implements the [ServiceInfoReader] interface.
-func (s *ServiceInfoSnapshot) GetServices() ServicesByType {
-	return maps.Clone(s.services)
-}
-
-// GetServiceForType implements the [ServiceInfoReader] interface.
-func (s *ServiceInfoSnapshot) GetServiceForType(serviceType db.ServiceType) (db.Service, bool) {
-	val, ok := s.services[serviceType]
-	return val, ok
-}
-
-// GetResources implements the [ServiceInfoReader] interface.
-func (s *ServiceInfoSnapshot) GetResources() ResourcesByNameType {
-	return deepCloneMap(s.resources, maps.Clone)
-}
-
-// GetResourcesForType implements the [ServiceInfoReader] interface.
-func (s *ServiceInfoSnapshot) GetResourcesForType(serviceType db.ServiceType) (ResourcesByName, bool) {
-	val, ok := s.resources[serviceType]
-	return maps.Clone(val), ok
-}
-
-// GetResourceForTypeName implements the [ServiceInfoReader] interface.
-func (s *ServiceInfoSnapshot) GetResourceForTypeName(serviceType db.ServiceType, resourceName liquid.ResourceName) (db.Resource, bool) {
-	val, ok := s.resources[serviceType][resourceName]
-	return val, ok
-}
-
-// GetResourceForPath implements the [ServiceInfoReader] interface.
-func (s *ServiceInfoSnapshot) GetResourceForPath(path db.ResourcePath) (db.Resource, bool) {
-	return s.GetResourceForTypeName(path.ServiceType, path.ResourceName)
-}
-
-// GetAZResources implements the [ServiceInfoReader] interface.
-func (s *ServiceInfoSnapshot) GetAZResources() AZResourcesByAZNameType {
-	return deepCloneMap(s.azResources, func(inner AZResourcesByAZName) AZResourcesByAZName {
-		return deepCloneMap(inner, maps.Clone)
-	})
-}
-
-// GetAZResourcesForType implements the [ServiceInfoReader] interface.
-func (s *ServiceInfoSnapshot) GetAZResourcesForType(serviceType db.ServiceType) (AZResourcesByAZName, bool) {
-	val, ok := s.azResources[serviceType]
-	return deepCloneMap(val, maps.Clone), ok
-}
-
-// GetAZResourcesForTypeName implements the [ServiceInfoReader] interface.
-func (s *ServiceInfoSnapshot) GetAZResourcesForTypeName(serviceType db.ServiceType, resourceName liquid.ResourceName) (AZResourcesByAZ, bool) {
-	val, ok := s.azResources[serviceType][resourceName]
-	return maps.Clone(val), ok
-}
-
-// GetAZResourceForTypeNameAZ implements the [ServiceInfoReader] interface.
-func (s *ServiceInfoSnapshot) GetAZResourceForTypeNameAZ(serviceType db.ServiceType, resourceName liquid.ResourceName, az limes.AvailabilityZone) (db.AZResource, bool) {
-	val, ok := s.azResources[serviceType][resourceName][az]
-	return val, ok
-}
-
-// GetAZResourceForPath implements the [ServiceInfoReader] interface.
-func (s *ServiceInfoSnapshot) GetAZResourceForPath(path db.AZResourcePath) (db.AZResource, bool) {
-	return s.GetAZResourceForTypeNameAZ(path.ServiceType, path.ResourceName, path.AvailabilityZone)
-}
-
-// GetRates implements the [ServiceInfoReader] interface.
-func (s *ServiceInfoSnapshot) GetRates() RatesByNameType {
-	return deepCloneMap(s.rates, maps.Clone)
-}
-
-// GetRatesForType implements the [ServiceInfoReader] interface.
-func (s *ServiceInfoSnapshot) GetRatesForType(serviceType db.ServiceType) (RatesByName, bool) {
-	val, ok := s.rates[serviceType]
-	return maps.Clone(val), ok
-}
-
-// GetRateForTypeName implements the [ServiceInfoReader] interface.
-func (s *ServiceInfoSnapshot) GetRateForTypeName(serviceType db.ServiceType, rateName liquid.RateName) (db.Rate, bool) {
-	val, ok := s.rates[serviceType][rateName]
-	return val, ok
-}
-
-// GetCategories implements the [ServiceInfoReader] interface.
-func (s *ServiceInfoSnapshot) GetCategories() CategoriesByID {
-	return maps.Clone(s.categories)
-}
-
-// GetCategoryForID implements the [ServiceInfoReader] interface.
-func (s *ServiceInfoSnapshot) GetCategoryForID(categoryID db.CategoryID) (db.Category, bool) {
-	val, ok := s.categories[categoryID]
-	return val, ok
-}
-
-// newEmptyServiceInfoSnapshot() returns an empty ServiceInfoSnapshot with all
-// maps initialized on their first level.
-func newEmptyServiceInfoSnapshot(config ClusterConfiguration) ServiceInfoSnapshot {
-	areaMapping := make(map[db.ServiceType]string)
-	for serviceType, liquidConfiguration := range config.Liquids {
-		areaMapping[serviceType] = liquidConfiguration.Area
-	}
-	return ServiceInfoSnapshot{
-		services:    make(ServicesByType),
-		resources:   make(ResourcesByNameType),
-		azResources: make(AZResourcesByAZNameType),
-		rates:       make(RatesByNameType),
-		categories:  make(CategoriesByID),
-		areaMapping: areaMapping,
-	}
-}
-
-///////////////////////////////////////////////////////////////////////
-
-// FilteredServiceInfoSnapshot is a ServiceInfoSnapshot
-// filtered by the specification of the ServiceInfoFilter.
-// It offers the same method-set as ServiceInfoSnapshot.
-type FilteredServiceInfoSnapshot struct {
-	snapshot *ServiceInfoSnapshot
-	filter   ServiceInfoFilter
-}
-
-// GetFilter returns the current filter.
-func (f *FilteredServiceInfoSnapshot) GetFilter() ServiceInfoFilter {
-	return f.filter
-}
-
-// AddToFilter merges the given filter to the existing filter.
-// The filter can only become more specific.
-// If a property was already filtered before, the additional filter is
-// omitted.
-func (f *FilteredServiceInfoSnapshot) AddToFilter(filter ServiceInfoFilter) *FilteredServiceInfoSnapshot {
-	if serviceArea, ok := filter.ServiceArea.Unpack(); ok && f.filter.ServiceArea.IsNone() {
+	if serviceArea, ok := filter.ServiceArea.Unpack(); ok {
 		f.filter.ServiceArea = Some(serviceArea)
 	}
-	if serviceType, ok := filter.ServiceType.Unpack(); ok && f.filter.ServiceType.IsNone() {
+	if serviceType, ok := filter.ServiceType.Unpack(); ok {
 		f.filter.ServiceType = Some(serviceType)
 	}
-	if resourceCategory, ok := filter.Category.Unpack(); ok && f.filter.Category.IsNone() {
+	if resourceCategory, ok := filter.Category.Unpack(); ok {
 		f.filter.Category = Some(resourceCategory)
 	}
-	if resourceName, ok := filter.ResourceName.Unpack(); ok && f.filter.ResourceName.IsNone() {
+	if resourceName, ok := filter.ResourceName.Unpack(); ok {
 		f.filter.ResourceName = Some(resourceName)
 	}
-	if rateName, ok := filter.RateName.Unpack(); ok && f.filter.RateName.IsNone() {
+	if rateName, ok := filter.RateName.Unpack(); ok {
 		f.filter.RateName = Some(rateName)
 	}
 
@@ -396,9 +265,127 @@ func (f *FilteredServiceInfoSnapshot) AddToFilter(filter ServiceInfoFilter) *Fil
 	return f
 }
 
+// GetServices implements the [ServiceInfoReader] interface.
+func (s ServiceInfoSnapshot) GetServices() ServicesByType {
+	return maps.Clone(s.services)
+}
+
+// GetServiceForType implements the [ServiceInfoReader] interface.
+func (s ServiceInfoSnapshot) GetServiceForType(serviceType db.ServiceType) (db.Service, bool) {
+	val, ok := s.services[serviceType]
+	return val, ok
+}
+
+// GetResources implements the [ServiceInfoReader] interface.
+func (s ServiceInfoSnapshot) GetResources() ResourcesByNameType {
+	return deepCloneMap(s.resources, maps.Clone)
+}
+
+// GetResourcesForType implements the [ServiceInfoReader] interface.
+func (s ServiceInfoSnapshot) GetResourcesForType(serviceType db.ServiceType) (ResourcesByName, bool) {
+	val, ok := s.resources[serviceType]
+	return maps.Clone(val), ok
+}
+
+// GetResourceForTypeName implements the [ServiceInfoReader] interface.
+func (s ServiceInfoSnapshot) GetResourceForTypeName(serviceType db.ServiceType, resourceName liquid.ResourceName) (db.Resource, bool) {
+	val, ok := s.resources[serviceType][resourceName]
+	return val, ok
+}
+
+// GetResourceForPath implements the [ServiceInfoReader] interface.
+func (s ServiceInfoSnapshot) GetResourceForPath(path db.ResourcePath) (db.Resource, bool) {
+	return s.GetResourceForTypeName(path.ServiceType, path.ResourceName)
+}
+
+// GetAZResources implements the [ServiceInfoReader] interface.
+func (s ServiceInfoSnapshot) GetAZResources() AZResourcesByAZNameType {
+	return deepCloneMap(s.azResources, func(inner AZResourcesByAZName) AZResourcesByAZName {
+		return deepCloneMap(inner, maps.Clone)
+	})
+}
+
+// GetAZResourcesForType implements the [ServiceInfoReader] interface.
+func (s ServiceInfoSnapshot) GetAZResourcesForType(serviceType db.ServiceType) (AZResourcesByAZName, bool) {
+	val, ok := s.azResources[serviceType]
+	return deepCloneMap(val, maps.Clone), ok
+}
+
+// GetAZResourcesForTypeName implements the [ServiceInfoReader] interface.
+func (s ServiceInfoSnapshot) GetAZResourcesForTypeName(serviceType db.ServiceType, resourceName liquid.ResourceName) (AZResourcesByAZ, bool) {
+	val, ok := s.azResources[serviceType][resourceName]
+	return maps.Clone(val), ok
+}
+
+// GetAZResourceForTypeNameAZ implements the [ServiceInfoReader] interface.
+func (s ServiceInfoSnapshot) GetAZResourceForTypeNameAZ(serviceType db.ServiceType, resourceName liquid.ResourceName, az limes.AvailabilityZone) (db.AZResource, bool) {
+	val, ok := s.azResources[serviceType][resourceName][az]
+	return val, ok
+}
+
+// GetAZResourceForPath implements the [ServiceInfoReader] interface.
+func (s ServiceInfoSnapshot) GetAZResourceForPath(path db.AZResourcePath) (db.AZResource, bool) {
+	return s.GetAZResourceForTypeNameAZ(path.ServiceType, path.ResourceName, path.AvailabilityZone)
+}
+
+// GetRates implements the [ServiceInfoReader] interface.
+func (s ServiceInfoSnapshot) GetRates() RatesByNameType {
+	return deepCloneMap(s.rates, maps.Clone)
+}
+
+// GetRatesForType implements the [ServiceInfoReader] interface.
+func (s ServiceInfoSnapshot) GetRatesForType(serviceType db.ServiceType) (RatesByName, bool) {
+	val, ok := s.rates[serviceType]
+	return maps.Clone(val), ok
+}
+
+// GetRateForTypeName implements the [ServiceInfoReader] interface.
+func (s ServiceInfoSnapshot) GetRateForTypeName(serviceType db.ServiceType, rateName liquid.RateName) (db.Rate, bool) {
+	val, ok := s.rates[serviceType][rateName]
+	return val, ok
+}
+
+// GetCategories implements the [ServiceInfoReader] interface.
+func (s ServiceInfoSnapshot) GetCategories() CategoriesByID {
+	return maps.Clone(s.categories)
+}
+
+// GetCategoryForID implements the [ServiceInfoReader] interface.
+func (s ServiceInfoSnapshot) GetCategoryForID(categoryID db.CategoryID) (db.Category, bool) {
+	val, ok := s.categories[categoryID]
+	return val, ok
+}
+
+// newEmptyServiceInfoSnapshot() returns an empty ServiceInfoSnapshot with all
+// maps initialized on their first level.
+func newEmptyServiceInfoSnapshot(config ClusterConfiguration) ServiceInfoSnapshot {
+	areaMapping := make(map[db.ServiceType]string)
+	for serviceType, liquidConfiguration := range config.Liquids {
+		areaMapping[serviceType] = liquidConfiguration.Area
+	}
+	return ServiceInfoSnapshot{
+		services:    make(ServicesByType),
+		resources:   make(ResourcesByNameType),
+		azResources: make(AZResourcesByAZNameType),
+		rates:       make(RatesByNameType),
+		categories:  make(CategoriesByID),
+		areaMapping: areaMapping,
+	}
+}
+
+///////////////////////////////////////////////////////////////////////
+
+// FilteredServiceInfoSnapshot is a ServiceInfoSnapshot
+// filtered by the specification of the ServiceInfoFilter.
+// It offers the same method-set as ServiceInfoSnapshot.
+type FilteredServiceInfoSnapshot struct {
+	snapshot ServiceInfoSnapshot
+	filter   ServiceInfoFilter
+}
+
 // GetFilteredService returns the service for the filtered type.
 // It is useful to access the service, when you know it was filtered.
-func (f *FilteredServiceInfoSnapshot) GetFilteredService() (db.Service, bool) {
+func (f FilteredServiceInfoSnapshot) GetFilteredService() (db.Service, bool) {
 	serviceType, ok := f.filter.ServiceType.Unpack()
 	if !ok {
 		return db.Service{}, false
@@ -409,7 +396,7 @@ func (f *FilteredServiceInfoSnapshot) GetFilteredService() (db.Service, bool) {
 
 // GetFilteredResource returns the resource for the filtered type and name.
 // It is useful to access the resource, when you know it was filtered.
-func (f *FilteredServiceInfoSnapshot) GetFilteredResource() (db.Resource, bool) {
+func (f FilteredServiceInfoSnapshot) GetFilteredResource() (db.Resource, bool) {
 	serviceType, ok := f.filter.ServiceType.Unpack()
 	if !ok {
 		return db.Resource{}, false
@@ -424,7 +411,7 @@ func (f *FilteredServiceInfoSnapshot) GetFilteredResource() (db.Resource, bool) 
 
 // GetFilteredRate returns the rate for the filtered type and name.
 // It is useful to access the rate, when you know it was filtered.
-func (f *FilteredServiceInfoSnapshot) GetFilteredRate() (db.Rate, bool) {
+func (f FilteredServiceInfoSnapshot) GetFilteredRate() (db.Rate, bool) {
 	serviceType, ok := f.filter.ServiceType.Unpack()
 	if !ok {
 		return db.Rate{}, false
@@ -438,82 +425,82 @@ func (f *FilteredServiceInfoSnapshot) GetFilteredRate() (db.Rate, bool) {
 }
 
 // GetServices implements the [ServiceInfoReader] interface.
-func (f *FilteredServiceInfoSnapshot) GetServices() ServicesByType {
+func (f FilteredServiceInfoSnapshot) GetServices() ServicesByType {
 	return f.snapshot.GetServices()
 }
 
 // GetServiceForType implements the [ServiceInfoReader] interface.
-func (f *FilteredServiceInfoSnapshot) GetServiceForType(serviceType db.ServiceType) (db.Service, bool) {
+func (f FilteredServiceInfoSnapshot) GetServiceForType(serviceType db.ServiceType) (db.Service, bool) {
 	return f.snapshot.GetServiceForType(serviceType)
 }
 
 // GetResources implements the [ServiceInfoReader] interface.
-func (f *FilteredServiceInfoSnapshot) GetResources() ResourcesByNameType {
+func (f FilteredServiceInfoSnapshot) GetResources() ResourcesByNameType {
 	return f.snapshot.GetResources()
 }
 
 // GetResourcesForType implements the [ServiceInfoReader] interface.
-func (f *FilteredServiceInfoSnapshot) GetResourcesForType(serviceType db.ServiceType) (ResourcesByName, bool) {
+func (f FilteredServiceInfoSnapshot) GetResourcesForType(serviceType db.ServiceType) (ResourcesByName, bool) {
 	return f.snapshot.GetResourcesForType(serviceType)
 }
 
 // GetResourceForTypeName implements the [ServiceInfoReader] interface.
-func (f *FilteredServiceInfoSnapshot) GetResourceForTypeName(serviceType db.ServiceType, resourceName liquid.ResourceName) (db.Resource, bool) {
+func (f FilteredServiceInfoSnapshot) GetResourceForTypeName(serviceType db.ServiceType, resourceName liquid.ResourceName) (db.Resource, bool) {
 	return f.snapshot.GetResourceForTypeName(serviceType, resourceName)
 }
 
 // GetResourceForPath implements the [ServiceInfoReader] interface.
-func (f *FilteredServiceInfoSnapshot) GetResourceForPath(path db.ResourcePath) (db.Resource, bool) {
+func (f FilteredServiceInfoSnapshot) GetResourceForPath(path db.ResourcePath) (db.Resource, bool) {
 	return f.snapshot.GetResourceForPath(path)
 }
 
 // GetAZResources implements the [ServiceInfoReader] interface.
-func (f *FilteredServiceInfoSnapshot) GetAZResources() AZResourcesByAZNameType {
+func (f FilteredServiceInfoSnapshot) GetAZResources() AZResourcesByAZNameType {
 	return f.snapshot.GetAZResources()
 }
 
 // GetAZResourcesForType implements the [ServiceInfoReader] interface.
-func (f *FilteredServiceInfoSnapshot) GetAZResourcesForType(serviceType db.ServiceType) (AZResourcesByAZName, bool) {
+func (f FilteredServiceInfoSnapshot) GetAZResourcesForType(serviceType db.ServiceType) (AZResourcesByAZName, bool) {
 	return f.snapshot.GetAZResourcesForType(serviceType)
 }
 
 // GetAZResourcesForTypeName implements the [ServiceInfoReader] interface.
-func (f *FilteredServiceInfoSnapshot) GetAZResourcesForTypeName(serviceType db.ServiceType, resourceName liquid.ResourceName) (AZResourcesByAZ, bool) {
+func (f FilteredServiceInfoSnapshot) GetAZResourcesForTypeName(serviceType db.ServiceType, resourceName liquid.ResourceName) (AZResourcesByAZ, bool) {
 	return f.snapshot.GetAZResourcesForTypeName(serviceType, resourceName)
 }
 
 // GetAZResourceForTypeNameAZ implements the [ServiceInfoReader] interface.
-func (f *FilteredServiceInfoSnapshot) GetAZResourceForTypeNameAZ(serviceType db.ServiceType, resourceName liquid.ResourceName, az limes.AvailabilityZone) (db.AZResource, bool) {
+func (f FilteredServiceInfoSnapshot) GetAZResourceForTypeNameAZ(serviceType db.ServiceType, resourceName liquid.ResourceName, az limes.AvailabilityZone) (db.AZResource, bool) {
 	return f.snapshot.GetAZResourceForTypeNameAZ(serviceType, resourceName, az)
 }
 
 // GetAZResourceForPath implements the [ServiceInfoReader] interface.
-func (f *FilteredServiceInfoSnapshot) GetAZResourceForPath(path db.AZResourcePath) (db.AZResource, bool) {
+func (f FilteredServiceInfoSnapshot) GetAZResourceForPath(path db.AZResourcePath) (db.AZResource, bool) {
 	return f.snapshot.GetAZResourceForPath(path)
 }
 
 // GetRates implements the [ServiceInfoReader] interface.
-func (f *FilteredServiceInfoSnapshot) GetRates() RatesByNameType {
+func (f FilteredServiceInfoSnapshot) GetRates() RatesByNameType {
 	return f.snapshot.GetRates()
 }
 
 // GetRatesForType implements the [ServiceInfoReader] interface.
-func (f *FilteredServiceInfoSnapshot) GetRatesForType(serviceType db.ServiceType) (RatesByName, bool) {
+func (f FilteredServiceInfoSnapshot) GetRatesForType(serviceType db.ServiceType) (RatesByName, bool) {
 	return f.snapshot.GetRatesForType(serviceType)
 }
 
 // GetRateForTypeName implements the [ServiceInfoReader] interface.
-func (f *FilteredServiceInfoSnapshot) GetRateForTypeName(serviceType db.ServiceType, rateName liquid.RateName) (db.Rate, bool) {
+func (f FilteredServiceInfoSnapshot) GetRateForTypeName(serviceType db.ServiceType, rateName liquid.RateName) (db.Rate, bool) {
 	return f.snapshot.GetRateForTypeName(serviceType, rateName)
 }
 
 // GetCategories implements the [ServiceInfoReader] interface.
-func (f *FilteredServiceInfoSnapshot) GetCategories() CategoriesByID {
+func (f FilteredServiceInfoSnapshot) GetCategories() CategoriesByID {
 	return f.snapshot.GetCategories()
 }
 
 // GetCategoryForID implements the [ServiceInfoReader] interface.
-func (f *FilteredServiceInfoSnapshot) GetCategoryForID(categoryID db.CategoryID) (db.Category, bool) {
+func (f FilteredServiceInfoSnapshot) GetCategoryForID(categoryID db.CategoryID) (db.Category, bool) {
 	return f.snapshot.GetCategoryForID(categoryID)
 }
 
@@ -640,7 +627,7 @@ func (s *ServiceInfoCache) InvalidateService(serviceType Option[db.ServiceType])
 	defer s.dataMutex.Unlock()
 
 	if st, ok := serviceType.Unpack(); ok {
-		s.data.removeType(st)
+		s.data = s.data.removeDataForType(st)
 	} else {
 		s.data = newEmptyServiceInfoSnapshot(s.config)
 	}
@@ -715,7 +702,7 @@ func (s *ServiceInfoCache) InvalidateService(serviceType Option[db.ServiceType])
 }
 
 // GetSnapshot returns a ServiceInfoSnapshot with the current data in the ServiceInfoCache.
-func (s *ServiceInfoCache) GetSnapshot() *ServiceInfoSnapshot {
+func (s *ServiceInfoCache) GetSnapshot() ServiceInfoSnapshot {
 	s.dataMutex.RLock()
 	defer s.dataMutex.RUnlock()
 	return s.data.deepClone()

--- a/internal/core/service_info_cache.go
+++ b/internal/core/service_info_cache.go
@@ -151,36 +151,35 @@ func (s ServiceInfoSnapshot) Filter(filter ServiceInfoFilter) FilteredServiceInf
 	}
 
 	// filter services by area
-	newSnapshot := f.snapshot.deepClone()
 	if areaFilter, ok := f.filter.ServiceArea.Unpack(); ok {
 		for serviceType, area := range f.snapshot.areaMapping {
 			if area == areaFilter {
 				continue
 			}
-			delete(newSnapshot.services, serviceType)
-			delete(newSnapshot.resources, serviceType)
-			delete(newSnapshot.azResources, serviceType)
-			delete(newSnapshot.rates, serviceType)
+			delete(f.snapshot.services, serviceType)
+			delete(f.snapshot.resources, serviceType)
+			delete(f.snapshot.azResources, serviceType)
+			delete(f.snapshot.rates, serviceType)
 		}
 	}
 	// filter services by type
 	if typeFilter, ok := f.filter.ServiceType.Unpack(); ok {
-		for serviceType := range newSnapshot.services {
+		for serviceType := range f.snapshot.services {
 			if typeFilter == serviceType {
 				continue
 			}
-			delete(newSnapshot.services, serviceType)
-			delete(newSnapshot.azResources, serviceType)
-			delete(newSnapshot.resources, serviceType)
-			delete(newSnapshot.rates, serviceType)
+			delete(f.snapshot.services, serviceType)
+			delete(f.snapshot.azResources, serviceType)
+			delete(f.snapshot.resources, serviceType)
+			delete(f.snapshot.rates, serviceType)
 		}
 	}
 	categoriesToRemove := make(map[db.CategoryID]struct{})
 	// find categories to remove
 	if categoryFilter, ok := f.filter.Category.Unpack(); ok {
-		for categoryID, info := range newSnapshot.categories {
+		for categoryID, info := range f.snapshot.categories {
 			if info.Name != categoryFilter {
-				delete(newSnapshot.categories, categoryID)
+				delete(f.snapshot.categories, categoryID)
 				categoriesToRemove[categoryID] = struct{}{}
 			}
 		}
@@ -190,20 +189,20 @@ func (s ServiceInfoSnapshot) Filter(filter ServiceInfoFilter) FilteredServiceInf
 	categoryFilterExists := f.filter.Category.IsSome()
 	// filter resources/ az_resources by category or name
 	if categoryFilterExists || resourceFilterExists {
-		for serviceType, resources := range newSnapshot.resources {
+		for serviceType, resources := range f.snapshot.resources {
 			for resourceName, resource := range resources {
 				categoryID, cExists := resource.CategoryID.Unpack()
 				_, inRemoveSet := categoriesToRemove[categoryID]
 				shouldRemove := (resourceFilterExists && resourceName != resourceNameFilter) ||
 					(categoryFilterExists && (!cExists || inRemoveSet))
 				if shouldRemove {
-					delete(newSnapshot.resources[serviceType], resourceName)
-					delete(newSnapshot.azResources[serviceType], resourceName)
-					if len(newSnapshot.resources[serviceType]) == 0 && len(newSnapshot.rates[serviceType]) == 0 {
-						delete(newSnapshot.services, serviceType)
-						delete(newSnapshot.resources, serviceType)
-						delete(newSnapshot.azResources, serviceType)
-						delete(newSnapshot.rates, serviceType)
+					delete(f.snapshot.resources[serviceType], resourceName)
+					delete(f.snapshot.azResources[serviceType], resourceName)
+					if len(f.snapshot.resources[serviceType]) == 0 && len(f.snapshot.rates[serviceType]) == 0 {
+						delete(f.snapshot.services, serviceType)
+						delete(f.snapshot.resources, serviceType)
+						delete(f.snapshot.azResources, serviceType)
+						delete(f.snapshot.rates, serviceType)
 					}
 				} else {
 					seenCategories[categoryID] = struct{}{}
@@ -214,19 +213,19 @@ func (s ServiceInfoSnapshot) Filter(filter ServiceInfoFilter) FilteredServiceInf
 	rateNameFilter, rateFilterExists := f.filter.RateName.Unpack()
 	// filter rates by category or name
 	if categoryFilterExists || rateFilterExists {
-		for serviceType, rates := range newSnapshot.rates {
+		for serviceType, rates := range f.snapshot.rates {
 			for rateName, rate := range rates {
 				categoryID, cExists := rate.CategoryID.Unpack()
 				_, inRemoveSet := categoriesToRemove[categoryID]
 				shouldRemove := (rateFilterExists && rateName != rateNameFilter) ||
 					(categoryFilterExists && (!cExists || inRemoveSet))
 				if shouldRemove {
-					delete(newSnapshot.rates[serviceType], rateName)
-					if len(newSnapshot.resources[serviceType]) == 0 && len(newSnapshot.rates[serviceType]) == 0 {
-						delete(newSnapshot.services, serviceType)
-						delete(newSnapshot.resources, serviceType)
-						delete(newSnapshot.azResources, serviceType)
-						delete(newSnapshot.rates, serviceType)
+					delete(f.snapshot.rates[serviceType], rateName)
+					if len(f.snapshot.resources[serviceType]) == 0 && len(f.snapshot.rates[serviceType]) == 0 {
+						delete(f.snapshot.services, serviceType)
+						delete(f.snapshot.resources, serviceType)
+						delete(f.snapshot.azResources, serviceType)
+						delete(f.snapshot.rates, serviceType)
 					}
 				} else {
 					seenCategories[categoryID] = struct{}{}
@@ -237,13 +236,12 @@ func (s ServiceInfoSnapshot) Filter(filter ServiceInfoFilter) FilteredServiceInf
 
 	// if we filtered by rate or service name, we must thin out the categories
 	if resourceFilterExists || rateFilterExists {
-		for categoryID := range newSnapshot.categories {
+		for categoryID := range f.snapshot.categories {
 			if _, ok := seenCategories[categoryID]; !ok {
-				delete(newSnapshot.categories, categoryID)
+				delete(f.snapshot.categories, categoryID)
 			}
 		}
 	}
-	f.snapshot = newSnapshot
 	return f
 }
 

--- a/internal/core/service_info_cache_test.go
+++ b/internal/core/service_info_cache_test.go
@@ -122,24 +122,6 @@ func TestServiceInfoSnapshotFilter(t *testing.T) {
 	assert.Equal(t, ok, true)
 	assert.Equal(t, rate.DisplayName, "Object Creations")
 
-	// stacking filters via AddToFilter
-	filtered = sis.Filter(core.ServiceInfoFilter{ServiceArea: Some("unshared")})
-	filtered = filtered.AddToFilter(core.ServiceInfoFilter{ResourceName: Some[liquid.ResourceName]("capacity")})
-	assert.Equal(t, len(filtered.GetServices()), 1)
-	resources, ok = filtered.GetResourcesForType("second")
-	assert.Equal(t, ok, true)
-	assert.Equal(t, len(resources), 1)
-	_, ok = resources["capacity"]
-	assert.Equal(t, ok, true)
-
-	// AddToFilter does not widen an existing filter
-	filtered = sis.Filter(core.ServiceInfoFilter{ServiceType: Some[db.ServiceType]("second")})
-	filtered = filtered.AddToFilter(core.ServiceInfoFilter{ServiceType: Some[db.ServiceType]("first")})
-	_, ok = filtered.GetServiceForType("second")
-	assert.Equal(t, ok, true)
-	_, ok = filtered.GetServiceForType("first")
-	assert.Equal(t, ok, false)
-
 	// snapshot immutability: mutations on returned maps don't affect snapshot
 	services := sis.GetServices()
 	services["injected"] = db.Service{DisplayName: "Injected"}

--- a/internal/core/service_info_cache_test.go
+++ b/internal/core/service_info_cache_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sapcc/go-bits/assert"
 	"github.com/sapcc/go-bits/easypg"
 	"github.com/sapcc/go-bits/must"
+	. "go.xyrillian.de/gg/option"
 	"go.xyrillian.de/gg/options"
 
 	"github.com/sapcc/limes/internal/core"
@@ -25,10 +26,142 @@ const configJSON = `{
 	},
 	"areas": { "shared": { "display_name": "Shared" }, "unshared": { "display_name": "Unshared" }},
 	"liquids": {
-		"shared": {"area": "shared"},
-		"unshared": {"area": "unshared"}
+		"first": {"area": "shared"},
+		"second": {"area": "unshared"}
 	}
 }`
+
+func TestServiceInfoSnapshotFilter(t *testing.T) {
+	// "first" has area "shared", resources empty, rates: objects:create, objects:delete, objects:update, objects:unlimited
+	// "second" has area "unshared", resources: capacity (category: foo_category), things (no category)
+	serviceInfoFirst := test.DefaultLiquidServiceInfo("First")
+	serviceInfoFirst.Rates = map[liquid.RateName]liquid.RateInfo{
+		"objects:create":    {DisplayName: "Object Creations", Topology: liquid.FlatTopology, HasUsage: true},
+		"objects:delete":    {DisplayName: "Object Deletions", Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: true},
+		"objects:update":    {DisplayName: "Object Updates", Topology: liquid.FlatTopology, HasUsage: true},
+		"objects:unlimited": {DisplayName: "Object Unlimited Operations", Unit: liquid.UnitKibibytes, Topology: liquid.FlatTopology, HasUsage: true},
+	}
+	serviceInfoFirst.Resources = map[liquid.ResourceName]liquid.ResourceInfo{}
+	s := test.NewSetup(t,
+		test.WithConfig(configJSON),
+		test.WithPersistedServiceInfo("first", serviceInfoFirst),
+		test.WithPersistedServiceInfo("second", test.DefaultLiquidServiceInfo("Second")),
+	)
+	s.Cluster.Connect(s.Ctx, nil, gophercloud.EndpointOpts{}, func(serviceType db.ServiceType) (core.LiquidClient, error) { return nil, nil }, options.FromPointer(easypg.BuildDBURL(t)))
+	t.Cleanup(func() { s.Cluster.SIC.Close() })
+
+	sis := s.Cluster.SIC.GetSnapshot()
+
+	// filter by ServiceType
+	filtered := sis.Filter(core.ServiceInfoFilter{ServiceType: Some[db.ServiceType]("second")})
+	assert.Equal(t, len(filtered.GetServices()), 1)
+	_, ok := filtered.GetServiceForType("second")
+	assert.Equal(t, ok, true)
+	_, ok = filtered.GetServiceForType("first")
+	assert.Equal(t, ok, false)
+	resources, ok := filtered.GetResourcesForType("second")
+	assert.Equal(t, ok, true)
+	assert.Equal(t, len(resources), 2)
+	_, ok = filtered.GetResourcesForType("first")
+	assert.Equal(t, ok, false)
+	_, ok = filtered.GetRatesForType("first")
+	assert.Equal(t, ok, false)
+	service, ok := filtered.GetFilteredService()
+	assert.Equal(t, ok, true)
+	assert.Equal(t, service.DisplayName, "Second")
+
+	// filter by ServiceArea
+	filtered = sis.Filter(core.ServiceInfoFilter{ServiceArea: Some("shared")})
+	assert.Equal(t, len(filtered.GetServices()), 1)
+	_, ok = filtered.GetServiceForType("first")
+	assert.Equal(t, ok, true)
+	_, ok = filtered.GetServiceForType("second")
+	assert.Equal(t, ok, false)
+	rates, ok := filtered.GetRatesForType("first")
+	assert.Equal(t, ok, true)
+	assert.Equal(t, len(rates), 4)
+
+	// filter by ResourceName
+	filtered = sis.Filter(core.ServiceInfoFilter{ResourceName: Some[liquid.ResourceName]("capacity")})
+	resources, ok = filtered.GetResourcesForType("second")
+	assert.Equal(t, ok, true)
+	assert.Equal(t, len(resources), 1)
+	_, ok = resources["capacity"]
+	assert.Equal(t, ok, true)
+	_, ok = resources["things"]
+	assert.Equal(t, ok, false)
+	_, ok = filtered.GetFilteredResource()
+	assert.Equal(t, ok, false) // ServiceType not set
+	filtered2 := sis.Filter(core.ServiceInfoFilter{ServiceType: Some[db.ServiceType]("second"), ResourceName: Some[liquid.ResourceName]("capacity")})
+	resource, ok := filtered2.GetFilteredResource()
+	assert.Equal(t, ok, true)
+	assert.Equal(t, resource.DisplayName, "Capacity")
+
+	// filter by Category
+	filtered = sis.Filter(core.ServiceInfoFilter{Category: Some[liquid.CategoryName]("foo_category")})
+	resources, ok = filtered.GetResourcesForType("second")
+	assert.Equal(t, ok, true)
+	_, ok = resources["capacity"]
+	assert.Equal(t, ok, true)
+	_, ok = resources["things"]
+	assert.Equal(t, ok, false)
+	_, ok = filtered.GetServiceForType("first")
+	assert.Equal(t, ok, false)
+
+	// filter by RateName
+	filtered = sis.Filter(core.ServiceInfoFilter{RateName: Some[liquid.RateName]("objects:create")})
+	rates, ok = filtered.GetRatesForType("first")
+	assert.Equal(t, ok, true)
+	assert.Equal(t, len(rates), 1)
+	_, ok = rates["objects:create"]
+	assert.Equal(t, ok, true)
+	_, ok = filtered.GetFilteredRate()
+	assert.Equal(t, ok, false) // ServiceType not set
+	filtered2 = sis.Filter(core.ServiceInfoFilter{ServiceType: Some[db.ServiceType]("first"), RateName: Some[liquid.RateName]("objects:create")})
+	rate, ok := filtered2.GetFilteredRate()
+	assert.Equal(t, ok, true)
+	assert.Equal(t, rate.DisplayName, "Object Creations")
+
+	// stacking filters via AddToFilter
+	filtered = sis.Filter(core.ServiceInfoFilter{ServiceArea: Some("unshared")})
+	filtered = filtered.AddToFilter(core.ServiceInfoFilter{ResourceName: Some[liquid.ResourceName]("capacity")})
+	assert.Equal(t, len(filtered.GetServices()), 1)
+	resources, ok = filtered.GetResourcesForType("second")
+	assert.Equal(t, ok, true)
+	assert.Equal(t, len(resources), 1)
+	_, ok = resources["capacity"]
+	assert.Equal(t, ok, true)
+
+	// AddToFilter does not widen an existing filter
+	filtered = sis.Filter(core.ServiceInfoFilter{ServiceType: Some[db.ServiceType]("second")})
+	filtered = filtered.AddToFilter(core.ServiceInfoFilter{ServiceType: Some[db.ServiceType]("first")})
+	_, ok = filtered.GetServiceForType("second")
+	assert.Equal(t, ok, true)
+	_, ok = filtered.GetServiceForType("first")
+	assert.Equal(t, ok, false)
+
+	// snapshot immutability: mutations on returned maps don't affect snapshot
+	services := sis.GetServices()
+	services["injected"] = db.Service{DisplayName: "Injected"}
+	_, ok = sis.GetServiceForType("injected")
+	assert.Equal(t, ok, false)
+	resourcesClone := must.BeOKT(sis.GetResourcesForType("second"))(t)
+	resourcesClone["injected"] = db.Resource{DisplayName: "Injected"}
+	originalResources := must.BeOKT(sis.GetResourcesForType("second"))(t)
+	_, ok = originalResources["injected"]
+	assert.Equal(t, ok, false)
+
+	// FilteredServiceInfoSnapshot immutability
+	filtered = sis.Filter(core.ServiceInfoFilter{ServiceType: Some[db.ServiceType]("second")})
+	filteredServices := filtered.GetServices()
+	filteredServices["injected"] = db.Service{DisplayName: "Injected"}
+	_, ok = filtered.GetServiceForType("injected")
+	assert.Equal(t, ok, false)
+
+	// Filter does not affect original snapshot
+	_ = sis.Filter(core.ServiceInfoFilter{ServiceType: Some[db.ServiceType]("second")})
+	assert.Equal(t, len(sis.GetServices()), 2)
+}
 
 func TestServiceInfoCache(t *testing.T) {
 	serviceInfoFirst := test.DefaultLiquidServiceInfo("First")

--- a/internal/core/service_info_cache_test.go
+++ b/internal/core/service_info_cache_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/sapcc/go-api-declarations/liquid"
 	"github.com/sapcc/go-bits/assert"
 	"github.com/sapcc/go-bits/easypg"
-	"github.com/sapcc/go-bits/logg"
+	"github.com/sapcc/go-bits/must"
 	"go.xyrillian.de/gg/options"
 
 	"github.com/sapcc/limes/internal/core"
@@ -29,39 +29,6 @@ const configJSON = `{
 		"unshared": {"area": "unshared"}
 	}
 }`
-
-// TODO: upstream this into go-bits/must, then remove here.
-func BeOK[V any](val V, ok bool) V {
-	if !ok {
-		logg.Error("Expected to succeed but it did not")
-	}
-	return val
-}
-
-func NotBeOK[V any](val V, ok bool) {
-	if ok {
-		logg.Error("Expected to fail but it did not")
-	}
-}
-
-func BeOKT[V any](val V, ok bool) func(testing.TB) V {
-	return func(t testing.TB) V {
-		t.Helper()
-		if !ok {
-			t.Fatal("Expected to succeed but it did not")
-		}
-		return val
-	}
-}
-
-func NotBeOKT[V any](val V, ok bool) func(testing.TB) {
-	return func(t testing.TB) {
-		t.Helper()
-		if ok {
-			t.Fatal("Expected to fail but it did not")
-		}
-	}
-}
 
 func TestServiceInfoCache(t *testing.T) {
 	serviceInfoFirst := test.DefaultLiquidServiceInfo("First")
@@ -85,44 +52,48 @@ func TestServiceInfoCache(t *testing.T) {
 	s.Cluster.Connect(s.Ctx, nil, gophercloud.EndpointOpts{}, func(serviceType db.ServiceType) (core.LiquidClient, error) { return nil, nil }, options.FromPointer(easypg.BuildDBURL(t)))
 	t.Cleanup(func() { s.Cluster.SIC.Close() })
 
-	sic := s.Cluster.SIC
-	assert.Equal(t, len(sic.GetServices()), 2)
-	NotBeOKT(sic.GetResourcesForType("first"))(t)
-	assert.Equal(t, len(BeOKT(sic.GetResourcesForType("second"))(t)), 2)
-	assert.Equal(t, BeOKT(sic.GetResourceForTypeName("second", "capacity"))(t).Name, "capacity")
-	NotBeOKT(sic.GetRatesForType("second"))(t)
-	assert.Equal(t, len(sic.GetCategories()), 1)
+	sis := s.Cluster.SIC.GetSnapshot()
+	assert.Equal(t, len(sis.GetServices()), 2)
+	must.NotBeOKT(sis.GetResourcesForType("first"))(t)
+	assert.Equal(t, len(must.BeOKT(sis.GetResourcesForType("second"))(t)), 2)
+	assert.Equal(t, must.BeOKT(sis.GetResourceForTypeName("second", "capacity"))(t).Name, "capacity")
+	must.NotBeOKT(sis.GetRatesForType("second"))(t)
+	assert.Equal(t, len(sis.GetCategories()), 1)
 
 	// check service update
-	assert.Equal(t, BeOKT(sic.GetServiceForType("first"))(t).DisplayName, "First")
-	assert.Equal(t, BeOKT(sic.GetServiceForType("second"))(t).DisplayName, "Second")
+	assert.Equal(t, must.BeOKT(sis.GetServiceForType("first"))(t).DisplayName, "First")
+	assert.Equal(t, must.BeOKT(sis.GetServiceForType("second"))(t).DisplayName, "Second")
 	s.MustDBExec("UPDATE services SET display_name = 'Changed' WHERE id = $1", first)
-	<-sic.OnInvalidate
-	assert.Equal(t, BeOKT(sic.GetServiceForType("first"))(t).DisplayName, "Changed")
-	assert.Equal(t, BeOKT(sic.GetServiceForType("second"))(t).DisplayName, "Second")
+	<-s.Cluster.SIC.OnInvalidate
+	sis = s.Cluster.SIC.GetSnapshot()
+	assert.Equal(t, must.BeOKT(sis.GetServiceForType("first"))(t).DisplayName, "Changed")
+	assert.Equal(t, must.BeOKT(sis.GetServiceForType("second"))(t).DisplayName, "Second")
 
 	// resource update
-	assert.Equal(t, BeOKT(sic.GetResourceForTypeName("second", "capacity"))(t).DisplayName, "Capacity")
-	assert.Equal(t, BeOKT(sic.GetResourceForTypeName("second", "things"))(t).DisplayName, "Things")
+	assert.Equal(t, must.BeOKT(sis.GetResourceForTypeName("second", "capacity"))(t).DisplayName, "Capacity")
+	assert.Equal(t, must.BeOKT(sis.GetResourceForTypeName("second", "things"))(t).DisplayName, "Things")
 	s.MustDBExec("UPDATE resources r SET display_name = 'Changed' where id = $1", secondCapacity)
-	<-sic.OnInvalidate
-	assert.Equal(t, BeOKT(sic.GetResourceForTypeName("second", "capacity"))(t).DisplayName, "Changed")
-	assert.Equal(t, BeOKT(sic.GetResourceForTypeName("second", "things"))(t).DisplayName, "Things")
+	<-s.Cluster.SIC.OnInvalidate
+	sis = s.Cluster.SIC.GetSnapshot()
+	assert.Equal(t, must.BeOKT(sis.GetResourceForTypeName("second", "capacity"))(t).DisplayName, "Changed")
+	assert.Equal(t, must.BeOKT(sis.GetResourceForTypeName("second", "things"))(t).DisplayName, "Things")
 
 	// check az_resource insert
-	assert.Equal(t, len(BeOKT(sic.GetAZResourcesForTypeName("second", "capacity"))(t)), 5) // gives out total, any and unknown, too
+	assert.Equal(t, len(must.BeOKT(sis.GetAZResourcesForTypeName("second", "capacity"))(t)), 5) // gives out total, any and unknown, too
 	s.MustDBInsert(&db.AZResource{
 		ResourceID:       secondCapacity,
 		AvailabilityZone: "test",
 		Path:             db.AZResourcePath{ServiceType: "second", ResourceName: "capacity", AvailabilityZone: "test"},
 		RawCapacity:      123,
 	})
-	<-sic.OnInvalidate
-	assert.Equal(t, len(BeOKT(sic.GetAZResourcesForTypeName("second", "capacity"))(t)), 6)
+	<-s.Cluster.SIC.OnInvalidate
+	sis = s.Cluster.SIC.GetSnapshot()
+	assert.Equal(t, len(must.BeOKT(sis.GetAZResourcesForTypeName("second", "capacity"))(t)), 6)
 
 	// check rate deletion
-	assert.Equal(t, len(BeOKT(sic.GetRatesForType("first"))(t)), 4)
+	assert.Equal(t, len(must.BeOKT(sis.GetRatesForType("first"))(t)), 4)
 	s.MustDBExec("DELETE FROM rates WHERE id = $1", firstObjectsCreate)
-	<-sic.OnInvalidate
-	assert.Equal(t, len(BeOKT(sic.GetRatesForType("first"))(t)), 3)
+	<-s.Cluster.SIC.OnInvalidate
+	sis = s.Cluster.SIC.GetSnapshot()
+	assert.Equal(t, len(must.BeOKT(sis.GetRatesForType("first"))(t)), 3)
 }

--- a/internal/core/service_info_cache_test.go
+++ b/internal/core/service_info_cache_test.go
@@ -171,7 +171,7 @@ func TestServiceInfoCache(t *testing.T) {
 	assert.Equal(t, len(sis.GetServices()), 2)
 	must.NotBeOKT(sis.GetResourcesForType("first"))(t)
 	assert.Equal(t, len(must.BeOKT(sis.GetResourcesForType("second"))(t)), 2)
-	assert.Equal(t, must.BeOKT(sis.GetResourceForTypeName("second", "capacity"))(t).Name, "capacity")
+	assert.Equal(t, must.BeOKT(sis.GetResourceForPath(db.ResourcePath{ServiceType: "second", ResourceName: "capacity"}))(t).Name, "capacity")
 	must.NotBeOKT(sis.GetRatesForType("second"))(t)
 	assert.Equal(t, len(sis.GetCategories()), 1)
 
@@ -185,16 +185,16 @@ func TestServiceInfoCache(t *testing.T) {
 	assert.Equal(t, must.BeOKT(sis.GetServiceForType("second"))(t).DisplayName, "Second")
 
 	// resource update
-	assert.Equal(t, must.BeOKT(sis.GetResourceForTypeName("second", "capacity"))(t).DisplayName, "Capacity")
-	assert.Equal(t, must.BeOKT(sis.GetResourceForTypeName("second", "things"))(t).DisplayName, "Things")
+	assert.Equal(t, must.BeOKT(sis.GetResourceForPath(db.ResourcePath{ServiceType: "second", ResourceName: "capacity"}))(t).DisplayName, "Capacity")
+	assert.Equal(t, must.BeOKT(sis.GetResourceForPath(db.ResourcePath{ServiceType: "second", ResourceName: "things"}))(t).DisplayName, "Things")
 	s.MustDBExec("UPDATE resources r SET display_name = 'Changed' where id = $1", secondCapacity)
 	<-s.Cluster.SIC.OnInvalidate
 	sis = s.Cluster.SIC.GetSnapshot()
-	assert.Equal(t, must.BeOKT(sis.GetResourceForTypeName("second", "capacity"))(t).DisplayName, "Changed")
-	assert.Equal(t, must.BeOKT(sis.GetResourceForTypeName("second", "things"))(t).DisplayName, "Things")
+	assert.Equal(t, must.BeOKT(sis.GetResourceForPath(db.ResourcePath{ServiceType: "second", ResourceName: "capacity"}))(t).DisplayName, "Changed")
+	assert.Equal(t, must.BeOKT(sis.GetResourceForPath(db.ResourcePath{ServiceType: "second", ResourceName: "things"}))(t).DisplayName, "Things")
 
 	// check az_resource insert
-	assert.Equal(t, len(must.BeOKT(sis.GetAZResourcesForTypeName("second", "capacity"))(t)), 5) // gives out total, any and unknown, too
+	assert.Equal(t, len(must.BeOKT(sis.GetAZResourcesForPath(db.ResourcePath{ServiceType: "second", ResourceName: "capacity"}))(t)), 5) // gives out total, any and unknown, too
 	s.MustDBInsert(&db.AZResource{
 		ResourceID:       secondCapacity,
 		AvailabilityZone: "test",
@@ -203,7 +203,7 @@ func TestServiceInfoCache(t *testing.T) {
 	})
 	<-s.Cluster.SIC.OnInvalidate
 	sis = s.Cluster.SIC.GetSnapshot()
-	assert.Equal(t, len(must.BeOKT(sis.GetAZResourcesForTypeName("second", "capacity"))(t)), 6)
+	assert.Equal(t, len(must.BeOKT(sis.GetAZResourcesForPath(db.ResourcePath{ServiceType: "second", ResourceName: "capacity"}))(t)), 6)
 
 	// check rate deletion
 	assert.Equal(t, len(must.BeOKT(sis.GetRatesForType("first"))(t)), 4)

--- a/internal/datamodel/commitment.go
+++ b/internal/datamodel/commitment.go
@@ -130,7 +130,7 @@ func ConvertCommitmentToDisplayForm(c db.ProjectCommitment, az limes.Availabilit
 // preloaded - but does not have to. In case the LiquidConnection is not filled,
 // a LiquidClient is instantiated on the fly to perform the operation remotely. It utilizes a given
 // ServiceInfo so that no double retrieval is necessary caused by operations to assemble the liquid.CommitmentChange.
-func DelegateChangeCommitments(ctx context.Context, cluster *core.Cluster, req liquid.CommitmentChangeRequest, service db.Service, resources core.ResourcesByName, dbi db.Interface) (result liquid.CommitmentChangeResponse, err error) {
+func DelegateChangeCommitments(ctx context.Context, cluster *core.Cluster, req liquid.CommitmentChangeRequest, sis core.ServiceInfoReader, serviceType db.ServiceType, dbi db.Interface) (result liquid.CommitmentChangeResponse, err error) {
 	localCommitmentChanges := liquid.CommitmentChangeRequest{
 		DryRun:      req.DryRun,
 		AZ:          req.AZ,
@@ -152,8 +152,11 @@ func DelegateChangeCommitments(ctx context.Context, cluster *core.Cluster, req l
 				commitment.OldExpiresAt = options.Map(commitment.OldExpiresAt, time.Time.UTC)
 				resourceCommitmentChangeset.Commitments[i] = commitment
 			}
-
-			if resources[resourceName].HandlesCommitments {
+			resource, ok := sis.GetResourceForTypeName(serviceType, resourceName)
+			if !ok {
+				return result, fmt.Errorf("resource %s not found when delegating commitment change for %s", resourceName, projectUUID)
+			}
+			if resource.HandlesCommitments {
 				_, exists := remoteCommitmentChanges.ByProject[projectUUID]
 				if !exists {
 					remoteCommitmentChanges.ByProject[projectUUID] = liquid.ProjectCommitmentChangeset{
@@ -171,6 +174,10 @@ func DelegateChangeCommitments(ctx context.Context, cluster *core.Cluster, req l
 			}
 			localCommitmentChanges.ByProject[projectUUID].ByResource[resourceName] = resourceCommitmentChangeset
 		}
+	}
+	service, ok := sis.GetServiceForType(serviceType)
+	if !ok {
+		return result, fmt.Errorf("service %s not found when delegating commitment change", serviceType)
 	}
 	for projectUUID, projectCommitmentChangeset := range localCommitmentChanges.ByProject {
 		if service.CommitmentHandlingNeedsProjectMetadata {

--- a/internal/datamodel/commitment.go
+++ b/internal/datamodel/commitment.go
@@ -130,7 +130,7 @@ func ConvertCommitmentToDisplayForm(c db.ProjectCommitment, az limes.Availabilit
 // preloaded - but does not have to. In case the LiquidConnection is not filled,
 // a LiquidClient is instantiated on the fly to perform the operation remotely. It utilizes a given
 // ServiceInfo so that no double retrieval is necessary caused by operations to assemble the liquid.CommitmentChange.
-func DelegateChangeCommitments(ctx context.Context, cluster *core.Cluster, req liquid.CommitmentChangeRequest, sis core.ServiceInfoReader, serviceType db.ServiceType, dbi db.Interface) (result liquid.CommitmentChangeResponse, err error) {
+func DelegateChangeCommitments(ctx context.Context, cluster *core.Cluster, req liquid.CommitmentChangeRequest, sis core.ServiceInfoSnapshot, serviceType db.ServiceType, dbi db.Interface) (result liquid.CommitmentChangeResponse, err error) {
 	localCommitmentChanges := liquid.CommitmentChangeRequest{
 		DryRun:      req.DryRun,
 		AZ:          req.AZ,

--- a/internal/datamodel/commitment.go
+++ b/internal/datamodel/commitment.go
@@ -152,7 +152,7 @@ func DelegateChangeCommitments(ctx context.Context, cluster *core.Cluster, req l
 				commitment.OldExpiresAt = options.Map(commitment.OldExpiresAt, time.Time.UTC)
 				resourceCommitmentChangeset.Commitments[i] = commitment
 			}
-			resource, ok := sis.GetResourceForTypeName(serviceType, resourceName)
+			resource, ok := sis.GetResourceForPath(db.ResourcePath{ServiceType: serviceType, ResourceName: resourceName})
 			if !ok {
 				return result, fmt.Errorf("resource %s not found when delegating commitment change for %s", resourceName, projectUUID)
 			}

--- a/internal/datamodel/confirm_project_commitments.go
+++ b/internal/datamodel/confirm_project_commitments.go
@@ -130,10 +130,14 @@ func ConfirmPendingCommitments(ctx context.Context, path db.AZResourcePath, clus
 	}
 
 	// load service info (used to generate liquid.ProjectMetadata)
-	service, sExists := cluster.SIC.GetServiceForType(path.ServiceType)
-	resources, _ := cluster.SIC.GetResourcesForType(path.ServiceType)
+	sis := cluster.SIC.GetSnapshot().Filter(core.ServiceInfoFilter{ServiceType: Some(path.ServiceType), ResourceName: Some(path.ResourceName)})
+	_, sExists := sis.GetServiceForType(path.ServiceType)
 	if !sExists {
-		return nil, fmt.Errorf("service/resource not found when trying to confirm commitments for %s", path.ServiceType)
+		return nil, fmt.Errorf("service not found when trying to confirm commitments for %s", path)
+	}
+	_, rExists := sis.GetResourceForPath(path.Resource())
+	if !rExists {
+		return nil, fmt.Errorf("resource not found when trying to confirm commitments for %s", path)
 	}
 
 	// load affected projects and domains
@@ -159,7 +163,7 @@ func ConfirmPendingCommitments(ctx context.Context, path db.AZResourcePath, clus
 	}
 
 	// initiate cache of transferable commitments
-	transferableCommitmentCache, err := NewTransferableCommitmentCache(dbi, cluster, service, resources, path, now, generateProjectCommitmentUUID, generateTransferToken, transferTemplate)
+	transferableCommitmentCache, err := NewTransferableCommitmentCache(dbi, cluster, sis, path, now, generateProjectCommitmentUUID, generateTransferToken, transferTemplate)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/datamodel/confirm_project_commitments.go
+++ b/internal/datamodel/confirm_project_commitments.go
@@ -130,7 +130,7 @@ func ConfirmPendingCommitments(ctx context.Context, path db.AZResourcePath, clus
 	}
 
 	// load service info (used to generate liquid.ProjectMetadata)
-	sis := cluster.SIC.GetSnapshot().Filter(core.ServiceInfoFilter{ServiceType: Some(path.ServiceType), ResourceName: Some(path.ResourceName)})
+	sis := cluster.SIC.GetSnapshot()
 	_, sExists := sis.GetServiceForType(path.ServiceType)
 	if !sExists {
 		return nil, fmt.Errorf("service not found when trying to confirm commitments for %s", path)

--- a/internal/datamodel/consume_transferable_commitments.go
+++ b/internal/datamodel/consume_transferable_commitments.go
@@ -70,7 +70,7 @@ type TransferableCommitmentCache struct {
 	// utilities
 	dbi                           db.Interface
 	cluster                       *core.Cluster
-	filteredSIS                   *core.FilteredServiceInfoSnapshot
+	filteredSIS                   core.FilteredServiceInfoSnapshot
 	path                          db.AZResourcePath
 	now                           time.Time
 	generateProjectCommitmentUUID func() liquid.CommitmentUUID
@@ -83,7 +83,7 @@ type TransferableCommitmentCache struct {
 }
 
 // NewTransferableCommitmentCache builds a TransferableCommitmentCache and fills it.
-func NewTransferableCommitmentCache(dbi db.Interface, cluster *core.Cluster, filteredSIS *core.FilteredServiceInfoSnapshot, path db.AZResourcePath, now time.Time, generateProjectCommitmentUUID func() liquid.CommitmentUUID, generateTransferToken func() string, mailTemplate Option[core.MailTemplate]) (t TransferableCommitmentCache, err error) {
+func NewTransferableCommitmentCache(dbi db.Interface, cluster *core.Cluster, filteredSIS core.FilteredServiceInfoSnapshot, path db.AZResourcePath, now time.Time, generateProjectCommitmentUUID func() liquid.CommitmentUUID, generateTransferToken func() string, mailTemplate Option[core.MailTemplate]) (t TransferableCommitmentCache, err error) {
 	_, err = dbi.Select(&t.transferableCommitments, getTransferableCommitmentsQuery, path)
 	if err != nil {
 		return t, fmt.Errorf("while enumerating transferable commitments for %s: %w", path, err)

--- a/internal/datamodel/consume_transferable_commitments.go
+++ b/internal/datamodel/consume_transferable_commitments.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sapcc/go-api-declarations/liquid"
 	"github.com/sapcc/go-bits/audittools"
 	"github.com/sapcc/go-bits/logg"
+	"github.com/sapcc/go-bits/must"
 	"github.com/sapcc/go-bits/sqlext"
 	. "go.xyrillian.de/gg/option"
 
@@ -69,8 +70,7 @@ type TransferableCommitmentCache struct {
 	// utilities
 	dbi                           db.Interface
 	cluster                       *core.Cluster
-	service                       db.Service
-	resources                     core.ResourcesByName
+	filteredSIS                   *core.FilteredServiceInfoSnapshot
 	path                          db.AZResourcePath
 	now                           time.Time
 	generateProjectCommitmentUUID func() liquid.CommitmentUUID
@@ -83,7 +83,7 @@ type TransferableCommitmentCache struct {
 }
 
 // NewTransferableCommitmentCache builds a TransferableCommitmentCache and fills it.
-func NewTransferableCommitmentCache(dbi db.Interface, cluster *core.Cluster, service db.Service, resources core.ResourcesByName, path db.AZResourcePath, now time.Time, generateProjectCommitmentUUID func() liquid.CommitmentUUID, generateTransferToken func() string, mailTemplate Option[core.MailTemplate]) (t TransferableCommitmentCache, err error) {
+func NewTransferableCommitmentCache(dbi db.Interface, cluster *core.Cluster, filteredSIS *core.FilteredServiceInfoSnapshot, path db.AZResourcePath, now time.Time, generateProjectCommitmentUUID func() liquid.CommitmentUUID, generateTransferToken func() string, mailTemplate Option[core.MailTemplate]) (t TransferableCommitmentCache, err error) {
 	_, err = dbi.Select(&t.transferableCommitments, getTransferableCommitmentsQuery, path)
 	if err != nil {
 		return t, fmt.Errorf("while enumerating transferable commitments for %s: %w", path, err)
@@ -116,15 +116,14 @@ func NewTransferableCommitmentCache(dbi db.Interface, cluster *core.Cluster, ser
 	// fill utilities
 	t.dbi = dbi
 	t.cluster = cluster
-	t.service = service
-	t.resources = resources
+	t.filteredSIS = filteredSIS
 	t.path = path
 	t.now = now
 	t.generateProjectCommitmentUUID = generateProjectCommitmentUUID
 	t.generateTransferToken = generateTransferToken
 	t.mailTemplate = mailTemplate
 
-	resource, ok := resources[path.ResourceName]
+	resource, ok := t.filteredSIS.GetResourceForPath(path.Resource())
 	if !ok {
 		return t, fmt.Errorf("resource %s not found in provided resources", path.ResourceName)
 	}
@@ -172,7 +171,7 @@ func (t *TransferableCommitmentCache) CanConfirmWithTransfers(ctx context.Contex
 	ccr := liquid.CommitmentChangeRequest{
 		DryRun:      dryRun,
 		AZ:          t.path.AvailabilityZone,
-		InfoVersion: t.service.LiquidVersion,
+		InfoVersion: must.BeOK(t.filteredSIS.GetServiceForType(t.path.ServiceType)).LiquidVersion,
 		ByProject: map[liquid.ProjectUUID]liquid.ProjectCommitmentChangeset{
 			project.UUID: {
 				ProjectMetadata: LiquidProjectMetadataFromDBProject(project, domain),
@@ -534,7 +533,7 @@ func (t *TransferableCommitmentCache) delegateChangeCommitmentsWithShortcut(ctx 
 			}
 		}
 	default:
-		commitmentChangeResponse, err := DelegateChangeCommitments(ctx, t.cluster, ccr, t.service, t.resources, t.dbi)
+		commitmentChangeResponse, err := DelegateChangeCommitments(ctx, t.cluster, ccr, t.filteredSIS, t.path.ServiceType, t.dbi)
 		if err != nil {
 			return result, err
 		}

--- a/internal/datamodel/consume_transferable_commitments.go
+++ b/internal/datamodel/consume_transferable_commitments.go
@@ -70,7 +70,7 @@ type TransferableCommitmentCache struct {
 	// utilities
 	dbi                           db.Interface
 	cluster                       *core.Cluster
-	filteredSIS                   core.FilteredServiceInfoSnapshot
+	sis                           core.ServiceInfoSnapshot
 	path                          db.AZResourcePath
 	now                           time.Time
 	generateProjectCommitmentUUID func() liquid.CommitmentUUID
@@ -83,7 +83,7 @@ type TransferableCommitmentCache struct {
 }
 
 // NewTransferableCommitmentCache builds a TransferableCommitmentCache and fills it.
-func NewTransferableCommitmentCache(dbi db.Interface, cluster *core.Cluster, filteredSIS core.FilteredServiceInfoSnapshot, path db.AZResourcePath, now time.Time, generateProjectCommitmentUUID func() liquid.CommitmentUUID, generateTransferToken func() string, mailTemplate Option[core.MailTemplate]) (t TransferableCommitmentCache, err error) {
+func NewTransferableCommitmentCache(dbi db.Interface, cluster *core.Cluster, sis core.ServiceInfoSnapshot, path db.AZResourcePath, now time.Time, generateProjectCommitmentUUID func() liquid.CommitmentUUID, generateTransferToken func() string, mailTemplate Option[core.MailTemplate]) (t TransferableCommitmentCache, err error) {
 	_, err = dbi.Select(&t.transferableCommitments, getTransferableCommitmentsQuery, path)
 	if err != nil {
 		return t, fmt.Errorf("while enumerating transferable commitments for %s: %w", path, err)
@@ -116,14 +116,14 @@ func NewTransferableCommitmentCache(dbi db.Interface, cluster *core.Cluster, fil
 	// fill utilities
 	t.dbi = dbi
 	t.cluster = cluster
-	t.filteredSIS = filteredSIS
+	t.sis = sis
 	t.path = path
 	t.now = now
 	t.generateProjectCommitmentUUID = generateProjectCommitmentUUID
 	t.generateTransferToken = generateTransferToken
 	t.mailTemplate = mailTemplate
 
-	resource, ok := t.filteredSIS.GetResourceForPath(path.Resource())
+	resource, ok := sis.GetResourceForPath(path.Resource())
 	if !ok {
 		return t, fmt.Errorf("resource %s not found in provided resources", path.ResourceName)
 	}
@@ -171,7 +171,7 @@ func (t *TransferableCommitmentCache) CanConfirmWithTransfers(ctx context.Contex
 	ccr := liquid.CommitmentChangeRequest{
 		DryRun:      dryRun,
 		AZ:          t.path.AvailabilityZone,
-		InfoVersion: must.BeOK(t.filteredSIS.GetServiceForType(t.path.ServiceType)).LiquidVersion,
+		InfoVersion: must.BeOK(t.sis.GetServiceForType(t.path.ServiceType)).LiquidVersion,
 		ByProject: map[liquid.ProjectUUID]liquid.ProjectCommitmentChangeset{
 			project.UUID: {
 				ProjectMetadata: LiquidProjectMetadataFromDBProject(project, domain),
@@ -533,7 +533,7 @@ func (t *TransferableCommitmentCache) delegateChangeCommitmentsWithShortcut(ctx 
 			}
 		}
 	default:
-		commitmentChangeResponse, err := DelegateChangeCommitments(ctx, t.cluster, ccr, t.filteredSIS, t.path.ServiceType, t.dbi)
+		commitmentChangeResponse, err := DelegateChangeCommitments(ctx, t.cluster, ccr, t.sis, t.path.ServiceType, t.dbi)
 		if err != nil {
 			return result, err
 		}

--- a/internal/datamodel/project_resource_update.go
+++ b/internal/datamodel/project_resource_update.go
@@ -28,7 +28,7 @@ type ProjectResourceUpdate struct {
 //   - Missing ProjectResource entries are created.
 //   - The `UpdateResource` callback is called for each resource to allow the
 //     caller to update resource data as necessary.
-func (u ProjectResourceUpdate) Run(dbi db.Interface, project db.Project, filteredSIS *core.FilteredServiceInfoSnapshot) error {
+func (u ProjectResourceUpdate) Run(dbi db.Interface, project db.Project, filteredSIS core.FilteredServiceInfoSnapshot) error {
 	service := must.BeOK(filteredSIS.GetFilteredService())
 	resources, _ := filteredSIS.GetResourcesForType(service.Type)
 	// We will first collect all existing data into one of these structs for each

--- a/internal/datamodel/project_resource_update.go
+++ b/internal/datamodel/project_resource_update.go
@@ -10,7 +10,9 @@ import (
 	"slices"
 
 	"github.com/sapcc/go-api-declarations/liquid"
+	"github.com/sapcc/go-bits/must"
 
+	"github.com/sapcc/limes/internal/core"
 	"github.com/sapcc/limes/internal/db"
 )
 
@@ -26,7 +28,9 @@ type ProjectResourceUpdate struct {
 //   - Missing ProjectResource entries are created.
 //   - The `UpdateResource` callback is called for each resource to allow the
 //     caller to update resource data as necessary.
-func (u ProjectResourceUpdate) Run(dbi db.Interface, project db.Project, srv db.Service, resources map[liquid.ResourceName]db.Resource) error {
+func (u ProjectResourceUpdate) Run(dbi db.Interface, project db.Project, filteredSIS *core.FilteredServiceInfoSnapshot) error {
+	service := must.BeOK(filteredSIS.GetFilteredService())
+	resources, _ := filteredSIS.GetResourcesForType(service.Type)
 	// We will first collect all existing data into one of these structs for each
 	// resource. Then we will compute the target state of the DB record. We only
 	// need to write into the DB if `.Target` ends up different from `.Original`.
@@ -48,9 +52,9 @@ func (u ProjectResourceUpdate) Run(dbi db.Interface, project db.Project, srv db.
 
 	// collect existing project_resources for this service
 	var projectResources []db.ProjectResource
-	_, err := dbi.Select(&projectResources, `SELECT pr.* FROM project_resources pr JOIN resources r ON pr.resource_id = r.id WHERE r.service_id = $1 AND pr.project_id = $2`, srv.ID, project.ID)
+	_, err := dbi.Select(&projectResources, `SELECT pr.* FROM project_resources pr JOIN resources r ON pr.resource_id = r.id WHERE r.service_id = $1 AND pr.project_id = $2`, service.ID, project.ID)
 	if err != nil {
-		return fmt.Errorf("while loading %s project resources: %w", srv.Type, err)
+		return fmt.Errorf("while loading %s project resources: %w", service.Type, err)
 	}
 	for _, res := range projectResources {
 		correspondingResource := resourcesByID[res.ResourceID]
@@ -85,12 +89,12 @@ func (u ProjectResourceUpdate) Run(dbi db.Interface, project db.Project, srv db.
 		if state.Original == nil {
 			err := dbi.Insert(&res)
 			if err != nil {
-				return fmt.Errorf("while inserting %s/%s resource in the DB: %w", srv.Type, resName, err)
+				return fmt.Errorf("while inserting %s/%s resource in the DB: %w", service.Type, resName, err)
 			}
 		} else if !reflect.DeepEqual(*state.Original, res) {
 			_, err := dbi.Update(&res)
 			if err != nil {
-				return fmt.Errorf("while updating %s/%s resource in the DB: %w", srv.Type, resName, err)
+				return fmt.Errorf("while updating %s/%s resource in the DB: %w", service.Type, resName, err)
 			}
 		}
 	}

--- a/internal/datamodel/project_resource_update.go
+++ b/internal/datamodel/project_resource_update.go
@@ -28,9 +28,9 @@ type ProjectResourceUpdate struct {
 //   - Missing ProjectResource entries are created.
 //   - The `UpdateResource` callback is called for each resource to allow the
 //     caller to update resource data as necessary.
-func (u ProjectResourceUpdate) Run(dbi db.Interface, project db.Project, filteredSIS core.FilteredServiceInfoSnapshot) error {
-	service := must.BeOK(filteredSIS.GetFilteredService())
-	resources, _ := filteredSIS.GetResourcesForType(service.Type)
+func (u ProjectResourceUpdate) Run(dbi db.Interface, project db.Project, sis core.ServiceInfoSnapshot, serviceType db.ServiceType) error {
+	service := must.BeOK(sis.GetServiceForType(serviceType)) // should have been checked to exist before, else no update makes sense
+	resources, _ := sis.GetResourcesForType(service.Type)
 	// We will first collect all existing data into one of these structs for each
 	// resource. Then we will compute the target state of the DB record. We only
 	// need to write into the DB if `.Target` ends up different from `.Original`.

--- a/internal/datamodel/quota_overrides.go
+++ b/internal/datamodel/quota_overrides.go
@@ -39,7 +39,7 @@ func LoadQuotaOverrides(c *core.Cluster) (result map[string]map[string]map[db.Se
 		if !exists {
 			return limes.UnitNone, fmt.Errorf("%s/%s is not a valid resource", serviceType, resourceName)
 		}
-		resource, exists := sis.GetResourceForTypeName(dbServiceType, dbResourceName)
+		resource, exists := sis.GetResourceForPath(db.ResourcePath{ServiceType: dbServiceType, ResourceName: dbResourceName})
 		if !exists {
 			return limes.UnitNone, fmt.Errorf("no data found in ServiceInfoCache for %s/%s", serviceType, resourceName)
 		}

--- a/internal/datamodel/quota_overrides.go
+++ b/internal/datamodel/quota_overrides.go
@@ -28,8 +28,8 @@ func LoadQuotaOverrides(c *core.Cluster) (result map[string]map[string]map[db.Se
 		return
 	}
 
-	resources := c.SIC.GetResources()
-	nameMapping := core.BuildResourceNameMapping(c, resources)
+	sis := c.SIC.GetSnapshot()
+	nameMapping := core.BuildResourceNameMapping(c, sis)
 
 	// the quota-overrides.json file refers to services and resources using IdentityInV1API, so we:
 	// a) need to lookup by API identity
@@ -39,7 +39,7 @@ func LoadQuotaOverrides(c *core.Cluster) (result map[string]map[string]map[db.Se
 		if !exists {
 			return limes.UnitNone, fmt.Errorf("%s/%s is not a valid resource", serviceType, resourceName)
 		}
-		resource, exists := resources[dbServiceType][dbResourceName]
+		resource, exists := sis.GetResourceForTypeName(dbServiceType, dbResourceName)
 		if !exists {
 			return limes.UnitNone, fmt.Errorf("no data found in ServiceInfoCache for %s/%s", serviceType, resourceName)
 		}

--- a/internal/reports/cluster.go
+++ b/internal/reports/cluster.go
@@ -84,7 +84,7 @@ var clusterRateReportQuery1 = sqlext.SimplifyWhitespace(`
 `)
 
 // GetClusterResources returns the resource data report for the whole cluster.
-func GetClusterResources(cluster *core.Cluster, now time.Time, dbi db.Interface, filter Filter, sis *core.ServiceInfoSnapshot) (*limesresources.ClusterReport, error) {
+func GetClusterResources(cluster *core.Cluster, now time.Time, dbi db.Interface, filter Filter, sis core.ServiceInfoSnapshot) (*limesresources.ClusterReport, error) {
 	report := &limesresources.ClusterReport{
 		ClusterInfo: limes.ClusterInfo{
 			ID: "current", // multi-cluster support has been removed; this value is only included for backwards-compatibility
@@ -351,7 +351,7 @@ func GetClusterResources(cluster *core.Cluster, now time.Time, dbi db.Interface,
 }
 
 // GetClusterRates returns the rate data report for the whole cluster.
-func GetClusterRates(cluster *core.Cluster, dbi db.Interface, filter Filter, sis *core.ServiceInfoSnapshot) (*limesrates.ClusterReport, error) {
+func GetClusterRates(cluster *core.Cluster, dbi db.Interface, filter Filter, sis core.ServiceInfoSnapshot) (*limesrates.ClusterReport, error) {
 	nm := core.BuildRateNameMapping(cluster, sis)
 	report := &limesrates.ClusterReport{
 		ClusterInfo: limes.ClusterInfo{
@@ -430,7 +430,7 @@ func GetClusterRates(cluster *core.Cluster, dbi db.Interface, filter Filter, sis
 	return report, nil
 }
 
-func findInClusterReport(cluster *core.Cluster, report *limesresources.ClusterReport, dbServiceType db.ServiceType, dbResourceName liquid.ResourceName, now time.Time, sis *core.ServiceInfoSnapshot) (*limesresources.ClusterServiceReport, *limesresources.ClusterResourceReport, core.ResourceBehavior) {
+func findInClusterReport(cluster *core.Cluster, report *limesresources.ClusterReport, dbServiceType db.ServiceType, dbResourceName liquid.ResourceName, now time.Time, sis core.ServiceInfoSnapshot) (*limesresources.ClusterServiceReport, *limesresources.ClusterResourceReport, core.ResourceBehavior) {
 	behavior := cluster.BehaviorForResource(dbServiceType, dbResourceName)
 	apiIdentity := behavior.IdentityInV1API
 

--- a/internal/reports/cluster.go
+++ b/internal/reports/cluster.go
@@ -128,7 +128,7 @@ func GetClusterResources(cluster *core.Cluster, now time.Time, dbi db.Interface,
 
 		if *availabilityZone == liquid.AvailabilityZoneTotal {
 			// we ignore when a resource can't be found in the app layer yet, we will set the quota here
-			resource, _ := sis.GetResourceForTypeName(dbServiceType, dbResourceName)
+			resource, _ := sis.GetResourceForPath(db.ResourcePath{ServiceType: dbServiceType, ResourceName: dbResourceName})
 			resourceReport.Usage = *usage
 			if quota != nil && !resourceReport.NoQuota && resource.Topology != liquid.AZSeparatedTopology {
 				// NOTE: This is called "DomainsQuota" for historical reasons, but it is actually
@@ -217,7 +217,7 @@ func GetClusterResources(cluster *core.Cluster, now time.Time, dbi db.Interface,
 			if subcapacities != nil && *subcapacities != "" && filter.IsSubcapacityAllowed(dbServiceType, dbResourceName) {
 				translate := behavior.TranslationRuleInV1API.TranslateSubcapacities
 				// we ignore when a resource can't be found in the app layer yet, it will appear with empty values
-				resource, _ := sis.GetResourceForTypeName(dbServiceType, dbResourceName)
+				resource, _ := sis.GetResourceForPath(db.ResourcePath{ServiceType: dbServiceType, ResourceName: dbResourceName})
 				if translate != nil {
 					*subcapacities, err = translate(*subcapacities, *availabilityZone, resource)
 					if err != nil {
@@ -374,7 +374,7 @@ func GetClusterRates(cluster *core.Cluster, dbi db.Interface, filter Filter, sis
 			return err
 		}
 
-		if _, ok := sis.GetRateForTypeName(dbServiceType, dbRateName); !ok {
+		if _, ok := sis.GetRateForPath(db.RatePath{ServiceType: dbServiceType, RateName: dbRateName}); !ok {
 			return nil
 		}
 		apiServiceType, _, exists := nm.MapToV1API(dbServiceType, dbRateName)
@@ -447,7 +447,7 @@ func findInClusterReport(cluster *core.Cluster, report *limesresources.ClusterRe
 	resourceReport, exists := serviceReport.Resources[apiIdentity.Name]
 	if !exists {
 		// we ignore when a resource can't be found in the app layer yet, it will appear with empty values
-		resource, _ := sis.GetResourceForTypeName(dbServiceType, dbResourceName)
+		resource, _ := sis.GetResourceForPath(db.ResourcePath{ServiceType: dbServiceType, ResourceName: dbResourceName})
 		resourceReport = &limesresources.ClusterResourceReport{
 			ResourceInfo:     behavior.BuildAPIResourceInfo(apiIdentity.Name, resource),
 			CommitmentConfig: cluster.CommitmentBehaviorForResource(dbServiceType, dbResourceName).ForCluster().ForAPI(now).AsPointer(),

--- a/internal/reports/cluster.go
+++ b/internal/reports/cluster.go
@@ -84,7 +84,7 @@ var clusterRateReportQuery1 = sqlext.SimplifyWhitespace(`
 `)
 
 // GetClusterResources returns the resource data report for the whole cluster.
-func GetClusterResources(cluster *core.Cluster, now time.Time, dbi db.Interface, filter Filter, resources core.ResourcesByNameType) (*limesresources.ClusterReport, error) {
+func GetClusterResources(cluster *core.Cluster, now time.Time, dbi db.Interface, filter Filter, sis *core.ServiceInfoSnapshot) (*limesresources.ClusterReport, error) {
 	report := &limesresources.ClusterReport{
 		ClusterInfo: limes.ClusterInfo{
 			ID: "current", // multi-cluster support has been removed; this value is only included for backwards-compatibility
@@ -117,7 +117,7 @@ func GetClusterResources(cluster *core.Cluster, now time.Time, dbi db.Interface,
 		if _, exists := cluster.Config.Liquids[dbServiceType]; !filter.Includes[dbServiceType][dbResourceName] || !exists {
 			return nil
 		}
-		serviceReport, resourceReport, _ := findInClusterReport(cluster, report, dbServiceType, dbResourceName, now, resources)
+		serviceReport, resourceReport, _ := findInClusterReport(cluster, report, dbServiceType, dbResourceName, now, sis)
 
 		serviceReport.MaxScrapedAt = mergeMaxTime(serviceReport.MaxScrapedAt, maxScrapedAt)
 		serviceReport.MinScrapedAt = mergeMinTime(serviceReport.MinScrapedAt, minScrapedAt)
@@ -128,7 +128,7 @@ func GetClusterResources(cluster *core.Cluster, now time.Time, dbi db.Interface,
 
 		if *availabilityZone == liquid.AvailabilityZoneTotal {
 			// we ignore when a resource can't be found in the app layer yet, we will set the quota here
-			resource := resources[dbServiceType][dbResourceName]
+			resource, _ := sis.GetResourceForTypeName(dbServiceType, dbResourceName)
 			resourceReport.Usage = *usage
 			if quota != nil && !resourceReport.NoQuota && resource.Topology != liquid.AZSeparatedTopology {
 				// NOTE: This is called "DomainsQuota" for historical reasons, but it is actually
@@ -184,7 +184,7 @@ func GetClusterResources(cluster *core.Cluster, now time.Time, dbi db.Interface,
 		if _, exists := cluster.Config.Liquids[dbServiceType]; !filter.Includes[dbServiceType][dbResourceName] || !exists {
 			return nil
 		}
-		_, resourceReport, behavior := findInClusterReport(cluster, report, dbServiceType, dbResourceName, now, resources)
+		_, resourceReport, behavior := findInClusterReport(cluster, report, dbServiceType, dbResourceName, now, sis)
 		overcommitFactor := behavior.OvercommitFactor
 
 		if availabilityZone == nil {
@@ -217,7 +217,7 @@ func GetClusterResources(cluster *core.Cluster, now time.Time, dbi db.Interface,
 			if subcapacities != nil && *subcapacities != "" && filter.IsSubcapacityAllowed(dbServiceType, dbResourceName) {
 				translate := behavior.TranslationRuleInV1API.TranslateSubcapacities
 				// we ignore when a resource can't be found in the app layer yet, it will appear with empty values
-				resource := resources[dbServiceType][dbResourceName]
+				resource, _ := sis.GetResourceForTypeName(dbServiceType, dbResourceName)
 				if translate != nil {
 					*subcapacities, err = translate(*subcapacities, *availabilityZone, resource)
 					if err != nil {
@@ -276,7 +276,7 @@ func GetClusterResources(cluster *core.Cluster, now time.Time, dbi db.Interface,
 			if _, exists := cluster.Config.Liquids[dbServiceType]; !filter.Includes[dbServiceType][dbResourceName] || !exists {
 				return nil
 			}
-			_, resourceReport, _ := findInClusterReport(cluster, report, dbServiceType, dbResourceName, now, resources)
+			_, resourceReport, _ := findInClusterReport(cluster, report, dbServiceType, dbResourceName, now, sis)
 
 			azReport := resourceReport.PerAZ[az]
 			if azReport == nil {
@@ -351,8 +351,8 @@ func GetClusterResources(cluster *core.Cluster, now time.Time, dbi db.Interface,
 }
 
 // GetClusterRates returns the rate data report for the whole cluster.
-func GetClusterRates(cluster *core.Cluster, dbi db.Interface, filter Filter, rates core.RatesByNameType) (*limesrates.ClusterReport, error) {
-	nm := core.BuildRateNameMapping(cluster, rates)
+func GetClusterRates(cluster *core.Cluster, dbi db.Interface, filter Filter, sis *core.ServiceInfoSnapshot) (*limesrates.ClusterReport, error) {
+	nm := core.BuildRateNameMapping(cluster, sis)
 	report := &limesrates.ClusterReport{
 		ClusterInfo: limes.ClusterInfo{
 			ID: "current", // multi-cluster support has been removed; this value is only included for backwards-compatibility
@@ -374,7 +374,7 @@ func GetClusterRates(cluster *core.Cluster, dbi db.Interface, filter Filter, rat
 			return err
 		}
 
-		if _, ok := rates[dbServiceType][dbRateName]; !ok {
+		if _, ok := sis.GetRateForTypeName(dbServiceType, dbRateName); !ok {
 			return nil
 		}
 		apiServiceType, _, exists := nm.MapToV1API(dbServiceType, dbRateName)
@@ -430,7 +430,7 @@ func GetClusterRates(cluster *core.Cluster, dbi db.Interface, filter Filter, rat
 	return report, nil
 }
 
-func findInClusterReport(cluster *core.Cluster, report *limesresources.ClusterReport, dbServiceType db.ServiceType, dbResourceName liquid.ResourceName, now time.Time, resources core.ResourcesByNameType) (*limesresources.ClusterServiceReport, *limesresources.ClusterResourceReport, core.ResourceBehavior) {
+func findInClusterReport(cluster *core.Cluster, report *limesresources.ClusterReport, dbServiceType db.ServiceType, dbResourceName liquid.ResourceName, now time.Time, sis *core.ServiceInfoSnapshot) (*limesresources.ClusterServiceReport, *limesresources.ClusterResourceReport, core.ResourceBehavior) {
 	behavior := cluster.BehaviorForResource(dbServiceType, dbResourceName)
 	apiIdentity := behavior.IdentityInV1API
 
@@ -447,7 +447,7 @@ func findInClusterReport(cluster *core.Cluster, report *limesresources.ClusterRe
 	resourceReport, exists := serviceReport.Resources[apiIdentity.Name]
 	if !exists {
 		// we ignore when a resource can't be found in the app layer yet, it will appear with empty values
-		resource := resources[dbServiceType][dbResourceName]
+		resource, _ := sis.GetResourceForTypeName(dbServiceType, dbResourceName)
 		resourceReport = &limesresources.ClusterResourceReport{
 			ResourceInfo:     behavior.BuildAPIResourceInfo(apiIdentity.Name, resource),
 			CommitmentConfig: cluster.CommitmentBehaviorForResource(dbServiceType, dbResourceName).ForCluster().ForAPI(now).AsPointer(),

--- a/internal/reports/domain.go
+++ b/internal/reports/domain.go
@@ -76,7 +76,7 @@ var domainReportQuery4 = sqlext.SimplifyWhitespace(db.ExpandEnumPlaceholders(`
 
 // GetDomains returns reports for all domains in the given cluster or, if
 // domainID is non-nil, for that domain only.
-func GetDomains(cluster *core.Cluster, domainID *db.DomainID, now time.Time, dbi db.Interface, filter Filter, sis *core.ServiceInfoSnapshot) ([]*limesresources.DomainReport, error) {
+func GetDomains(cluster *core.Cluster, domainID *db.DomainID, now time.Time, dbi db.Interface, filter Filter, sis core.ServiceInfoSnapshot) ([]*limesresources.DomainReport, error) {
 	var fields map[string]any
 	if domainID != nil {
 		fields = map[string]any{"d.id": *domainID}
@@ -292,7 +292,7 @@ func GetDomains(cluster *core.Cluster, domainID *db.DomainID, now time.Time, dbi
 	return result, nil
 }
 
-func findInDomainReport(domain *limesresources.DomainReport, cluster *core.Cluster, dbServiceType db.ServiceType, dbResourceName liquid.ResourceName, now time.Time, sis *core.ServiceInfoSnapshot) (*limesresources.DomainServiceReport, *limesresources.DomainResourceReport) {
+func findInDomainReport(domain *limesresources.DomainReport, cluster *core.Cluster, dbServiceType db.ServiceType, dbResourceName liquid.ResourceName, now time.Time, sis core.ServiceInfoSnapshot) (*limesresources.DomainServiceReport, *limesresources.DomainResourceReport) {
 	behavior := cluster.BehaviorForResource(dbServiceType, dbResourceName)
 	apiIdentity := behavior.IdentityInV1API
 

--- a/internal/reports/domain.go
+++ b/internal/reports/domain.go
@@ -155,7 +155,7 @@ func GetDomains(cluster *core.Cluster, domainID *db.DomainID, now time.Time, dbi
 
 		if az == liquid.AvailabilityZoneTotal {
 			// we ignore when a resource can't be found in the app layer yet, it will appear with empty values
-			resource, _ := sis.GetResourceForTypeName(dbServiceType, dbResourceName)
+			resource, _ := sis.GetResourceForPath(db.ResourcePath{ServiceType: dbServiceType, ResourceName: dbResourceName})
 			serviceReport.MaxScrapedAt = mergeMaxTime(serviceReport.MaxScrapedAt, maxScrapedAt)
 			serviceReport.MinScrapedAt = mergeMinTime(serviceReport.MinScrapedAt, minScrapedAt)
 
@@ -309,7 +309,7 @@ func findInDomainReport(domain *limesresources.DomainReport, cluster *core.Clust
 	resourceReport, exists := serviceReport.Resources[apiIdentity.Name]
 	if !exists {
 		// we ignore when a resource can't be found in the app layer yet, it will appear with empty values
-		resource, _ := sis.GetResourceForTypeName(dbServiceType, dbResourceName)
+		resource, _ := sis.GetResourceForPath(db.ResourcePath{ServiceType: dbServiceType, ResourceName: dbResourceName})
 		resourceReport = &limesresources.DomainResourceReport{
 			ResourceInfo:     behavior.BuildAPIResourceInfo(apiIdentity.Name, resource),
 			CommitmentConfig: cluster.CommitmentBehaviorForResource(dbServiceType, dbResourceName).ForDomain(domain.Name).ForAPI(now).AsPointer(),

--- a/internal/reports/domain.go
+++ b/internal/reports/domain.go
@@ -76,7 +76,7 @@ var domainReportQuery4 = sqlext.SimplifyWhitespace(db.ExpandEnumPlaceholders(`
 
 // GetDomains returns reports for all domains in the given cluster or, if
 // domainID is non-nil, for that domain only.
-func GetDomains(cluster *core.Cluster, domainID *db.DomainID, now time.Time, dbi db.Interface, filter Filter, resources core.ResourcesByNameType) ([]*limesresources.DomainReport, error) {
+func GetDomains(cluster *core.Cluster, domainID *db.DomainID, now time.Time, dbi db.Interface, filter Filter, sis *core.ServiceInfoSnapshot) ([]*limesresources.DomainReport, error) {
 	var fields map[string]any
 	if domainID != nil {
 		fields = map[string]any{"d.id": *domainID}
@@ -151,11 +151,11 @@ func GetDomains(cluster *core.Cluster, domainID *db.DomainID, now time.Time, dbi
 		if !filter.Includes[dbServiceType][dbResourceName] {
 			return nil
 		}
-		serviceReport, resourceReport := findInDomainReport(domains[domainID], cluster, dbServiceType, dbResourceName, now, resources)
+		serviceReport, resourceReport := findInDomainReport(domains[domainID], cluster, dbServiceType, dbResourceName, now, sis)
 
 		if az == liquid.AvailabilityZoneTotal {
 			// we ignore when a resource can't be found in the app layer yet, it will appear with empty values
-			resource := resources[dbServiceType][dbResourceName]
+			resource, _ := sis.GetResourceForTypeName(dbServiceType, dbResourceName)
 			serviceReport.MaxScrapedAt = mergeMaxTime(serviceReport.MaxScrapedAt, maxScrapedAt)
 			serviceReport.MinScrapedAt = mergeMinTime(serviceReport.MinScrapedAt, minScrapedAt)
 
@@ -225,7 +225,7 @@ func GetDomains(cluster *core.Cluster, domainID *db.DomainID, now time.Time, dbi
 			if !filter.Includes[dbServiceType][dbResourceName] {
 				return nil
 			}
-			_, resourceReport := findInDomainReport(domains[domainID], cluster, dbServiceType, dbResourceName, now, resources)
+			_, resourceReport := findInDomainReport(domains[domainID], cluster, dbServiceType, dbResourceName, now, sis)
 
 			if resourceReport.PerAZ[az] == nil {
 				return nil
@@ -292,7 +292,7 @@ func GetDomains(cluster *core.Cluster, domainID *db.DomainID, now time.Time, dbi
 	return result, nil
 }
 
-func findInDomainReport(domain *limesresources.DomainReport, cluster *core.Cluster, dbServiceType db.ServiceType, dbResourceName liquid.ResourceName, now time.Time, resources core.ResourcesByNameType) (*limesresources.DomainServiceReport, *limesresources.DomainResourceReport) {
+func findInDomainReport(domain *limesresources.DomainReport, cluster *core.Cluster, dbServiceType db.ServiceType, dbResourceName liquid.ResourceName, now time.Time, sis *core.ServiceInfoSnapshot) (*limesresources.DomainServiceReport, *limesresources.DomainResourceReport) {
 	behavior := cluster.BehaviorForResource(dbServiceType, dbResourceName)
 	apiIdentity := behavior.IdentityInV1API
 
@@ -309,7 +309,7 @@ func findInDomainReport(domain *limesresources.DomainReport, cluster *core.Clust
 	resourceReport, exists := serviceReport.Resources[apiIdentity.Name]
 	if !exists {
 		// we ignore when a resource can't be found in the app layer yet, it will appear with empty values
-		resource := resources[dbServiceType][dbResourceName]
+		resource, _ := sis.GetResourceForTypeName(dbServiceType, dbResourceName)
 		resourceReport = &limesresources.DomainResourceReport{
 			ResourceInfo:     behavior.BuildAPIResourceInfo(apiIdentity.Name, resource),
 			CommitmentConfig: cluster.CommitmentBehaviorForResource(dbServiceType, dbResourceName).ForDomain(domain.Name).ForAPI(now).AsPointer(),

--- a/internal/reports/filter.go
+++ b/internal/reports/filter.go
@@ -34,7 +34,8 @@ type Filter struct {
 }
 
 // ReadFilter extracts a Filter from the given Request.
-func ReadFilter(r *http.Request, cluster *core.Cluster, resources core.ResourcesByNameType) Filter {
+func ReadFilter(r *http.Request, cluster *core.Cluster, sis *core.ServiceInfoSnapshot) Filter {
+	resources := sis.GetResources()
 	queryValues := r.URL.Query()
 	apiServiceTypes := apiFilter(queryValues["service"])
 	apiResourceNames := apiFilter(queryValues["resource"])

--- a/internal/reports/filter.go
+++ b/internal/reports/filter.go
@@ -34,7 +34,7 @@ type Filter struct {
 }
 
 // ReadFilter extracts a Filter from the given Request.
-func ReadFilter(r *http.Request, cluster *core.Cluster, sis *core.ServiceInfoSnapshot) Filter {
+func ReadFilter(r *http.Request, cluster *core.Cluster, sis core.ServiceInfoSnapshot) Filter {
 	resources := sis.GetResources()
 	queryValues := r.URL.Query()
 	apiServiceTypes := apiFilter(queryValues["service"])

--- a/internal/reports/inconsistency.go
+++ b/internal/reports/inconsistency.go
@@ -98,6 +98,7 @@ func GetInconsistencies(cluster *core.Cluster, dbi db.Interface, filter Filter, 
 			&ospq.Project.UUID, &ospq.Project.Name, &dbServiceType,
 			&dbResourceName, &ospq.Quota, &ospq.Usage,
 		)
+		path := db.ResourcePath{ServiceType: dbServiceType, ResourceName: dbResourceName}
 		if err != nil {
 			return err
 		}
@@ -109,7 +110,7 @@ func GetInconsistencies(cluster *core.Cluster, dbi db.Interface, filter Filter, 
 		}
 
 		// we ignore when a resource can't be found in the app layer yet, it will appear with default value
-		resource, _ := sis.GetResourceForTypeName(dbServiceType, dbResourceName)
+		resource, _ := sis.GetResourceForPath(path)
 		ospq.Unit = resource.Unit
 		inconsistencies.OverspentQuotas = append(inconsistencies.OverspentQuotas, ospq)
 
@@ -144,7 +145,7 @@ func GetInconsistencies(cluster *core.Cluster, dbi db.Interface, filter Filter, 
 		}
 
 		// we ignore when a resource can't be found in the app layer yet, it will appear with default value
-		resource, _ := sis.GetResourceForTypeName(dbServiceType, dbResourceName)
+		resource, _ := sis.GetResourceForPath(db.ResourcePath{ServiceType: dbServiceType, ResourceName: dbResourceName})
 		mmpq.Unit = resource.Unit
 		inconsistencies.MismatchQuotas = append(inconsistencies.MismatchQuotas, mmpq)
 

--- a/internal/reports/inconsistency.go
+++ b/internal/reports/inconsistency.go
@@ -72,7 +72,7 @@ var mmpqReportQuery = sqlext.SimplifyWhitespace(db.ExpandEnumPlaceholders(`
 `))
 
 // GetInconsistencies returns Inconsistency reports for all inconsistencies and their projects in the current cluster.
-func GetInconsistencies(cluster *core.Cluster, dbi db.Interface, filter Filter, resources core.ResourcesByNameType) (*Inconsistencies, error) {
+func GetInconsistencies(cluster *core.Cluster, dbi db.Interface, filter Filter, sis *core.ServiceInfoSnapshot) (*Inconsistencies, error) {
 	// Initialize inconsistencies as Inconsistencies type.
 	// The inconsistency data will be assigned in the respective SQL queries.
 	inconsistencies := Inconsistencies{
@@ -82,7 +82,7 @@ func GetInconsistencies(cluster *core.Cluster, dbi db.Interface, filter Filter, 
 		MismatchQuotas:      []MismatchProjectQuota{},
 	}
 
-	nm := core.BuildResourceNameMapping(cluster, resources)
+	nm := core.BuildResourceNameMapping(cluster, sis)
 
 	// ospqReportQuery: data for overspent project quota inconsistencies
 	queryStr, joinArgs := filter.PrepareQuery(ospqReportQuery)
@@ -109,7 +109,8 @@ func GetInconsistencies(cluster *core.Cluster, dbi db.Interface, filter Filter, 
 		}
 
 		// we ignore when a resource can't be found in the app layer yet, it will appear with default value
-		ospq.Unit = resources[dbServiceType][dbResourceName].Unit
+		resource, _ := sis.GetResourceForTypeName(dbServiceType, dbResourceName)
+		ospq.Unit = resource.Unit
 		inconsistencies.OverspentQuotas = append(inconsistencies.OverspentQuotas, ospq)
 
 		return nil
@@ -143,7 +144,8 @@ func GetInconsistencies(cluster *core.Cluster, dbi db.Interface, filter Filter, 
 		}
 
 		// we ignore when a resource can't be found in the app layer yet, it will appear with default value
-		mmpq.Unit = resources[dbServiceType][dbResourceName].Unit
+		resource, _ := sis.GetResourceForTypeName(dbServiceType, dbResourceName)
+		mmpq.Unit = resource.Unit
 		inconsistencies.MismatchQuotas = append(inconsistencies.MismatchQuotas, mmpq)
 
 		return nil

--- a/internal/reports/inconsistency.go
+++ b/internal/reports/inconsistency.go
@@ -72,7 +72,7 @@ var mmpqReportQuery = sqlext.SimplifyWhitespace(db.ExpandEnumPlaceholders(`
 `))
 
 // GetInconsistencies returns Inconsistency reports for all inconsistencies and their projects in the current cluster.
-func GetInconsistencies(cluster *core.Cluster, dbi db.Interface, filter Filter, sis *core.ServiceInfoSnapshot) (*Inconsistencies, error) {
+func GetInconsistencies(cluster *core.Cluster, dbi db.Interface, filter Filter, sis core.ServiceInfoSnapshot) (*Inconsistencies, error) {
 	// Initialize inconsistencies as Inconsistencies type.
 	// The inconsistency data will be assigned in the respective SQL queries.
 	inconsistencies := Inconsistencies{

--- a/internal/reports/project.go
+++ b/internal/reports/project.go
@@ -74,12 +74,12 @@ var (
 // reports with the highest detail levels can be several MB large, we don't just
 // return them all in a big list. Instead, the `submit` callback gets called
 // once for each project report once that report is complete.
-func GetProjectResources(cluster *core.Cluster, domain db.Domain, project *db.Project, now time.Time, dbi db.Interface, filter Filter, resources core.ResourcesByNameType, submit func(*limesresources.ProjectReport) error) error {
+func GetProjectResources(cluster *core.Cluster, domain db.Domain, project *db.Project, now time.Time, dbi db.Interface, filter Filter, sis *core.ServiceInfoSnapshot, submit func(*limesresources.ProjectReport) error) error {
 	fields := map[string]any{"p.domain_id": domain.ID}
 	if project != nil {
 		fields["p.id"] = project.ID
 	}
-	nm := core.BuildResourceNameMapping(cluster, resources)
+	nm := core.BuildResourceNameMapping(cluster, sis)
 
 	// first, query for basic project information
 	//
@@ -195,7 +195,7 @@ func GetProjectResources(cluster *core.Cluster, domain db.Domain, project *db.Pr
 		// start new resource report when necessary
 		resReport := srvReport.Resources[apiIdentity.Name]
 		// we ignore when a resource can't be found in the app layer yet, it will appear with empty values
-		resource := resources[dbServiceType][dbResourceName]
+		resource, _ := sis.GetResourceForTypeName(dbServiceType, dbResourceName)
 		if resReport == nil {
 			resReport = &limesresources.ProjectResourceReport{
 				ResourceInfo: behavior.BuildAPIResourceInfo(apiIdentity.Name, resource),
@@ -409,12 +409,12 @@ func finalizeProjectResourceReport(projectReport *limesresources.ProjectReport, 
 }
 
 // GetProjectRates works just like GetProjects, except that rate data is returned instead of resource data.
-func GetProjectRates(cluster *core.Cluster, domain db.Domain, project *db.Project, dbi db.Interface, filter Filter, rates core.RatesByNameType, submit func(*limesrates.ProjectReport) error) error {
+func GetProjectRates(cluster *core.Cluster, domain db.Domain, project *db.Project, dbi db.Interface, filter Filter, sis *core.ServiceInfoSnapshot, submit func(*limesrates.ProjectReport) error) error {
 	fields := map[string]any{"p.domain_id": domain.ID}
 	if project != nil {
 		fields["p.id"] = project.ID
 	}
-	nm := core.BuildRateNameMapping(cluster, rates)
+	nm := core.BuildRateNameMapping(cluster, sis)
 
 	// first, query for basic project information
 	//
@@ -484,11 +484,12 @@ func GetProjectRates(cluster *core.Cluster, domain db.Domain, project *db.Projec
 				currentProjectID = 0
 				return nil
 			}
-			projectReport = initProjectRateReport(projectInfo, cluster, nm, rates)
+			projectReport = initProjectRateReport(projectInfo, cluster, nm, sis)
 		}
 
-		// if we don't have a valid service type, we're done with this result row
-		if _, ok := rates[dbServiceType]; !ok {
+		// if we don't have a valid rate, we're done with this result row
+		rate, ok := sis.GetRateForTypeName(dbServiceType, dbRateName)
+		if !ok {
 			return nil
 		}
 		apiServiceType, apiRateName, exists := nm.MapToV1API(dbServiceType, dbRateName)
@@ -516,9 +517,8 @@ func GetProjectRates(cluster *core.Cluster, domain db.Domain, project *db.Projec
 		// one because of the default rate limit, so this is only relevant for
 		// rates that only have a usage)
 		rateReport := srvReport.Rates[apiRateName]
-		if rateReport == nil && usageAsBigint != nil && *usageAsBigint != "" && rates.HasUsageForRate(dbServiceType, dbRateName) {
+		if rateReport == nil && usageAsBigint != nil && *usageAsBigint != "" && rate.HasUsage {
 			// if we are in here, the rate has to exist
-			rate := rates[dbServiceType][dbRateName]
 			rateReport = &limesrates.ProjectRateReport{
 				RateInfo: core.BuildAPIRateInfo(apiRateName, rate.Unit),
 			}
@@ -559,7 +559,7 @@ func GetProjectRates(cluster *core.Cluster, domain db.Domain, project *db.Projec
 	// (e.g. because the request filter was for `?service=none`)
 	emptyProjectReports := make([]*limesrates.ProjectReport, 0, len(allProjectInfos))
 	for _, projectInfo := range allProjectInfos {
-		emptyProjectReports = append(emptyProjectReports, initProjectRateReport(projectInfo, cluster, nm, rates))
+		emptyProjectReports = append(emptyProjectReports, initProjectRateReport(projectInfo, cluster, nm, sis))
 	}
 	slices.SortFunc(emptyProjectReports, func(lhs, rhs *limesrates.ProjectReport) int {
 		return strings.Compare(lhs.UUID, rhs.UUID)
@@ -575,7 +575,7 @@ func GetProjectRates(cluster *core.Cluster, domain db.Domain, project *db.Projec
 }
 
 // Builds a fresh ProjectReport with default rate-limits pre-filled from the cluster config.
-func initProjectRateReport(projectInfo limes.ProjectInfo, cluster *core.Cluster, nm core.RateNameMapping, rates core.RatesByNameType) *limesrates.ProjectReport {
+func initProjectRateReport(projectInfo limes.ProjectInfo, cluster *core.Cluster, nm core.RateNameMapping, sis *core.ServiceInfoSnapshot) *limesrates.ProjectReport {
 	report := limesrates.ProjectReport{
 		ProjectInfo: projectInfo,
 		Services:    make(limesrates.ProjectServiceReports),
@@ -599,7 +599,7 @@ func initProjectRateReport(projectInfo limes.ProjectInfo, cluster *core.Cluster,
 			}
 
 			// we ignore when a rate can't be found in the app layer yet, it will appear with empty values
-			rate := rates[dbServiceType][rateLimitConfig.Name]
+			rate, _ := sis.GetRateForTypeName(dbServiceType, rateLimitConfig.Name)
 			srvReport.Rates[apiRateName] = &limesrates.ProjectRateReport{
 				RateInfo: core.BuildAPIRateInfo(apiRateName, rate.Unit),
 				Limit:    rateLimitConfig.Limit,

--- a/internal/reports/project.go
+++ b/internal/reports/project.go
@@ -195,7 +195,7 @@ func GetProjectResources(cluster *core.Cluster, domain db.Domain, project *db.Pr
 		// start new resource report when necessary
 		resReport := srvReport.Resources[apiIdentity.Name]
 		// we ignore when a resource can't be found in the app layer yet, it will appear with empty values
-		resource, _ := sis.GetResourceForTypeName(dbServiceType, dbResourceName)
+		resource, _ := sis.GetResourceForPath(db.ResourcePath{ServiceType: dbServiceType, ResourceName: dbResourceName})
 		if resReport == nil {
 			resReport = &limesresources.ProjectResourceReport{
 				ResourceInfo: behavior.BuildAPIResourceInfo(apiIdentity.Name, resource),
@@ -488,7 +488,7 @@ func GetProjectRates(cluster *core.Cluster, domain db.Domain, project *db.Projec
 		}
 
 		// if we don't have a valid rate, we're done with this result row
-		rate, ok := sis.GetRateForTypeName(dbServiceType, dbRateName)
+		rate, ok := sis.GetRateForPath(db.RatePath{ServiceType: dbServiceType, RateName: dbRateName})
 		if !ok {
 			return nil
 		}
@@ -599,7 +599,7 @@ func initProjectRateReport(projectInfo limes.ProjectInfo, cluster *core.Cluster,
 			}
 
 			// we ignore when a rate can't be found in the app layer yet, it will appear with empty values
-			rate, _ := sis.GetRateForTypeName(dbServiceType, rateLimitConfig.Name)
+			rate, _ := sis.GetRateForPath(db.RatePath{ServiceType: dbServiceType, RateName: rateLimitConfig.Name})
 			srvReport.Rates[apiRateName] = &limesrates.ProjectRateReport{
 				RateInfo: core.BuildAPIRateInfo(apiRateName, rate.Unit),
 				Limit:    rateLimitConfig.Limit,

--- a/internal/reports/project.go
+++ b/internal/reports/project.go
@@ -74,7 +74,7 @@ var (
 // reports with the highest detail levels can be several MB large, we don't just
 // return them all in a big list. Instead, the `submit` callback gets called
 // once for each project report once that report is complete.
-func GetProjectResources(cluster *core.Cluster, domain db.Domain, project *db.Project, now time.Time, dbi db.Interface, filter Filter, sis *core.ServiceInfoSnapshot, submit func(*limesresources.ProjectReport) error) error {
+func GetProjectResources(cluster *core.Cluster, domain db.Domain, project *db.Project, now time.Time, dbi db.Interface, filter Filter, sis core.ServiceInfoSnapshot, submit func(*limesresources.ProjectReport) error) error {
 	fields := map[string]any{"p.domain_id": domain.ID}
 	if project != nil {
 		fields["p.id"] = project.ID
@@ -409,7 +409,7 @@ func finalizeProjectResourceReport(projectReport *limesresources.ProjectReport, 
 }
 
 // GetProjectRates works just like GetProjects, except that rate data is returned instead of resource data.
-func GetProjectRates(cluster *core.Cluster, domain db.Domain, project *db.Project, dbi db.Interface, filter Filter, sis *core.ServiceInfoSnapshot, submit func(*limesrates.ProjectReport) error) error {
+func GetProjectRates(cluster *core.Cluster, domain db.Domain, project *db.Project, dbi db.Interface, filter Filter, sis core.ServiceInfoSnapshot, submit func(*limesrates.ProjectReport) error) error {
 	fields := map[string]any{"p.domain_id": domain.ID}
 	if project != nil {
 		fields["p.id"] = project.ID
@@ -575,7 +575,7 @@ func GetProjectRates(cluster *core.Cluster, domain db.Domain, project *db.Projec
 }
 
 // Builds a fresh ProjectReport with default rate-limits pre-filled from the cluster config.
-func initProjectRateReport(projectInfo limes.ProjectInfo, cluster *core.Cluster, nm core.RateNameMapping, sis *core.ServiceInfoSnapshot) *limesrates.ProjectReport {
+func initProjectRateReport(projectInfo limes.ProjectInfo, cluster *core.Cluster, nm core.RateNameMapping, sis core.ServiceInfoSnapshot) *limesrates.ProjectReport {
 	report := limesrates.ProjectReport{
 		ProjectInfo: projectInfo,
 		Services:    make(limesrates.ProjectServiceReports),


### PR DESCRIPTION
The idea of this PR is to introduce the `ServiceInfoSnapshot`, which is a coherent set of objects of types `db.Service, db.Resource, db.AZResource, db.Rate, db.Category`.
From this, a `FilteredServiceInfoSnapshot` can be built, which has the same method-set for access as `ServiceInfoSnapshot`, denoted by interface `ServiceInfoReader`.

This change solves 2 things:
* when accessing `ServiceInfoCache` in the past, the cache could have theoretically changed between calls to different entities. 
* When doing all the reporting for `/v2`, we can operate on a `FilteredServiceInfoSnapshot`, which we can directly build from query params.

I have a few questions:
* Do we want to pass `ServiceInfoSnapshot` as pointer like I did? I figured this would cause much less memory load...
* Do we want to reserve usage of `FilteredServiceInfoSnapshot` for cases, where we iterate the `services, resources, ....` etc. - which is mostly reports? When accessing individual objects, operating on a filtered version does not really make sense. I sometimes used the filtered version to express, that we evaluated certain contents are there (e.g. on `/commitment`), but this does not really benefit us, because when accessing the individual `service/resource`, the call-sites don't get shorter.
* bikeshedding of naming