### PR TITLE
v2 report types

### DIFF
--- a/internal/apideclarations/apiv2/common/objects.go
+++ b/internal/apideclarations/apiv2/common/objects.go
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+// DomainMetadata contains the metadata for a domain.
+// It appears in types [resourcesv2.DomainReport] and [ratesv2.DomainReport].
+type DomainMetadata struct {
+	// UUID is what OpenStack commonly refers to as domain_id.
+	UUID string `json:"uuid"`
+	Name string `json:"name"`
+}
+
+// ProjectMetadata contains the metadata for a project.
+// It appears in types [resourcesv2.ProjectReport] and [ratesv2.ProjectReport].
+type ProjectMetadata struct {
+	// UUID is what OpenStack commonly refers to as project_id.
+	UUID string `json:"uuid"`
+	Name string `json:"name"`
+	// The ParentUUID is the ID of the domain in case the project is not a subproject,
+	// else it is the UUID of another project. This hierarchy can have multiple levels.
+	ParentUUID string         `json:"parent_uuid"`
+	DomainInfo DomainMetadata `json:"domain"`
+}

--- a/internal/apideclarations/apiv2/common/opts.go
+++ b/internal/apideclarations/apiv2/common/opts.go
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"time"
+
+	"github.com/sapcc/go-api-declarations/liquid"
+	. "go.xyrillian.de/gg/option"
+
+	"github.com/sapcc/limes/internal/db"
+)
+
+// GenericReportOpts contains query parameter options shared between
+// resources and rates reports.
+// It appears in types ResourceReportOpts and RateReportOpts.
+type GenericReportOpts struct {
+	// Area is a grouping, used to filter for multiple services
+	Area Option[string] `q:"area"`
+	// ServiceType filters services by type
+	ServiceType Option[db.ServiceType] `q:"service"`
+	// Category is a grouping, used to filter for multiple resources or rates
+	Category Option[liquid.CategoryName] `q:"category"`
+	// enrich response with InfoReport
+	WithInfo bool `q:"with,value:info"`
+}
+
+// ResourceReportOpts contains query parameter options for resource reports.
+// It appears in types ClusterResourceReportOpts, DomainResourceReportOpts and ProjectResourceReportOpts.
+type ResourceReportOpts struct {
+	GenericReportOpts
+	// ResourceName filters resources by name
+	ResourceName Option[liquid.ResourceName] `q:"resource"`
+	// WithUserSpecifiedConstraints enriches the response with MaxQuota and ForbidAutogrowth values
+	WithUserSpecifiedConstraints bool `q:"with,value:constraints"`
+	// WithCommitmentStats enriches the response with Committed values
+	WithCommitmentStats bool `q:"with,value:commitment_stats"`
+	// MinScrapedAt and MaxScrapedAt allow to filter services by their latest successful scrape time
+	MinScrapedAt Option[time.Time] `q:"min_scraped_at"`
+	MaxScrapedAt Option[time.Time] `q:"max_scraped_at"`
+}
+
+// ClusterResourceReportOpts contains query parameter options for cluster
+// resource reports.
+type ClusterResourceReportOpts struct {
+	ResourceReportOpts
+	// WithTiming enriches the response with ScrapedAt values
+	WithTiming bool `q:"with,value:timing"`
+	// WithSubcapacities enriches the response with Subcapacities values which is only allowed for users with certain permissions
+	WithSubcapacities bool `q:"with,value:subcapacities"`
+}
+
+// DomainResourceReportOpts contains query parameter options for domain
+// resource reports.
+type DomainResourceReportOpts struct {
+	ResourceReportOpts
+}
+
+// ProjectResourceReportOpts contains query parameter options for project
+// resource reports.
+type ProjectResourceReportOpts struct {
+	ResourceReportOpts
+	// WithTiming enriches the response with ScrapedAt values which is only allowed for users with certain permissions
+	WithTiming bool `q:"with,value:timing"`
+	// WithSubresources enriches the response with Subresources values which is only allowed for users with certain permissions
+	WithSubresources bool `q:"with,value:subresources"`
+	// DomainUUID is a special entity filter which is only allowed for users with certain permissions
+	DomainUUID Option[string] `q:"domain_uuid"`
+}
+
+// RateReportOpts contains query parameter options for rate reports.
+// It appears in type ClusterRateReportOpts, DomainRateReportOpts and ProjectRateReportOpts.
+type RateReportOpts struct {
+	GenericReportOpts
+	// RateName filters rates by name
+	RateName Option[liquid.RateName] `q:"rate"`
+}
+
+// ClusterRateReportOpts contains query parameter options for cluster
+// rate reports.
+type ClusterRateReportOpts struct {
+	RateReportOpts
+}
+
+// DomainRateReportOpts contains query parameter options for domain
+// rate reports.
+type DomainRateReportOpts struct {
+	RateReportOpts
+}
+
+// ProjectRateReportOpts contains query parameter options for project
+// rate reports.
+type ProjectRateReportOpts struct {
+	RateReportOpts
+	// WithTiming enriches the response with ScrapedAt values which is only allowed for users with certain permissions
+	WithTiming bool `q:"with,value:timing"`
+	// DomainUUID is a special entity filter which is only allowed for users with certain permissions
+	DomainUUID Option[string] `q:"domain_uuid"`
+}

