### PR TITLE
bump gg to v1.10.1, replace go-bits/assert with gg/assert

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/sapcc/go-api-declarations v1.24.0
 	github.com/sapcc/go-bits v0.0.0-20260618170412-b440edfb4e25
 	github.com/sergi/go-diff v1.4.0
-	go.xyrillian.de/gg v1.9.1
+	go.xyrillian.de/gg v1.10.1
 	go.xyrillian.de/schwift/v2 v2.1.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -183,8 +183,8 @@ go.opentelemetry.io/otel/trace v1.37.0 h1:HLdcFNbRQBE2imdSEgm/kwqmQj1Or1l/7bW6mx
 go.opentelemetry.io/otel/trace v1.37.0/go.mod h1:TlgrlQ+PtQO5XFerSPUYG0JSgGyryXewPGyayAWSBS0=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
-go.xyrillian.de/gg v1.9.1 h1:PzB9Dn6YQmDu5pkJCEcncnCS1ddJ/fVqzMqwLBdjuOQ=
-go.xyrillian.de/gg v1.9.1/go.mod h1:dj+ZhCwC6JKWyFvImhVNXQAErrRcYMUkXu6vwWYNrzQ=
+go.xyrillian.de/gg v1.10.1 h1:V6oSU+tl25vaRQaMy6Y3jl/0kNoY/a25x4WIk5zQFAw=
+go.xyrillian.de/gg v1.10.1/go.mod h1:DoO4fQSWIrBRlNlCjVyrYM0kAEBt/Jg2GkMH+cGRZ0k=
 go.xyrillian.de/schwift/v2 v2.1.0 h1:KEnEJTdUbCXnoESUK/waaEiegXQs+L7WZquHOgbrGZw=
 go.xyrillian.de/schwift/v2 v2.1.0/go.mod h1:05JqPAQQzeRTPJtpUD7NciJpjpDhS57/MDEMrH5SJy0=
 go.yaml.in/yaml/v2 v2.4.4 h1:tuyd0P+2Ont/d6e2rl3be67goVK4R6deVxCUX5vyPaQ=

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -21,10 +21,10 @@ import (
 	limesrates "github.com/sapcc/go-api-declarations/limes/rates"
 	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
 	"github.com/sapcc/go-api-declarations/liquid"
-	"github.com/sapcc/go-bits/assert"
 	"github.com/sapcc/go-bits/easypg"
 	"github.com/sapcc/go-bits/must"
 	"github.com/sapcc/go-bits/sqlext"
+	"go.xyrillian.de/gg/assert"
 	. "go.xyrillian.de/gg/option"
 
 	"github.com/sapcc/limes/internal/collector"
@@ -903,7 +903,7 @@ func expectStaleProjectServices(t *testing.T, dbm *gorp.DbMap, pairs ...string) 
 		actualPairs = append(actualPairs, fmt.Sprintf("%s:%s", projectName, string(serviceType)))
 		return nil
 	}))