--- a/internal/apideclarations/apiv2/doc.go
+++ b/internal/apideclarations/apiv2/doc.go
@@ -43,15 +43,25 @@
 //
 // # Endpoint: GET /resources/v2/cluster
 //
-// TODO: fill when implemented
+// Returns the latest state of all dynamic resource data for the whole cluster.
+// This path is only available to users with cloud-admin token.
+//   - On success, the response body payload will be of type [resourcesv2.ClusterGetResponse].
 //
-// # Endpoint: GET /resources/v2/domains(/:domain_id)?
+// # Endpoint: GET /resources/v2/domains(/:domain_uuid)?
 //
-// TODO: fill when implemented
+// Returns the latest state of all dynamic resource data for one or many domains.
+// A project-scoped token cannot access this path.
+// A domain-scoped token can only access this path, if its domain_uuid is set in the URL parameter.
+// A cloud-admin token can receive data for requests with and without domain_uuid.
+//   - On success, the response body payload will be of type [resourcesv2.DomainGetResponse].
 //
-// # Endpoint: GET /resources/v2/projects(/:project_id)?
+// # Endpoint: GET /resources/v2/projects(/:project_uuid)?
 //
-// TODO: fill when implemented
+// Returns the latest state of all dynamic resource data for one or many projects.
+// A project-scoped token can only access this path, if its project_uuid is set in the URL parameter.
+// A domain-scoped token can only access this path, if a project_uuid from its domain is set in the URL parameter or when a domain_uuid query parameter is set.
+// A cloud-admin token can receive data for requests with and without project_uuid/ domain_uuid.
+//   - On success, the response body payload will be of type [resourcesv2.ProjectGetResponse].
 //
 // # Endpoint: GET /resources/v2/availability
 //
@@ -67,15 +77,25 @@
 //
 // # Endpoint: GET /rates/v2/cluster
 //
-// TODO: fill when implemented
+// Returns the latest state of all dynamic rate data for the whole cluster.
+// This path is only available to users with cloud-admin token.
+//   - On success, the response body payload will be of type [ratesv2.ClusterGetResponse].
 //
-// # Endpoint: GET /rates/v2/domains(/:domain_id)?
+// # Endpoint: GET /rates/v2/domains(/:domain_uuid)?
 //
-// TODO: fill when implemented
+// Returns the latest state of all dynamic rate data for one or many domains.
+// A project-scoped token cannot access this path.
+// A domain-scoped token can only access this path, if its domain_uuid is set in the URL parameter.
+// A cloud-admin token can receive data for requests with and without domain_uuid.
+//   - On success, the response body payload will be of type [ratesv2.DomainGetResponse].
 //
-// # Endpoint: GET /rates/v2/projects(/:project_id)?
+// # Endpoint: GET /rates/v2/projects(/:project_uuid)?
 //
-// TODO: fill when implemented
+// Returns the latest state of all dynamic rate data for one or many projects.
+// A project-scoped token can only access this path, if its project_uuid is set in the URL parameter.
+// A domain-scoped token can only access this path, if a project_uuid from its domain is set in the URL parameter or when a domain_uuid query parameter is set.
+// A cloud-admin token can receive data for requests with and without project_uuid/ domain_uuid.
+//   - On success, the response body payload will be of type [ratesv2.ProjectGetResponse].
 //
 // [Keystone token]: https://docs.openstack.org/api-ref/identity/v3/index.html#password-authentication-with-scoped-authorization
 // [Limes]: https://github.com/sapcc/limes

--- a/internal/apideclarations/apiv2/rates/cluster.go
+++ b/internal/apideclarations/apiv2/rates/cluster.go
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package ratesv2
+
+import (
+	"github.com/sapcc/go-api-declarations/liquid"
+	. "go.xyrillian.de/gg/option"
+
+	"github.com/sapcc/limes/internal/db"
+)
+
+// ClusterGetResponse is the response type for GET /rates/v2/cluster.
+// It contains the latest state of all dynamic rate data for the whole cluster.
+// This can only contain summed data from project level.
+type ClusterGetResponse struct {
+	// InfoReport is what GET /rates/v2/info would report.
+	// It is only returned when the respective query option with=info is set.
+	InfoReport    Option[InfoReport] `json:"info,omitzero"`
+	ClusterReport ClusterReport      `json:"cluster_report"`
+}
+
+// ClusterReport groups services of the whole cluster into areas,
+// which are defined in the config.
+// It appears in [ClusterGetResponse].
+type ClusterReport struct {
+	Areas map[string]ClusterAreaReport `json:"service_areas"`
+}
+
+// ClusterAreaReport contains data for one area.
+// It appears in [ClusterReport].
+type ClusterAreaReport struct {
+	Services map[db.ServiceType]ClusterServiceReport `json:"services"`
+}
+
+// ClusterServiceReport contains data for one service.
+// It appears in [ClusterAreaReport].
+type ClusterServiceReport struct {
+	Categories map[liquid.CategoryName]ClusterCategoryReport `json:"categories"`
+}
+
+// ClusterCategoryReport groups rates into categories, which are defined in the config.
+// It appears in [ClusterServiceReport].
+type ClusterCategoryReport struct {
+	Rates map[liquid.RateName]ClusterRateReport `json:"rates"`
+}
+
+// ClusterRateReport contains data for one rate.
+// It appears in [ClusterCategoryReport].
+type ClusterRateReport struct {
+	// UsageAsBigint is a big.Int that has to be serialized as string.
+	// If the rate does not report usage, the rate is omitted from the ClusterCategoryReport.Rates map.
+	UsageAsBigint string `json:"usage_as_bigint"`
+}