-	assert.DeepEqual(t, "stale project services", actualPairs, pairs)
+	assert.Equal(t, actualPairs, pairs)
 }
 
 func Test_EmptyProjectList(t *testing.T) {
@@ -1435,83 +1435,83 @@ func TestResourceRenaming(t *testing.T) {
 	expect := func(query string, expectedDurations ...string) {
 		t.Helper()
 
-		////// project level
+		t.Run("scope=project,query="+query, func(t *testing.T) {
+			var projectData struct {
+				Report limesresources.ProjectReport `json:"project"`
+			}
+			oldassert.HTTPRequest{
+				Method:       "GET",
+				Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin" + query,
+				ExpectStatus: 200,
+				ExpectBody:   JSONThatUnmarshalsInto{Value: &projectData},
+			}.Check(t, s.Handler)
 
-		var projectData struct {
-			Report limesresources.ProjectReport `json:"project"`
-		}
-		oldassert.HTTPRequest{
-			Method:       "GET",
-			Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin" + query,
-			ExpectStatus: 200,
-			ExpectBody:   JSONThatUnmarshalsInto{Value: &projectData},
-		}.Check(t, s.Handler)
-
-		var actualDurationsInProject []string
-		for serviceType, serviceReport := range projectData.Report.Services {
-			for resourceName, resourceReport := range serviceReport.Resources {
-				if resourceReport.CommitmentConfig != nil {
-					for _, duration := range resourceReport.CommitmentConfig.Durations {
-						msg := fmt.Sprintf("%s: %s/%s", duration.String(), serviceType, resourceName)
-						actualDurationsInProject = append(actualDurationsInProject, msg)
+			var actualDurationsInProject []string
+			for serviceType, serviceReport := range projectData.Report.Services {
+				for resourceName, resourceReport := range serviceReport.Resources {
+					if resourceReport.CommitmentConfig != nil {
+						for _, duration := range resourceReport.CommitmentConfig.Durations {
+							msg := fmt.Sprintf("%s: %s/%s", duration.String(), serviceType, resourceName)
+							actualDurationsInProject = append(actualDurationsInProject, msg)
+						}
 					}
 				}
 			}
-		}
-		sort.Strings(actualDurationsInProject)
-		assert.DeepEqual(t, "durations on project level with query "+query, actualDurationsInProject, expectedDurations)
+			sort.Strings(actualDurationsInProject)
+			assert.Equal(t, actualDurationsInProject, expectedDurations)
+		})
 
-		////// domain level
+		t.Run("scope=domain,query="+query, func(t *testing.T) {
+			var domainData struct {
+				Report limesresources.DomainReport `json:"domain"`
+			}
+			oldassert.HTTPRequest{
+				Method:       "GET",
+				Path:         "/v1/domains/uuid-for-germany" + query,
+				ExpectStatus: 200,
+				ExpectBody:   JSONThatUnmarshalsInto{Value: &domainData},
+			}.Check(t, s.Handler)
 
-		var domainData struct {
-			Report limesresources.DomainReport `json:"domain"`
-		}
-		oldassert.HTTPRequest{
-			Method:       "GET",
-			Path:         "/v1/domains/uuid-for-germany" + query,
-			ExpectStatus: 200,
-			ExpectBody:   JSONThatUnmarshalsInto{Value: &domainData},
-		}.Check(t, s.Handler)
-
-		var actualDurationsInDomain []string
-		for serviceType, serviceReport := range domainData.Report.Services {
-			for resourceName, resourceReport := range serviceReport.Resources {
-				if resourceReport.CommitmentConfig != nil {
-					for _, duration := range resourceReport.CommitmentConfig.Durations {
-						msg := fmt.Sprintf("%s: %s/%s", duration.String(), serviceType, resourceName)
-						actualDurationsInDomain = append(actualDurationsInDomain, msg)
+			var actualDurationsInDomain []string
+			for serviceType, serviceReport := range domainData.Report.Services {
+				for resourceName, resourceReport := range serviceReport.Resources {
+					if resourceReport.CommitmentConfig != nil {
+						for _, duration := range resourceReport.CommitmentConfig.Durations {
+							msg := fmt.Sprintf("%s: %s/%s", duration.String(), serviceType, resourceName)
+							actualDurationsInDomain = append(actualDurationsInDomain, msg)
+						}
 					}
 				}
 			}
-		}
-		sort.Strings(actualDurationsInDomain)
-		assert.DeepEqual(t, "durations on domain level with query "+query, actualDurationsInDomain, expectedDurations)
+			sort.Strings(actualDurationsInDomain)
+			assert.Equal(t, actualDurationsInDomain, expectedDurations)
+		})
 
-		////// cluster level
+		t.Run("scope=cluster,query="+query, func(t *testing.T) {
+			var clusterData struct {
+				Report limesresources.ClusterReport `json:"cluster"`
+			}
+			oldassert.HTTPRequest{
+				Method:       "GET",
+				Path:         "/v1/clusters/current" + query,
+				ExpectStatus: 200,
+				ExpectBody:   JSONThatUnmarshalsInto{Value: &clusterData},
+			}.Check(t, s.Handler)
 
-		var clusterData struct {
-			Report limesresources.ClusterReport `json:"cluster"`
-		}
-		oldassert.HTTPRequest{
-			Method:       "GET",
-			Path:         "/v1/clusters/current" + query,
-			ExpectStatus: 200,
-			ExpectBody:   JSONThatUnmarshalsInto{Value: &clusterData},
-		}.Check(t, s.Handler)
-
-		var actualDurationsInCluster []string
-		for serviceType, serviceReport := range clusterData.Report.Services {
-			for resourceName, resourceReport := range serviceReport.Resources {
-				if resourceReport.CommitmentConfig != nil {
-					for _, duration := range resourceReport.CommitmentConfig.Durations {
-						msg := fmt.Sprintf("%s: %s/%s", duration.String(), serviceType, resourceName)
-						actualDurationsInCluster = append(actualDurationsInCluster, msg)
+			var actualDurationsInCluster []string
+			for serviceType, serviceReport := range clusterData.Report.Services {
+				for resourceName, resourceReport := range serviceReport.Resources {
+					if resourceReport.CommitmentConfig != nil {
+						for _, duration := range resourceReport.CommitmentConfig.Durations {
+							msg := fmt.Sprintf("%s: %s/%s", duration.String(), serviceType, resourceName)
+							actualDurationsInCluster = append(actualDurationsInCluster, msg)
+						}
 					}
 				}
 			}
-		}
-		sort.Strings(actualDurationsInCluster)
-		assert.DeepEqual(t, "durations on cluster level with query "+query, actualDurationsInCluster, expectedDurations)
+			sort.Strings(actualDurationsInCluster)
+			assert.Equal(t, actualDurationsInCluster, expectedDurations)
+		})
 	}
 
 	// baseline

--- a/internal/api/api_v2/commitment_create_test.go
+++ b/internal/api/api_v2/commitment_create_test.go
@@ -13,10 +13,10 @@ import (
 
 	"github.com/sapcc/go-api-declarations/cadf"
 	"github.com/sapcc/go-api-declarations/liquid"
-	"github.com/sapcc/go-bits/assert"
 	"github.com/sapcc/go-bits/easypg"
 	"github.com/sapcc/go-bits/httptest"
 	"github.com/sapcc/go-bits/must"
+	"go.xyrillian.de/gg/assert"
 	"go.xyrillian.de/gg/jsonmatch"
 	. "go.xyrillian.de/gg/option"
 

--- a/internal/api/commitment_test.go
+++ b/internal/api/commitment_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/sapcc/go-api-declarations/cadf"
 	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
 	"github.com/sapcc/go-api-declarations/liquid"
-	"github.com/sapcc/go-bits/assert"
 	"github.com/sapcc/go-bits/easypg"
 	"github.com/sapcc/go-bits/must"
+	"go.xyrillian.de/gg/assert"
 
 	"github.com/sapcc/limes/internal/datamodel"
 	"github.com/sapcc/limes/internal/db"
@@ -364,7 +364,7 @@ func TestCommitmentLifecycleWithDelayedConfirmation(t *testing.T) {
 		ExpectStatus: http.StatusCreated,
 		ExpectBody:   oldassert.JSONObject{"commitment": resp1},
 	}.Check(t, s.Handler)
-	assert.DeepEqual(t, "CommitmentChangeRequest", s.LiquidClients["first"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{
+	assert.Equal(t, s.LiquidClients["first"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{
 		AZ:          "az-one",
 		InfoVersion: 1,
 		ByProject: map[liquid.ProjectUUID]liquid.ProjectCommitmentChangeset{
@@ -419,7 +419,7 @@ func TestCommitmentLifecycleWithDelayedConfirmation(t *testing.T) {
 		ExpectStatus: http.StatusCreated,
 		ExpectBody:   oldassert.JSONObject{"commitment": resp2},
 	}.Check(t, s.Handler)
-	assert.DeepEqual(t, "CommitmentChangeRequest", s.LiquidClients["first"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{
+	assert.Equal(t, s.LiquidClients["first"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{
 		AZ:          "any",
 		InfoVersion: 1,
 		ByProject: map[liquid.ProjectUUID]liquid.ProjectCommitmentChangeset{
@@ -502,7 +502,7 @@ func TestCommitmentLifecycleWithDelayedConfirmation(t *testing.T) {
 		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/2",
 		ExpectStatus: http.StatusNoContent,
 	}.Check(t, s.Handler)
-	assert.DeepEqual(t, "CommitmentChangeRequest", s.LiquidClients["first"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{
+	assert.Equal(t, s.LiquidClients["first"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{
 		AZ:          "any",
 		InfoVersion: 1,
 		ByProject: map[liquid.ProjectUUID]liquid.ProjectCommitmentChangeset{
@@ -577,7 +577,7 @@ func TestCommitmentLifecycleWithDelayedConfirmation(t *testing.T) {
 		ExpectStatus: http.StatusCreated,
 		ExpectBody:   oldassert.JSONObject{"commitment": resp3},
 	}.Check(t, s.Handler)
-	assert.DeepEqual(t, "CommitmentChangeRequest", s.LiquidClients["first"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{
+	assert.Equal(t, s.LiquidClients["first"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{
 		AZ:          "any",
 		InfoVersion: 1,
 		ByProject: map[liquid.ProjectUUID]liquid.ProjectCommitmentChangeset{
@@ -603,7 +603,7 @@ func TestCommitmentLifecycleWithDelayedConfirmation(t *testing.T) {
 		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/3",
 		ExpectStatus: http.StatusNoContent,
 	}.Check(t, s.Handler)
-	assert.DeepEqual(t, "CommitmentChangeRequest", s.LiquidClients["first"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{
+	assert.Equal(t, s.LiquidClients["first"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{
 		AZ:          "any",
 		InfoVersion: 1,
 		ByProject: map[liquid.ProjectUUID]liquid.ProjectCommitmentChangeset{
@@ -651,7 +651,7 @@ func TestCommitmentLifecycleWithDelayedConfirmation(t *testing.T) {
 		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/1",
 		ExpectStatus: http.StatusNoContent,
 	}.Check(t, s.Handler)
-	assert.DeepEqual(t, "CommitmentChangeRequest", s.LiquidClients["first"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{
+	assert.Equal(t, s.LiquidClients["first"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{
 		AZ:          "az-one",
 		InfoVersion: 1,
 		ByProject: map[liquid.ProjectUUID]liquid.ProjectCommitmentChangeset{
@@ -723,7 +723,7 @@ func TestCommitmentLifecycleWithImmediateConfirmation(t *testing.T) {
 		ExpectBody:   oldassert.JSONObject{"result": false},
 	}.Check(t, s.Handler)
 	// no request was done
-	assert.DeepEqual(t, "CommitmentChangeRequest", s.LiquidClients["first"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{})
+	assert.Equal(t, s.LiquidClients["first"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{})
 	oldassert.HTTPRequest{
 		Method:       http.MethodPost,
 		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/new",
@@ -778,7 +778,7 @@ func TestCommitmentLifecycleWithImmediateConfirmation(t *testing.T) {
 		ExpectStatus: http.StatusOK,
 		ExpectBody:   oldassert.JSONObject{"result": true},
 	}.Check(t, s.Handler)
-	assert.DeepEqual(t, "CommitmentChangeRequest", s.LiquidClients["first"].LastCommitmentChangeRequest, commitmentChangeRequest)
+	assert.Equal(t, s.LiquidClients["first"].LastCommitmentChangeRequest, commitmentChangeRequest)
 
 	// this won't work because we request too much
 	capacityResourceCommitmentChangeset.Commitments[0].Amount = maxCommittableCapacity + 1
@@ -796,7 +796,7 @@ func TestCommitmentLifecycleWithImmediateConfirmation(t *testing.T) {
 		ExpectStatus: http.StatusOK,
 		ExpectBody:   oldassert.JSONObject{"result": false},
 	}.Check(t, s.Handler)
-	assert.DeepEqual(t, "CommitmentChangeRequest", s.LiquidClients["first"].LastCommitmentChangeRequest, commitmentChangeRequest)
+	assert.Equal(t, s.LiquidClients["first"].LastCommitmentChangeRequest, commitmentChangeRequest)
 
 	// create a commitment for some of that capacity
 	capacityResourceCommitmentChangeset.Commitments[0].Amount = committedCapacity
@@ -814,7 +814,7 @@ func TestCommitmentLifecycleWithImmediateConfirmation(t *testing.T) {
 		Body:         request(committedCapacity),
 		ExpectStatus: http.StatusCreated,
 	}.Check(t, s.Handler)
-	assert.DeepEqual(t, "CommitmentChangeRequest", s.LiquidClients["first"].LastCommitmentChangeRequest, commitmentChangeRequest)
+	assert.Equal(t, s.LiquidClients["first"].LastCommitmentChangeRequest, commitmentChangeRequest)
 
 	// check that can-confirm can only confirm the remainder of the available capacity, not more
 	remainingCommittableCapacity := maxCommittableCapacity - committedCapacity
@@ -834,7 +834,7 @@ func TestCommitmentLifecycleWithImmediateConfirmation(t *testing.T) {
 		ExpectStatus: http.StatusOK,
 		ExpectBody:   oldassert.JSONObject{"result": true},
 	}.Check(t, s.Handler)
-	assert.DeepEqual(t, "CommitmentChangeRequest", s.LiquidClients["first"].LastCommitmentChangeRequest, commitmentChangeRequest)
+	assert.Equal(t, s.LiquidClients["first"].LastCommitmentChangeRequest, commitmentChangeRequest)
 
 	capacityResourceCommitmentChangeset.Commitments[0].Amount = remainingCommittableCapacity + 1
 	capacityResourceCommitmentChangeset.Commitments[0].UUID = "00000000-0000-0000-0000-000000000006"
@@ -851,7 +851,7 @@ func TestCommitmentLifecycleWithImmediateConfirmation(t *testing.T) {
 		ExpectStatus: http.StatusOK,
 		ExpectBody:   oldassert.JSONObject{"result": false},
 	}.Check(t, s.Handler)
-	assert.DeepEqual(t, "CommitmentChangeRequest", s.LiquidClients["first"].LastCommitmentChangeRequest, commitmentChangeRequest)
+	assert.Equal(t, s.LiquidClients["first"].LastCommitmentChangeRequest, commitmentChangeRequest)
 
 	// check that can-confirm ignores expired commitments
 	s.MustDBExec(`UPDATE project_commitments SET expires_at = $1, status = $2`,
@@ -873,7 +873,7 @@ func TestCommitmentLifecycleWithImmediateConfirmation(t *testing.T) {
 		ExpectStatus: http.StatusOK,
 		ExpectBody:   oldassert.JSONObject{"result": true},
 	}.Check(t, s.Handler)
-	assert.DeepEqual(t, "CommitmentChangeRequest", s.LiquidClients["first"].LastCommitmentChangeRequest, commitmentChangeRequest)
+	assert.Equal(t, s.LiquidClients["first"].LastCommitmentChangeRequest, commitmentChangeRequest)
 
 	// try to create a commitment with a mail notification flag (only possible to set for planned commitments)
 	notificationReq := oldassert.JSONObject{
@@ -1455,7 +1455,7 @@ func Test_StartCommitmentTransfer(t *testing.T) {
 		ExpectBody:   oldassert.JSONObject{"commitment": resp1},
 		Body:         oldassert.JSONObject{"commitment": oldassert.JSONObject{"amount": 10, "transfer_status": "public"}},
 	}.Check(t, s.Handler)
-	assert.DeepEqual(t, "CommitmentChangeRequest", s.LiquidClients["second"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{})
+	assert.Equal(t, s.LiquidClients["second"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{})
 
 	// try to set the same status again, should complain
 	oldassert.HTTPRequest{
@@ -1531,7 +1531,7 @@ func Test_StartCommitmentTransfer(t *testing.T) {
 		ExpectBody:   oldassert.JSONObject{"commitment": resp2},
 		Body:         oldassert.JSONObject{"commitment": oldassert.JSONObject{"amount": 9, "transfer_status": "public"}},
 	}.Check(t, s.Handler)
-	assert.DeepEqual(t, "CommitmentChangeRequest", s.LiquidClients["second"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{
+	assert.Equal(t, s.LiquidClients["second"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{
 		AZ:          "az-two",
 		InfoVersion: 1,
 		ByProject: map[liquid.ProjectUUID]liquid.ProjectCommitmentChangeset{
@@ -1579,7 +1579,7 @@ func Test_StartCommitmentTransfer(t *testing.T) {
 		ExpectBody:   oldassert.JSONObject{"commitment": resp2},
 	}.Check(t, s.Handler)
 
-	assert.DeepEqual(t, "CommitmentChangeRequest", s.LiquidClients["second"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{})
+	assert.Equal(t, s.LiquidClients["second"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{})
 
 	// Negative Test, amount = 0.
 	oldassert.HTTPRequest{
@@ -1781,7 +1781,7 @@ func Test_TransferCommitment(t *testing.T) {
 		ExpectBody:   oldassert.JSONObject{"commitment": resp2},
 		ExpectStatus: http.StatusAccepted,
 	}.Check(t, s.Handler)
-	assert.DeepEqual(t, "CommitmentChangeRequest", s.LiquidClients["second"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{
+	assert.Equal(t, s.LiquidClients["second"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{
 		AZ:          "az-two",
 		InfoVersion: 1,
 		ByProject: map[liquid.ProjectUUID]liquid.ProjectCommitmentChangeset{
@@ -1855,7 +1855,7 @@ func Test_TransferCommitment(t *testing.T) {
 		ExpectBody:   oldassert.JSONObject{"commitment": resp4},
 		ExpectStatus: http.StatusAccepted,
 	}.Check(t, s.Handler)
-	assert.DeepEqual(t, "CommitmentChangeRequest", s.LiquidClients["second"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{
+	assert.Equal(t, s.LiquidClients["second"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{
 		AZ:          "az-two",
 		InfoVersion: 1,
 		ByProject: map[liquid.ProjectUUID]liquid.ProjectCommitmentChangeset{
@@ -2029,7 +2029,7 @@ func Test_TransferCommitmentForbiddenByCapacityCheck(t *testing.T) {
 		ExpectBody:   oldassert.StringData("not enough committable capacity on the receiving side\n"),
 		ExpectStatus: http.StatusConflict,
 	}.Check(t, s.Handler)
-	assert.DeepEqual(t, "CommitmentChangeRequest", s.LiquidClients["second"].LastCommitmentChangeRequest, commitmentChangeRequest)
+	assert.Equal(t, s.LiquidClients["second"].LastCommitmentChangeRequest, commitmentChangeRequest)
 }
 
 func TestTransferCommitmentForbiddenResource(t *testing.T) {
@@ -2227,7 +2227,7 @@ func Test_ConvertCommitments(t *testing.T) {
 		ExpectBody:   oldassert.StringData("liquid says: not enough capacity!\n"),
 		ExpectStatus: http.StatusConflict,
 	}.Check(t, s.Handler)
-	assert.DeepEqual(t, "CommitmentChangeRequest", s.LiquidClients["fourth"].LastCommitmentChangeRequest, commitmentChangeRequest)
+	assert.Equal(t, s.LiquidClients["fourth"].LastCommitmentChangeRequest, commitmentChangeRequest)
 	*s.CurrentProjectCommitmentID-- // request was unsuccessful
 
 	// Conversion with remainder should be rejected.
@@ -2264,7 +2264,7 @@ func Test_ConvertCommitments(t *testing.T) {
 		ExpectBody:   oldassert.JSONObject{"commitment": resp(3, 2, "fourth", "capacity_a")},
 		ExpectStatus: http.StatusAccepted,
 	}.Check(t, s.Handler)
-	assert.DeepEqual(t, "CommitmentChangeRequest", s.LiquidClients["fourth"].LastCommitmentChangeRequest, commitmentChangeRequest)
+	assert.Equal(t, s.LiquidClients["fourth"].LastCommitmentChangeRequest, commitmentChangeRequest)
 
 	var commitmentToCheck db.ProjectCommitment
 	// original
@@ -2368,7 +2368,7 @@ func Test_ConvertCommitments(t *testing.T) {
 		ExpectBody:   oldassert.JSONObject{"commitment": respWithConfirmBy(5, 2, "fourth", "capacity_a")},
 		ExpectStatus: http.StatusAccepted,
 	}.Check(t, s.Handler)
-	assert.DeepEqual(t, "CommitmentChangeRequest", s.LiquidClients["fourth"].LastCommitmentChangeRequest, commitmentChangeRequest)
+	assert.Equal(t, s.LiquidClients["fourth"].LastCommitmentChangeRequest, commitmentChangeRequest)
 }
 
 func Test_UpdateCommitmentDuration(t *testing.T) {
@@ -2416,7 +2416,7 @@ func Test_UpdateCommitmentDuration(t *testing.T) {
 		}},
 		ExpectStatus: http.StatusOK,
 	}.Check(t, s.Handler)
-	assert.DeepEqual(t, "CommitmentChangeRequest", s.LiquidClients["second"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{
+	assert.Equal(t, s.LiquidClients["second"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{
 		AZ:          "az-one",
 		InfoVersion: 1,
 		ByProject: map[liquid.ProjectUUID]liquid.ProjectCommitmentChangeset{
@@ -2481,7 +2481,7 @@ func Test_UpdateCommitmentDuration(t *testing.T) {
 		}},
 		ExpectStatus: http.StatusOK,
 	}.Check(t, s.Handler)
-	assert.DeepEqual(t, "CommitmentChangeRequest", s.LiquidClients["second"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{
+	assert.Equal(t, s.LiquidClients["second"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{
 		AZ:          "az-one",
 		InfoVersion: 1,
 		ByProject: map[liquid.ProjectUUID]liquid.ProjectCommitmentChangeset{
@@ -2774,7 +2774,7 @@ func Test_MergeCommitments(t *testing.T) {
 		ExpectBody:   oldassert.JSONObject{"commitment": resp5},
 		ExpectStatus: http.StatusAccepted,
 	}.Check(t, s.Handler)
-	assert.DeepEqual(t, "CommitmentChangeRequest", s.LiquidClients["second"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{
+	assert.Equal(t, s.LiquidClients["second"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{
 		AZ:          "az-one",
 		InfoVersion: 1,
 		ByProject: map[liquid.ProjectUUID]liquid.ProjectCommitmentChangeset{
@@ -2830,11 +2830,11 @@ func Test_MergeCommitments(t *testing.T) {
 	}
 	var supersedeContext db.CommitmentWorkflowContext
 	must.SucceedT(t, json.Unmarshal(supersededCommitment.SupersedeContextJSON.UnwrapOr(nil), &supersedeContext))
-	assert.DeepEqual(t, "commitment supersede context", supersedeContext, expectedContext)
+	assert.Equal(t, supersedeContext, expectedContext)
 	must.SucceedT(t, s.DB.SelectOne(&supersededCommitment, `SELECT * FROM project_commitments where ID = 2`))
 	assert.Equal(t, supersededCommitment.Status, liquid.CommitmentStatusSuperseded)
 	must.SucceedT(t, json.Unmarshal(supersededCommitment.SupersedeContextJSON.UnwrapOr(nil), &supersedeContext))
-	assert.DeepEqual(t, "commitment supersede context", supersedeContext, expectedContext)
+	assert.Equal(t, supersedeContext, expectedContext)
 }
 
 func Test_RenewCommitments(t *testing.T) {
@@ -2912,7 +2912,7 @@ func Test_RenewCommitments(t *testing.T) {
 		ExpectBody:   oldassert.JSONObject{"commitment": resp1},
 		ExpectStatus: http.StatusAccepted,
 	}.Check(t, s.Handler)
-	assert.DeepEqual(t, "CommitmentChangeRequest", s.LiquidClients["second"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{
+	assert.Equal(t, s.LiquidClients["second"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{
 		AZ:          "az-one",
 		InfoVersion: 1,
 		ByProject: map[liquid.ProjectUUID]liquid.ProjectCommitmentChangeset{
@@ -2941,7 +2941,7 @@ func Test_RenewCommitments(t *testing.T) {
 		ExpectBody:   oldassert.JSONObject{"commitment": resp2},
 		ExpectStatus: http.StatusAccepted,
 	}.Check(t, s.Handler)
-	assert.DeepEqual(t, "CommitmentChangeRequest", s.LiquidClients["second"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{
+	assert.Equal(t, s.LiquidClients["second"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{
 		AZ:          "az-two",
 		InfoVersion: 1,
 		ByProject: map[liquid.ProjectUUID]liquid.ProjectCommitmentChangeset{
@@ -3067,7 +3067,7 @@ func Test_PublicCommitmentCloudAdminActions(t *testing.T) {
 		ExpectBody:   oldassert.JSONObject{"commitment": resp1},
 		Body:         oldassert.JSONObject{"commitment": oldassert.JSONObject{"amount": 10, "transfer_status": "unlisted"}},
 	}.Check(t, s.Handler)
-	assert.DeepEqual(t, "CommitmentChangeRequest", s.LiquidClients["second"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{})
+	assert.Equal(t, s.LiquidClients["second"].LastCommitmentChangeRequest, liquid.CommitmentChangeRequest{})
 
 	// Access forbidden
 	s.TokenValidator.Enforcer.AllowEdit = false

--- a/internal/collector/capacity_scrape_test.go
+++ b/internal/collector/capacity_scrape_test.go
@@ -17,11 +17,11 @@ import (
 	"github.com/sapcc/go-api-declarations/cadf"
 	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
 	"github.com/sapcc/go-api-declarations/liquid"
-	"github.com/sapcc/go-bits/assert"
 	"github.com/sapcc/go-bits/easypg"
 	"github.com/sapcc/go-bits/httptest"
 	"github.com/sapcc/go-bits/jobloop"
 	"github.com/sapcc/go-bits/must"
+	"go.xyrillian.de/gg/assert"
 	. "go.xyrillian.de/gg/option"
 
 	"github.com/sapcc/limes/internal/collector"
@@ -1214,10 +1214,10 @@ func Test_ScanCapacityWithCommitments(t *testing.T) {
 	}
 	for serviceType, expectedDemandsByResource := range expectedDemandsByService {
 		for resourceName, expectedDemands := range expectedDemandsByResource {
-			actualDemands, err := bc.GetResourceDemand(serviceType, resourceName)
-			must.SucceedT(t, err)
-			desc := fmt.Sprintf("GetGlobalResourceDemand for %s/%s", serviceType, resourceName)
-			assert.DeepEqual(t, desc, actualDemands.PerAZ, expectedDemands)
+			t.Run(fmt.Sprintf("service=%s,resource=%s", serviceType, resourceName), func(t *testing.T) {
+				actualDemands := must.ReturnT(bc.GetResourceDemand(serviceType, resourceName))(t)
+				assert.Equal(t, actualDemands.PerAZ, expectedDemands)
+			})
 		}
 	}
 

--- a/internal/collector/keystone_test.go
+++ b/internal/collector/keystone_test.go
@@ -11,9 +11,9 @@ import (
 
 	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
 	"github.com/sapcc/go-api-declarations/liquid"
-	"github.com/sapcc/go-bits/assert"
 	"github.com/sapcc/go-bits/easypg"
 	"github.com/sapcc/go-bits/must"
+	"go.xyrillian.de/gg/assert"
 	. "go.xyrillian.de/gg/option"
 
 	"github.com/sapcc/limes/internal/collector"
@@ -78,14 +78,14 @@ func Test_ScanDomains(t *testing.T) {
 	actualNewDomains := must.ReturnT(s.Collector.ScanDomains(s.Ctx, collector.ScanDomainsOpts{}))(t)
 	sort.Strings(expectedNewDomains) // order does not matter
 	sort.Strings(actualNewDomains)
-	assert.DeepEqual(t, "new domains after ScanDomains #1", actualNewDomains, expectedNewDomains)
+	assert.Equal(t, actualNewDomains, expectedNewDomains)
 	tr, tr0 := easypg.NewTracker(t, s.DB.Db)
 	tr0.AssertEqualToFile("fixtures/scandomains1.sql")
 
 	// second ScanDomains should not discover anything new
 	s.Clock.StepBy(10 * time.Minute)
 	actualNewDomains = must.ReturnT(s.Collector.ScanDomains(s.Ctx, collector.ScanDomainsOpts{}))(t)
-	assert.DeepEqual(t, "new domains after ScanDomains #2", actualNewDomains, []string(nil))
+	assert.Equal(t, actualNewDomains, []string(nil))
 	tr.DBChanges().AssertEmpty()
 
 	// add another project
@@ -97,13 +97,13 @@ func Test_ScanDomains(t *testing.T) {
 	// ScanDomains without ScanAllProjects should not see this new project
 	s.Clock.StepBy(10 * time.Minute)
 	actualNewDomains = must.ReturnT(s.Collector.ScanDomains(s.Ctx, collector.ScanDomainsOpts{}))(t)
-	assert.DeepEqual(t, "new domains after ScanDomains #3", actualNewDomains, []string(nil))
+	assert.Equal(t, actualNewDomains, []string(nil))
 	tr.DBChanges().AssertEmpty()
 
 	// ScanDomains with ScanAllProjects should discover the new project
 	s.Clock.StepBy(10 * time.Minute)
 	actualNewDomains = must.ReturnT(s.Collector.ScanDomains(s.Ctx, collector.ScanDomainsOpts{ScanAllProjects: true}))(t)
-	assert.DeepEqual(t, "new domains after ScanDomains #4", actualNewDomains, []string(nil))
+	assert.Equal(t, actualNewDomains, []string(nil))
 	tr.DBChanges().AssertEqualf(`
 		INSERT INTO project_services (id, project_id, service_id, stale, next_scrape_at) VALUES (7, 4, 1, TRUE, %[1]d);
 		INSERT INTO project_services (id, project_id, service_id, stale, next_scrape_at) VALUES (8, 4, 2, TRUE, %[1]d);
@@ -118,7 +118,7 @@ func Test_ScanDomains(t *testing.T) {
 	// ScanDomains without ScanAllProjects should not notice anything
 	s.Clock.StepBy(10 * time.Minute)
 	actualNewDomains = must.ReturnT(s.Collector.ScanDomains(s.Ctx, collector.ScanDomainsOpts{}))(t)
-	assert.DeepEqual(t, "new domains after ScanDomains #5", actualNewDomains, []string(nil))
+	assert.Equal(t, actualNewDomains, []string(nil))
 	tr.DBChanges().AssertEmpty()
 
 	// ScanDomains with ScanAllProjects should notice the deleted project and don't cleanup because of active commitments
@@ -154,7 +154,7 @@ func Test_ScanDomains(t *testing.T) {
 	s.MustDBExec(`UPDATE project_commitments SET status = $1`, liquid.CommitmentStatusExpired)
 	s.Clock.StepBy(10 * time.Minute)
 	actualNewDomains = must.ReturnT(s.Collector.ScanDomains(s.Ctx, collector.ScanDomainsOpts{ScanAllProjects: true}))(t)
-	assert.DeepEqual(t, "new domains after ScanDomains #6", actualNewDomains, []string(nil))
+	assert.Equal(t, actualNewDomains, []string(nil))
 	tr.DBChanges().AssertEqualf(`
 		DELETE FROM project_commitments WHERE id = 1 AND uuid = '00000000-0000-0000-0000-000000000001' AND transfer_token = NULL;
 		DELETE FROM project_services WHERE id = 7 AND project_id = 4 AND service_id = 1;
@@ -168,7 +168,7 @@ func Test_ScanDomains(t *testing.T) {
 	// ScanDomains should notice the deleted domain and cleanup its records and also its projects
 	s.Clock.StepBy(10 * time.Minute)
 	actualNewDomains = must.ReturnT(s.Collector.ScanDomains(s.Ctx, collector.ScanDomainsOpts{}))(t)
-	assert.DeepEqual(t, "new domains after ScanDomains #8", actualNewDomains, []string(nil))
+	assert.Equal(t, actualNewDomains, []string(nil))
 	tr.DBChanges().AssertEqualf(`
 		DELETE FROM domains WHERE id = 2 AND uuid = 'uuid-for-france';
 		DELETE FROM project_services WHERE id = 5 AND project_id = 3 AND service_id = 1;
@@ -183,7 +183,7 @@ func Test_ScanDomains(t *testing.T) {
 	// ScanDomains should notice the changed names and update the domain/project records accordingly
 	s.Clock.StepBy(10 * time.Minute)
 	actualNewDomains = must.ReturnT(s.Collector.ScanDomains(s.Ctx, collector.ScanDomainsOpts{ScanAllProjects: true}))(t)
-	assert.DeepEqual(t, "new domains after ScanDomains #9", actualNewDomains, []string(nil))
+	assert.Equal(t, actualNewDomains, []string(nil))
 	tr.DBChanges().AssertEqualf(`
 		UPDATE domains SET name = 'germany-changed' WHERE id = 1 AND uuid = 'uuid-for-germany';
 		UPDATE projects SET name = 'berlin-changed' WHERE id = 1 AND uuid = 'uuid-for-berlin';

--- a/internal/collector/mail_delivery_test.go
+++ b/internal/collector/mail_delivery_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sapcc/go-bits/assert"
 	"github.com/sapcc/go-bits/easypg"
 	"github.com/sapcc/go-bits/must"
+	"go.xyrillian.de/gg/assert"
 
 	"github.com/sapcc/limes/internal/collector"
 	"github.com/sapcc/limes/internal/db"

--- a/internal/collector/scrape_test.go
+++ b/internal/collector/scrape_test.go
@@ -20,11 +20,11 @@ import (
 	limesrates "github.com/sapcc/go-api-declarations/limes/rates"
 	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
 	"github.com/sapcc/go-api-declarations/liquid"
-	"github.com/sapcc/go-bits/assert"
 	"github.com/sapcc/go-bits/easypg"
 	"github.com/sapcc/go-bits/httptest"
 	"github.com/sapcc/go-bits/jobloop"
 	"github.com/sapcc/go-bits/must"
+	"go.xyrillian.de/gg/assert"
 	. "go.xyrillian.de/gg/option"
 
 	"github.com/sapcc/limes/internal/collector"

--- a/internal/core/cluster_test.go
+++ b/internal/core/cluster_test.go
@@ -13,10 +13,10 @@ import (
 	limesrates "github.com/sapcc/go-api-declarations/limes/rates"
 	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
 	"github.com/sapcc/go-api-declarations/liquid"
-	"github.com/sapcc/go-bits/assert"
 	"github.com/sapcc/go-bits/easypg"
 	"github.com/sapcc/go-bits/errext"
 	"github.com/sapcc/go-bits/must"
+	"go.xyrillian.de/gg/assert"
 	. "go.xyrillian.de/gg/option"
 
 	"github.com/sapcc/limes/internal/core"

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sapcc/go-bits/assert"
 	"github.com/sapcc/go-bits/errext"
+	"go.xyrillian.de/gg/assert"
 
 	"github.com/sapcc/limes/internal/core"
 )
@@ -28,7 +28,7 @@ func TestFilterDomains(t *testing.T) {
 	expected := []core.KeystoneDomain{
 		{Name: "foo1"},
 	}
-	assert.DeepEqual(t, "filtered domains", cfg.FilterDomains(input), expected)
+	assert.Equal(t, cfg.FilterDomains(input), expected)
 }
 
 func TestConfigValidation(t *testing.T) {

--- a/internal/core/service_info_cache_test.go
+++ b/internal/core/service_info_cache_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/sapcc/go-api-declarations/liquid"
-	"github.com/sapcc/go-bits/assert"
 	"github.com/sapcc/go-bits/easypg"
 	"github.com/sapcc/go-bits/must"
+	"go.xyrillian.de/gg/assert"
 	. "go.xyrillian.de/gg/option"
 	"go.xyrillian.de/gg/options"
 

--- a/internal/datamodel/allocation_stats_test.go
+++ b/internal/datamodel/allocation_stats_test.go
@@ -9,7 +9,7 @@ package datamodel
 import (
 	"testing"
 
-	"github.com/sapcc/go-bits/assert"
+	"go.xyrillian.de/gg/assert"
 	. "go.xyrillian.de/gg/option"
 
 	"github.com/sapcc/limes/internal/core"

--- a/internal/datamodel/apply_computed_project_quota_test.go
+++ b/internal/datamodel/apply_computed_project_quota_test.go
@@ -8,12 +8,12 @@ package datamodel
 
 import (
 	"encoding/json"
-	"reflect"
 	"testing"
 
 	"github.com/sapcc/go-api-declarations/limes"
 	"github.com/sapcc/go-api-declarations/liquid"
 	"github.com/sapcc/go-bits/must"
+	"go.xyrillian.de/gg/assert"
 	. "go.xyrillian.de/gg/option"
 
 	"github.com/sapcc/limes/internal/core"
@@ -1249,16 +1249,8 @@ func expectACPQResult(t *testing.T, input map[limes.AvailabilityZone]clusterAZAl
 		}
 	}
 
-	// We could just assert.DeepEqual() at this point, but the output of that
-	// would not be really helpful because fmt.Printf("%#v", ...) stops at
-	// pointer boundaries.
-	if reflect.DeepEqual(actual, expected) {
-		return
+	if !assert.Equal(t, actual, expected) {
+		t.Logf("config was %#v", cfg)
+		t.Logf("input was %s", must.ReturnT(json.Marshal(input))(t))
 	}
-
-	t.Error("ExpectACPQResult failed")
-	t.Logf("    config = %#v", cfg)
-	t.Logf("     input = %s", must.ReturnT(json.Marshal(input))(t))
-	t.Logf("  expected = %s", must.ReturnT(json.Marshal(expected))(t))
-	t.Logf("    actual = %s", must.ReturnT(json.Marshal(actual))(t))
 }

--- a/internal/datamodel/quota_overrides_test.go
+++ b/internal/datamodel/quota_overrides_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/sapcc/go-api-declarations/liquid"
-	"github.com/sapcc/go-bits/assert"
 	"github.com/sapcc/go-bits/easypg"
+	"go.xyrillian.de/gg/assert"
 
 	"github.com/sapcc/limes/internal/datamodel"
 	"github.com/sapcc/limes/internal/db"
@@ -122,8 +122,8 @@ func TestQuotaOverridesWithoutResourceRenaming(t *testing.T) {
 		test.WithLiquidConnections,
 	)
 	overrides, errs := datamodel.LoadQuotaOverrides(s.Cluster)
-	assert.Equal(t, errs.Join(", "), "")
-	assert.DeepEqual(t, "quota overrides", overrides, expectedQuotaOverrides)
+	assert.Equal(t, errs, nil)
+	assert.Equal(t, overrides, expectedQuotaOverrides)
 }
 
 func TestQuotaOverridesWithResourceRenaming(t *testing.T) {
@@ -136,6 +136,6 @@ func TestQuotaOverridesWithResourceRenaming(t *testing.T) {
 		test.WithLiquidConnections,
 	)
 	overrides, errs := datamodel.LoadQuotaOverrides(s.Cluster)
-	assert.Equal(t, errs.Join(", "), "")
-	assert.DeepEqual(t, "quota overrides", overrides, expectedQuotaOverrides)
+	assert.Equal(t, errs, nil)
+	assert.Equal(t, overrides, expectedQuotaOverrides)
 }

--- a/internal/util/string_test.go
+++ b/internal/util/string_test.go
@@ -6,7 +6,7 @@ package util
 import (
 	"testing"
 
-	"github.com/sapcc/go-bits/assert"
+	"go.xyrillian.de/gg/assert"
 )
 
 func TestTitleCase(t *testing.T) {

--- a/internal/util/timeseries_test.go
+++ b/internal/util/timeseries_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sapcc/go-bits/assert"
 	"github.com/sapcc/go-bits/must"
+	"go.xyrillian.de/gg/assert"
 
 	"github.com/sapcc/limes/internal/util"
 )
@@ -121,6 +121,6 @@ func expectJSON[T cmp.Ordered](t *testing.T, value util.TimeSeries[T], repr stri
 	if err != nil {
 		t.Error("while unmarshaling: " + err.Error())
 	} else {
-		assert.DeepEqual(t, "unmarshaled value", unmarshaled, value)
+		assert.Equal(t, unmarshaled, value)
 	}
 }

--- a/vendor/go.xyrillian.de/gg/assert/assert.go
+++ b/vendor/go.xyrillian.de/gg/assert/assert.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 Stefan Majewsky <majewsky@gmx.net>
+// SPDX-License-Identifier: Apache-2.0
+
+// Package assert contains assertions for use in unit tests.
+// Each assertion in this package returns a bool to indicate whether the check succeeded, and logs a t.Error() when the check does not succeed.
+package assert
+
+import (
+	"context"
+	"io"
+	"testing"
+)
+
+// TestingTB contains all the public functions of [testing.TB] (as of Go 1.26).
+// Functions in this package use this type instead of [testing.TB] because the capture device used by package testcapture cannot implement [testing.TB]: It contains methods that are private to the standard library.
+type TestingTB interface {
+	ArtifactDir() string
+	Attr(key, value string)
+	Chdir(dir string)
+	Cleanup(func())
+	Context() context.Context
+	Error(args ...any)
+	Errorf(format string, args ...any)
+	Fail()
+	Failed() bool
+	FailNow()
+	Fatal(args ...any)
+	Fatalf(format string, args ...any)
+	Helper()
+	Log(args ...any)
+	Logf(format string, args ...any)
+	Name() string
+	Output() io.Writer
+	Setenv(key, value string)
+	Skip(args ...any)
+	Skipf(format string, args ...any)
+	SkipNow()
+	Skipped() bool
+	TempDir() string
+}
+
+var _ TestingTB = testing.TB(nil)

--- a/vendor/go.xyrillian.de/gg/assert/equal.go
+++ b/vendor/go.xyrillian.de/gg/assert/equal.go
@@ -1,0 +1,298 @@
+// SPDX-FileCopyrightText: 2026 Stefan Majewsky <majewsky@gmx.net>
+// SPDX-License-Identifier: Apache-2.0
+
+package assert
+
+import (
+	"fmt"
+	"reflect"
+	"slices"
+	"strings"
+	"unicode/utf8"
+
+	"go.xyrillian.de/gg/internal/path"
+)
+
+// Equal checks whether both supplied values are equal according to the rules of [reflect.DeepEqual].
+//
+// If there is a difference within a structured data type,
+// this function will try to be smart about reporting only the most specific pieces that differ,
+// but this is done on a best-effort basis.
+// The error messages produced by this assertion should be expected to change between releases
+// as additional effort is expended to establish a new level of best effort.
+func Equal[V any](t TestingTB, actual, expected V) bool {
+	if reflect.DeepEqual(actual, expected) {
+		return true
+	}
+	t.Helper()
+
+	// NOTE: consider the warning in the docstring of [path.Path]
+	p := path.NewPath()
+	result := findInequalities(p, reflect.ValueOf(actual), reflect.ValueOf(expected))
+
+	// serialize results into strings first in order to print in sorted order (for deterministic behavior in this package's own tests)
+	errors := make([]string, len(result))
+	for idx, ineq := range result {
+		if ineq.Pointer == "actual" {
+			errors[idx] = fmt.Sprintf("expected %s, but got %s", ineq.Expected, ineq.Actual)
+		} else {
+			errors[idx] = fmt.Sprintf("at %s: expected %s, but got %s", ineq.Pointer, ineq.Expected, ineq.Actual)
+		}
+	}
+	slices.Sort(errors)
+	for _, err := range errors {
+		t.Error(err)
+	}
+
+	return false
+}
+
+// NOTE: Several notes on the implementation of Equal().
+//
+// - All findInequalities...() functions assume that `actual` and `expected` are definitely unequal,
+//   and so may only be called if reflect.Equal() on these same arguments has returned false.
+//
+// - All findInequalities...() functions further assume that `actual.Type() == expected.Type()`.
+//   This is ensured at the API boundary through the type signature of assert.Equal(),
+//   and then only needs to be re-established when recursing into values of kind Interface.
+//
+// - When nonempty diffs are generated, running a full DeepEqual() at each level is indeed extremely inefficient.
+//   However, reflect.DeepEqual() is more likely to handle bizarre corner cases
+//   and new type system features better than our implementation,
+//   so we rely on it as a source of ground truth.
+//
+//   Furthermore, in the vastly more important case of an empty diff (i.e. a passing test),
+//   reflect.DeepEqual() is likely to be more efficient than what we do because of
+//   having both been around and scrutinized for much longer than our implementation,
+//   so doing it first will usually be faster.
+
+type inequality struct {
+	Pointer  string
+	Actual   string
+	Expected string
+}
+
+func formatValue(v reflect.Value) string {
+	return fmt.Sprintf("%#v", v)
+}
+
+func findInequalities(p path.Path, actual, expected reflect.Value) (result []inequality) {
+	// try to recurse into structured type to find the specific location of the inequality
+	// (thus producing a more succinct error message esp. with large and deeply nested structures)
+	switch actual.Kind() { //nolint:exhaustive
+	case reflect.Array, reflect.Slice:
+		result = findInequalitiesInArrayOrSlice(p, actual, expected)
+	case reflect.Map:
+		result = findInequalitiesInMap(p, actual, expected)
+	case reflect.Struct:
+		result = findInequalitiesInStruct(p, actual, expected)
+	case reflect.Pointer:
+		result = findInequalitiesInPointer(p, actual, expected)
+	case reflect.Interface:
+		if !actual.IsNil() && !expected.IsNil() {
+			// can only recurse if the invariant of this function is upheld: both sides must be of equal types
+			actualElem := actual.Elem()
+			expectedElem := expected.Elem()
+			if actualElem.Type() == expectedElem.Type() {
+				subpath := append(p, path.TypeCastElement(fmt.Sprintf("%T", actualElem.Interface())))
+				result = findInequalities(subpath, actualElem, expectedElem)
+			}
+		}
+	}
+
+	// if we do not have a recursion method for the type in question,
+	// or if our own implementation somehow fails to find the inequality,
+	// the safe fallback is to report the entire value as unequal
+	if len(result) == 0 {
+		return []inequality{{p.AsGoExpression("actual"), formatValue(actual), formatValue(expected)}}
+	}
+	return result
+}
+
+func findInequalitiesInArrayOrSlice(p path.Path, actual, expected reflect.Value) (result []inequality) {
+	// special case: for ~[]byte types (e.g. json.RawMessage) containing a valid Unicode string on both sides,
+	// a diff using string literals is likely to be vastly more readable
+	if actual.Type().Elem() == reflect.TypeFor[byte]() {
+		actualPayload := actual.Convert(reflect.TypeFor[[]byte]()).Interface().([]byte)
+		expectedPayload := expected.Convert(reflect.TypeFor[[]byte]()).Interface().([]byte)
+		if utf8.Valid(actualPayload) && utf8.Valid(expectedPayload) {
+			return []inequality{{
+				Pointer:  p.AsGoExpression("actual"),
+				Actual:   formatByteSliceViaString(actualPayload),
+				Expected: formatByteSliceViaString(expectedPayload),
+			}}
+		}
+	}
+
+	// recurse into all elements
+	for idx := range max(actual.Len(), expected.Len()) {
+		subpath := append(p, path.IndexElement(idx))
+		switch {
+		case idx >= actual.Len():
+			result = append(result, inequality{
+				Pointer:  subpath.AsGoExpression("actual"),
+				Actual:   "<missing>",
+				Expected: formatValue(expected.Index(idx)),
+			})
+		case idx >= expected.Len():
+			result = append(result, inequality{
+				Pointer:  subpath.AsGoExpression("actual"),
+				Actual:   formatValue(actual.Index(idx)),
+				Expected: "<missing>",
+			})
+		default:
+			actualElem := actual.Index(idx)
+			expectedElem := expected.Index(idx)
+			if !reflect.DeepEqual(actualElem.Interface(), expectedElem.Interface()) {
+				result = append(result, findInequalities(subpath, actualElem, expectedElem)...)
+			}
+		}
+	}
+
+	// if multiple elements differ, check if reporting the whole slice as different is more compact
+	// (this helps with slices of simple types, e.g. []int,
+	// but will not be used for large records where only a single field differs in all of them)
+	if len(result) > 4 {
+		overallTextLength := 0
+		for _, ineq := range result {
+			overallTextLength += len(ineq.Pointer) + len(ineq.Actual) + len(ineq.Expected)
+		}
+		ineq := buildSingleInequalityForArrayOrSlice(p, actual, expected)
+		if len(ineq.Pointer)+len(ineq.Actual)+len(ineq.Expected) < overallTextLength {
+			return []inequality{ineq}
+		}
+	}
+
+	return result
+}
+
+func formatByteSliceViaString(buf []byte) string {
+	str := string(buf)
+	if strings.Contains(str, `"`) && !strings.Contains(str, "`") {
+		return fmt.Sprintf("[]byte(`%s`)", str)
+	} else {
+		return fmt.Sprintf("[]byte(%q)", str)
+	}
+}
+
+func buildSingleInequalityForArrayOrSlice(p path.Path, actual, expected reflect.Value) inequality {
+	// This is a helper for findInequalitiesInArrayOrSlice() that reports only a single inequality for the entire thing.
+	// But it still tries to be clever, and will omit the longest common prefix and suffix to shorten the output.
+	maxTruncateableLength := min(actual.Len(), expected.Len())
+
+	commonPrefixLength := 0
+	for idx := range maxTruncateableLength {
+		actualElem := actual.Index(idx)
+		expectedElem := expected.Index(idx)
+		if reflect.DeepEqual(actualElem.Interface(), expectedElem.Interface()) {
+			commonPrefixLength = idx + 1
+		} else {
+			break
+		}
+	}
+
+	commonSuffixLength := 0
+	for idx := range max(0, maxTruncateableLength-commonPrefixLength) {
+		actualElem := actual.Index(actual.Len() - 1 - idx)
+		expectedElem := expected.Index(expected.Len() - 1 - idx)
+		if reflect.DeepEqual(actualElem.Interface(), expectedElem.Interface()) {
+			commonSuffixLength = idx + 1
+		} else {
+			break
+		}
+	}
+
+	if commonPrefixLength > 0 || commonSuffixLength > 0 {
+		p = append(p, path.SliceElement(commonPrefixLength, expected.Len()-commonSuffixLength))
+		actual = actual.Slice(commonPrefixLength, actual.Len()-commonSuffixLength)
+		expected = expected.Slice(commonPrefixLength, expected.Len()-commonSuffixLength)
+	}
+
+	return inequality{
+		Pointer:  p.AsGoExpression("actual"),
+		Actual:   formatValue(actual),
+		Expected: formatValue(expected),
+	}
+}
+
+func findInequalitiesInMap(p path.Path, actual, expected reflect.Value) (result []inequality) {
+	// recurse into all keys of `actual`
+	iter := actual.MapRange()
+	for iter.Next() {
+		key, actualElem := iter.Key(), iter.Value()
+		subpath := append(p, path.MapKeyElement(key.Interface()))
+		expectedElem := expected.MapIndex(key)
+		if expectedElem.IsValid() {
+			if !reflect.DeepEqual(actualElem.Interface(), expectedElem.Interface()) {
+				result = append(result, findInequalities(subpath, actualElem, expectedElem)...)
+			}
+		} else {
+			result = append(result, inequality{
+				Pointer:  subpath.AsGoExpression("actual"),
+				Actual:   formatValue(actualElem),
+				Expected: "<missing>",
+			})
+		}
+	}
+
+	// recurse into all keys of `expected` (but consider only those missing in `actual` to avoid duplicate reports)
+	iter = expected.MapRange()
+	for iter.Next() {
+		key, expectedElem := iter.Key(), iter.Value()
+		subpath := append(p, path.MapKeyElement(key.Interface()))
+		if !actual.MapIndex(key).IsValid() {
+			result = append(result, inequality{
+				Pointer:  subpath.AsGoExpression("actual"),
+				Actual:   "<missing>",
+				Expected: formatValue(expectedElem),
+			})
+		}
+	}
+
+	return result
+}
+
+func findInequalitiesInStruct(p path.Path, actual, expected reflect.Value) (result []inequality) {
+	// recurse into all addressable fields
+	//
+	// If only values in unexported fields differ, this function will return nothing,
+	// but that's fine because of the fallback behavior in findInequalities().
+	for field := range actual.Type().Fields() {
+		if !field.IsExported() {
+			continue
+		}
+		subpath := append(p, path.KeyElement(field.Name))
+		actualElem := actual.FieldByIndex(field.Index)
+		expectedElem := expected.FieldByIndex(field.Index)
+		if !reflect.DeepEqual(actualElem.Interface(), expectedElem.Interface()) {
+			result = append(result, findInequalities(subpath, actualElem, expectedElem)...)
+		}
+	}
+	return result
+}
+
+func findInequalitiesInPointer(p path.Path, actual, expected reflect.Value) []inequality {
+	if actual.IsNil() {
+		if expected.IsNil() {
+			// defense in depth: should not be reachable -> use the fallback behavior in findInequalities()
+			return nil
+		} else {
+			return []inequality{{
+				Pointer:  p.AsGoExpression("actual"),
+				Actual:   "nil",
+				Expected: "pointer to " + formatValue(expected.Elem()),
+			}}
+		}
+	} else {
+		if expected.IsNil() {
+			return []inequality{{
+				Pointer:  p.AsGoExpression("actual"),
+				Actual:   "pointer to " + formatValue(actual.Elem()),
+				Expected: "nil",
+			}}
+		} else {
+			subpath := append(p, path.DereferenceElement())
+			return findInequalities(subpath, actual.Elem(), expected.Elem())
+		}
+	}
+}

--- a/vendor/go.xyrillian.de/gg/assert/errequal.go
+++ b/vendor/go.xyrillian.de/gg/assert/errequal.go
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2026 Stefan Majewsky <majewsky@gmx.net>
+// SPDX-License-Identifier: Apache-2.0
+
+package assert
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"regexp"
+)
+
+// ErrEqual checks if the actual error matches the expectation.
+//   - If expected is nil, the actual error must be nil.
+//   - If expected is of type error, the actual error must be exactly equal to it or contain it, as reported by the [errors.Is] function.
+//   - If expected is of type string, the actual error must have a message exactly equal to it.
+//   - If expected is of type [*regexp.Regexp], the actual error must have a message matching that regexp.
+//   - If expected is of any other type, ErrEqual will panic.
+func ErrEqual(t TestingTB, actual error, expected any) bool {
+	// coerce all types that implement `error` into the interface type `error`,
+	// and also coerce all nil values of concrete `error` types into untyped nil
+	if expectedErr, ok := expected.(error); ok {
+		// convert nil values of concrete error types into a generic nil value
+		expectedValue := reflect.ValueOf(expectedErr)
+		kind := expectedValue.Kind()
+		if (kind == reflect.Pointer || kind == reflect.Interface) && expectedValue.IsNil() {
+			expected = nil
+		} else {
+			expected = expectedErr
+		}
+	}
+
+	switch expected := expected.(type) {
+	case nil:
+		if actual == nil {
+			return true
+		} else {
+			t.Errorf("expected no error, but got %q", actual.Error())
+			return false
+		}
+	case error:
+		if actual == nil {
+			t.Errorf("expected %q, but got no error", expected.Error())
+			return false
+		} else if errors.Is(actual, expected) {
+			return true
+		} else {
+			t.Errorf("expected %q, but got %q", expected.Error(), actual.Error())
+			return false
+		}
+	case string:
+		if actual == nil {
+			t.Errorf("expected %q, but got no error", expected)
+			return false
+		} else if actual.Error() == expected {
+			return true
+		} else {
+			t.Errorf("expected %q, but got %q", expected, actual.Error())
+			return false
+		}
+	case *regexp.Regexp:
+		if actual == nil {
+			t.Errorf("expected an error matching /%s/, but got no error", expected.String())
+			return false
+		} else if expected.MatchString(actual.Error()) {
+			return true
+		} else {
+			t.Errorf("expected an error matching /%s/, but got %q", expected.String(), actual.Error())
+			return false
+		}
+	default:
+		panic(fmt.Sprintf("cannot handle `expected` of type %T", expected))
+	}
+}

--- a/vendor/go.xyrillian.de/gg/internal/path/path.go
+++ b/vendor/go.xyrillian.de/gg/internal/path/path.go
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: 2026 Stefan Majewsky <majewsky@gmx.net>
+// SPDX-License-Identifier: Apache-2.0
+
+package path
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	. "go.xyrillian.de/gg/option"
+)
+
+// Path is used to identify the current location within a nested data structure
+// while recursing through it. For example, when comparing
+//
+//	actual = { "foo": { "bar": [ 5, 23 ] } }
+//	expected = { "foo": { "bar": [ 5, 42 ] } }
+//
+// we would generate a diff at the path {"foo", "bar", 1}.
+// Since diffs are usually rare, we only build Pointer strings
+// out of these paths when we really need them.
+// During recursion, Path holds a sequence of path elements,
+// most of which are constants to keep allocations to a minimum.
+//
+// # Warning
+//
+// Because the same Path slice is heavily reused across nested function calls,
+// it is not safe to store references to the Path slice during such a recursion.
+type Path []Element
+
+// Path preallocates a decently sized path buffer for use in a recursion.
+func NewPath() Path {
+	return make([]Element, 0, 32)
+}
+
+// Element occurs in type [Path]. Only one of both fields is set per instance.
+type Element struct {
+	// used by both package jsonmatch and package assert
+	Key   Option[string]
+	Index int
+
+	// only used by package assert (panics when used with AsJSONPointer())
+	Slice       Option[SliceBounds]
+	MapKey      Option[any] // holds a value of type K for traversing into types ~map[K]V
+	TypeCast    string      // holds a %T formatting of a type
+	Dereference bool        // marks when a pointer is dereferenced
+}
+
+// SliceBounds appears in type [Element].
+type SliceBounds struct {
+	Start int
+	End   int
+}
+
+// KeyElement is a shorthand for constructing an Element with the Key field set.
+func KeyElement(key string) Element { return Element{Key: Some(key)} }
+
+// IndexElement is a shorthand for constructing an Element with the Index field set.
+func IndexElement(idx int) Element { return Element{Index: idx} }
+
+// SliceElement is a shorthand for constructing an Element with the Slice field set.
+func SliceElement(start, end int) Element { return Element{Slice: Some(SliceBounds{start, end})} }
+
+// MapKeyElement is a shorthand for constructing an Element with the MapKey field set.
+func MapKeyElement(key any) Element { return Element{MapKey: Some(key)} }
+
+// TypeCastElement is a shorthand for constructing an Element with the TypeCast field set.
+func TypeCastElement(typeStr string) Element { return Element{TypeCast: typeStr} }
+
+// DereferenceElement is a shorthand for constructing an Element with the Dereference field set.
+func DereferenceElement() Element { return Element{Dereference: true} }
+
+// AsJSONPointer serializes p as a JSON pointer (RFC 6901).
+func (p Path) AsJSONPointer() string {
+	if len(p) == 0 {
+		return ""
+	}
+	fragments := make([]string, len(p)+1)
+	fragments[0] = ""
+	for idx, elem := range p {
+		if elem.Dereference {
+			panic("Dereference elements cannot be used with AsJSONPointer()")
+		}
+		if elem.TypeCast != "" {
+			panic("TypeCast elements cannot be used with AsJSONPointer()")
+		}
+		if elem.MapKey.IsSome() {
+			panic("MapKey elements cannot be used with AsJSONPointer()")
+		}
+		if elem.Slice.IsSome() {
+			panic("Slice elements cannot be used with AsJSONPointer()")
+		}
+		if key, ok := elem.Key.Unpack(); ok {
+			fragments[idx+1] = keyIntoPointerFragment(key)
+		} else {
+			fragments[idx+1] = strconv.Itoa(elem.Index)
+		}
+	}
+	return strings.Join(fragments, "/")
+}
+
+func keyIntoPointerFragment(key string) string {
+	buf, _ := json.Marshal(key)
+	s := string(buf)
+	s = strings.TrimPrefix(s, "\"")
+	s = strings.TrimSuffix(s, "\"")
+	s = strings.ReplaceAll(s, "~", "~0")
+	s = strings.ReplaceAll(s, "/", "~1")
+	return s
+}
+
+// AsGoExpression serializes p as a partial Go expression like `value.Objects["foo.txt"].Lines[42]`.
+func (p Path) AsGoExpression(baseVariable string) string {
+	b := &strings.Builder{}
+	fmt.Fprint(b, baseVariable)
+	for idx, elem := range p {
+		if elem.Dereference {
+			if idx != len(p)-1 && p[idx+1].Key.IsSome() {
+				// simplify `(*foo).Bar` to `foo.Bar`
+				continue
+			}
+			str := b.String()
+			b = &strings.Builder{}
+			fmt.Fprintf(b, "(*%s)", str)
+		} else if elem.TypeCast != "" {
+			fmt.Fprintf(b, `.(%s)`, elem.TypeCast)
+		} else if mapKey, ok := elem.MapKey.Unpack(); ok {
+			fmt.Fprintf(b, `[%#v]`, mapKey)
+		} else if bounds, ok := elem.Slice.Unpack(); ok {
+			fmt.Fprintf(b, `[%d:%d]`, bounds.Start, bounds.End)
+		} else if key, ok := elem.Key.Unpack(); ok {
+			fmt.Fprintf(b, `.%s`, key)
+		} else {
+			fmt.Fprintf(b, `[%d]`, elem.Index)
+		}
+	}
+	return b.String()
+}

--- a/vendor/go.xyrillian.de/gg/jsonmatch/machinery.go
+++ b/vendor/go.xyrillian.de/gg/jsonmatch/machinery.go
@@ -8,10 +8,9 @@ import (
 	"fmt"
 	"maps"
 	"slices"
-	"strconv"
 	"strings"
 
-	. "go.xyrillian.de/gg/option"
+	"go.xyrillian.de/gg/internal/path"
 )
 
 func marshalExpectedForDiff(value any) string {
@@ -70,54 +69,9 @@ func diffAgainst(expected any, buf []byte) []Diff {
 		}}
 	}
 
-	// While recursing through the object, we maintain a `path` that identifies
-	// where we are in the callstack, e.g. when comparing
-	//
-	//	actual = { "foo": { "bar": [ 5, 23 ] } }
-	//	expected = { "foo": { "bar": [ 5, 42 ] } }
-	//
-	// we would generate a diff at Path = {"foo", "bar", 1}. Since diffs are
-	// usually rare, we only build Pointer strings out of these paths when we
-	// really need them. During recursion, `path` is maintained as a sequence of
-	// path fragments, most of which are constants to keep allocations to a
-	// minimum. WARNING: Because the `path` slice is heavily reused across nested
-	// function calls, it is not safe to store references to the `path` slice.
-	path := make([]pathElement, 0, 32)
-	return getDiffsForValue(path, expected, actual)
-}
-
-type pathElement struct {
-	Key   Option[string]
-	Index int
-}
-
-func keyElement(key string) pathElement { return pathElement{Some(key), 0} }
-func indexElement(idx int) pathElement  { return pathElement{None[string](), idx} }
-
-func pathIntoPointer(path []pathElement) Pointer {
-	if len(path) == 0 {
-		return ""
-	}
-	fragments := make([]string, len(path)+1)
-	fragments[0] = ""
-	for idx, elem := range path {
-		if key, ok := elem.Key.Unpack(); ok {
-			fragments[idx+1] = keyIntoPointerFragment(key)
-		} else {
-			fragments[idx+1] = strconv.Itoa(elem.Index)
-		}
-	}
-	return Pointer(strings.Join(fragments, "/"))
-}
-
-func keyIntoPointerFragment(key string) string {
-	buf, _ := json.Marshal(key)
-	s := string(buf)
-	s = strings.TrimPrefix(s, "\"")
-	s = strings.TrimSuffix(s, "\"")
-	s = strings.ReplaceAll(s, "~", "~0")
-	s = strings.ReplaceAll(s, "/", "~1")
-	return s
+	// NOTE: consider the warning in the docstring of [path.Path]
+	p := path.NewPath()
+	return getDiffsForValue(p, expected, actual)
 }
 
 const (
@@ -127,31 +81,31 @@ const (
 )
 
 // NOTE: getDiffsForValue is the main part of the recursion to generate the diff.
-func getDiffsForValue(path []pathElement, expected, actual any) []Diff {
+func getDiffsForValue(p path.Path, expected, actual any) []Diff {
 	// specialized handling for relevant recursible or capturable types
 	switch expected := expected.(type) {
 	case map[string]any:
-		return getDiffsForObject(path, expected, actual)
+		return getDiffsForObject(p, expected, actual)
 	case Object:
-		return getDiffsForObject(path, expected, actual)
+		return getDiffsForObject(p, expected, actual)
 	case []any:
-		return getDiffsForArray(path, expected, actual)
+		return getDiffsForArray(p, expected, actual)
 	case Array:
-		return getDiffsForArray(path, expected, actual)
+		return getDiffsForArray(p, expected, actual)
 	case []map[string]any:
 		downcasted := make([]any, len(expected))
 		for idx, val := range expected {
 			downcasted[idx] = val
 		}
-		return getDiffsForArray(path, downcasted, actual)
+		return getDiffsForArray(p, downcasted, actual)
 	case []Object:
 		downcasted := make([]any, len(expected))
 		for idx, val := range expected {
 			downcasted[idx] = val
 		}
-		return getDiffsForArray(path, downcasted, actual)
+		return getDiffsForArray(p, downcasted, actual)
 	case capturedField:
-		return getDiffsForCapturedField(path, expected, actual)
+		return getDiffsForCapturedField(p, expected, actual)
 	case irrelevant:
 		return nil
 	case nil:
@@ -162,7 +116,7 @@ func getDiffsForValue(path []pathElement, expected, actual any) []Diff {
 		} else {
 			return []Diff{{
 				Kind:         kindTypeMismatch,
-				Pointer:      pathIntoPointer(path),
+				Pointer:      Pointer(p.AsJSONPointer()),
 				ExpectedJSON: "null",
 				ActualJSON:   marshalActualForDiff(actual),
 			}}
@@ -179,14 +133,14 @@ func getDiffsForValue(path []pathElement, expected, actual any) []Diff {
 			// this branch is therefore unreachable in tests and only exists as defense in depth
 			return []Diff{{
 				Kind:         kindDispatchFailed,
-				Pointer:      pathIntoPointer(path),
+				Pointer:      Pointer(p.AsJSONPointer()),
 				ExpectedJSON: fmt.Sprintf("<custom diffable: %#v>", diffable),
 				ActualJSON:   fmt.Sprintf("<marshal error: %s>", err.Error()),
 			}}
 		}
 		diffs := diffable.DiffAgainst(buf)
 		for idx, diff := range diffs {
-			diff.Pointer = pathIntoPointer(path) + diff.Pointer
+			diff.Pointer = Pointer(p.AsJSONPointer()) + diff.Pointer
 			diffs[idx] = diff
 		}
 		return diffs
@@ -223,35 +177,35 @@ func getDiffsForValue(path []pathElement, expected, actual any) []Diff {
 	}
 	return []Diff{{
 		Kind:         kind,
-		Pointer:      pathIntoPointer(path),
+		Pointer:      Pointer(p.AsJSONPointer()),
 		ExpectedJSON: expectedJSON,
 		ActualJSON:   actualJSON,
 	}}
 }
 
-func getDiffsForObject(path []pathElement, expected map[string]any, actual any) []Diff {
+func getDiffsForObject(p path.Path, expected map[string]any, actual any) []Diff {
 	if actual, ok := actual.(map[string]any); ok {
-		return getDiffsForConfirmedObject(path, expected, actual)
+		return getDiffsForConfirmedObject(p, expected, actual)
 	}
 	return []Diff{{
 		Kind:         kindTypeMismatch,
-		Pointer:      pathIntoPointer(path),
+		Pointer:      Pointer(p.AsJSONPointer()),
 		ExpectedJSON: marshalExpectedForDiff(expected),
 		ActualJSON:   marshalActualForDiff(actual),
 	}}
 }
 
-func getDiffsForConfirmedObject(path []pathElement, expected, actual map[string]any) (diffs []Diff) {
+func getDiffsForConfirmedObject(p path.Path, expected, actual map[string]any) (diffs []Diff) {
 	// recurse into all fields
 	for _, key := range slices.Sorted(maps.Keys(actual)) {
-		subpath := append(path, keyElement(key))
+		subpath := append(p, path.KeyElement(key))
 		expectedValue, exists := expected[key]
 		if exists {
 			diffs = append(diffs, getDiffsForValue(subpath, expectedValue, actual[key])...)
 		} else {
 			diffs = append(diffs, Diff{
 				Kind:         kindValueMismatch,
-				Pointer:      pathIntoPointer(subpath),
+				Pointer:      Pointer(subpath.AsJSONPointer()),
 				ExpectedJSON: "<missing>",
 				ActualJSON:   marshalActualForDiff(actual[key]),
 			})
@@ -260,10 +214,10 @@ func getDiffsForConfirmedObject(path []pathElement, expected, actual map[string]
 	for _, key := range slices.Sorted(maps.Keys(expected)) {
 		_, exists := actual[key]
 		if !exists {
-			subpath := append(path, keyElement(key))
+			subpath := append(p, path.KeyElement(key))
 			diffs = append(diffs, Diff{
 				Kind:         kindValueMismatch,
-				Pointer:      pathIntoPointer(subpath),
+				Pointer:      Pointer(subpath.AsJSONPointer()),
 				ExpectedJSON: marshalExpectedForDiff(expected[key]),
 				ActualJSON:   "<missing>",
 			})
@@ -273,34 +227,34 @@ func getDiffsForConfirmedObject(path []pathElement, expected, actual map[string]
 	return diffs
 }
 
-func getDiffsForArray(path []pathElement, expected []any, actual any) []Diff {
+func getDiffsForArray(p path.Path, expected []any, actual any) []Diff {
 	if actual, ok := actual.([]any); ok {
-		return getDiffsForConfirmedArray(path, expected, actual)
+		return getDiffsForConfirmedArray(p, expected, actual)
 	}
 	return []Diff{{
 		Kind:         kindTypeMismatch,
-		Pointer:      pathIntoPointer(path),
+		Pointer:      Pointer(p.AsJSONPointer()),
 		ExpectedJSON: marshalExpectedForDiff(expected),
 		ActualJSON:   marshalActualForDiff(actual),
 	}}
 }
 
-func getDiffsForConfirmedArray(path []pathElement, expected, actual []any) (diffs []Diff) {
+func getDiffsForConfirmedArray(p path.Path, expected, actual []any) (diffs []Diff) {
 	// recurse into all elements
 	for idx := range max(len(actual), len(expected)) {
-		subpath := append(path, indexElement(idx))
+		subpath := append(p, path.IndexElement(idx))
 		switch {
 		case idx >= len(actual):
 			diffs = append(diffs, Diff{
 				Kind:         kindValueMismatch,
-				Pointer:      pathIntoPointer(subpath),
+				Pointer:      Pointer(subpath.AsJSONPointer()),
 				ActualJSON:   "<missing>",
 				ExpectedJSON: marshalExpectedForDiff(expected[idx]),
 			})
 		case idx >= len(expected):
 			diffs = append(diffs, Diff{
 				Kind:         kindValueMismatch,
-				Pointer:      pathIntoPointer(subpath),
+				Pointer:      Pointer(subpath.AsJSONPointer()),
 				ActualJSON:   marshalActualForDiff(actual[idx]),
 				ExpectedJSON: "<missing>",
 			})
@@ -312,13 +266,13 @@ func getDiffsForConfirmedArray(path []pathElement, expected, actual []any) (diff
 	return diffs
 }
 
-func getDiffsForCapturedField(path []pathElement, expected capturedField, actual any) []Diff {
+func getDiffsForCapturedField(p path.Path, expected capturedField, actual any) []Diff {
 	actualJSON := marshalActualForDiff(actual)
 	err := json.Unmarshal([]byte(actualJSON), expected.PointerToTarget)
 	if err != nil {
 		return []Diff{{
 			Kind:         fmt.Sprintf("cannot unmarshal into capture slot (%s)", err.Error()),
-			Pointer:      pathIntoPointer(path),
+			Pointer:      Pointer(p.AsJSONPointer()),
 			ActualJSON:   actualJSON,
 			ExpectedJSON: fmt.Sprintf("<capture slot of type %T>", expected.PointerToTarget),
 		}}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -181,8 +181,10 @@ github.com/sapcc/go-bits/syncext
 # github.com/sergi/go-diff v1.4.0
 ## explicit; go 1.13
 github.com/sergi/go-diff/diffmatchpatch
-# go.xyrillian.de/gg v1.9.1
-## explicit; go 1.24
+# go.xyrillian.de/gg v1.10.1
+## explicit; go 1.26
+go.xyrillian.de/gg/assert
+go.xyrillian.de/gg/internal/path
 go.xyrillian.de/gg/is
 go.xyrillian.de/gg/jsonmatch
 go.xyrillian.de/gg/option


### PR DESCRIPTION
The main part of the diff is replacing gobits_assert.DeepEqual() with gg_assert.Equal(), which drops the argument containing a description of the compared value. Where this argument was used to disambiguate output from individual assertions, I replaced this with t.Run()-based subtests.