--- a/internal/apideclarations/apiv2/rates/domain.go
+++ b/internal/apideclarations/apiv2/rates/domain.go
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package ratesv2
+
+import (
+	"github.com/sapcc/go-api-declarations/liquid"
+
+	"github.com/sapcc/limes/internal/apideclarations/apiv2/common"
+	"github.com/sapcc/limes/internal/db"
+
+	. "go.xyrillian.de/gg/option"
+)
+
+// DomainGetResponse is the response type for GET /rates/v2/domains(/:domain_uuid)?.
+// It contains the latest state of all dynamic rate data for one or many domains.
+// This can only contain summed data from project level.
+type DomainGetResponse struct {
+	// InfoReport is what GET /rates/v2/info would report.
+	// It is only returned when the respective query option with=info is set.
+	InfoReport    Option[InfoReport]      `json:"info,omitzero"`
+	DomainReports map[string]DomainReport `json:"domains"`
+}
+
+// DomainReport groups all services for one domain into areas,
+// which are defined in the config.
+// It appears in [DomainGetResponse].
+type DomainReport struct {
+	common.DomainMetadata
+	Areas map[string]DomainAreaReport `json:"service_areas"`
+}
+
+// DomainAreaReport contains data for one area.
+// It appears in [DomainReport].
+type DomainAreaReport struct {
+	Services map[db.ServiceType]DomainServiceReport `json:"services"`
+}
+
+// DomainServiceReport contains data for one service.
+// It appears in [DomainAreaReport].
+type DomainServiceReport struct {
+	Categories map[liquid.CategoryName]DomainCategoryReport `json:"categories"`
+}
+
+// DomainCategoryReport groups rates into categories, which are defined in the config.
+// It appears in [DomainServiceReport].
+type DomainCategoryReport struct {
+	Rates map[liquid.RateName]DomainRateReport `json:"rates"`
+}
+
+// DomainRateReport contains data for one rate.
+// It appears in [DomainCategoryReport].
+type DomainRateReport struct {
+	// UsageAsBigint is a big.Int that has to be serialized as string.
+	// If the rate does not report usage, the rate is omitted from the DomainCategoryReport.Rates map.
+	UsageAsBigint string `json:"usage_as_bigint"`
+}

--- a/internal/apideclarations/apiv2/rates/info.go
+++ b/internal/apideclarations/apiv2/rates/info.go
@@ -49,7 +49,7 @@ type CategoryInfoReport struct {
 }
 
 // RateInfoReport contains details about a rate.
-// It appears in [ServiceInfoReport].
+// It appears in [CategoryInfoReport].
 type RateInfoReport struct {
 	DisplayName          string                    `json:"display_name"`
 	Unit                 liquid.Unit               `json:"unit,omitzero"`

--- a/internal/apideclarations/apiv2/rates/project.go
+++ b/internal/apideclarations/apiv2/rates/project.go
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package ratesv2
+
+import (
+	"github.com/sapcc/go-api-declarations/limes"
+	limesrates "github.com/sapcc/go-api-declarations/limes/rates"
+	"github.com/sapcc/go-api-declarations/liquid"
+
+	"github.com/sapcc/limes/internal/apideclarations/apiv2/common"
+	"github.com/sapcc/limes/internal/db"
+
+	. "go.xyrillian.de/gg/option"
+)
+
+// ProjectGetResponse is the response type for GET /rates/v2/projects(/:project_uuid)?.
+// It contains the latest state of all dynamic rate data for one or many projects.
+// The data comes directly from the project level.
+type ProjectGetResponse struct {
+	// InfoReport is what GET /rates/v2/info would report.
+	// It is only returned when the respective query option with=info is set.
+	InfoReport    Option[InfoReport]                `json:"info,omitzero"`
+	DomainReports map[string]ProjectsByDomainReport `json:"domains"`
+}
+
+// ProjectsByDomainReport groups all projects for one domain.
+// It appears in [ProjectGetResponse].
+type ProjectsByDomainReport struct {
+	ProjectReports map[string]ProjectReport `json:"projects"`
+}
+
+// ProjectReport groups all services for one project into areas,
+// which are defined in the config.
+// It appears in [ProjectGetResponse].
+type ProjectReport struct {
+	common.ProjectMetadata
+	Areas map[string]ProjectAreaReport `json:"service_areas"`
+}
+
+// ProjectAreaReport contains data for one area.
+// It appears in [ProjectReport].
+type ProjectAreaReport struct {
+	Services map[db.ServiceType]ProjectServiceReport `json:"services"`
+}
+
+// ProjectServiceReport contains data for one service.
+// It appears in [ProjectAreaReport].
+type ProjectServiceReport struct {
+	// ScrapedAt is the most recent time at which usage data for this service within this
+	// project was successfully collected from the backend, or None if no usage data has been collected yet.
+	// It is only returned when the respective query option with=timing is set.
+	ScrapedAt  Option[limes.UnixEncodedTime]                 `json:"scraped_at,omitzero"`
+	Categories map[liquid.CategoryName]ProjectCategoryReport `json:"categories"`
+}
+
+// ProjectCategoryReport groups rates into categories, which are defined in the config.
+// It appears in [ProjectServiceReport].
+type ProjectCategoryReport struct {
+	Rates map[liquid.RateName]ProjectRateReport `json:"rates"`
+}
+
+// ProjectRateReport contains data for one rate.
+// It appears in [ProjectCategoryReport].
+type ProjectRateReport struct {
+	// UsageAsBigint is a big.Int that has to be serialized as string.
+	// If the rate does not report usage and has no ProjectLimit, the rate is omitted from the ProjectCategoryReport.Rates map.
+	// If the rate does not report usage and has a ProjectLimit, this will be None.
+	UsageAsBigint Option[string] `json:"usage_as_bigint,omitzero"`
+	// ProjectLimit and ProjectWindow can be set by a project admin.
+	// If the rate does not have a local project rate limit, this will be None.
+	ProjectLimit  Option[uint64]            `json:"project_limit,omitzero"`
+	ProjectWindow Option[limesrates.Window] `json:"project_window,omitzero"`
+}

--- a/internal/apideclarations/apiv2/resources/cluster.go
+++ b/internal/apideclarations/apiv2/resources/cluster.go
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcesv2
+
+import (
+	"encoding/json"
+
+	"github.com/sapcc/go-api-declarations/limes"
+	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
+	"github.com/sapcc/go-api-declarations/liquid"
+	. "go.xyrillian.de/gg/option"
+
+	"github.com/sapcc/limes/internal/db"
+)
+
+// ClusterGetResponse is the response type for GET /resources/v2/cluster.
+// It contains the latest state of all dynamic resource data for the whole cluster.
+// This can contain summed data from project level or data only available on cluster level.
+type ClusterGetResponse struct {
+	// InfoReport is what GET /resources/v2/info would report.
+	// It is only returned when the respective query option with=info is set.
+	InfoReport    Option[InfoReport] `json:"info,omitzero"`
+	ClusterReport ClusterReport      `json:"cluster_report"`
+}
+
+// ClusterReport groups services of the whole cluster into areas,
+// which are defined in the config.
+// It appears in [ClusterGetResponse].
+type ClusterReport struct {
+	Areas map[string]ClusterAreaReport `json:"service_areas"`
+}
+
+// ClusterAreaReport contains data for one area.
+// It appears in [ClusterReport].
+type ClusterAreaReport struct {
+	Services map[db.ServiceType]ClusterServiceReport `json:"services"`
+}
+
+// ClusterServiceReport contains data for one service.
+// It appears in [ClusterAreaReport].
+type ClusterServiceReport struct {
+	// ScrapedAt is the most recent time at which capacity and usage data for this service within this
+	// cluster was successfully collected from the backend, or None if no usage data has been collected yet.
+	// It is only returned when the respective query option with=timing is set.
+	ScrapedAt  Option[limes.UnixEncodedTime]                 `json:"scraped_at,omitzero"`
+	Categories map[liquid.CategoryName]ClusterCategoryReport `json:"categories"`
+}
+
+// ClusterCategoryReport groups resources into categories, which are defined in the config.
+// It appears in [ClusterServiceReport].
+type ClusterCategoryReport struct {
+	Resources map[liquid.ResourceName]ClusterResourceReport `json:"resources"`
+}
+
+// ClusterResourceReport contains data for one resource.
+// It appears in [ClusterCategoryReport].
+type ClusterResourceReport struct {
+	// TODO: note which AZs can surface here, depending on topology and various scenarios.
+	AvailabilityZones map[limes.AvailabilityZone]ClusterAvailabilityZoneReport `json:"availability_zones"`
+}
+
+// ClusterAvailabilityZoneReport contains the data for an availability zone.
+// It appears in [ClusterResourceReport].
+type ClusterAvailabilityZoneReport struct {
+	// Capacity is what Limes considers the usable amount of this resource.
+	// It is calculated as RawCapacity*OvercommitFactor, where OvercommitFactor=1 when not configured.
+	Capacity uint64 `json:"capacity"`
+	// RawCapacity is what the service reports as capacity for this resource.
+	RawCapacity uint64 `json:"raw_capacity"`
+	// OverallUsage is what the service reports as overall usage, including usages that cannot be attributed to
+	// OpenStack-projects (like management workload). This is only shown if the backend does report this figure.
+	OverallUsage Option[uint64] `json:"overall_usage,omitzero"`
+	// Usage is the sum of the usages across all projects as reported by the service.
+	Usage uint64 `json:"usage"`
+	// Committed is the sum of committed amounts across all projects grouped by their Status and then CommitmentDuration.
+	// It is only returned when the respective query option with=commitment_stats is set.
+	Committed map[liquid.CommitmentStatus]map[limesresources.CommitmentDuration]uint64 `json:"committed,omitempty"`
+	// CommittedConfirmedUnutilized is the sum of CommittedConfirmed - Usage for each project in this cluster.
+	// If computed as sum of CommittedConfirmed - sum of Usage, the result is semantically wrong (commitments cannot cover other projects).
+	// It is only returned when the respective query option with=commitment_stats is set.
+	CommittedConfirmedUnutilized Option[uint64] `json:"committed_confirmed_unutilized,omitzero"`
+	// UncommittedUsage can also be derived as sum of Usage - (Committed.Values().Sum() - CommittedConfirmedUnutilized).
+	// so this is only reported for convenience purposes.
+	// It is only returned when the respective query option with=commitment_stats is set.
+	UncommittedUsage Option[uint64] `json:"uncommitted_usage,omitzero"`
+	// PhysicalUsage is collected per project and then summed, same as Usage.
+	PhysicalUsage Option[uint64] `json:"physical_usage,omitzero"`
+	// Subcapacities is formatted as json.RawMessage for convenience for reading from the database.
+	// The content will be a marshalled []liquid.Subcapacity.
+	// It is only returned when the respective query option with=subcapacities is set.
+	Subcapacities json.RawMessage `json:"subcapacities,omitempty"`
+}

--- a/internal/apideclarations/apiv2/resources/domain.go
+++ b/internal/apideclarations/apiv2/resources/domain.go
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcesv2
+
+import (
+	"github.com/sapcc/go-api-declarations/limes"
+	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
+	"github.com/sapcc/go-api-declarations/liquid"
+
+	"github.com/sapcc/limes/internal/apideclarations/apiv2/common"
+	"github.com/sapcc/limes/internal/db"
+
+	. "go.xyrillian.de/gg/option"
+)
+
+// DomainGetResponse is the response type for GET /resources/v2/domains(/:domain_uuid)?.
+// It contains the latest state of all dynamic resource data for one or many domains.
+// This can only contain summed data from project level.
+type DomainGetResponse struct {
+	// InfoReport is what GET /resources/v2/info would report.
+	// It is only returned when the respective query option with=info is set.
+	InfoReport    Option[InfoReport]      `json:"info,omitzero"`
+	DomainReports map[string]DomainReport `json:"domains"`
+}
+
+// DomainReport groups all services for one domain into areas,
+// which are defined in the config.
+// It appears in [DomainGetResponse].
+type DomainReport struct {
+	common.DomainMetadata
+	Areas map[string]DomainAreaReport `json:"service_areas"`
+}
+
+// DomainAreaReport contains data for one area.
+// It appears in [DomainReport].
+type DomainAreaReport struct {
+	Services map[db.ServiceType]DomainServiceReport `json:"services"`
+}
+
+// DomainServiceReport contains data for one service.
+// It appears in [DomainAreaReport].
+type DomainServiceReport struct {
+	Categories map[liquid.CategoryName]DomainCategoryReport `json:"categories"`
+}
+
+// DomainCategoryReport groups resources into categories, which are defined in the config.
+// It appears in [DomainServiceReport].
+type DomainCategoryReport struct {
+	Resources map[liquid.ResourceName]DomainResourceReport `json:"resources"`
+}
+
+// DomainResourceReport contains data for one resource.
+// It appears in [DomainCategoryReport].
+type DomainResourceReport struct {
+	// TODO: note which AZs can surface here, depending on topology and various scenarios.
+	AvailabilityZones map[limes.AvailabilityZone]DomainAvailabilityZoneReport `json:"availability_zones"`
+}
+
+// DomainAvailabilityZoneReport contains the data for an availability zone.
+// It appears in [DomainResourceReport].
+type DomainAvailabilityZoneReport struct {
+	// Usage is the sum of the usages across projects in this domain as reported by the service.
+	Usage uint64 `json:"usage"`
+	// Committed is the sum of committed amounts across projects in this domain grouped by their Status and then CommitmentDuration.
+	// It is only returned when the respective query option with=commitment_stats is set.
+	Committed map[liquid.CommitmentStatus]map[limesresources.CommitmentDuration]uint64 `json:"committed,omitempty"`
+	// CommittedConfirmedUnutilized is the sum of CommittedConfirmed - Usage for each project in this domain.
+	// If computed as sum of CommittedConfirmed - sum of Usage, the result is semantically wrong (commitments cannot cover other projects).
+	// It is only returned when the respective query option with=commitment_stats is set.
+	CommittedConfirmedUnutilized Option[uint64] `json:"committed_confirmed_unutilized,omitzero"`
+	// UncommittedUsage can also be derived as sum of Usage - (Committed.Values().Sum() - CommittedConfirmedUnutilized).
+	// so this is only reported for convenience purposes.
+	// It is only returned when the respective query option with=commitment_stats is set.
+	UncommittedUsage Option[uint64] `json:"uncommitted_usage,omitzero"`
+	// PhysicalUsage is collected per project and then summed, same as Usage.
+	PhysicalUsage Option[uint64] `json:"physical_usage,omitzero"`
+}

--- a/internal/apideclarations/apiv2/resources/project.go
+++ b/internal/apideclarations/apiv2/resources/project.go
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcesv2
+
+import (
+	"encoding/json"
+
+	"github.com/sapcc/go-api-declarations/limes"
+	limesrates "github.com/sapcc/go-api-declarations/limes/rates"
+	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
+	"github.com/sapcc/go-api-declarations/liquid"
+
+	"github.com/sapcc/limes/internal/apideclarations/apiv2/common"
+	"github.com/sapcc/limes/internal/db"
+
+	. "go.xyrillian.de/gg/option"
+)
+
+// ProjectGetResponse is the response type for GET /resources/v2/projects(/:project_uuid)?.
+// It contains the latest state of all dynamic resource data for one or many projects.
+// The data comes directly from the project level.
+type ProjectGetResponse struct {
+	// InfoReport is what GET /resources/v2/info would report.
+	// It is only returned when the respective query option with=info is set.
+	InfoReport    Option[InfoReport]                `json:"info,omitzero"`
+	DomainReports map[string]ProjectsByDomainReport `json:"domains"`
+}
+
+// ProjectsByDomainReport groups all projects for one domain.
+// It appears in [ProjectGetResponse].
+type ProjectsByDomainReport struct {
+	ProjectReports map[string]ProjectReport `json:"projects"`
+}
+
+// ProjectReport groups all services for one project into areas,
+// which are defined in the config.
+// It appears in [ProjectGetResponse].
+type ProjectReport struct {
+	common.ProjectMetadata
+	Areas map[string]ProjectAreaReport `json:"service_areas"`
+}
+
+// ProjectAreaReport contains data for one area.
+// It appears in [ProjectReport].
+type ProjectAreaReport struct {
+	Services map[db.ServiceType]ProjectServiceReport `json:"services"`
+}
+
+// ProjectServiceReport contains data for one service.
+// It appears in [ProjectAreaReport].
+type ProjectServiceReport struct {
+	// ScrapedAt is the most recent time at which usage data for this service within this
+	// project was successfully collected from the backend, or None if no usage data has been collected yet.
+	// It is only returned when the respective query option with=timing is set.
+	ScrapedAt  Option[limes.UnixEncodedTime]                 `json:"scraped_at,omitzero"`
+	Categories map[liquid.CategoryName]ProjectCategoryReport `json:"categories"`
+}
+
+// ProjectCategoryReport groups resources into categories, which are defined in the config.
+// It appears in [ProjectServiceReport].
+type ProjectCategoryReport struct {
+	Resources map[liquid.ResourceName]ProjectResourceReport `json:"resources"`
+}
+
+// ProjectResourceReport contains data for one resource.
+// It appears in [ProjectCategoryReport].
+type ProjectResourceReport struct {
+	// TODO: note which AZs can surface here, depending on topology and various scenarios.
+	AvailabilityZones map[limes.AvailabilityZone]ProjectAvailabilityZoneReport `json:"availability_zones"`
+	// MaxQuota and ForbidAutogrowth can be set by a project admin.
+	// They are only returned when the respective query option with=constraints is set.
+	MaxQuota         Option[uint64] `json:"max_quota,omitzero"`
+	ForbidAutogrowth Option[bool]   `json:"forbid_autogrowth,omitzero"`
+}
+
+// ProjectAvailabilityZoneReport contains the data for an availability zone.
+// It appears in [ProjectResourceReport].
+type ProjectAvailabilityZoneReport struct {
+	// Usage is the usage in this project as reported by the service.
+	Usage uint64 `json:"usage"`
+	// Quota is the quota value which was calculated in Limes for this availability zone.
+	// It might differ to the value set in the service, when the backend of the service was not yet updated.
+	// It is only returned when the resource has quota.
+	Quota Option[uint64] `json:"quota,omitzero"`
+	// Committed is the sum of committed amounts grouped by their Status and then CommitmentDuration.
+	// It is only returned when the respective query option with=commitment_stats is set.
+	Committed map[liquid.CommitmentStatus]map[limesresources.CommitmentDuration]uint64 `json:"committed,omitempty"`
+	// PhysicalUsage is usage of physical hardware resources which results from the Usage.
+	// It is only returned when the service reports it.
+	PhysicalUsage Option[uint64] `json:"physical_usage,omitzero"`
+	// HistoricalUsage are the statistics on which the automatic quota distribution is based on.
+	// It is only returned when automatic quota distribution is configured for this resource.
+	HistoricalUsage Option[ProjectHistoricalReport] `json:"historical_usage,omitzero"`
+	// Subresources is formatted as json.RawMessage for convenience for reading from the database.
+	// The content will be a marshalled []liquid.Subresource.
+	// It is only returned when the respective query option with=subresources is set.
+	Subresources json.RawMessage `json:"subresources,omitempty"`
+}
+
+// ProjectHistoricalReport contains historical summed data for an availability zone.
+// It appears in [ProjectAvailabilityZoneReport].
+type ProjectHistoricalReport struct {
+	MinUsage uint64            `json:"min_usage"`
+	MaxUsage uint64            `json:"max_usage"`
+	Duration limesrates.Window `json:"duration"`
+}


### PR DESCRIPTION
I figured to make development easier and break down the PRs, we should have a discussion about the rough typing first, so that we can spot any major problems before I am too deep in the implementation.

Some specific questions of mine are:
* Do we want to nest `opts` like I did? It's easier to read for the API consumers if we copy-paste the params around, but it's much longer...
* For the report structure, I currently have it so that `cluster` has no level for the cluster itself anymore (because Limes dropped support for multiple clusters) which `domains` and `projects` reports can have multiple. What do you think about the nesting? I was unsure whether we want the projects/domains to be a map, also (made them an array right now). In the array setup, I have the `domain_info` for projects as named nested struct. Please give feedback on that.
* I was unsure about the placement of quota properties depending on the `topology` on `ProjectResourceReport` and its childs. Please check whether this is fine. 
* Do we mention about the special `AvailabilityZoneAny, AvailabilityZoneUnknown` in the respective cases when they can appear?
* I saw in the old world, we don't summed rate reports on domain + cluster level, most likely because we store the values as string. We would have to do the summing on application layer. I think it would be good to have the endpoints available, but I can also drop them?