### PR TITLE
v2 report API scaffold and /rates implementations

### DIFF
--- a/docs/example-policy.json
+++ b/docs/example-policy.json
@@ -2,6 +2,7 @@
     "project_scope": "project_domain_id:%(domain_id)s and project_id:%(project_id)s",
     "domain_scope": "domain_id:%(domain_id)s",
     "cluster_admin": "role:cloud_resource_admin",
+    "cluster_viewer": "role:cloud_resource_viewer or rule:cluster_admin",
     "domain_editor": "rule:cluster_admin or (rule:domain_scope and role:resource_admin)",
     "domain_viewer": "rule:domain_editor or (rule:domain_scope and role:resource_viewer)",
     "project_editor": "rule:domain_editor or (rule:project_scope and role:admin)",
@@ -27,13 +28,22 @@
     "cluster:show_errors": "rule:cluster_admin",
     "cluster:edit": "rule:cluster_admin",
 
+    "v2:project:scope": "project_domain_id:%(domain_uuid)s and project_id:%(project_uuid)s",
+    "v2:domain:scope": "domain_id:%(domain_uuid)s",
+    "v2:project:role": "role:member or role:admin",
+    "v2:domain:role": "role:resource_viewer or role:resource_admin",
     "v2:meta:no_error_obfuscation": "rule:cluster_admin",
 
-    "v2:project:info": "rule:project_viewer",
-    "v2:project:commitment_create": "rule:project_editor",
+    "v2:project:info": "rule:'v2:domain:info' or rule:'v2:project:role'",
+    "v2:project:report_single": "rule:'v2:project:report_multiple' or (rule:'v2:project:scope' and rule:'v2:project:role')",
+    "v2:project:report_multiple": "rule:cluster_viewer or (rule:'v2:domain:scope' and rule:'v2:domain:role')",
+    "v2:project:commitment_create": "rule:cluster_admin or (rule:'v2:domain:scope' and role:resource_admin) or (rule:'v2:project:scope' and role:admin)",
 
-    "v2:domain:info": "rule:domain_viewer",
+    "v2:domain:info": "rule:'v2:cluster:info' or rule:'v2:domain:role'",
+    "v2:domain:report_single": "rule:'v2:domain:report_multiple' or (rule:'v2:domain:scope' and rule:'v2:domain:role')",
+    "v2:domain:report_multiple": "rule:cluster_viewer",
 
-    "v2:cluster:info": "rule:cluster_admin",
+    "v2:cluster:info": "rule:cluster_viewer",
+    "v2:cluster:report_single": "rule:cluster_viewer",
     "v2:cluster:validation": "project_name:service and project_domain_name:Default and user_name:limes-validation and user_domain_name:Default"
 }

--- a/internal/api/api_v2/cluster.go
+++ b/internal/api/api_v2/cluster.go
@@ -3,6 +3,55 @@
 
 package api_v2
 
-import "github.com/sapcc/go-api-declarations/opts"
+import (
+	"net/http"
 
-var _ = opts.ParseQueryString[struct{}]
+	"github.com/sapcc/go-api-declarations/opts"
+	"github.com/sapcc/go-bits/gopherpolicy"
+	"github.com/sapcc/go-bits/httpapi"
+
+	"github.com/sapcc/limes/internal/api/reports_v2"
+	"github.com/sapcc/limes/internal/apideclarations/apiv2/common"
+	ratesv2 "github.com/sapcc/limes/internal/apideclarations/apiv2/rates"
+	resourcesv2 "github.com/sapcc/limes/internal/apideclarations/apiv2/resources"
+)
+
+// handleGetResourcesCluster handles GET /resources/v2/cluster.
+func (p *v2Provider) handleGetResourcesCluster(r *http.Request, token *gopherpolicy.Token) (_ resourcesv2.ClusterGetResponse, err error) {
+	httpapi.IdentifyEndpoint(r, "/resources/v2/cluster")
+	none := resourcesv2.ClusterGetResponse{}
+
+	err = token.Enforce("v2:cluster:report")
+	if err != nil {
+		return none, err
+	}
+	options, err := opts.ParseQueryString[common.ClusterResourceReportOpts](r.URL.Query())
+	if err != nil {
+		return none, err
+	}
+	_, err = reports_v2.FilterFromResourceOpts(p.Cluster, options.ResourceReportOpts)
+	if err != nil {
+		return none, err
+	}
+	return none, nil
+}
+
+// handleGetRatesCluster handles GET /rates/v2/cluster.
+func (p *v2Provider) handleGetRatesCluster(r *http.Request, token *gopherpolicy.Token) (_ ratesv2.ClusterGetResponse, err error) {
+	httpapi.IdentifyEndpoint(r, "/rates/v2/cluster")
+	none := ratesv2.ClusterGetResponse{}
+
+	err = token.Enforce("v2:cluster:report")
+	if err != nil {
+		return none, err
+	}
+	options, err := opts.ParseQueryString[common.ClusterRateReportOpts](r.URL.Query())
+	if err != nil {
+		return none, err
+	}
+	_, err = reports_v2.FilterFromRateOpts(p.Cluster, options.RateReportOpts)
+	if err != nil {
+		return none, err
+	}
+	return none, nil
+}

--- a/internal/api/api_v2/cluster.go
+++ b/internal/api/api_v2/cluster.go
@@ -21,7 +21,7 @@ func (p *v2Provider) handleGetResourcesCluster(r *http.Request, token *gopherpol
 	httpapi.IdentifyEndpoint(r, "/resources/v2/cluster")
 	none := resourcesv2.ClusterGetResponse{}
 
-	err = token.Enforce("v2:cluster:report")
+	err = token.Enforce("v2:cluster:report_single")
 	if err != nil {
 		return none, err
 	}
@@ -41,7 +41,7 @@ func (p *v2Provider) handleGetRatesCluster(r *http.Request, token *gopherpolicy.
 	httpapi.IdentifyEndpoint(r, "/rates/v2/cluster")
 	none := ratesv2.ClusterGetResponse{}
 
-	err = token.Enforce("v2:cluster:report")
+	err = token.Enforce("v2:cluster:report_single")
 	if err != nil {
 		return none, err
 	}
@@ -49,9 +49,13 @@ func (p *v2Provider) handleGetRatesCluster(r *http.Request, token *gopherpolicy.
 	if err != nil {
 		return none, err
 	}
-	_, err = reports_v2.FilterFromRateOpts(p.Cluster, options.RateReportOpts)
+	filter, err := reports_v2.FilterFromRateOpts(p.Cluster, options.RateReportOpts)
 	if err != nil {
 		return none, err
 	}
-	return none, nil
+	result, err := reports_v2.GetClusterRates(p.Cluster, token, filter, options)
+	if err != nil {
+		return none, err
+	}
+	return result, nil
 }

--- a/internal/api/api_v2/cluster_test.go
+++ b/internal/api/api_v2/cluster_test.go
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package api_v2_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/sapcc/go-api-declarations/liquid"
+	"github.com/sapcc/go-bits/httptest"
+
+	. "go.xyrillian.de/gg/option"
+
+	"github.com/sapcc/limes/internal/test"
+)
+
+const clusterReportConfigJSON = `{
+	"availability_zones": ["az-one", "az-two"],
+	"discovery": {
+		"method": "static",
+		"static_config": {
+			"domains": [
+				{"name": "germany", "id": "uuid-for-germany"},
+				{"name": "france", "id": "uuid-for-france"}
+			],
+			"projects": {
+				"uuid-for-germany": [
+					{"name": "berlin", "id": "uuid-for-berlin", "parent_id": "uuid-for-germany"},
+					{"name": "dresden", "id": "uuid-for-dresden", "parent_id": "uuid-for-berlin"}
+				],
+				"uuid-for-france": [
+					{"name": "paris", "id": "uuid-for-paris", "parent_id": "uuid-for-france"}
+				]
+			}
+		}
+	},
+	"areas": { "first": { "display_name": "First" }, "second": { "display_name": "Second" }},
+	"liquids": {
+		"first": {
+			"area": "first",
+			"commitment_behavior_per_resource": [],
+			"rate_limits": {
+				"global": [
+					{"name": "objects:create", "limit": 5000, "window": "1s", "unit": "piece"}
+				],
+				"project_default": [
+					{"name": "objects:create", "limit": 5, "window": "1m", "unit": "piece"},
+					{"name": "objects:update", "limit": 2, "window": "1s", "unit": "piece"}
+				]
+			}
+		},
+		"second": {
+			"area": "second",
+			"commitment_behavior_per_resource": [{
+				"key": "capacity",
+				"value": {
+					"durations_per_domain": [{"key": "germany", "value": ["1 hour", "2 hours"]}],
+					"min_confirm_date": "1970-01-08T00:00:00Z"
+				}
+			}]
+		}
+	}
+}`
+
+func TestV2ClusterRateReport(t *testing.T) {
+	srvInfoFirst := test.DefaultLiquidServiceInfo("First")
+	srvInfoFirst.Rates = map[liquid.RateName]liquid.RateInfo{
+		"objects:create":    {DisplayName: "Object Creations", Topology: liquid.FlatTopology, HasUsage: true, Category: Some(liquid.CategoryName("foo_category"))},
+		"objects:delete":    {DisplayName: "Object Deletions", Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: true},
+		"objects:update":    {DisplayName: "Object Updates", Topology: liquid.FlatTopology, HasUsage: false},
+		"objects:unlimited": {DisplayName: "Object Unlimited Operations", Unit: liquid.UnitKibibytes, Topology: liquid.FlatTopology, HasUsage: true},
+	}
+
+	s := test.NewSetup(t,
+		test.WithConfig(clusterReportConfigJSON),
+		test.WithPersistedServiceInfo("first", srvInfoFirst),
+		test.WithPersistedServiceInfo("second", test.DefaultLiquidServiceInfo("Second")),
+		test.WithInitialDiscovery,
+		test.WithEmptyResourceRecordsAsNeeded,
+		test.WithEmptyRateRecordsAsNeeded,
+	)
+	fixturePath := "./fixtures/rate-cluster.json"
+
+	// we will just update all project_rates with usage to have a value of 5, so 3 projects * 5 = 15 usage
+	objectsCreateRateID := s.GetRateID("first", "objects:update")
+	s.MustDBExec(`UPDATE project_rates SET usage_as_bigint = '5' WHERE rate_id != $1`, objectsCreateRateID)
+
+	s.TokenValidator.Enforcer.AllowReportSingle = false
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/cluster").
+		ExpectText(t, http.StatusForbidden, "Forbidden\n")
+	s.TokenValidator.Enforcer.AllowReportSingle = true
+
+	// the maximum result set includes the info
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/cluster?with=info").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "with-info"))
+
+	// without info
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/cluster").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "no params").
+			Modify("del(.info)"))
+
+	// when filtering for a certain rate, the info and report get filtered similarly
+	// area: this will lead to an empty report, hence the structure is cut off at a higher level!
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/cluster?with=info&area=second").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "area filter").
+			Modify(".cluster_report.service_areas=null").
+			Modify("del(.info.service_areas.first)"))
+	// service: also empty report
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/cluster?with=info&service=second").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "service filter").
+			Modify(".cluster_report.service_areas=null").
+			Modify("del(.info.service_areas.first)"))
+	// category
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/cluster?with=info&category=foo_category").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "category filter").
+			Modify("del(.cluster_report.service_areas.first.services.first.categories.first)").
+			Modify("del(.info.service_areas.first.services.first.categories.first)"))
+	// category - special case: empty category (category = service type)
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/cluster?with=info&category=first").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "category filter - empty category/ equal service type").
+			Modify("del(.cluster_report.service_areas.first.services.first.categories.foo_category)").
+			Modify("del(.info.service_areas.first.services.first.categories.foo_category)").
+			Modify("del(.info.service_areas.second)"))
+	// rate
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/cluster?with=info&rate=objects:create").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "rate filter").
+			Modify("del(.cluster_report.service_areas.first.services.first.categories.first)").
+			Modify("del(.info.service_areas.first.services.first.categories.first)"))
+}

--- a/internal/api/api_v2/core.go
+++ b/internal/api/api_v2/core.go
@@ -58,8 +58,19 @@ func (p *v2Provider) AddTo(r *mux.Router) {
 
 	tv := p.tokenValidator
 	resRouter.Methods("GET").Path("/info").HandlerFunc(handlerFunc(http.StatusOK, tv, p.handleGetResourcesInfo))
-	ratesRouter.Methods("GET").Path("/info").HandlerFunc(handlerFunc(http.StatusOK, tv, p.handleGetRatesInfo))
+	resRouter.Methods("GET").Path("/cluster").HandlerFunc(handlerFunc(http.StatusOK, tv, p.handleGetResourcesCluster))
+	resRouter.Methods("GET").Path("/domains").HandlerFunc(handlerFunc(http.StatusOK, tv, p.handleGetResourcesDomains))
+	resRouter.Methods("GET").Path("/domains/{domain_uuid}").HandlerFunc(handlerFunc(http.StatusOK, tv, p.handleGetResourcesDomain))
+	resRouter.Methods("GET").Path("/projects").HandlerFunc(handlerFunc(http.StatusOK, tv, p.handleGetResourcesProjects))
+	resRouter.Methods("GET").Path("/projects/{project_uuid}").HandlerFunc(handlerFunc(http.StatusOK, tv, p.handleGetResourcesProject))
 	resRouter.Methods("POST").Path("/commitments/new").HandlerFunc(handlerFunc(http.StatusCreated, tv, p.handlePostNewCommitment))
+
+	ratesRouter.Methods("GET").Path("/info").HandlerFunc(handlerFunc(http.StatusOK, tv, p.handleGetRatesInfo))
+	ratesRouter.Methods("GET").Path("/cluster").HandlerFunc(handlerFunc(http.StatusOK, tv, p.handleGetRatesCluster))
+	ratesRouter.Methods("GET").Path("/domains").HandlerFunc(handlerFunc(http.StatusOK, tv, p.handleGetRatesDomains))
+	ratesRouter.Methods("GET").Path("/domains/{domain_uuid}").HandlerFunc(handlerFunc(http.StatusOK, tv, p.handleGetRatesDomain))
+	ratesRouter.Methods("GET").Path("/projects").HandlerFunc(handlerFunc(http.StatusOK, tv, p.handleGetRatesProjects))
+	ratesRouter.Methods("GET").Path("/projects/{project_uuid}").HandlerFunc(handlerFunc(http.StatusOK, tv, p.handleGetRatesProject))
 }
 
 // Wrapper for request handlers that enforces a structure,

--- a/internal/api/api_v2/core.go
+++ b/internal/api/api_v2/core.go
@@ -71,6 +71,7 @@ func (p *v2Provider) AddTo(r *mux.Router) {
 func handlerFunc[T any](successCode int, tv gopherpolicy.Validator, action func(*http.Request, *gopherpolicy.Token) (T, error)) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		t := tv.CheckToken(r)
+		t.Context.Request = mux.Vars(r)
 
 		var (
 			resp T
@@ -164,8 +165,8 @@ func (p *v2Provider) checkProjectAccess(t *gopherpolicy.Token, projectUUID liqui
 	switch {
 	case err == nil:
 		t.Context.Request = map[string]string{
-			"domain_id":  domain.UUID,
-			"project_id": string(projectUUID),
+			"domain_uuid":  domain.UUID,
+			"project_uuid": string(projectUUID),
 		}
 		err = t.Enforce(policyRule)
 		if err != nil {
@@ -173,8 +174,8 @@ func (p *v2Provider) checkProjectAccess(t *gopherpolicy.Token, projectUUID liqui
 		}
 	case errors.Is(err, sql.ErrNoRows):
 		t.Context.Request = map[string]string{
-			"domain_id":  "unknown",
-			"project_id": string(projectUUID),
+			"domain_uuid":  "unknown",
+			"project_uuid": string(projectUUID),
 		}
 		err = t.Enforce(policyRule)
 		if err == nil {

--- a/internal/api/api_v2/domain.go
+++ b/internal/api/api_v2/domain.go
@@ -69,37 +69,24 @@ func (p *v2Provider) handleGetResourcesDomain(r *http.Request, token *gopherpoli
 // handleGetRatesDomains handles GET /rates/v2/domains.
 func (p *v2Provider) handleGetRatesDomains(r *http.Request, token *gopherpolicy.Token) (_ ratesv2.DomainGetResponse, err error) {
 	httpapi.IdentifyEndpoint(r, "/rates/v2/domains")
-	none := ratesv2.DomainGetResponse{}
-
-	err = token.Enforce("v2:domain:report_multiple")
-	if err != nil {
-		return none, err
-	}
-	_, err = reports_v2.NewScope(false, r, None[string](), token, p.DB)
-	if err != nil {
-		return none, err
-	}
-	options, err := opts.ParseQueryString[common.DomainRateReportOpts](r.URL.Query())
-	if err != nil {
-		return none, err
-	}
-	_, err = reports_v2.FilterFromRateOpts(p.Cluster, options.RateReportOpts)
-	if err != nil {
-		return none, err
-	}
-	return none, nil
+	return p.commonHandleGetRatesDomain(r, token, "v2:domain:report_multiple")
 }
 
 // handleGetRatesDomain handles GET /rates/v2/domains/:domain_uuid.
 func (p *v2Provider) handleGetRatesDomain(r *http.Request, token *gopherpolicy.Token) (_ ratesv2.DomainGetResponse, err error) {
 	httpapi.IdentifyEndpoint(r, "/rates/v2/domains/:domain_uuid")
+	return p.commonHandleGetRatesDomain(r, token, "v2:domain:report_single")
+}
+
+// commonHandleGetRatesDomain handles single- and multi-domain rate calls.
+func (p *v2Provider) commonHandleGetRatesDomain(r *http.Request, token *gopherpolicy.Token, rule string) (_ ratesv2.DomainGetResponse, err error) {
 	none := ratesv2.DomainGetResponse{}
 
-	err = token.Enforce("v2:domain:report_single")
+	err = token.Enforce(rule)
 	if err != nil {
 		return none, err
 	}
-	_, err = reports_v2.NewScope(false, r, None[string](), token, p.DB)
+	scope, err := reports_v2.NewScope(false, r, None[string](), token, p.DB)
 	if err != nil {
 		return none, err
 	}
@@ -107,9 +94,13 @@ func (p *v2Provider) handleGetRatesDomain(r *http.Request, token *gopherpolicy.T
 	if err != nil {
 		return none, err
 	}
-	_, err = reports_v2.FilterFromRateOpts(p.Cluster, options.RateReportOpts)
+	filter, err := reports_v2.FilterFromRateOpts(p.Cluster, options.RateReportOpts)
 	if err != nil {
 		return none, err
 	}
-	return none, nil
+	result, err := reports_v2.GetDomainRates(p.Cluster, token, filter, options, scope)
+	if err != nil {
+		return none, err
+	}
+	return result, nil
 }

--- a/internal/api/api_v2/domain.go
+++ b/internal/api/api_v2/domain.go
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package api_v2
+
+import (
+	"net/http"
+
+	"github.com/sapcc/go-api-declarations/opts"
+	"github.com/sapcc/go-bits/gopherpolicy"
+	"github.com/sapcc/go-bits/httpapi"
+
+	. "go.xyrillian.de/gg/option"
+
+	"github.com/sapcc/limes/internal/api/reports_v2"
+	"github.com/sapcc/limes/internal/apideclarations/apiv2/common"
+	ratesv2 "github.com/sapcc/limes/internal/apideclarations/apiv2/rates"
+	resourcesv2 "github.com/sapcc/limes/internal/apideclarations/apiv2/resources"
+)
+
+// handleGetResourcesDomains handles GET /resources/v2/domains.
+func (p *v2Provider) handleGetResourcesDomains(r *http.Request, token *gopherpolicy.Token) (_ resourcesv2.DomainGetResponse, err error) {
+	httpapi.IdentifyEndpoint(r, "/resources/v2/domains")
+	none := resourcesv2.DomainGetResponse{}
+
+	err = token.Enforce("v2:domain:report_multiple")
+	if err != nil {
+		return none, err
+	}
+	_, err = reports_v2.NewScope(false, r, None[string](), token, p.DB)
+	if err != nil {
+		return none, err
+	}
+	options, err := opts.ParseQueryString[common.DomainResourceReportOpts](r.URL.Query())
+	if err != nil {
+		return none, err
+	}
+	_, err = reports_v2.FilterFromResourceOpts(p.Cluster, options.ResourceReportOpts)
+	if err != nil {
+		return none, err
+	}
+	return none, nil
+}
+
+// handleGetResourcesDomain handles GET /resources/v2/domains/:domain_uuid.
+func (p *v2Provider) handleGetResourcesDomain(r *http.Request, token *gopherpolicy.Token) (_ resourcesv2.DomainGetResponse, err error) {
+	httpapi.IdentifyEndpoint(r, "/resources/v2/domains/:domain_uuid")
+	none := resourcesv2.DomainGetResponse{}
+
+	err = token.Enforce("v2:domain:report_single")
+	if err != nil {
+		return none, err
+	}
+	_, err = reports_v2.NewScope(false, r, None[string](), token, p.DB)
+	if err != nil {
+		return none, err
+	}
+	options, err := opts.ParseQueryString[common.DomainResourceReportOpts](r.URL.Query())
+	if err != nil {
+		return none, err
+	}
+	_, err = reports_v2.FilterFromResourceOpts(p.Cluster, options.ResourceReportOpts)
+	if err != nil {
+		return none, err
+	}
+	return none, nil
+}
+
+// handleGetRatesDomains handles GET /rates/v2/domains.
+func (p *v2Provider) handleGetRatesDomains(r *http.Request, token *gopherpolicy.Token) (_ ratesv2.DomainGetResponse, err error) {
+	httpapi.IdentifyEndpoint(r, "/rates/v2/domains")
+	none := ratesv2.DomainGetResponse{}
+
+	err = token.Enforce("v2:domain:report_multiple")
+	if err != nil {
+		return none, err
+	}
+	_, err = reports_v2.NewScope(false, r, None[string](), token, p.DB)
+	if err != nil {
+		return none, err
+	}
+	options, err := opts.ParseQueryString[common.DomainRateReportOpts](r.URL.Query())
+	if err != nil {
+		return none, err
+	}
+	_, err = reports_v2.FilterFromRateOpts(p.Cluster, options.RateReportOpts)
+	if err != nil {
+		return none, err
+	}
+	return none, nil
+}
+
+// handleGetRatesDomain handles GET /rates/v2/domains/:domain_uuid.
+func (p *v2Provider) handleGetRatesDomain(r *http.Request, token *gopherpolicy.Token) (_ ratesv2.DomainGetResponse, err error) {
+	httpapi.IdentifyEndpoint(r, "/rates/v2/domains/:domain_uuid")
+	none := ratesv2.DomainGetResponse{}
+
+	err = token.Enforce("v2:domain:report_single")
+	if err != nil {
+		return none, err
+	}
+	_, err = reports_v2.NewScope(false, r, None[string](), token, p.DB)
+	if err != nil {
+		return none, err
+	}
+	options, err := opts.ParseQueryString[common.DomainRateReportOpts](r.URL.Query())
+	if err != nil {
+		return none, err
+	}
+	_, err = reports_v2.FilterFromRateOpts(p.Cluster, options.RateReportOpts)
+	if err != nil {
+		return none, err
+	}
+	return none, nil
+}

--- a/internal/api/api_v2/domain_test.go
+++ b/internal/api/api_v2/domain_test.go
@@ -15,49 +15,7 @@ import (
 	"github.com/sapcc/limes/internal/test"
 )
 
-const rateReportConfigJSON = `{
-	"availability_zones": ["az-one", "az-two"],
-	"discovery": {
-		"method": "static",
-		"static_config": {
-			"domains": [
-				{"name": "germany", "id": "uuid-for-germany"},
-				{"name": "france", "id": "uuid-for-france"}
-			],
-			"projects": {
-				"uuid-for-germany": [
-					{"name": "berlin", "id": "uuid-for-berlin", "parent_id": "uuid-for-germany"},
-					{"name": "dresden", "id": "uuid-for-dresden", "parent_id": "uuid-for-berlin"}
-				],
-				"uuid-for-france": [
-					{"name": "paris", "id": "uuid-for-paris", "parent_id": "uuid-for-france"}
-				]
-			}
-		}
-	},
-	"areas": { "first": { "display_name": "First" }, "second": { "display_name": "Second" }},
-	"liquids": {
-		"first": {
-			"area": "first",
-			"commitment_behavior_per_resource": [],
-			"rate_limits": {
-				"global": [
-					{"name": "objects:create", "limit": 5000, "window": "1s", "unit": "piece"}
-				],
-				"project_default": [
-					{"name": "objects:create", "limit": 5, "window": "1m", "unit": "piece"},
-					{"name": "objects:update", "limit": 2, "window": "1s", "unit": "piece"}
-				]
-			}
-		},
-		"second": {
-			"area": "second",
-			"commitment_behavior_per_resource": []
-		}
-	}
-}`
-
-func TestV2ClusterRateReport(t *testing.T) {
+func TestV2DomainRateReport(t *testing.T) {
 	srvInfoFirst := test.DefaultLiquidServiceInfo("First")
 	srvInfoFirst.Rates = map[liquid.RateName]liquid.RateInfo{
 		"objects:create":    {DisplayName: "Object Creations", Topology: liquid.FlatTopology, HasUsage: true, Category: Some(liquid.CategoryName("foo_category"))},
@@ -74,51 +32,67 @@ func TestV2ClusterRateReport(t *testing.T) {
 		test.WithEmptyResourceRecordsAsNeeded,
 		test.WithEmptyRateRecordsAsNeeded,
 	)
-	fixturePath := "./fixtures/rate-cluster.json"
+	fixturePath := "./fixtures/rate-domains.json"
 
-	// we will just update all project_rates with usage to have a value of 5, so 3 projects * 5 = 15 usage
-	objectsCreateRateID := s.GetRateID("first", "objects:update")
-	s.MustDBExec(`UPDATE project_rates SET usage_as_bigint = '5' WHERE rate_id != $1`, objectsCreateRateID)
+	// we will just update all project_rates with usage to have a value of 5, so one domain has 10 usage and the other 5
+	updatesUpdateRateID := s.GetRateID("first", "objects:update")
+	s.MustDBExec(`UPDATE project_rates SET usage_as_bigint = '5' WHERE rate_id != $1`, updatesUpdateRateID)
 
+	s.TokenValidator.Enforcer.AllowReportMultiple = false
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/domains").
+		ExpectText(t, http.StatusForbidden, "Forbidden\n")
+	s.TokenValidator.Enforcer.AllowReportMultiple = true
 	s.TokenValidator.Enforcer.AllowReportSingle = false
-	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/cluster").
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/domains/uuid-for-france").
 		ExpectText(t, http.StatusForbidden, "Forbidden\n")
 	s.TokenValidator.Enforcer.AllowReportSingle = true
 
 	// the maximum result set includes the info
-	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/cluster?with=info").ExpectJSON(t, http.StatusOK,
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/domains?with=info").ExpectJSON(t, http.StatusOK,
 		httptest.NewJQModifiableJSONFixture(fixturePath, "with-info"))
 
 	// without info
-	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/cluster").ExpectJSON(t, http.StatusOK,
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/domains").ExpectJSON(t, http.StatusOK,
 		httptest.NewJQModifiableJSONFixture(fixturePath, "no params").
 			Modify("del(.info)"))
 
+	// one domain
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/domains/uuid-for-france?with=info").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "domain filter france").
+			Modify(`del(.domains["uuid-for-germany"])`))
+	// the other domain
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/domains/uuid-for-germany?with=info").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "domain filter germany").
+			Modify(`del(.domains["uuid-for-france"])`))
+
 	// when filtering for a certain rate, the info and report get filtered similarly
 	// area: this will lead to an empty report, hence the structure is cut off at a higher level!
-	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/cluster?with=info&area=second").ExpectJSON(t, http.StatusOK,
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/domains?with=info&area=second").ExpectJSON(t, http.StatusOK,
 		httptest.NewJQModifiableJSONFixture(fixturePath, "area filter").
-			Modify(".cluster_report.service_areas=null").
+			Modify(".domains=null").
 			Modify("del(.info.service_areas.first)"))
 	// service: also empty report
-	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/cluster?with=info&service=second").ExpectJSON(t, http.StatusOK,
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/domains?with=info&service=second").ExpectJSON(t, http.StatusOK,
 		httptest.NewJQModifiableJSONFixture(fixturePath, "service filter").
-			Modify(".cluster_report.service_areas=null").
+			Modify(".domains=null").
 			Modify("del(.info.service_areas.first)"))
 	// category
-	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/cluster?with=info&category=foo_category").ExpectJSON(t, http.StatusOK,
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/domains?with=info&category=foo_category").ExpectJSON(t, http.StatusOK,
 		httptest.NewJQModifiableJSONFixture(fixturePath, "category filter").
-			Modify("del(.cluster_report.service_areas.first.services.first.categories.first)").
+			Modify("del(.domains[].service_areas.first.services.first.categories.first)").
 			Modify("del(.info.service_areas.first.services.first.categories.first)"))
 	// category - special case: empty category (category = service type)
-	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/cluster?with=info&category=first").ExpectJSON(t, http.StatusOK,
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/domains?with=info&category=first").ExpectJSON(t, http.StatusOK,
 		httptest.NewJQModifiableJSONFixture(fixturePath, "category filter - empty category/ equal service type").
-			Modify("del(.cluster_report.service_areas.first.services.first.categories.foo_category)").
+			Modify("del(.domains[].service_areas.first.services.first.categories.foo_category)").
 			Modify("del(.info.service_areas.first.services.first.categories.foo_category)").
 			Modify("del(.info.service_areas.second)"))
 	// rate
-	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/cluster?with=info&rate=objects:create").ExpectJSON(t, http.StatusOK,
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/domains?with=info&rate=objects:create").ExpectJSON(t, http.StatusOK,
 		httptest.NewJQModifiableJSONFixture(fixturePath, "rate filter").
-			Modify("del(.cluster_report.service_areas.first.services.first.categories.first)").
+			Modify("del(.domains[].service_areas.first.services.first.categories.first)").
 			Modify("del(.info.service_areas.first.services.first.categories.first)"))
+
+	// unknown domain
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/domains/does-not-exists").ExpectText(t, http.StatusNotFound, "no such domain (UUID = does-not-exists)\n")
 }

--- a/internal/api/api_v2/fixtures/rate-cluster.json
+++ b/internal/api/api_v2/fixtures/rate-cluster.json
@@ -1,0 +1,98 @@
+{
+  "info": {
+    "all_azs": [
+      "az-one",
+      "az-two"
+    ],
+    "service_areas": {
+      "first": {
+        "display_name": "First",
+        "services": {
+          "first": {
+            "categories": {
+              "first": {
+                "display_name": "First",
+                "rates": {
+                  "objects:delete": {
+                    "display_name": "Object Deletions",
+                    "has_usage": true,
+                    "topology": "flat",
+                    "unit": "MiB"
+                  },
+                  "objects:unlimited": {
+                    "display_name": "Object Unlimited Operations",
+                    "has_usage": true,
+                    "topology": "flat",
+                    "unit": "KiB"
+                  },
+                  "objects:update": {
+                    "display_name": "Object Updates",
+                    "has_usage": false,
+                    "project_default_limit": 2,
+                    "project_default_window": "1s",
+                    "topology": "flat",
+                    "unit": "piece"
+                  }
+                }
+              },
+              "foo_category": {
+                "display_name": "Foo Category",
+                "rates": {
+                  "objects:create": {
+                    "display_name": "Object Creations",
+                    "has_usage": true,
+                    "project_default_limit": 5,
+                    "project_default_window": "1m",
+                    "topology": "flat",
+                    "unit": "piece"
+                  }
+                }
+              }
+            },
+            "display_name": "First",
+            "version": 1
+          }
+        }
+      },
+      "second": {
+        "display_name": "Second",
+        "services": {
+          "second": {
+            "categories": {},
+            "display_name": "Second",
+            "version": 1
+          }
+        }
+      }
+    }
+  },
+  "cluster_report": {
+    "service_areas": {
+      "first": {
+        "services": {
+          "first": {
+            "categories": {
+              "first": {
+                "rates": {
+                  "objects:delete": {
+                    "usage_as_bigint": "15"
+                  },
+                  "objects:unlimited": {
+                    "usage_as_bigint": "15"
+                  }
+                }
+              },
+              "foo_category": {
+                "rates": {
+                  "objects:create": {
+                    "usage_as_bigint": "15"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/api/api_v2/fixtures/rate-domains.json
+++ b/internal/api/api_v2/fixtures/rate-domains.json
@@ -1,0 +1,133 @@
+{
+  "info": {
+    "all_azs": [
+      "az-one",
+      "az-two"
+    ],
+    "service_areas": {
+      "first": {
+        "display_name": "First",
+        "services": {
+          "first": {
+            "categories": {
+              "first": {
+                "display_name": "First",
+                "rates": {
+                  "objects:delete": {
+                    "display_name": "Object Deletions",
+                    "has_usage": true,
+                    "topology": "flat",
+                    "unit": "MiB"
+                  },
+                  "objects:unlimited": {
+                    "display_name": "Object Unlimited Operations",
+                    "has_usage": true,
+                    "topology": "flat",
+                    "unit": "KiB"
+                  },
+                  "objects:update": {
+                    "display_name": "Object Updates",
+                    "has_usage": false,
+                    "project_default_limit": 2,
+                    "project_default_window": "1s",
+                    "topology": "flat",
+                    "unit": "piece"
+                  }
+                }
+              },
+              "foo_category": {
+                "display_name": "Foo Category",
+                "rates": {
+                  "objects:create": {
+                    "display_name": "Object Creations",
+                    "has_usage": true,
+                    "project_default_limit": 5,
+                    "project_default_window": "1m",
+                    "topology": "flat",
+                    "unit": "piece"
+                  }
+                }
+              }
+            },
+            "display_name": "First",
+            "version": 1
+          }
+        }
+      },
+      "second": {
+        "display_name": "Second",
+        "services": {
+          "second": {
+            "categories": {},
+            "display_name": "Second",
+            "version": 1
+          }
+        }
+      }
+    }
+  },
+  "domains": {
+    "uuid-for-france": {
+      "uuid": "uuid-for-france",
+      "name": "france",
+      "service_areas": {
+        "first": {
+          "services": {
+            "first": {
+              "categories": {
+                "first": {
+                  "rates": {
+                    "objects:delete": {
+                      "usage_as_bigint": "5"
+                    },
+                    "objects:unlimited": {
+                      "usage_as_bigint": "5"
+                    }
+                  }
+                },
+                "foo_category": {
+                  "rates": {
+                    "objects:create": {
+                      "usage_as_bigint": "5"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "uuid-for-germany": {
+      "uuid": "uuid-for-germany",
+      "name": "germany",
+      "service_areas": {
+        "first": {
+          "services": {
+            "first": {
+              "categories": {
+                "first": {
+                  "rates": {
+                    "objects:delete": {
+                      "usage_as_bigint": "10"
+                    },
+                    "objects:unlimited": {
+                      "usage_as_bigint": "10"
+                    }
+                  }
+                },
+                "foo_category": {
+                  "rates": {
+                    "objects:create": {
+                      "usage_as_bigint": "10"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/api/api_v2/fixtures/rate-projects.json
+++ b/internal/api/api_v2/fixtures/rate-projects.json
@@ -1,0 +1,187 @@
+{
+  "info": {
+    "all_azs": [
+      "az-one",
+      "az-two"
+    ],
+    "service_areas": {
+      "first": {
+        "display_name": "First",
+        "services": {
+          "first": {
+            "categories": {
+              "first": {
+                "display_name": "First",
+                "rates": {
+                  "objects:delete": {
+                    "display_name": "Object Deletions",
+                    "has_usage": true,
+                    "topology": "flat",
+                    "unit": "MiB"
+                  },
+                  "objects:unlimited": {
+                    "display_name": "Object Unlimited Operations",
+                    "has_usage": true,
+                    "topology": "flat",
+                    "unit": "KiB"
+                  },
+                  "objects:update": {
+                    "display_name": "Object Updates",
+                    "has_usage": false,
+                    "project_default_limit": 2,
+                    "project_default_window": "1s",
+                    "topology": "flat",
+                    "unit": "piece"
+                  }
+                }
+              },
+              "foo_category": {
+                "display_name": "Foo Category",
+                "rates": {
+                  "objects:create": {
+                    "display_name": "Object Creations",
+                    "has_usage": true,
+                    "project_default_limit": 5,
+                    "project_default_window": "1m",
+                    "topology": "flat",
+                    "unit": "piece"
+                  }
+                }
+              }
+            },
+            "display_name": "First",
+            "version": 1
+          }
+        }
+      },
+      "second": {
+        "display_name": "Second",
+        "services": {
+          "second": {
+            "categories": {},
+            "display_name": "Second",
+            "version": 1
+          }
+        }
+      }
+    }
+  },
+  "domains": {
+    "uuid-for-france": {
+      "projects": {
+        "uuid-for-paris": {
+          "uuid": "uuid-for-paris",
+          "name": "paris",
+          "parent_uuid": "uuid-for-france",
+          "domain": {
+            "uuid": "uuid-for-france",
+            "name": "france"
+          },
+          "service_areas": {
+            "first": {
+              "services": {
+                "first": {
+                  "categories": {
+                    "first": {
+                      "rates": {
+                        "objects:delete": {
+                          "usage_as_bigint": "5"
+                        },
+                        "objects:unlimited": {
+                          "usage_as_bigint": "5"
+                        }
+                      }
+                    },
+                    "foo_category": {
+                      "rates": {
+                        "objects:create": {
+                          "usage_as_bigint": "5"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "uuid-for-germany": {
+      "projects": {
+        "uuid-for-berlin": {
+          "uuid": "uuid-for-berlin",
+          "name": "berlin",
+          "parent_uuid": "uuid-for-germany",
+          "domain": {
+            "uuid": "uuid-for-germany",
+            "name": "germany"
+          },
+          "service_areas": {
+            "first": {
+              "services": {
+                "first": {
+                  "categories": {
+                    "first": {
+                      "rates": {
+                        "objects:delete": {
+                          "usage_as_bigint": "5"
+                        },
+                        "objects:unlimited": {
+                          "usage_as_bigint": "5"
+                        }
+                      }
+                    },
+                    "foo_category": {
+                      "rates": {
+                        "objects:create": {
+                          "usage_as_bigint": "5"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "uuid-for-dresden": {
+          "uuid": "uuid-for-dresden",
+          "name": "dresden",
+          "parent_uuid": "uuid-for-berlin",
+          "domain": {
+            "uuid": "uuid-for-germany",
+            "name": "germany"
+          },
+          "service_areas": {
+            "first": {
+              "services": {
+                "first": {
+                  "categories": {
+                    "first": {
+                      "rates": {
+                        "objects:delete": {
+                          "usage_as_bigint": "5"
+                        },
+                        "objects:unlimited": {
+                          "usage_as_bigint": "5"
+                        }
+                      }
+                    },
+                    "foo_category": {
+                      "rates": {
+                        "objects:create": {
+                          "usage_as_bigint": "5"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/api/api_v2/info.go
+++ b/internal/api/api_v2/info.go
@@ -4,238 +4,24 @@
 package api_v2
 
 import (
-	"database/sql"
-	"maps"
 	"net/http"
-	"slices"
 
-	"github.com/sapcc/go-api-declarations/liquid"
 	"github.com/sapcc/go-bits/gopherpolicy"
 	"github.com/sapcc/go-bits/httpapi"
-	"github.com/sapcc/go-bits/sqlext"
-	. "go.xyrillian.de/gg/option"
 
+	"github.com/sapcc/limes/internal/api/reports_v2"
 	ratesv2 "github.com/sapcc/limes/internal/apideclarations/apiv2/rates"
 	resourcesv2 "github.com/sapcc/limes/internal/apideclarations/apiv2/resources"
-	"github.com/sapcc/limes/internal/core"
-	"github.com/sapcc/limes/internal/db"
 )
-
-var findAllowedResourcesQuery = sqlext.SimplifyWhitespace(`
-	SELECT DISTINCT s.type, r.name
-	FROM project_resources pr
-	JOIN resources r ON pr.resource_id = r.id
-	JOIN services s ON r.service_id = s.id
-	JOIN projects p ON pr.project_id = p.id
-	JOIN domains d ON p.domain_id = d.id
-	WHERE ((p.uuid = $1 OR $1 = '') AND (d.uuid = $2 OR $2 = ''))
-	AND pr.forbidden = false
-`)
-
-func (p *v2Provider) authenticateInfoRequest(token *gopherpolicy.Token) (projectUUID, domainUUID, domainName string, err error) {
-	projectUUID = token.ProjectScopeUUID()
-	projectDomainUUID := token.ProjectScopeDomainUUID()
-	projectDomainName := token.ProjectScopeDomainName()
-	domainUUID = token.DomainScopeUUID()
-	domainName = token.DomainScopeName()
-
-	switch {
-	case token.Check("v2:cluster:info"):
-		return "", "", "", nil
-	case token.Check("v2:domain:info"):
-		return "", domainUUID, domainName, nil
-	default:
-		// the final token.Check() is a token.Enforce() because Enforce can properly distinguish between 401 and 403 errors
-		err := token.Enforce("v2:project:info")
-		if err == nil {
-			return projectUUID, projectDomainUUID, projectDomainName, nil
-		} else {
-			return "", "", "", err
-		}
-	}
-}
 
 // handleGetResourcesInfo handles GET /resources/v2/info.
 func (p *v2Provider) handleGetResourcesInfo(r *http.Request, token *gopherpolicy.Token) (resourcesv2.InfoReport, error) {
 	httpapi.IdentifyEndpoint(r, "/resources/v2/info")
-	var none resourcesv2.InfoReport // used on error return paths only
-
-	projectUUID, domainUUID, domainName, err := p.authenticateInfoRequest(token)
-	if err != nil {
-		return none, err
-	}
-
-	// collect allowed items for this user
-	allowedResourcesByService := make(map[db.ServiceType][]liquid.ResourceName)
-	err = sqlext.ForeachRow(p.DB, findAllowedResourcesQuery, []any{projectUUID, domainUUID}, func(rows *sql.Rows) error {
-		var (
-			serviceType  db.ServiceType
-			resourceName liquid.ResourceName
-		)
-		err := rows.Scan(&serviceType, &resourceName)
-		if err == nil {
-			allowedResourcesByService[serviceType] = append(allowedResourcesByService[serviceType], resourceName)
-		}
-		return err
-	})
-	if err != nil {
-		return none, err
-	}
-
-	// assemble the report
-	report := resourcesv2.InfoReport{
-		AllAZs: p.Cluster.Config.AvailabilityZones,
-		Areas:  make(map[string]resourcesv2.AreaInfoReport),
-	}
-	sis := p.Cluster.SIC.GetSnapshot()
-	services := sis.GetServices()
-	categories := sis.GetCategories()
-
-	for _, serviceType := range slices.Sorted(maps.Keys(services)) {
-		service := services[serviceType]
-		resources, _ := sis.GetResourcesForType(serviceType) // can have no resources
-		// skip non-allowed resources for this user, if any
-		allowedResources, serviceTypeOK := allowedResourcesByService[serviceType]
-		if !serviceTypeOK {
-			continue
-		}
-		config := p.Cluster.Config.Liquids[serviceType]
-		area := config.Area
-		// defense in depth: config should be in sync with serviceInfo
-		if area == "" {
-			continue
-		}
-		areaDisplayName := ""
-		// defense in depth: when area was found in config, a displayName has to be available
-		if areaConfig, exists := p.Cluster.Config.Areas[area]; exists {
-			areaDisplayName = areaConfig.DisplayName
-		}
-
-		if _, exists := report.Areas[area]; !exists {
-			report.Areas[area] = resourcesv2.AreaInfoReport{
-				DisplayName: areaDisplayName,
-				Services:    make(map[db.ServiceType]resourcesv2.ServiceInfoReport),
-			}
-		}
-		report.Areas[area].Services[serviceType] = resourcesv2.ServiceInfoReport{
-			Version:     service.LiquidVersion,
-			DisplayName: service.DisplayName,
-			Categories:  make(map[liquid.CategoryName]resourcesv2.CategoryInfoReport),
-		}
-		serviceReport := report.Areas[area].Services[serviceType]
-
-		for _, resourceName := range slices.Sorted(maps.Keys(resources)) {
-			resource := resources[resourceName]
-			// skip non-allowed resources for this user, if any
-			if !slices.Contains(allowedResources, resourceName) {
-				continue
-			}
-			category := liquid.CategoryName(serviceType)
-			categoryDisplayName := service.DisplayName
-			if categoryID, exists := resource.CategoryID.Unpack(); exists {
-				category = categories[categoryID].Name
-				categoryDisplayName = categories[categoryID].DisplayName
-			}
-			if _, exists := serviceReport.Categories[category]; !exists {
-				serviceReport.Categories[category] = resourcesv2.CategoryInfoReport{
-					DisplayName: categoryDisplayName,
-					Resources:   make(map[liquid.ResourceName]resourcesv2.ResourceInfoReport),
-				}
-			}
-			commitmentBehavior := p.Cluster.CommitmentBehaviorForResource(serviceType, resourceName)
-			var scopedCommitmentBehavior core.ScopedCommitmentBehavior
-
-			if domainUUID == "" {
-				scopedCommitmentBehavior = commitmentBehavior.ForCluster()
-			} else {
-				scopedCommitmentBehavior = commitmentBehavior.ForDomain(domainName)
-			}
-			serviceReport.Categories[category].Resources[resourceName] = resourcesv2.ResourceInfoReport{
-				DisplayName:      resource.DisplayName,
-				Unit:             resource.Unit,
-				Topology:         resource.Topology,
-				HasCapacity:      resource.HasCapacity,
-				HasQuota:         resource.HasQuota,
-				CommitmentConfig: scopedCommitmentBehavior.ForV2API(p.timeNow()),
-			}
-		}
-	}
-	return report, nil
+	return reports_v2.GetResourcesInfo(p.Cluster, token, p.timeNow(), p.Cluster.SIC.GetSnapshot())
 }
 
 // handleGetRatesInfo handles GET /rates/v2/info.
 func (p *v2Provider) handleGetRatesInfo(r *http.Request, token *gopherpolicy.Token) (ratesv2.InfoReport, error) {
 	httpapi.IdentifyEndpoint(r, "/rates/v2/info")
-	var none ratesv2.InfoReport // used on error return paths only
-
-	_, _, _, err := p.authenticateInfoRequest(token)
-	if err != nil {
-		return none, err
-	}
-
-	// assemble the report
-	report := ratesv2.InfoReport{
-		AllAZs: p.Cluster.Config.AvailabilityZones,
-		Areas:  make(map[string]ratesv2.AreaInfoReport),
-	}
-	sis := p.Cluster.SIC.GetSnapshot()
-	services := sis.GetServices()
-	categories := sis.GetCategories()
-
-	for _, serviceType := range slices.Sorted(maps.Keys(services)) {
-		service := services[serviceType]
-		rates, _ := sis.GetRatesForType(serviceType) // can have no rates
-		config := p.Cluster.Config.Liquids[serviceType]
-		area := config.Area
-		// defense in depth: config should be in sync with serviceInfo
-		if area == "" {
-			continue
-		}
-		areaDisplayName := ""
-		// defense in depth: when area was found in config, a displayName has to be available
-		if areaConfig, exists := p.Cluster.Config.Areas[area]; exists {
-			areaDisplayName = areaConfig.DisplayName
-		}
-
-		if _, exists := report.Areas[area]; !exists {
-			report.Areas[area] = ratesv2.AreaInfoReport{
-				DisplayName: areaDisplayName,
-				Services:    make(map[db.ServiceType]ratesv2.ServiceInfoReport),
-			}
-		}
-		report.Areas[area].Services[serviceType] = ratesv2.ServiceInfoReport{
-			Version:     service.LiquidVersion,
-			DisplayName: service.DisplayName,
-			Categories:  make(map[liquid.CategoryName]ratesv2.CategoryInfoReport),
-		}
-		serviceReport := report.Areas[area].Services[serviceType]
-
-		for _, rateName := range slices.Sorted(maps.Keys(rates)) {
-			rate := rates[rateName]
-			rir := ratesv2.RateInfoReport{
-				DisplayName: rate.DisplayName,
-				Topology:    rate.Topology,
-				HasUsage:    rate.HasUsage,
-				Unit:        rate.Unit,
-			}
-			if rateConfig, ok := config.RateLimits.GetProjectDefaultRateLimit(rateName).Unpack(); ok {
-				rir.ProjectDefaultLimit = rateConfig.Limit
-				rir.ProjectDefaultWindow = Some(rateConfig.Window)
-			}
-			category := liquid.CategoryName(serviceType)
-			categoryDisplayName := service.DisplayName
-			if categoryID, exists := rate.CategoryID.Unpack(); exists {
-				category = categories[categoryID].Name
-				categoryDisplayName = categories[categoryID].DisplayName
-			}
-			if _, exists := serviceReport.Categories[category]; !exists {
-				serviceReport.Categories[category] = ratesv2.CategoryInfoReport{
-					DisplayName: categoryDisplayName,
-					Rates:       make(map[liquid.RateName]ratesv2.RateInfoReport),
-				}
-			}
-			serviceReport.Categories[category].Rates[rateName] = rir
-		}
-	}
-	return report, nil
+	return reports_v2.GetRatesInfo(p.Cluster, token, p.Cluster.SIC.GetSnapshot())
 }

--- a/internal/api/api_v2/project.go
+++ b/internal/api/api_v2/project.go
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package api_v2
+
+import (
+	"net/http"
+
+	"github.com/sapcc/go-api-declarations/opts"
+	"github.com/sapcc/go-bits/gopherpolicy"
+	"github.com/sapcc/go-bits/httpapi"
+
+	"github.com/sapcc/limes/internal/api/reports_v2"
+	"github.com/sapcc/limes/internal/apideclarations/apiv2/common"
+	ratesv2 "github.com/sapcc/limes/internal/apideclarations/apiv2/rates"
+	resourcesv2 "github.com/sapcc/limes/internal/apideclarations/apiv2/resources"
+)
+
+// handleGetResourcesProjects handles GET /resources/v2/projects.
+func (p *v2Provider) handleGetResourcesProjects(r *http.Request, token *gopherpolicy.Token) (_ resourcesv2.ProjectGetResponse, err error) {
+	httpapi.IdentifyEndpoint(r, "/resources/v2/projects")
+	none := resourcesv2.ProjectGetResponse{}
+
+	// important: validate scope before token.Enforce, so that URL/ query domain_uuid is written back to token scope
+	options, err := opts.ParseQueryString[common.ProjectResourceReportOpts](r.URL.Query())
+	if err != nil {
+		return none, err
+	}
+	_, err = reports_v2.NewScope(true, r, options.DomainUUID, token, p.DB)
+	if err != nil {
+		return none, err
+	}
+	err = token.Enforce("v2:project:report_multiple")
+	if err != nil {
+		return none, err
+	}
+	_, err = reports_v2.FilterFromResourceOpts(p.Cluster, options.ResourceReportOpts)
+	if err != nil {
+		return none, err
+	}
+	return none, nil
+}
+
+// handleGetResourcesProject handles GET /resources/v2/projects/:project_uuid.
+func (p *v2Provider) handleGetResourcesProject(r *http.Request, token *gopherpolicy.Token) (_ resourcesv2.ProjectGetResponse, err error) {
+	httpapi.IdentifyEndpoint(r, "/resources/v2/projects/:project_uuid")
+	none := resourcesv2.ProjectGetResponse{}
+
+	// important: validate scope before token.Enforce, so that URL/ query domain_uuid is written back to token scope
+	options, err := opts.ParseQueryString[common.ProjectResourceReportOpts](r.URL.Query())
+	if err != nil {
+		return none, err
+	}
+	_, err = reports_v2.NewScope(true, r, options.DomainUUID, token, p.DB)
+	if err != nil {
+		return none, err
+	}
+	err = token.Enforce("v2:project:report_single")
+	if err != nil {
+		return none, err
+	}
+	_, err = reports_v2.FilterFromResourceOpts(p.Cluster, options.ResourceReportOpts)
+	if err != nil {
+		return none, err
+	}
+	return none, nil
+}
+
+// handleGetRatesProjects handles GET /rates/v2/projects.
+func (p *v2Provider) handleGetRatesProjects(r *http.Request, token *gopherpolicy.Token) (_ ratesv2.ProjectGetResponse, err error) {
+	httpapi.IdentifyEndpoint(r, "/rates/v2/projects")
+	none := ratesv2.ProjectGetResponse{}
+
+	// important: validate scope before token.Enforce, so that URL/ query domain_uuid is written back to token scope
+	options, err := opts.ParseQueryString[common.ProjectRateReportOpts](r.URL.Query())
+	if err != nil {
+		return none, err
+	}
+	_, err = reports_v2.NewScope(true, r, options.DomainUUID, token, p.DB)
+	if err != nil {
+		return none, err
+	}
+	err = token.Enforce("v2:project:report_multiple")
+	if err != nil {
+		return none, err
+	}
+	_, err = reports_v2.FilterFromRateOpts(p.Cluster, options.RateReportOpts)
+	if err != nil {
+		return none, err
+	}
+	return none, nil
+}
+
+// handleGetRatesProject handles GET /rates/v2/projects/:project_uuid.
+func (p *v2Provider) handleGetRatesProject(r *http.Request, token *gopherpolicy.Token) (_ ratesv2.ProjectGetResponse, err error) {
+	httpapi.IdentifyEndpoint(r, "/rates/v2/projects/:project_uuid")
+	none := ratesv2.ProjectGetResponse{}
+
+	// important: validate scope before token.Enforce, so that URL/ query domain_uuid is written back to token scope
+	options, err := opts.ParseQueryString[common.ProjectRateReportOpts](r.URL.Query())
+	if err != nil {
+		return none, err
+	}
+	_, err = reports_v2.NewScope(true, r, options.DomainUUID, token, p.DB)
+	if err != nil {
+		return none, err
+	}
+	err = token.Enforce("v2:project:report_single")
+	if err != nil {
+		return none, err
+	}
+	_, err = reports_v2.FilterFromRateOpts(p.Cluster, options.RateReportOpts)
+	if err != nil {
+		return none, err
+	}
+	return none, nil
+}

--- a/internal/api/api_v2/project.go
+++ b/internal/api/api_v2/project.go
@@ -21,7 +21,7 @@ func (p *v2Provider) handleGetResourcesProjects(r *http.Request, token *gopherpo
 	httpapi.IdentifyEndpoint(r, "/resources/v2/projects")
 	none := resourcesv2.ProjectGetResponse{}
 
-	// important: validate scope before token.Enforce, so that URL/ query domain_uuid is written back to token scope
+	// important: validate scope before token.Enforce, so that projects domain_uuid is written back to token scope
 	options, err := opts.ParseQueryString[common.ProjectResourceReportOpts](r.URL.Query())
 	if err != nil {
 		return none, err
@@ -46,7 +46,7 @@ func (p *v2Provider) handleGetResourcesProject(r *http.Request, token *gopherpol
 	httpapi.IdentifyEndpoint(r, "/resources/v2/projects/:project_uuid")
 	none := resourcesv2.ProjectGetResponse{}
 
-	// important: validate scope before token.Enforce, so that URL/ query domain_uuid is written back to token scope
+	// important: validate scope before token.Enforce, so that projects domain_uuid is written back to token scope
 	options, err := opts.ParseQueryString[common.ProjectResourceReportOpts](r.URL.Query())
 	if err != nil {
 		return none, err
@@ -69,49 +69,39 @@ func (p *v2Provider) handleGetResourcesProject(r *http.Request, token *gopherpol
 // handleGetRatesProjects handles GET /rates/v2/projects.
 func (p *v2Provider) handleGetRatesProjects(r *http.Request, token *gopherpolicy.Token) (_ ratesv2.ProjectGetResponse, err error) {
 	httpapi.IdentifyEndpoint(r, "/rates/v2/projects")
-	none := ratesv2.ProjectGetResponse{}
-
-	// important: validate scope before token.Enforce, so that URL/ query domain_uuid is written back to token scope
-	options, err := opts.ParseQueryString[common.ProjectRateReportOpts](r.URL.Query())
-	if err != nil {
-		return none, err
-	}
-	_, err = reports_v2.NewScope(true, r, options.DomainUUID, token, p.DB)
-	if err != nil {
-		return none, err
-	}
-	err = token.Enforce("v2:project:report_multiple")
-	if err != nil {
-		return none, err
-	}
-	_, err = reports_v2.FilterFromRateOpts(p.Cluster, options.RateReportOpts)
-	if err != nil {
-		return none, err
-	}
-	return none, nil
+	return p.commonHandleGetRatesProject(r, token, "v2:project:report_multiple")
 }
 
 // handleGetRatesProject handles GET /rates/v2/projects/:project_uuid.
 func (p *v2Provider) handleGetRatesProject(r *http.Request, token *gopherpolicy.Token) (_ ratesv2.ProjectGetResponse, err error) {
 	httpapi.IdentifyEndpoint(r, "/rates/v2/projects/:project_uuid")
+	return p.commonHandleGetRatesProject(r, token, "v2:project:report_single")
+}
+
+// commonHandleGetRatesProject handles single- and multi-project rate calls.
+func (p *v2Provider) commonHandleGetRatesProject(r *http.Request, token *gopherpolicy.Token, rule string) (_ ratesv2.ProjectGetResponse, err error) {
 	none := ratesv2.ProjectGetResponse{}
 
-	// important: validate scope before token.Enforce, so that URL/ query domain_uuid is written back to token scope
+	// important: validate scope before token.Enforce, so that projects domain_uuid is written back to token scope
 	options, err := opts.ParseQueryString[common.ProjectRateReportOpts](r.URL.Query())
 	if err != nil {
 		return none, err
 	}
-	_, err = reports_v2.NewScope(true, r, options.DomainUUID, token, p.DB)
+	scope, err := reports_v2.NewScope(true, r, options.DomainUUID, token, p.DB)
 	if err != nil {
 		return none, err
 	}
-	err = token.Enforce("v2:project:report_single")
+	err = token.Enforce(rule)
 	if err != nil {
 		return none, err
 	}
-	_, err = reports_v2.FilterFromRateOpts(p.Cluster, options.RateReportOpts)
+	filter, err := reports_v2.FilterFromRateOpts(p.Cluster, options.RateReportOpts)
 	if err != nil {
 		return none, err
 	}
-	return none, nil
+	result, err := reports_v2.GetProjectRates(p.Cluster, token, filter, options, scope)
+	if err != nil {
+		return none, err
+	}
+	return result, nil
 }

--- a/internal/api/api_v2/project_test.go
+++ b/internal/api/api_v2/project_test.go
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package api_v2_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/sapcc/go-api-declarations/liquid"
+	"github.com/sapcc/go-bits/httptest"
+
+	. "go.xyrillian.de/gg/option"
+
+	"github.com/sapcc/limes/internal/test"
+)
+
+func TestV2ProjectRateReport(t *testing.T) {
+	srvInfoFirst := test.DefaultLiquidServiceInfo("First")
+	srvInfoFirst.Rates = map[liquid.RateName]liquid.RateInfo{
+		"objects:create":    {DisplayName: "Object Creations", Topology: liquid.FlatTopology, HasUsage: true, Category: Some(liquid.CategoryName("foo_category"))},
+		"objects:delete":    {DisplayName: "Object Deletions", Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: true},
+		"objects:update":    {DisplayName: "Object Updates", Topology: liquid.FlatTopology, HasUsage: false},
+		"objects:unlimited": {DisplayName: "Object Unlimited Operations", Unit: liquid.UnitKibibytes, Topology: liquid.FlatTopology, HasUsage: true},
+	}
+
+	s := test.NewSetup(t,
+		test.WithConfig(rateReportConfigJSON),
+		test.WithPersistedServiceInfo("first", srvInfoFirst),
+		test.WithPersistedServiceInfo("second", test.DefaultLiquidServiceInfo("Second")),
+		test.WithInitialDiscovery,
+		test.WithEmptyResourceRecordsAsNeeded,
+		test.WithEmptyRateRecordsAsNeeded,
+	)
+	fixturePath := "./fixtures/rate-projects.json"
+
+	// for now, we will set all rates to usage - later we will check the combination with rate limits
+	objectsUpdateRateID := s.GetRateID("first", "objects:update")
+	s.MustDBExec(`UPDATE project_rates SET usage_as_bigint = '5' WHERE rate_id != $1`, objectsUpdateRateID)
+
+	s.TokenValidator.Enforcer.AllowReportMultiple = false
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/projects").
+		ExpectText(t, http.StatusForbidden, "Forbidden\n")
+	s.TokenValidator.Enforcer.AllowReportMultiple = true
+	s.TokenValidator.Enforcer.AllowReportSingle = false
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/projects/uuid-for-paris").
+		ExpectText(t, http.StatusForbidden, "Forbidden\n")
+	s.TokenValidator.Enforcer.AllowReportSingle = true
+
+	// the maximum result set includes the info
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/projects?with=info").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "with-info"))
+
+	// without info
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/projects").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "no params").
+			Modify("del(.info)"))
+
+	// one project
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/projects/uuid-for-paris?with=info").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "project filter paris").
+			Modify(`del(.domains["uuid-for-germany"])`))
+	// another project
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/projects/uuid-for-berlin?with=info").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "project filter berlin").
+			Modify(`del(.domains["uuid-for-france"])`).
+			Modify(`del(.domains["uuid-for-germany"].projects["uuid-for-dresden"])`))
+	// another project
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/projects/uuid-for-dresden?with=info").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "project filter dresden").
+			Modify(`del(.domains["uuid-for-france"])`).
+			Modify(`del(.domains["uuid-for-germany"].projects["uuid-for-berlin"])`))
+
+	// one full domain
+	// for this, a cloud_admin or domain token is required.
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/projects?with=info&domain_uuid=uuid-for-france").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "domain filter france").
+			Modify(`del(.domains["uuid-for-germany"])`))
+	// the other domain
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/projects?with=info&domain_uuid=uuid-for-germany").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "domain filter france").
+			Modify(`del(.domains["uuid-for-france"])`))
+
+	// when filtering for a certain rate, the info and report get filtered similarly
+	// area: this will lead to an empty report, hence the structure is cut off at a higher level!
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/projects?with=info&area=second").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "area filter").
+			Modify(".domains=null").
+			Modify("del(.info.service_areas.first)"))
+	// service: also empty report
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/projects?with=info&service=second").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "service filter").
+			Modify(".domains=null").
+			Modify("del(.info.service_areas.first)"))
+	// category
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/projects?with=info&category=foo_category").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "category filter").
+			Modify("del(.domains[].projects[].service_areas.first.services.first.categories.first)").
+			Modify("del(.info.service_areas.first.services.first.categories.first)"))
+	// category - special case: empty category (category = service type)
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/projects?with=info&category=first").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "category filter - empty category/ equal service type").
+			Modify("del(.domains[].projects[].service_areas.first.services.first.categories.foo_category)").
+			Modify("del(.info.service_areas.first.services.first.categories.foo_category)").
+			Modify("del(.info.service_areas.second)"))
+	// rate
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/projects?with=info&rate=objects:create").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "rate filter").
+			Modify("del(.domains[].projects[].service_areas.first.services.first.categories.first)").
+			Modify("del(.info.service_areas.first.services.first.categories.first)"))
+
+	// no we add some rate limits to get the other 2 combinations (objects:update=limit only, object:delete=limit + usage)
+	objectsDeleteRateID := s.GetRateID("first", "objects:delete")
+	s.MustDBExec(`UPDATE project_rates SET rate_limit = 10, window_ns = 5000000000 WHERE rate_id IN ($1, $2)`, objectsDeleteRateID, objectsUpdateRateID)
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/projects?with=info").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "with limits").
+			Modify(`.domains[].projects[].service_areas.first.services.first.categories.first.rates["objects:delete"]={"usage_as_bigint":"5", "project_limit":10, "project_window":"5s"}`).
+			Modify(`.domains[].projects[].service_areas.first.services.first.categories.first.rates["objects:update"]={"project_limit":10, "project_window":"5s"}`))
+
+	// there are some error cases possible depending on the scope in this endpoint:
+	// a domain user needs to have one of the filters set
+	s.TokenValidator.Enforcer.IsDomainRole = true
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/projects").ExpectText(t, http.StatusBadRequest, "specify URL project_uuid or query domain_uuid\n")
+
+	// cannot set both at the same time
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/projects/uuid-for-paris?domain_uuid=uuid-for-france").ExpectText(t, http.StatusBadRequest, "query domain_uuid cannot be set, when URL project_uuid is set\n")
+
+	// same for cloud admin
+	s.TokenValidator.Enforcer.IsDomainRole = false
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/projects/uuid-for-paris?domain_uuid=uuid-for-france").ExpectText(t, http.StatusBadRequest, "query domain_uuid cannot be set, when URL project_uuid is set\n")
+
+	// unknown domain/ project
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/projects?domain_uuid=does-not-exists").ExpectText(t, http.StatusNotFound, "no such domain (UUID = does-not-exists)\n")
+	s.Handler.RespondTo(s.Ctx, "GET /rates/v2/projects/does-not-exists").ExpectText(t, http.StatusNotFound, "no such project (UUID = does-not-exists)\n")
+}

--- a/internal/api/reports_v2/cluster.go
+++ b/internal/api/reports_v2/cluster.go
@@ -20,7 +20,7 @@ import (
 	"github.com/sapcc/limes/internal/db"
 )
 
-var clusterReportQuery = sqlext.SimplifyWhitespace(`
+var clusterRateReportQuery = sqlext.SimplifyWhitespace(`
 	SELECT pra.rate_id, SUM(pra.usage_as_bigint::BIGINT)::TEXT AS usage_as_bigint
 	FROM project_rates pra
 	WHERE {{pra.rate_id = ANY($rate_id)}}
@@ -41,7 +41,7 @@ func GetClusterRates(cluster *core.Cluster, token *gopherpolicy.Token, filter Fi
 	}
 
 	// the result will have all rates without usage --> we will filter later
-	query, args := filter.ExpandServiceFilters(clusterReportQuery)
+	query, args := filter.ExpandServiceFilters(clusterRateReportQuery)
 	err := sqlext.ForeachRow(cluster.DB, query, args, func(rows *sql.Rows) error {
 		var (
 			rateID        db.RateID
@@ -51,7 +51,7 @@ func GetClusterRates(cluster *core.Cluster, token *gopherpolicy.Token, filter Fi
 		if err != nil {
 			return err
 		}
-		setInRateReport(filter, cluster, result, rateID, ratesv2.ClusterRateReport{UsageAsBigint: usageAsBigint})
+		setInClusterRateReport(filter, cluster, result, rateID, ratesv2.ClusterRateReport{UsageAsBigint: usageAsBigint})
 		return nil
 	})
 
@@ -61,10 +61,10 @@ func GetClusterRates(cluster *core.Cluster, token *gopherpolicy.Token, filter Fi
 	return *result, nil
 }
 
-// setInRateReport creates or iterates higher level structs on the way to the nested
+// setInClusterRateReport creates or iterates higher level structs on the way to the nested
 // location of the db.RateID in the report and assigns the value for ratesv2.ClusterRateReport.
 // If this rate should not get set because it does not have usage, this is a no-op.
-func setInRateReport(filter Filter, cluster *core.Cluster, report *ratesv2.ClusterGetResponse, rateID db.RateID, value ratesv2.ClusterRateReport) {
+func setInClusterRateReport(filter Filter, cluster *core.Cluster, report *ratesv2.ClusterGetResponse, rateID db.RateID, value ratesv2.ClusterRateReport) {
 	services := filter.GetServices()
 	categories := filter.GetCategories()
 

--- a/internal/api/reports_v2/cluster.go
+++ b/internal/api/reports_v2/cluster.go
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package reports_v2
+
+import (
+	"database/sql"
+	"maps"
+	"slices"
+
+	"github.com/sapcc/go-api-declarations/liquid"
+	"github.com/sapcc/go-bits/sqlext"
+	. "go.xyrillian.de/gg/option"
+
+	"github.com/sapcc/go-bits/gopherpolicy"
+
+	"github.com/sapcc/limes/internal/apideclarations/apiv2/common"
+	ratesv2 "github.com/sapcc/limes/internal/apideclarations/apiv2/rates"
+	"github.com/sapcc/limes/internal/core"
+	"github.com/sapcc/limes/internal/db"
+)
+
+var clusterReportQuery = sqlext.SimplifyWhitespace(`
+	SELECT pra.rate_id, SUM(pra.usage_as_bigint::BIGINT)::TEXT AS usage_as_bigint
+	FROM project_rates pra
+	WHERE {{pra.rate_id = ANY($rate_id)}}
+	GROUP BY pra.rate_id
+`)
+
+// GetClusterRates returns a ratesv2.ClusterGetResponse.
+func GetClusterRates(cluster *core.Cluster, token *gopherpolicy.Token, filter Filter, options common.ClusterRateReportOpts) (ratesv2.ClusterGetResponse, error) {
+	result := &ratesv2.ClusterGetResponse{}
+
+	// fill info report
+	if options.WithInfo {
+		infoReport, err := GetRatesInfo(cluster, token, filter)
+		if err != nil {
+			return *result, err
+		}
+		result.InfoReport = Some(infoReport)
+	}
+
+	// the result will have all rates without usage --> we will filter later
+	query, args := filter.ExpandServiceFilters(clusterReportQuery)
+	err := sqlext.ForeachRow(cluster.DB, query, args, func(rows *sql.Rows) error {
+		var (
+			rateID        db.RateID
+			usageAsBigint string
+		)
+		err := rows.Scan(&rateID, &usageAsBigint)
+		if err != nil {
+			return err
+		}
+		setInRateReport(filter, cluster, result, rateID, ratesv2.ClusterRateReport{UsageAsBigint: usageAsBigint})
+		return nil
+	})
+
+	if err != nil {
+		return *result, err
+	}
+	return *result, nil
+}
+
+// setInRateReport creates or iterates higher level structs on the way to the nested
+// location of the db.RateID in the report and assigns the value for ratesv2.ClusterRateReport.
+// If this rate should not get set because it does not have usage, this is a no-op.
+func setInRateReport(filter Filter, cluster *core.Cluster, report *ratesv2.ClusterGetResponse, rateID db.RateID, value ratesv2.ClusterRateReport) {
+	services := filter.GetServices()
+	categories := filter.GetCategories()
+
+	for _, serviceType := range slices.Sorted(maps.Keys(services)) {
+		rates, _ := filter.GetRatesForType(serviceType) // can have no resources
+		for _, rateName := range slices.Sorted(maps.Keys(rates)) {
+			rate := rates[rateName]
+			if rate.ID != rateID {
+				continue
+			}
+			if !rate.HasUsage {
+				return
+			}
+
+			config := cluster.Config.Liquids[serviceType]
+			area := config.Area
+			// defense in depth: config should be in sync with serviceInfo
+			if area == "" {
+				return
+			}
+
+			// check area level (might be uninitialized)
+			if report.ClusterReport.Areas == nil {
+				report.ClusterReport.Areas = make(map[string]ratesv2.ClusterAreaReport)
+			}
+			if _, exists := report.ClusterReport.Areas[area]; !exists {
+				report.ClusterReport.Areas[area] = ratesv2.ClusterAreaReport{Services: make(map[db.ServiceType]ratesv2.ClusterServiceReport)}
+			}
+			areaReport := report.ClusterReport.Areas[area]
+
+			// check service level
+			if _, exists := areaReport.Services[serviceType]; !exists {
+				areaReport.Services[serviceType] = ratesv2.ClusterServiceReport{Categories: make(map[liquid.CategoryName]ratesv2.ClusterCategoryReport)}
+			}
+			serviceReport := areaReport.Services[serviceType]
+
+			// check category level
+			category := liquid.CategoryName(serviceType)
+			if categoryID, exists := rate.CategoryID.Unpack(); exists {
+				category = categories[categoryID].Name
+			}
+			if _, exists := serviceReport.Categories[category]; !exists {
+				serviceReport.Categories[category] = ratesv2.ClusterCategoryReport{Rates: make(map[liquid.RateName]ratesv2.ClusterRateReport)}
+			}
+			categoryReport := serviceReport.Categories[category]
+
+			// check rate level
+			categoryReport.Rates[rate.Name] = value
+			return
+		}
+	}
+}

--- a/internal/api/reports_v2/domain.go
+++ b/internal/api/reports_v2/domain.go
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package reports_v2
+
+import (
+	"database/sql"
+	"maps"
+	"slices"
+
+	. "go.xyrillian.de/gg/option"
+
+	"github.com/sapcc/go-api-declarations/liquid"
+	"github.com/sapcc/go-bits/gopherpolicy"
+	"github.com/sapcc/go-bits/sqlext"
+
+	"github.com/sapcc/limes/internal/apideclarations/apiv2/common"
+	ratesv2 "github.com/sapcc/limes/internal/apideclarations/apiv2/rates"
+	"github.com/sapcc/limes/internal/core"
+	"github.com/sapcc/limes/internal/db"
+)
+
+var domainRateReportQuery = sqlext.SimplifyWhitespace(`
+	SELECT d.uuid, d.name, pra.rate_id, SUM(pra.usage_as_bigint::BIGINT)::TEXT AS usage_as_bigint
+	FROM project_rates pra
+	JOIN projects p
+	ON p.id = pra.project_id
+	JOIN domains d
+	ON d.id = p.domain_id
+	WHERE {{pra.rate_id = ANY($rate_id)}}
+	AND {{d.id = $domain_id}}
+	GROUP BY d.uuid, d.name, pra.rate_id
+`)
+
+// GetDomainRates returns a ratesv2.DomainGetResponse.
+func GetDomainRates(cluster *core.Cluster, token *gopherpolicy.Token, filter Filter, options common.DomainRateReportOpts, scope Scope) (ratesv2.DomainGetResponse, error) {
+	result := &ratesv2.DomainGetResponse{}
+
+	// fill info report
+	if options.WithInfo {
+		infoReport, err := GetRatesInfo(cluster, token, filter)
+		if err != nil {
+			return *result, err
+		}
+		result.InfoReport = Some(infoReport)
+	}
+
+	// the result will have all rates without usage --> we will filter later
+	query, args := filter.ExpandServiceFilters(domainRateReportQuery)
+	query, args = scope.ExpandScopeFilters(query, args...)
+	err := sqlext.ForeachRow(cluster.DB, query, args, func(rows *sql.Rows) error {
+		var (
+			domainUUID    string
+			domainName    string
+			rateID        db.RateID
+			usageAsBigint string
+		)
+		err := rows.Scan(&domainUUID, &domainName, &rateID, &usageAsBigint)
+		if err != nil {
+			return err
+		}
+		setInDomainRateReport(filter, cluster, result, rateID, common.DomainMetadata{
+			UUID: domainUUID,
+			Name: domainName,
+		}, ratesv2.DomainRateReport{
+			UsageAsBigint: usageAsBigint,
+		})
+		return nil
+	})
+
+	if err != nil {
+		return *result, err
+	}
+	return *result, nil
+}
+
+// setInDomainReport creates or iterates higher level structs on the way to the nested
+// location of the db.RateID in the report and assigns the value for ratesv2.DomainRateReport.
+// If this rate should not get set because it does not have usage, this is a no-op.
+func setInDomainRateReport(filter Filter, cluster *core.Cluster, report *ratesv2.DomainGetResponse, rateID db.RateID, domain common.DomainMetadata, value ratesv2.DomainRateReport) {
+	services := filter.GetServices()
+	categories := filter.GetCategories()
+
+	for _, serviceType := range slices.Sorted(maps.Keys(services)) {
+		rates, _ := filter.GetRatesForType(serviceType) // can have no resources
+		for _, rateName := range slices.Sorted(maps.Keys(rates)) {
+			rate := rates[rateName]
+			if rate.ID != rateID {
+				continue
+			}
+			if !rate.HasUsage {
+				return
+			}
+
+			config := cluster.Config.Liquids[serviceType]
+			area := config.Area
+			// defense in depth: config should be in sync with serviceInfo
+			if area == "" {
+				return
+			}
+
+			// check domain level (might be uninitialized)
+			if report.DomainReports == nil {
+				report.DomainReports = make(map[string]ratesv2.DomainReport)
+			}
+			if _, exists := report.DomainReports[domain.UUID]; !exists {
+				report.DomainReports[domain.UUID] = ratesv2.DomainReport{
+					DomainMetadata: domain,
+					Areas:          make(map[string]ratesv2.DomainAreaReport),
+				}
+			}
+			domainReport := report.DomainReports[domain.UUID]
+
+			// check area level
+			if _, exists := domainReport.Areas[area]; !exists {
+				domainReport.Areas[area] = ratesv2.DomainAreaReport{Services: make(map[db.ServiceType]ratesv2.DomainServiceReport)}
+			}
+			areaReport := domainReport.Areas[area]
+
+			// check service level
+			if _, exists := areaReport.Services[serviceType]; !exists {
+				areaReport.Services[serviceType] = ratesv2.DomainServiceReport{Categories: make(map[liquid.CategoryName]ratesv2.DomainCategoryReport)}
+			}
+			serviceReport := areaReport.Services[serviceType]
+
+			// check category level
+			category := liquid.CategoryName(serviceType)
+			if categoryID, exists := rate.CategoryID.Unpack(); exists {
+				category = categories[categoryID].Name
+			}
+			if _, exists := serviceReport.Categories[category]; !exists {
+				serviceReport.Categories[category] = ratesv2.DomainCategoryReport{Rates: make(map[liquid.RateName]ratesv2.DomainRateReport)}
+			}
+			categoryReport := serviceReport.Categories[category]
+
+			// check rate level
+			categoryReport.Rates[rate.Name] = value
+			return
+		}
+	}
+}

--- a/internal/api/reports_v2/filter.go
+++ b/internal/api/reports_v2/filter.go
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package reports_v2
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+
+	"github.com/lib/pq"
+
+	"github.com/sapcc/limes/internal/apideclarations/apiv2/common"
+	"github.com/sapcc/limes/internal/core"
+	"github.com/sapcc/limes/internal/db"
+	"github.com/sapcc/limes/internal/util"
+)
+
+// Filter is a version of FilteredServiceInfoSnapshot which gets
+// constructed from API query options. It has a method for applying
+// the FilteredServiceInfoSnapshot values to sql strings, to allow
+// for less joins of service info related tables.
+type Filter struct {
+	core.FilteredServiceInfoSnapshot
+}
+
+// FilterFromResourceOpts returns a Filter from apiv2.ResourceReportOpts.
+func FilterFromResourceOpts(cluster *core.Cluster, opts common.ResourceReportOpts) (f Filter, err error) {
+	sis := cluster.SIC.GetSnapshot()
+	f = Filter{sis.Filter(core.ServiceInfoFilter{
+		ServiceArea:  opts.Area,
+		ServiceType:  opts.ServiceType,
+		Category:     opts.Category,
+		ResourceName: opts.ResourceName,
+	})}
+	services := f.GetServices()
+	if area, ok := opts.Area.Unpack(); ok && len(services) == 0 {
+		return f, fmt.Errorf(`no services found for area %q`, area)
+	}
+	if serviceType, ok := opts.ServiceType.Unpack(); ok && len(services) == 0 {
+		return f, fmt.Errorf(`no services found for type %q`, serviceType)
+	}
+	resources := f.GetResources()
+	if category, ok := opts.Category.Unpack(); ok && len(resources) == 0 {
+		return f, fmt.Errorf(`no resources found for category %q`, category)
+	}
+	if name, ok := opts.ResourceName.Unpack(); ok && len(resources) == 0 {
+		return f, fmt.Errorf(`no resources found for name %q`, name)
+	}
+	return f, nil
+}
+
+// FilterFromRateOpts returns a Filter from apiv2.RateReportOpts.
+func FilterFromRateOpts(cluster *core.Cluster, opts common.RateReportOpts) (f Filter, err error) {
+	sis := cluster.SIC.GetSnapshot()
+	f = Filter{sis.Filter(core.ServiceInfoFilter{
+		ServiceArea: opts.Area,
+		ServiceType: opts.ServiceType,
+		Category:    opts.Category,
+		RateName:    opts.RateName,
+	})}
+	services := f.GetServices()
+	if area, ok := opts.Area.Unpack(); ok && len(services) == 0 {
+		return f, fmt.Errorf(`no services found for area %q`, area)
+	}
+	if serviceType, ok := opts.ServiceType.Unpack(); ok && len(services) == 0 {
+		return f, fmt.Errorf(`no services found for type %q`, serviceType)
+	}
+	rates := f.GetRates()
+	if category, ok := opts.Category.Unpack(); ok && len(rates) == 0 {
+		return f, fmt.Errorf(`no rates found for category %q`, category)
+	}
+	if name, ok := opts.RateName.Unpack(); ok && len(rates) == 0 {
+		return f, fmt.Errorf(`no rates found for name %q`, name)
+	}
+	return f, nil
+}
+
+var filterReplaceRx = regexp.MustCompile(`{{(.*?) = ANY\(\$(service_id|resource_id|rate_id)\)}}`)
+
+// ExpandServiceFilters takes an SQL query string with curly-bracketed
+// where-clauses and will replace each one with an arg position and return the
+// according SQL args for this filter, namely a list of entity IDs.
+// The expressions must be of the form "{{[filter-field] = ANY($[id-field])}}"
+// where filter-field can be a primary key column or a foreign key and id-field
+// is the name of the entity whose ID-column values are used.
+// It supports service_id, resource_id and rate_id.
+// On unknown keywords it will panic.
+func (f Filter) ExpandServiceFilters(originalQuery string, originalArgs ...any) (query string, args []any) {
+	// get current highest index
+	var err error
+	i := 0
+	queryVariables := regexp.MustCompile(`\$(\d+)`)
+	matches := queryVariables.FindAllString(originalQuery, -1)
+	if len(matches) > 0 {
+		last := matches[len(matches)-1]
+		i, err = strconv.Atoi(queryVariables.FindStringSubmatch(last)[1])
+		if err != nil {
+			panic("digits should be parseable integer")
+		}
+	}
+	args = append(args, originalArgs...)
+
+	query = filterReplaceRx.ReplaceAllStringFunc(originalQuery, func(matchStr string) string {
+		// optimization: when not filtered, replace filter with no-op
+		if f.FilterIsEmpty() {
+			return util.SQLFilterNoop
+		}
+		match := filterReplaceRx.FindStringSubmatch(matchStr)
+
+		switch match[2] {
+		case "service_id":
+			args = append(args, pq.Array(f.getServiceIDs()))
+		case "resource_id":
+			args = append(args, pq.Array(f.getResourceIDs()))
+		case "rate_id":
+			args = append(args, pq.Array(f.getRateIDs()))
+		default:
+			panic("unreachable")
+		}
+		i++
+		return match[1] + " = ANY($" + strconv.Itoa(i) + ")"
+	})
+	return query, args
+}
+
+func (f Filter) getServiceIDs() (ids []db.ServiceID) {
+	for _, service := range f.GetServices() {
+		ids = append(ids, service.ID)
+	}
+	return ids
+}
+
+func (f Filter) getResourceIDs() (ids []db.ResourceID) {
+	for _, resources := range f.GetResources() {
+		for _, resource := range resources {
+			ids = append(ids, resource.ID)
+		}
+	}
+	return ids
+}
+
+func (f Filter) getRateIDs() (ids []db.RateID) {
+	for _, rates := range f.GetRates() {
+		for _, rate := range rates {
+			ids = append(ids, rate.ID)
+		}
+	}
+	return ids
+}

--- a/internal/api/reports_v2/filter_test.go
+++ b/internal/api/reports_v2/filter_test.go
@@ -1,0 +1,245 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package reports_v2_test
+
+import (
+	"testing"
+
+	"github.com/sapcc/go-api-declarations/liquid"
+	"github.com/sapcc/go-bits/must"
+	"go.xyrillian.de/gg/assert"
+
+	. "go.xyrillian.de/gg/option"
+
+	"github.com/sapcc/limes/internal/api/reports_v2"
+	"github.com/sapcc/limes/internal/apideclarations/apiv2/common"
+	"github.com/sapcc/limes/internal/db"
+	"github.com/sapcc/limes/internal/test"
+)
+
+const filterConfigJSON = `{
+	"availability_zones": ["az-one"],
+	"discovery": {
+		"method": "static",
+		"static_config": {
+			"domains": [],
+			"projects": {}
+		}
+	},
+	"areas": { "first": { "display_name": "First" }, "second": { "display_name": "Second" }},
+	"liquids": {
+		"first": {
+			"area": "first"
+		},
+		"second": {
+			"area": "second"
+		}
+	}
+}`
+
+func TestV2FilterCreation(t *testing.T) {
+	srvInfoFirst := test.DefaultLiquidServiceInfo("First")
+	srvInfoFirst.Rates = map[liquid.RateName]liquid.RateInfo{
+		"objects:create": {Topology: liquid.FlatTopology, HasUsage: false, Category: Some(liquid.CategoryName("foo_category"))},
+		"objects:update": {Topology: liquid.FlatTopology, HasUsage: false},
+	}
+
+	s := test.NewSetup(t,
+		test.WithConfig(filterConfigJSON),
+		test.WithPersistedServiceInfo("first", srvInfoFirst),
+		test.WithPersistedServiceInfo("second", test.DefaultLiquidServiceInfo("Second")),
+	)
+	// do some basic assertions to compare the filtered results against
+	sis := s.Cluster.SIC.GetSnapshot()
+	assert.Equal(t, len(sis.GetServices()), 2)
+	assert.Equal(t, len(must.BeOK(sis.GetResourcesForType("first"))), 2)
+	assert.Equal(t, len(must.BeOK(sis.GetResourcesForType("second"))), 2)
+	assert.Equal(t, len(must.BeOK(sis.GetRatesForType("first"))), 2)
+	assert.Equal(t, len(must.NotBeOK(sis.GetRatesForType("second"))), 0)
+
+	// empty opts yields the same service info
+	resourceOpts := common.ResourceReportOpts{}
+	resourceFilter := must.ReturnT(reports_v2.FilterFromResourceOpts(s.Cluster, resourceOpts))(t)
+	assert.Equal(t, len(resourceFilter.GetServices()), 2)
+	assert.Equal(t, len(must.BeOK(resourceFilter.GetResourcesForType("first"))), 2)
+	assert.Equal(t, len(must.BeOK(resourceFilter.GetResourcesForType("second"))), 2)
+	assert.Equal(t, len(must.BeOK(resourceFilter.GetRatesForType("first"))), 2)
+	assert.Equal(t, len(must.NotBeOK(resourceFilter.GetRatesForType("second"))), 0)
+
+	rateOpts := common.RateReportOpts{}
+	rateFilter := must.ReturnT(reports_v2.FilterFromRateOpts(s.Cluster, rateOpts))(t)
+	assert.Equal(t, len(rateFilter.GetServices()), 2)
+	assert.Equal(t, len(must.BeOK(rateFilter.GetResourcesForType("first"))), 2)
+	assert.Equal(t, len(must.BeOK(rateFilter.GetResourcesForType("second"))), 2)
+	assert.Equal(t, len(must.BeOK(rateFilter.GetRatesForType("first"))), 2)
+	assert.Equal(t, len(must.NotBeOK(rateFilter.GetRatesForType("second"))), 0)
+
+	// area filter
+	resourceOpts = common.ResourceReportOpts{GenericReportOpts: common.GenericReportOpts{Area: Some("second")}}
+	resourceFilter = must.ReturnT(reports_v2.FilterFromResourceOpts(s.Cluster, resourceOpts))(t)
+	assert.Equal(t, len(resourceFilter.GetServices()), 1)
+	assert.Equal(t, len(must.NotBeOK(resourceFilter.GetResourcesForType("first"))), 0)
+	assert.Equal(t, len(must.BeOK(resourceFilter.GetResourcesForType("second"))), 2)
+	assert.Equal(t, len(must.NotBeOK(resourceFilter.GetRatesForType("first"))), 0)
+	assert.Equal(t, len(must.NotBeOK(resourceFilter.GetRatesForType("second"))), 0)
+
+	rateOpts = common.RateReportOpts{GenericReportOpts: common.GenericReportOpts{Area: Some("second")}}
+	rateFilter = must.ReturnT(reports_v2.FilterFromRateOpts(s.Cluster, rateOpts))(t)
+	assert.Equal(t, len(rateFilter.GetServices()), 1)
+	assert.Equal(t, len(must.NotBeOK(rateFilter.GetResourcesForType("first"))), 0)
+	assert.Equal(t, len(must.BeOK(rateFilter.GetResourcesForType("second"))), 2)
+	assert.Equal(t, len(must.NotBeOK(rateFilter.GetRatesForType("first"))), 0)
+	assert.Equal(t, len(must.NotBeOK(rateFilter.GetRatesForType("second"))), 0)
+
+	// service filter
+	resourceOpts = common.ResourceReportOpts{GenericReportOpts: common.GenericReportOpts{ServiceType: Some(db.ServiceType("second"))}}
+	resourceFilter = must.ReturnT(reports_v2.FilterFromResourceOpts(s.Cluster, resourceOpts))(t)
+	assert.Equal(t, len(resourceFilter.GetServices()), 1)
+	assert.Equal(t, len(must.NotBeOK(resourceFilter.GetResourcesForType("first"))), 0)
+	assert.Equal(t, len(must.BeOK(resourceFilter.GetResourcesForType("second"))), 2)
+	assert.Equal(t, len(must.NotBeOK(resourceFilter.GetRatesForType("first"))), 0)
+	assert.Equal(t, len(must.NotBeOK(resourceFilter.GetRatesForType("second"))), 0)
+
+	rateOpts = common.RateReportOpts{GenericReportOpts: common.GenericReportOpts{ServiceType: Some(db.ServiceType("second"))}}
+	rateFilter = must.ReturnT(reports_v2.FilterFromRateOpts(s.Cluster, rateOpts))(t)
+	assert.Equal(t, len(rateFilter.GetServices()), 1)
+	assert.Equal(t, len(must.NotBeOK(rateFilter.GetResourcesForType("first"))), 0)
+	assert.Equal(t, len(must.BeOK(rateFilter.GetResourcesForType("second"))), 2)
+	assert.Equal(t, len(must.NotBeOK(rateFilter.GetRatesForType("first"))), 0)
+	assert.Equal(t, len(must.NotBeOK(rateFilter.GetRatesForType("second"))), 0)
+
+	// category filter
+	resourceOpts = common.ResourceReportOpts{GenericReportOpts: common.GenericReportOpts{Category: Some(liquid.CategoryName("foo_category"))}}
+	resourceFilter = must.ReturnT(reports_v2.FilterFromResourceOpts(s.Cluster, resourceOpts))(t)
+	assert.Equal(t, len(resourceFilter.GetServices()), 2)
+	assert.Equal(t, len(must.BeOK(resourceFilter.GetResourcesForType("first"))), 1)
+	assert.Equal(t, (must.BeOK(resourceFilter.GetResourcesForType("first")))["capacity"].CategoryID.IsSome(), true)
+	assert.Equal(t, len(must.BeOK(resourceFilter.GetResourcesForType("second"))), 1)
+	assert.Equal(t, len(must.BeOK(resourceFilter.GetRatesForType("first"))), 1)
+	assert.Equal(t, (must.BeOK(resourceFilter.GetRatesForType("first")))["objects:create"].CategoryID.IsSome(), true)
+	assert.Equal(t, len(must.NotBeOK(resourceFilter.GetRatesForType("second"))), 0)
+
+	rateOpts = common.RateReportOpts{GenericReportOpts: common.GenericReportOpts{Category: Some(liquid.CategoryName("foo_category"))}}
+	rateFilter = must.ReturnT(reports_v2.FilterFromRateOpts(s.Cluster, rateOpts))(t)
+	assert.Equal(t, len(rateFilter.GetServices()), 2)
+	assert.Equal(t, len(must.BeOK(rateFilter.GetResourcesForType("first"))), 1)
+	assert.Equal(t, (must.BeOK(resourceFilter.GetResourcesForType("first")))["capacity"].CategoryID.IsSome(), true)
+	assert.Equal(t, len(must.BeOK(rateFilter.GetResourcesForType("second"))), 1)
+	assert.Equal(t, len(must.BeOK(rateFilter.GetRatesForType("first"))), 1)
+	assert.Equal(t, (must.BeOK(resourceFilter.GetRatesForType("first")))["objects:create"].CategoryID.IsSome(), true)
+	assert.Equal(t, len(must.NotBeOK(rateFilter.GetRatesForType("second"))), 0)
+
+	// category filter: using serviceType value as category to get resources/rates without explicit category
+	resourceOpts = common.ResourceReportOpts{GenericReportOpts: common.GenericReportOpts{Category: Some(liquid.CategoryName("first"))}}
+	resourceFilter = must.ReturnT(reports_v2.FilterFromResourceOpts(s.Cluster, resourceOpts))(t)
+	assert.Equal(t, len(resourceFilter.GetServices()), 1)
+	assert.Equal(t, len(must.BeOK(resourceFilter.GetResourcesForType("first"))), 1)
+	assert.Equal(t, (must.BeOK(resourceFilter.GetResourcesForType("first")))["things"].CategoryID.IsSome(), false)
+	assert.Equal(t, len(must.NotBeOK(resourceFilter.GetResourcesForType("second"))), 0)
+	assert.Equal(t, len(must.BeOK(resourceFilter.GetRatesForType("first"))), 1)
+	assert.Equal(t, (must.BeOK(resourceFilter.GetRatesForType("first")))["objects:update"].CategoryID.IsSome(), false)
+	assert.Equal(t, len(must.NotBeOK(resourceFilter.GetRatesForType("second"))), 0)
+
+	rateOpts = common.RateReportOpts{GenericReportOpts: common.GenericReportOpts{Category: Some(liquid.CategoryName("first"))}}
+	rateFilter = must.ReturnT(reports_v2.FilterFromRateOpts(s.Cluster, rateOpts))(t)
+	assert.Equal(t, len(rateFilter.GetServices()), 1)
+	assert.Equal(t, len(must.BeOK(rateFilter.GetResourcesForType("first"))), 1)
+	assert.Equal(t, (must.BeOK(rateFilter.GetResourcesForType("first")))["things"].CategoryID.IsSome(), false)
+	assert.Equal(t, len(must.NotBeOK(rateFilter.GetResourcesForType("second"))), 0)
+	assert.Equal(t, len(must.BeOK(rateFilter.GetRatesForType("first"))), 1)
+	assert.Equal(t, (must.BeOK(rateFilter.GetRatesForType("first")))["objects:update"].CategoryID.IsSome(), false)
+	assert.Equal(t, len(must.NotBeOK(rateFilter.GetRatesForType("second"))), 0)
+
+	// resource filter
+	resourceOpts = common.ResourceReportOpts{ResourceName: Some(liquid.ResourceName("capacity"))}
+	resourceFilter = must.ReturnT(reports_v2.FilterFromResourceOpts(s.Cluster, resourceOpts))(t)
+	assert.Equal(t, len(resourceFilter.GetServices()), 2)
+	assert.Equal(t, len(must.BeOK(resourceFilter.GetResourcesForType("first"))), 1)
+	assert.Equal(t, len(must.BeOK(resourceFilter.GetResourcesForType("second"))), 1)
+	assert.Equal(t, len(must.BeOK(resourceFilter.GetRatesForType("first"))), 2)
+	assert.Equal(t, len(must.NotBeOK(resourceFilter.GetRatesForType("second"))), 0)
+
+	// rate filter
+	rateOpts = common.RateReportOpts{RateName: Some(liquid.RateName("objects:create"))}
+	rateFilter = must.ReturnT(reports_v2.FilterFromRateOpts(s.Cluster, rateOpts))(t)
+	assert.Equal(t, len(rateFilter.GetServices()), 2)
+	assert.Equal(t, len(must.BeOK(rateFilter.GetResourcesForType("first"))), 2)
+	assert.Equal(t, len(must.BeOK(rateFilter.GetResourcesForType("second"))), 2)
+	assert.Equal(t, len(must.BeOK(rateFilter.GetRatesForType("first"))), 1)
+	assert.Equal(t, len(must.NotBeOK(rateFilter.GetRatesForType("second"))), 0)
+}
+
+func TestV2ExpandServiceFilters(t *testing.T) {
+	srvInfoFirst := test.DefaultLiquidServiceInfo("First")
+	srvInfoFirst.Rates = map[liquid.RateName]liquid.RateInfo{
+		"objects:create": {Topology: liquid.FlatTopology, HasUsage: false, Category: Some(liquid.CategoryName("foo_category"))},
+		"objects:update": {Topology: liquid.FlatTopology, HasUsage: false},
+	}
+
+	s := test.NewSetup(t,
+		test.WithConfig(filterConfigJSON),
+		test.WithPersistedServiceInfo("first", srvInfoFirst),
+		test.WithPersistedServiceInfo("second", test.DefaultLiquidServiceInfo("Second")),
+	)
+
+	// unfiltered: all placeholders become TRUE = TRUE
+	unfiltered := must.ReturnT(reports_v2.FilterFromResourceOpts(s.Cluster, common.ResourceReportOpts{}))(t)
+	query, args := unfiltered.ExpandServiceFilters(
+		`SELECT * FROM t WHERE {{s.id = ANY($service_id)}} AND {{r.id = ANY($resource_id)}} AND {{ra.id = ANY($rate_id)}}`,
+	)
+	assert.Equal(t, query, `SELECT * FROM t WHERE TRUE = TRUE AND TRUE = TRUE AND TRUE = TRUE`)
+	assert.Equal(t, len(args), 0)
+
+	// filtered by area: all three get replaced with args
+	filtered := must.ReturnT(reports_v2.FilterFromResourceOpts(s.Cluster, common.ResourceReportOpts{
+		GenericReportOpts: common.GenericReportOpts{Area: Some("first")},
+	}))(t)
+	query, args = filtered.ExpandServiceFilters(
+		`SELECT * FROM t WHERE {{s.id = ANY($service_id)}} AND {{r.id = ANY($resource_id)}} AND {{ra.id = ANY($rate_id)}}`,
+	)
+	assert.Equal(t, query, `SELECT * FROM t WHERE s.id = ANY($1) AND r.id = ANY($2) AND ra.id = ANY($3)`)
+	assert.Equal(t, len(args), 3)
+
+	// filtered by service type: service_id and resource_id get arg positions
+	filtered = must.ReturnT(reports_v2.FilterFromResourceOpts(s.Cluster, common.ResourceReportOpts{
+		GenericReportOpts: common.GenericReportOpts{ServiceType: Some(db.ServiceType("first"))},
+	}))(t)
+	query, args = filtered.ExpandServiceFilters(
+		`SELECT * FROM t WHERE {{s.id = ANY($service_id)}} AND {{r.id = ANY($resource_id)}}`,
+	)
+	assert.Equal(t, query, `SELECT * FROM t WHERE s.id = ANY($1) AND r.id = ANY($2)`)
+	assert.Equal(t, len(args), 2)
+
+	// filtered by resource name only: all placeholders get args (filter is non-empty)
+	filtered = must.ReturnT(reports_v2.FilterFromResourceOpts(s.Cluster, common.ResourceReportOpts{
+		ResourceName: Some(liquid.ResourceName("capacity")),
+	}))(t)
+	query, args = filtered.ExpandServiceFilters(
+		`SELECT * FROM t WHERE {{s.id = ANY($service_id)}} AND {{r.id = ANY($resource_id)}}`,
+	)
+	assert.Equal(t, query, `SELECT * FROM t WHERE s.id = ANY($1) AND r.id = ANY($2)`)
+	assert.Equal(t, len(args), 2)
+
+	// filtered by rate name only: all placeholders get args (filter is non-empty)
+	rateFiltered := must.ReturnT(reports_v2.FilterFromRateOpts(s.Cluster, common.RateReportOpts{
+		RateName: Some(liquid.RateName("objects:create")),
+	}))(t)
+	query, args = rateFiltered.ExpandServiceFilters(
+		`SELECT * FROM t WHERE {{s.id = ANY($service_id)}} AND {{ra.id = ANY($rate_id)}}`,
+	)
+	assert.Equal(t, query, `SELECT * FROM t WHERE s.id = ANY($1) AND ra.id = ANY($2)`)
+	assert.Equal(t, len(args), 2)
+
+	// with pre-existing args: arg positions continue from highest existing position
+	filtered = must.ReturnT(reports_v2.FilterFromResourceOpts(s.Cluster, common.ResourceReportOpts{
+		GenericReportOpts: common.GenericReportOpts{ServiceType: Some(db.ServiceType("first"))},
+	}))(t)
+	query, args = filtered.ExpandServiceFilters(
+		`SELECT * FROM t WHERE t.name = $14 AND {{s.id = ANY($service_id)}}`,
+		"some-value",
+	)
+	assert.Equal(t, query, `SELECT * FROM t WHERE t.name = $14 AND s.id = ANY($15)`)
+	assert.Equal(t, len(args), 2)
+	assert.Equal(t, args[0].(string), "some-value")
+}

--- a/internal/api/reports_v2/info.go
+++ b/internal/api/reports_v2/info.go
@@ -1,0 +1,240 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package reports_v2
+
+import (
+	"database/sql"
+	"maps"
+	"slices"
+	"time"
+
+	. "go.xyrillian.de/gg/option"
+
+	"github.com/sapcc/go-api-declarations/liquid"
+	"github.com/sapcc/go-bits/gopherpolicy"
+	"github.com/sapcc/go-bits/sqlext"
+
+	ratesv2 "github.com/sapcc/limes/internal/apideclarations/apiv2/rates"
+	resourcesv2 "github.com/sapcc/limes/internal/apideclarations/apiv2/resources"
+	"github.com/sapcc/limes/internal/core"
+	"github.com/sapcc/limes/internal/db"
+)
+
+var findAllowedResourcesQuery = sqlext.SimplifyWhitespace(`
+	SELECT DISTINCT s.type, r.name
+	FROM project_resources pr
+	JOIN resources r ON pr.resource_id = r.id
+	JOIN services s ON r.service_id = s.id
+	JOIN projects p ON pr.project_id = p.id
+	JOIN domains d ON p.domain_id = d.id
+	WHERE ((p.uuid = $1 OR $1 = '') AND (d.uuid = $2 OR $2 = ''))
+	AND pr.forbidden = false
+`)
+
+func authenticateInfoRequest(token *gopherpolicy.Token) (projectUUID, domainUUID, domainName string, err error) {
+	projectUUID = token.ProjectScopeUUID()
+	projectDomainUUID := token.ProjectScopeDomainUUID()
+	projectDomainName := token.ProjectScopeDomainName()
+	domainUUID = token.DomainScopeUUID()
+	domainName = token.DomainScopeName()
+
+	switch {
+	case token.Check("v2:cluster:info"):
+		return "", "", "", nil
+	case token.Check("v2:domain:info"):
+		return "", domainUUID, domainName, nil
+	default:
+		// the final token.Check() is a token.Enforce() because Enforce can properly distinguish between 401 and 403 errors
+		err := token.Enforce("v2:project:info")
+		if err == nil {
+			return projectUUID, projectDomainUUID, projectDomainName, nil
+		} else {
+			return "", "", "", err
+		}
+	}
+}
+
+// GetResourcesInfo returns a resourcesv2.InfoReport, which can be exposed via
+// an own endpoint or re-used in resource reports.
+func GetResourcesInfo(cluster *core.Cluster, token *gopherpolicy.Token, timeNow time.Time, sis core.ServiceInfoReader) (resourcesv2.InfoReport, error) {
+	dbm := cluster.DB
+	var none resourcesv2.InfoReport // used on error return paths only
+
+	projectUUID, domainUUID, domainName, err := authenticateInfoRequest(token)
+	if err != nil {
+		return none, err
+	}
+
+	// collect allowed items for this user
+	allowedResourcesByService := make(map[db.ServiceType][]liquid.ResourceName)
+	err = sqlext.ForeachRow(dbm, findAllowedResourcesQuery, []any{projectUUID, domainUUID}, func(rows *sql.Rows) error {
+		var (
+			serviceType  db.ServiceType
+			resourceName liquid.ResourceName
+		)
+		err := rows.Scan(&serviceType, &resourceName)
+		if err == nil {
+			allowedResourcesByService[serviceType] = append(allowedResourcesByService[serviceType], resourceName)
+		}
+		return err
+	})
+	if err != nil {
+		return none, err
+	}
+
+	// assemble the report
+	report := resourcesv2.InfoReport{
+		AllAZs: cluster.Config.AvailabilityZones,
+		Areas:  make(map[string]resourcesv2.AreaInfoReport),
+	}
+	services := sis.GetServices()
+	categories := sis.GetCategories()
+
+	for _, serviceType := range slices.Sorted(maps.Keys(services)) {
+		service := services[serviceType]
+		resources, _ := sis.GetResourcesForType(serviceType) // can have no resources
+		// skip non-allowed resources for this user, if any
+		allowedResources, serviceTypeOK := allowedResourcesByService[serviceType]
+		if !serviceTypeOK {
+			continue
+		}
+		config := cluster.Config.Liquids[serviceType]
+		area := config.Area
+		// defense in depth: config should be in sync with serviceInfo
+		if area == "" {
+			continue
+		}
+		areaDisplayName := ""
+		// defense in depth: when area was found in config, a displayName has to be available
+		if areaConfig, exists := cluster.Config.Areas[area]; exists {
+			areaDisplayName = areaConfig.DisplayName
+		}
+
+		if _, exists := report.Areas[area]; !exists {
+			report.Areas[area] = resourcesv2.AreaInfoReport{
+				DisplayName: areaDisplayName,
+				Services:    make(map[db.ServiceType]resourcesv2.ServiceInfoReport),
+			}
+		}
+		report.Areas[area].Services[serviceType] = resourcesv2.ServiceInfoReport{
+			Version:     service.LiquidVersion,
+			DisplayName: service.DisplayName,
+			Categories:  make(map[liquid.CategoryName]resourcesv2.CategoryInfoReport),
+		}
+		serviceReport := report.Areas[area].Services[serviceType]
+
+		for _, resourceName := range slices.Sorted(maps.Keys(resources)) {
+			resource := resources[resourceName]
+			// skip non-allowed resources for this user, if any
+			if !slices.Contains(allowedResources, resourceName) {
+				continue
+			}
+			category := liquid.CategoryName(serviceType)
+			categoryDisplayName := service.DisplayName
+			if categoryID, exists := resource.CategoryID.Unpack(); exists {
+				category = categories[categoryID].Name
+				categoryDisplayName = categories[categoryID].DisplayName
+			}
+			if _, exists := serviceReport.Categories[category]; !exists {
+				serviceReport.Categories[category] = resourcesv2.CategoryInfoReport{
+					DisplayName: categoryDisplayName,
+					Resources:   make(map[liquid.ResourceName]resourcesv2.ResourceInfoReport),
+				}
+			}
+			commitmentBehavior := cluster.CommitmentBehaviorForResource(serviceType, resourceName)
+			var scopedCommitmentBehavior core.ScopedCommitmentBehavior
+
+			if domainUUID == "" {
+				scopedCommitmentBehavior = commitmentBehavior.ForCluster()
+			} else {
+				scopedCommitmentBehavior = commitmentBehavior.ForDomain(domainName)
+			}
+			serviceReport.Categories[category].Resources[resourceName] = resourcesv2.ResourceInfoReport{
+				DisplayName:      resource.DisplayName,
+				Unit:             resource.Unit,
+				Topology:         resource.Topology,
+				HasCapacity:      resource.HasCapacity,
+				HasQuota:         resource.HasQuota,
+				CommitmentConfig: scopedCommitmentBehavior.ForV2API(timeNow),
+			}
+		}
+	}
+	return report, nil
+}
+
+// GetRatesInfo returns a ratesv2.InfoReport, which can be exposed via
+// an own endpoint or re-used in rate reports.
+func GetRatesInfo(cluster *core.Cluster, token *gopherpolicy.Token, sis core.ServiceInfoReader) (ratesv2.InfoReport, error) {
+	var none ratesv2.InfoReport // used on error return paths only
+
+	_, _, _, err := authenticateInfoRequest(token)
+	if err != nil {
+		return none, err
+	}
+
+	// assemble the report
+	report := ratesv2.InfoReport{
+		AllAZs: cluster.Config.AvailabilityZones,
+		Areas:  make(map[string]ratesv2.AreaInfoReport),
+	}
+	services := sis.GetServices()
+	categories := sis.GetCategories()
+
+	for _, serviceType := range slices.Sorted(maps.Keys(services)) {
+		service := services[serviceType]
+		rates, _ := sis.GetRatesForType(serviceType) // can have no rates
+		config := cluster.Config.Liquids[serviceType]
+		area := config.Area
+		// defense in depth: config should be in sync with serviceInfo
+		if area == "" {
+			continue
+		}
+		areaDisplayName := ""
+		// defense in depth: when area was found in config, a displayName has to be available
+		if areaConfig, exists := cluster.Config.Areas[area]; exists {
+			areaDisplayName = areaConfig.DisplayName
+		}
+
+		if _, exists := report.Areas[area]; !exists {
+			report.Areas[area] = ratesv2.AreaInfoReport{
+				DisplayName: areaDisplayName,
+				Services:    make(map[db.ServiceType]ratesv2.ServiceInfoReport),
+			}
+		}
+		report.Areas[area].Services[serviceType] = ratesv2.ServiceInfoReport{
+			Version:     service.LiquidVersion,
+			DisplayName: service.DisplayName,
+			Categories:  make(map[liquid.CategoryName]ratesv2.CategoryInfoReport),
+		}
+		serviceReport := report.Areas[area].Services[serviceType]
+
+		for _, rateName := range slices.Sorted(maps.Keys(rates)) {
+			rate := rates[rateName]
+			rir := ratesv2.RateInfoReport{
+				DisplayName: rate.DisplayName,
+				Topology:    rate.Topology,
+				HasUsage:    rate.HasUsage,
+				Unit:        rate.Unit,
+			}
+			if rateConfig, ok := config.RateLimits.GetProjectDefaultRateLimit(rateName).Unpack(); ok {
+				rir.ProjectDefaultLimit = rateConfig.Limit
+				rir.ProjectDefaultWindow = Some(rateConfig.Window)
+			}
+			category := liquid.CategoryName(serviceType)
+			categoryDisplayName := service.DisplayName
+			if categoryID, exists := rate.CategoryID.Unpack(); exists {
+				category = categories[categoryID].Name
+				categoryDisplayName = categories[categoryID].DisplayName
+			}
+			if _, exists := serviceReport.Categories[category]; !exists {
+				serviceReport.Categories[category] = ratesv2.CategoryInfoReport{
+					DisplayName: categoryDisplayName,
+					Rates:       make(map[liquid.RateName]ratesv2.RateInfoReport),
+				}
+			}
+			serviceReport.Categories[category].Rates[rateName] = rir
+		}
+	}
+	return report, nil
+}

--- a/internal/api/reports_v2/project.go
+++ b/internal/api/reports_v2/project.go
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package reports_v2
+
+import (
+	"database/sql"
+	"maps"
+	"slices"
+
+	limesrates "github.com/sapcc/go-api-declarations/limes/rates"
+	. "go.xyrillian.de/gg/option"
+
+	"github.com/sapcc/go-api-declarations/liquid"
+	"github.com/sapcc/go-bits/gopherpolicy"
+	"github.com/sapcc/go-bits/sqlext"
+
+	"github.com/sapcc/limes/internal/apideclarations/apiv2/common"
+	ratesv2 "github.com/sapcc/limes/internal/apideclarations/apiv2/rates"
+	"github.com/sapcc/limes/internal/core"
+	"github.com/sapcc/limes/internal/db"
+)
+
+var projectRateReportQuery = sqlext.SimplifyWhitespace(`
+	SELECT d.uuid, d.name, p.uuid, p.name, p.parent_uuid, pra.rate_id, pra.usage_as_bigint, pra.rate_limit, pra.window_ns
+	FROM project_rates pra
+	JOIN projects p
+	ON p.id = pra.project_id
+	JOIN domains d
+	ON d.id = p.domain_id
+	WHERE {{pra.rate_id = ANY($rate_id)}}
+	AND {{d.id = $domain_id}}
+	AND {{p.id = $project_id}}
+`)
+
+// GetProjectRates returns a ratesv2.ProjectGetResponse.
+func GetProjectRates(cluster *core.Cluster, token *gopherpolicy.Token, filter Filter, options common.ProjectRateReportOpts, scope Scope) (ratesv2.ProjectGetResponse, error) {
+	result := &ratesv2.ProjectGetResponse{}
+
+	// fill info report
+	if options.WithInfo {
+		infoReport, err := GetRatesInfo(cluster, token, filter)
+		if err != nil {
+			return *result, err
+		}
+		result.InfoReport = Some(infoReport)
+	}
+
+	// the result will have all rates without usage --> we will filter later
+	query, args := filter.ExpandServiceFilters(projectRateReportQuery)
+	query, args = scope.ExpandScopeFilters(query, args...)
+	err := sqlext.ForeachRow(cluster.DB, query, args, func(rows *sql.Rows) error {
+		var (
+			domainUUID        string
+			domainName        string
+			projectUUID       string
+			projectName       string
+			projectParentUUID string
+			rateID            db.RateID
+			usageAsBigint     string
+			projectLimit      Option[uint64]
+			projectWindow     Option[limesrates.Window]
+		)
+		err := rows.Scan(&domainUUID, &domainName, &projectUUID, &projectName, &projectParentUUID,
+			&rateID, &usageAsBigint, &projectLimit, &projectWindow)
+		if err != nil {
+			return err
+		}
+		setInProjectRateReport(filter, cluster, result, rateID, common.ProjectMetadata{
+			UUID:       projectUUID,
+			Name:       projectName,
+			ParentUUID: projectParentUUID,
+			DomainInfo: common.DomainMetadata{
+				UUID: domainUUID,
+				Name: domainName,
+			},
+		}, ratesv2.ProjectRateReport{
+			UsageAsBigint: Some(usageAsBigint), // note: the database has a non-null constraint here, make None when setting
+			ProjectLimit:  projectLimit,
+			ProjectWindow: projectWindow,
+		})
+		return nil
+	})
+
+	if err != nil {
+		return *result, err
+	}
+	return *result, nil
+}
+
+// setInProjectRateReport creates or iterates higher level structs on the way to the nested
+// location of the db.RateID in the report and assigns the value for ratesv2.ProjectRateReport.
+// If this rate should not get set because it does not have usage, this is a no-op.
+func setInProjectRateReport(filter Filter, cluster *core.Cluster, report *ratesv2.ProjectGetResponse, rateID db.RateID, project common.ProjectMetadata, value ratesv2.ProjectRateReport) {
+	services := filter.GetServices()
+	categories := filter.GetCategories()
+
+	for _, serviceType := range slices.Sorted(maps.Keys(services)) {
+		rates, _ := filter.GetRatesForType(serviceType) // can have no resources
+		for _, rateName := range slices.Sorted(maps.Keys(rates)) {
+			rate := rates[rateName]
+			if rate.ID != rateID {
+				continue
+			}
+			if !rate.HasUsage && value.ProjectLimit.IsNone() && value.ProjectWindow.IsNone() {
+				return
+			}
+			// note: the database has a non-null constraint here, so we correct this after the fact
+			if !rate.HasUsage {
+				value.UsageAsBigint = None[string]()
+			}
+
+			config := cluster.Config.Liquids[serviceType]
+			area := config.Area
+			// defense in depth: config should be in sync with serviceInfo
+			if area == "" {
+				return
+			}
+
+			// check domain level (might be uninitialized)
+			if report.DomainReports == nil {
+				report.DomainReports = make(map[string]ratesv2.ProjectsByDomainReport)
+			}
+			if _, exists := report.DomainReports[project.DomainInfo.UUID]; !exists {
+				report.DomainReports[project.DomainInfo.UUID] = ratesv2.ProjectsByDomainReport{
+					ProjectReports: make(map[string]ratesv2.ProjectReport),
+				}
+			}
+			domainReport := report.DomainReports[project.DomainInfo.UUID]
+
+			// check project level
+			if _, exists := domainReport.ProjectReports[project.UUID]; !exists {
+				domainReport.ProjectReports[project.UUID] = ratesv2.ProjectReport{
+					ProjectMetadata: project,
+					Areas:           make(map[string]ratesv2.ProjectAreaReport),
+				}
+			}
+			projectReport := domainReport.ProjectReports[project.UUID]
+
+			// check area level
+			if _, exists := projectReport.Areas[area]; !exists {
+				projectReport.Areas[area] = ratesv2.ProjectAreaReport{Services: make(map[db.ServiceType]ratesv2.ProjectServiceReport)}
+			}
+			areaReport := projectReport.Areas[area]
+
+			// check service level
+			if _, exists := areaReport.Services[serviceType]; !exists {
+				areaReport.Services[serviceType] = ratesv2.ProjectServiceReport{Categories: make(map[liquid.CategoryName]ratesv2.ProjectCategoryReport)}
+			}
+			serviceReport := areaReport.Services[serviceType]
+
+			// check category level
+			category := liquid.CategoryName(serviceType)
+			if categoryID, exists := rate.CategoryID.Unpack(); exists {
+				category = categories[categoryID].Name
+			}
+			if _, exists := serviceReport.Categories[category]; !exists {
+				serviceReport.Categories[category] = ratesv2.ProjectCategoryReport{Rates: make(map[liquid.RateName]ratesv2.ProjectRateReport)}
+			}
+			categoryReport := serviceReport.Categories[category]
+
+			// check rate level
+			categoryReport.Rates[rate.Name] = value
+			return
+		}
+	}
+}

--- a/internal/api/reports_v2/scope.go
+++ b/internal/api/reports_v2/scope.go
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package reports_v2
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/go-gorp/gorp/v3"
+	"github.com/sapcc/go-bits/gopherpolicy"
+	"github.com/sapcc/go-bits/respondwith"
+
+	"github.com/sapcc/limes/internal/db"
+	"github.com/sapcc/limes/internal/util"
+
+	"github.com/gorilla/mux"
+	. "go.xyrillian.de/gg/option"
+)
+
+// Scope describes the object Scope of a validated request.
+// Currently, there is no option to have a Scope with more than one domain or project.
+// If project.IsSome(), then domain.IsSome() too.
+type Scope struct {
+	Domain  Option[db.Domain]
+	Project Option[db.Project]
+}
+
+// NewScope obtains the project and domain from the database.
+// When forProject=true, this should be called before evaluating the tokens authorization
+// so that the project-->domain relation of domain admins is checked properly.
+// It returns the validated scope information or an error.
+func NewScope(forProject bool, r *http.Request, queryDomainUUID Option[string], token *gopherpolicy.Token, dbm *gorp.DbMap) (s Scope, err error) {
+	urlDomainUUID := mux.Vars(r)["domain_uuid"]
+	urlProjectUUID := mux.Vars(r)["project_uuid"]
+
+	isDomainUser := token.Check("v2:domain:role")
+	isProjectUser := token.Check("v2:project:role")
+
+	// a project user for project API without URL param will get an authentication error from the token check, so we just return here
+	if forProject && isProjectUser && urlProjectUUID == "" {
+		return Scope{Project: Some(db.Project{ID: -1})}, nil
+	}
+	// a domain user needs to have one of the values set
+	if forProject && isDomainUser && urlProjectUUID == "" && queryDomainUUID.IsNone() {
+		return s, respondwith.CustomStatus(http.StatusBadRequest, errors.New("specify URL project_uuid or query domain_uuid"))
+	}
+	// both values cannot be set together, this check is superfluous for non-project because it's not in opts there
+	if forProject && queryDomainUUID.IsSome() && urlProjectUUID != "" {
+		return s, respondwith.CustomStatus(http.StatusBadRequest, errors.New("query domain_uuid cannot be set, when URL project_uuid is set"))
+	}
+	// For domain and cluster mode, auth check is done in advance, so we don't need to check urlDomainUUID and urlProjectUUID.
+	// queryDomainUUID.IsSome() gets rejected by option parsing for domain and cluster.
+
+	if urlProjectUUID != "" {
+		var project db.Project
+		err := dbm.SelectOne(&project, "SELECT * FROM projects WHERE uuid = $1", urlProjectUUID)
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			return s, respondwith.CustomStatus(http.StatusNotFound, fmt.Errorf("no such project (UUID = %s)", urlProjectUUID))
+		case err != nil:
+			return s, err
+		default:
+			s.Project = Some(project)
+		}
+	}
+
+	var (
+		filter string
+		arg    any
+	)
+	switch {
+	case urlDomainUUID != "":
+		filter = "UUID = $1"
+		arg = urlDomainUUID
+	case queryDomainUUID.IsSome():
+		filter = "UUID = $1"
+		arg = queryDomainUUID.UnwrapOrPanic("queryDomainUUID was checked to be Some()")
+	case s.Project.IsSome():
+		filter = "ID = $1"
+		arg = s.Project.UnwrapOrPanic("project was checked to be Some()").DomainID
+	default:
+		return s, nil
+	}
+	var domain db.Domain
+	err = dbm.SelectOne(&domain, "SELECT * FROM domains WHERE "+filter, arg)
+
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return s, respondwith.CustomStatus(http.StatusNotFound, fmt.Errorf("no such domain (%s)", fmt.Sprintf(strings.ReplaceAll(filter, "$1", "%s"), arg)))
+	case err != nil:
+		return s, err
+	default:
+		s.Domain = Some(domain)
+		// important: we need this for the token authentication with specific requested
+		// project to work as the paths don't contain the domain_uuid anymore.
+		if forProject && (isProjectUser || isDomainUser) {
+			if token.Context.Request == nil {
+				token.Context.Request = make(map[string]string, 1)
+			}
+			token.Context.Request["domain_uuid"] = domain.UUID
+		}
+	}
+
+	return s, nil
+}
+
+var scopeFilterReplaceRx = regexp.MustCompile(`{{(.*?) = \$(domain_id|project_id)}}`)
+
+// ExpandScopeFilters takes an SQL query string with curly-bracketed
+// where-clauses and will replace each one with an arg position and return the
+// according SQL arg for this filter, namely a scope ID.
+// The expressions must be of the form "{{[filter-field] = $[id-field]}}"
+// where filter-field can be a primary key column or a foreign key and id-field
+// is the name of the scope entity whose ID-column values are used.
+// It supports domain_id and project_id.
+// On unknown keywords it will panic.
+func (s Scope) ExpandScopeFilters(originalQuery string, originalArgs ...any) (query string, args []any) {
+	// get current highest index
+	var err error
+	i := 0
+	queryVariables := regexp.MustCompile(`\$(\d+)`)
+	matches := queryVariables.FindAllString(originalQuery, -1)
+	if len(matches) > 0 {
+		last := matches[len(matches)-1]
+		i, err = strconv.Atoi(queryVariables.FindStringSubmatch(last)[1])
+		if err != nil {
+			panic("digits should be parseable integer")
+		}
+	}
+	args = append(args, originalArgs...)
+
+	query = scopeFilterReplaceRx.ReplaceAllStringFunc(originalQuery, func(matchStr string) string {
+		match := scopeFilterReplaceRx.FindStringSubmatch(matchStr)
+
+		switch match[2] {
+		case "domain_id":
+			if domain, ok := s.Domain.Unpack(); ok {
+				args = append(args, domain.ID)
+			} else {
+				return util.SQLFilterNoop
+			}
+		case "project_id":
+			if project, ok := s.Project.Unpack(); ok {
+				args = append(args, project.ID)
+			} else {
+				return util.SQLFilterNoop
+			}
+		default:
+			panic("unreachable")
+		}
+		i++
+		return match[1] + " = $" + strconv.Itoa(i)
+	})
+	return query, args
+}

--- a/internal/api/reports_v2/scope_test.go
+++ b/internal/api/reports_v2/scope_test.go
@@ -1,0 +1,290 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package reports_v2_test
+
+import (
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/sapcc/go-bits/easypg"
+	"github.com/sapcc/go-bits/must"
+	"go.xyrillian.de/gg/assert"
+	. "go.xyrillian.de/gg/option"
+
+	"github.com/sapcc/limes/internal/api/reports_v2"
+	"github.com/sapcc/limes/internal/db"
+	"github.com/sapcc/limes/internal/test"
+)
+
+func TestMain(m *testing.M) {
+	easypg.WithTestDB(m, func() int { return m.Run() })
+}
+
+const scopeConfigJSON = `{
+	"availability_zones": ["az-one"],
+	"discovery": {
+		"method": "static",
+		"static_config": {
+			"domains": [
+				{"name": "germany", "id": "uuid-for-germany"},
+				{"name": "france", "id": "uuid-for-france"}
+			],
+			"projects": {
+				"uuid-for-germany": [
+					{"name": "berlin", "id": "uuid-for-berlin", "parent_id": "uuid-for-germany"},
+					{"name": "dresden", "id": "uuid-for-dresden", "parent_id": "uuid-for-berlin"}
+				],
+				"uuid-for-france": [
+					{"name": "paris", "id": "uuid-for-paris", "parent_id": "uuid-for-france"}
+				]
+			}
+		}
+	},
+	"areas": {
+		"some": {
+			"display_name": "Some"
+		}
+	},
+	"liquids": {
+		"some": {
+			"area": "some"
+		}
+	}
+}`
+
+type singleScopeTestInput struct {
+	s               test.Setup
+	r               *http.Request
+	forProject      bool
+	queryDomainUUID Option[string]
+}
+
+type singleScopeTestExpectation struct {
+	err                Option[string]
+	project            Option[db.Project]
+	domain             Option[db.Domain]
+	requestProjectUUID Option[string]
+	requestDomainUUID  Option[string]
+}
+
+func executeSingleScopeTest(t *testing.T, i singleScopeTestInput, e singleScopeTestExpectation) {
+	t.Helper()
+
+	token := i.s.TokenValidator.CheckToken(i.r)
+	// the real validator fills the Request, so we have to emulate this here
+	maps.Copy(token.Context.Request, mux.Vars(i.r))
+	scope, err := reports_v2.NewScope(i.forProject, i.r, i.queryDomainUUID, token, i.s.DB)
+
+	if errMsg, ok := e.err.Unpack(); ok {
+		assert.ErrEqual(t, err, errMsg)
+	} else {
+		assert.ErrEqual(t, err, nil)
+	}
+	assert.Equal(t, scope.Project, e.project)
+	assert.Equal(t, scope.Domain, e.domain)
+	assert.Equal(t, token.Context.Request["project_uuid"], e.requestProjectUUID.UnwrapOr(""))
+	assert.Equal(t, token.Context.Request["domain_uuid"], e.requestDomainUUID.UnwrapOr(""))
+}
+
+func TestV2ScopeCreation(t *testing.T) {
+	s := test.NewSetup(t,
+		test.WithConfig(scopeConfigJSON),
+		test.WithInitialDiscovery,
+	)
+	var (
+		domainFrance db.Domain
+		projectParis db.Project
+	)
+	must.SucceedT(t, s.DB.SelectOne(&domainFrance, "SELECT * FROM domains WHERE uuid = 'uuid-for-france'"))
+	must.SucceedT(t, s.DB.SelectOne(&projectParis, "SELECT * FROM projects WHERE uuid = 'uuid-for-paris'"))
+
+	// cluster level is only possible for cloud_admin, so nothing happens
+	r := httptest.NewRequest(http.MethodGet, "/some/unimportant/path", http.NoBody)
+	executeSingleScopeTest(t, singleScopeTestInput{
+		s:          s,
+		r:          r,
+		forProject: false,
+	}, singleScopeTestExpectation{})
+
+	// domain level is possible for domain tokens, does not alter the token
+	r = httptest.NewRequest(http.MethodGet, "/some/path/with/uuid-for-france", http.NoBody)
+	r = mux.SetURLVars(r, map[string]string{"domain_uuid": "uuid-for-france"})
+	s.TokenValidator.Enforcer.IsDomainRole = true
+	executeSingleScopeTest(t, singleScopeTestInput{
+		s:          s,
+		r:          r,
+		forProject: false,
+	}, singleScopeTestExpectation{
+		requestDomainUUID: Some("uuid-for-france"),
+		domain:            Some(domainFrance),
+	})
+	// domain level is possible for cloud_admin, does not alter the token
+	s.TokenValidator.Enforcer.IsDomainRole = false
+	executeSingleScopeTest(t, singleScopeTestInput{
+		s:          s,
+		r:          r,
+		forProject: false,
+	}, singleScopeTestExpectation{
+		requestDomainUUID: Some("uuid-for-france"),
+		domain:            Some(domainFrance),
+	})
+
+	// project level is possible for project tokens, will add domain to the token context
+	r = httptest.NewRequest(http.MethodGet, "/some/path/with/uuid-for-paris", http.NoBody)
+	r = mux.SetURLVars(r, map[string]string{"project_uuid": "uuid-for-paris"})
+	s.TokenValidator.Enforcer.IsProjectRole = true
+	executeSingleScopeTest(t, singleScopeTestInput{
+		s:          s,
+		r:          r,
+		forProject: true,
+	}, singleScopeTestExpectation{
+		requestProjectUUID: Some("uuid-for-paris"),
+		requestDomainUUID:  Some("uuid-for-france"),
+		domain:             Some(domainFrance),
+		project:            Some(projectParis),
+	})
+
+	// project level is possible for domain token (specific project), will add domain to the token context
+	r = httptest.NewRequest(http.MethodGet, "/some/path/with/uuid-for-paris", http.NoBody)
+	r = mux.SetURLVars(r, map[string]string{"project_uuid": "uuid-for-paris"})
+	s.TokenValidator.Enforcer.IsDomainRole = true
+	s.TokenValidator.Enforcer.IsProjectRole = false
+	executeSingleScopeTest(t, singleScopeTestInput{
+		s:          s,
+		r:          r,
+		forProject: true,
+	}, singleScopeTestExpectation{
+		requestProjectUUID: Some("uuid-for-paris"),
+		requestDomainUUID:  Some("uuid-for-france"),
+		domain:             Some(domainFrance),
+		project:            Some(projectParis),
+	})
+	// project level is possible for domain token (whole domain), will add domain to the token context
+	r = httptest.NewRequest(http.MethodGet, "/some/unimportant/path", http.NoBody)
+	executeSingleScopeTest(t, singleScopeTestInput{
+		s:               s,
+		r:               r,
+		forProject:      true,
+		queryDomainUUID: Some("uuid-for-france"),
+	}, singleScopeTestExpectation{
+		requestDomainUUID: Some("uuid-for-france"),
+		domain:            Some(domainFrance),
+	})
+
+	// project level is possible for cloud_admin (specific project), does not alter the token
+	r = httptest.NewRequest(http.MethodGet, "/some/path/with/uuid-for-paris", http.NoBody)
+	r = mux.SetURLVars(r, map[string]string{"project_uuid": "uuid-for-paris"})
+	s.TokenValidator.Enforcer.IsDomainRole = false
+	executeSingleScopeTest(t, singleScopeTestInput{
+		s:          s,
+		r:          r,
+		forProject: true,
+	}, singleScopeTestExpectation{
+		requestProjectUUID: Some("uuid-for-paris"),
+		domain:             Some(domainFrance),
+		project:            Some(projectParis),
+	})
+	// project level is possible for cloud_admin (whole domain), does not alter the token
+	r = httptest.NewRequest(http.MethodGet, "/some/unimportant/path", http.NoBody)
+	executeSingleScopeTest(t, singleScopeTestInput{
+		s:               s,
+		r:               r,
+		forProject:      true,
+		queryDomainUUID: Some("uuid-for-france"),
+	}, singleScopeTestExpectation{
+		domain: Some(domainFrance),
+	})
+
+	// errors:
+	// project level with domain token but no identifier specified
+	r = httptest.NewRequest(http.MethodGet, "/some/unimportant/path", http.NoBody)
+	s.TokenValidator.Enforcer.IsDomainRole = true
+	executeSingleScopeTest(t, singleScopeTestInput{
+		s:          s,
+		r:          r,
+		forProject: true,
+	}, singleScopeTestExpectation{
+		err: Some("specify URL project_uuid or query domain_uuid"),
+	})
+
+	// both identifiers set at the same time
+	r = httptest.NewRequest(http.MethodGet, "/some/path/with/uuid-for-paris", http.NoBody)
+	r = mux.SetURLVars(r, map[string]string{"project_uuid": "uuid-for-paris"})
+	executeSingleScopeTest(t, singleScopeTestInput{
+		s:               s,
+		r:               r,
+		forProject:      true,
+		queryDomainUUID: Some("uuid-for-france"),
+	}, singleScopeTestExpectation{
+		err:                Some("query domain_uuid cannot be set, when URL project_uuid is set"),
+		requestProjectUUID: Some("uuid-for-paris"),
+	})
+}
+
+func TestV2ExpandScopeFilters(t *testing.T) {
+	s := test.NewSetup(t,
+		test.WithConfig(scopeConfigJSON),
+		test.WithInitialDiscovery,
+	)
+	var (
+		domainFrance db.Domain
+		projectParis db.Project
+	)
+	must.SucceedT(t, s.DB.SelectOne(&domainFrance, "SELECT * FROM domains WHERE uuid = 'uuid-for-france'"))
+	must.SucceedT(t, s.DB.SelectOne(&projectParis, "SELECT * FROM projects WHERE uuid = 'uuid-for-paris'"))
+
+	// empty scope: all placeholders become TRUE = TRUE
+	emptyScope := reports_v2.Scope{}
+	query, args := emptyScope.ExpandScopeFilters(
+		`SELECT * FROM t WHERE {{d.id = $domain_id}} AND {{p.id = $project_id}}`,
+	)
+	assert.Equal(t, query, `SELECT * FROM t WHERE TRUE = TRUE AND TRUE = TRUE`)
+	assert.Equal(t, len(args), 0)
+
+	// domain-only scope: domain_id gets replaced, project_id becomes noop
+	domainScope := reports_v2.Scope{
+		Domain: Some(domainFrance),
+	}
+	query, args = domainScope.ExpandScopeFilters(
+		`SELECT * FROM t WHERE {{d.id = $domain_id}} AND {{p.id = $project_id}}`,
+	)
+	assert.Equal(t, query, `SELECT * FROM t WHERE d.id = $1 AND TRUE = TRUE`)
+	assert.Equal(t, len(args), 1)
+	assert.Equal(t, args[0].(db.DomainID), domainFrance.ID)
+
+	// project scope (both domain and project set): both get replaced
+	projectScope := reports_v2.Scope{
+		Domain:  Some(domainFrance),
+		Project: Some(projectParis),
+	}
+	query, args = projectScope.ExpandScopeFilters(
+		`SELECT * FROM t WHERE {{d.id = $domain_id}} AND {{p.id = $project_id}}`,
+	)
+	assert.Equal(t, query, `SELECT * FROM t WHERE d.id = $1 AND p.id = $2`)
+	assert.Equal(t, len(args), 2)
+	assert.Equal(t, args[0].(db.DomainID), domainFrance.ID)
+	assert.Equal(t, args[1].(db.ProjectID), projectParis.ID)
+
+	// with pre-existing args: arg positions continue from the highest existing index
+	query, args = projectScope.ExpandScopeFilters(
+		`SELECT * FROM t WHERE t.name = $14 AND {{d.id = $domain_id}} AND {{p.id = $project_id}}`,
+		"some-value",
+	)
+	assert.Equal(t, query, `SELECT * FROM t WHERE t.name = $14 AND d.id = $15 AND p.id = $16`)
+	assert.Equal(t, len(args), 3)
+	assert.Equal(t, args[0].(string), "some-value")
+	assert.Equal(t, args[1].(db.DomainID), domainFrance.ID)
+	assert.Equal(t, args[2].(db.ProjectID), projectParis.ID)
+
+	// only project_id placeholder in query with project scope
+	query, args = projectScope.ExpandScopeFilters(
+		`SELECT * FROM t WHERE {{p.id = $project_id}}`,
+	)
+	assert.Equal(t, query, `SELECT * FROM t WHERE p.id = $1`)
+	assert.Equal(t, len(args), 1)
+	assert.Equal(t, args[0].(db.ProjectID), projectParis.ID)
+}

--- a/internal/core/cluster.go
+++ b/internal/core/cluster.go
@@ -397,9 +397,10 @@ func SaveServiceInfoToDB(serviceType db.ServiceType, serviceInfo liquid.ServiceI
 			categoryID := options.Map(serviceInfo.Resources[resourceName].Category,
 				func(cn liquid.CategoryName) db.CategoryID { return categoryByName[cn].ID })
 			return db.Resource{
-				ServiceID:           srv.ID,
-				Name:                resourceName,
-				DisplayName:         serviceInfo.Resources[resourceName].DisplayName,
+				ServiceID:   srv.ID,
+				Name:        resourceName,
+				DisplayName: serviceInfo.Resources[resourceName].DisplayName,
+				// TODO: consider serializing empty categories as serviceType here, instead at the consumers
 				CategoryID:          categoryID,
 				Path:                db.ResourcePath{ServiceType: serviceType, ResourceName: resourceName},
 				LiquidVersion:       serviceInfo.Version,
@@ -424,6 +425,7 @@ func SaveServiceInfoToDB(serviceType db.ServiceType, serviceInfo liquid.ServiceI
 				}
 			}
 			res.DisplayName = serviceInfo.Resources[res.Name].DisplayName
+			// TODO: consider serializing empty categories as serviceType here, instead at the consumers
 			res.CategoryID = options.Map(serviceInfo.Resources[res.Name].Category,
 				func(cn liquid.CategoryName) db.CategoryID { return categoryByName[cn].ID })
 			res.Unit = serviceInfo.Resources[res.Name].Unit

--- a/internal/core/service_info_cache.go
+++ b/internal/core/service_info_cache.go
@@ -36,6 +36,11 @@ type ServiceInfoFilter struct {
 	RateName     Option[liquid.RateName]
 }
 
+// isEmpty returns whether all optional filters are not set.
+func (s ServiceInfoFilter) isEmpty() bool {
+	return s.ServiceArea.IsNone() && s.ServiceType.IsNone() && s.Category.IsNone() && s.ResourceName.IsNone() && s.RateName.IsNone()
+}
+
 ///////////////////////////////////////////////////////////////////////
 
 // ServiceInfoReader defines shared methods for reading filtered or unfiltered ServiceInfoSnapshots.
@@ -176,7 +181,8 @@ func (s ServiceInfoSnapshot) Filter(filter ServiceInfoFilter) FilteredServiceInf
 	}
 	categoriesToRemove := make(map[db.CategoryID]struct{})
 	// find categories to remove
-	if categoryFilter, ok := f.filter.Category.Unpack(); ok {
+	categoryFilter, categoryFilterExists := f.filter.Category.Unpack()
+	if categoryFilterExists {
 		for categoryID, info := range f.snapshot.categories {
 			if info.Name != categoryFilter {
 				delete(f.snapshot.categories, categoryID)
@@ -186,7 +192,6 @@ func (s ServiceInfoSnapshot) Filter(filter ServiceInfoFilter) FilteredServiceInf
 	}
 	seenCategories := make(map[db.CategoryID]struct{})
 	resourceNameFilter, resourceFilterExists := f.filter.ResourceName.Unpack()
-	categoryFilterExists := f.filter.Category.IsSome()
 	// filter resources/ az_resources by category or name
 	if categoryFilterExists || resourceFilterExists {
 		for serviceType, resources := range f.snapshot.resources {
@@ -194,7 +199,8 @@ func (s ServiceInfoSnapshot) Filter(filter ServiceInfoFilter) FilteredServiceInf
 				categoryID, cExists := resource.CategoryID.Unpack()
 				_, inRemoveSet := categoriesToRemove[categoryID]
 				shouldRemove := (resourceFilterExists && resourceName != resourceNameFilter) ||
-					(categoryFilterExists && (!cExists || inRemoveSet))
+					(categoryFilterExists && cExists && inRemoveSet) ||
+					(categoryFilterExists && !cExists && string(categoryFilter) != string(serviceType))
 				if shouldRemove {
 					delete(f.snapshot.resources[serviceType], resourceName)
 					delete(f.snapshot.azResources[serviceType], resourceName)
@@ -218,7 +224,8 @@ func (s ServiceInfoSnapshot) Filter(filter ServiceInfoFilter) FilteredServiceInf
 				categoryID, cExists := rate.CategoryID.Unpack()
 				_, inRemoveSet := categoriesToRemove[categoryID]
 				shouldRemove := (rateFilterExists && rateName != rateNameFilter) ||
-					(categoryFilterExists && (!cExists || inRemoveSet))
+					(categoryFilterExists && cExists && inRemoveSet) ||
+					(categoryFilterExists && !cExists && string(categoryFilter) != string(serviceType))
 				if shouldRemove {
 					delete(f.snapshot.rates[serviceType], rateName)
 					if len(f.snapshot.resources[serviceType]) == 0 && len(f.snapshot.rates[serviceType]) == 0 {
@@ -353,45 +360,11 @@ type FilteredServiceInfoSnapshot struct {
 	filter   ServiceInfoFilter
 }
 
-// GetFilteredService returns the service for the filtered type.
-// It is useful to access the service, when you know it was filtered.
-func (f FilteredServiceInfoSnapshot) GetFilteredService() (db.Service, bool) {
-	serviceType, ok := f.filter.ServiceType.Unpack()
-	if !ok {
-		return db.Service{}, false
-	}
-	service, ok := f.snapshot.services[serviceType]
-	return service, ok
-}
-
-// GetFilteredResource returns the resource for the filtered type and name.
-// It is useful to access the resource, when you know it was filtered.
-func (f FilteredServiceInfoSnapshot) GetFilteredResource() (db.Resource, bool) {
-	serviceType, ok := f.filter.ServiceType.Unpack()
-	if !ok {
-		return db.Resource{}, false
-	}
-	resourceName, ok := f.filter.ResourceName.Unpack()
-	if !ok {
-		return db.Resource{}, false
-	}
-	resource, ok := f.snapshot.resources[serviceType][resourceName]
-	return resource, ok
-}
-
-// GetFilteredRate returns the rate for the filtered type and name.
-// It is useful to access the rate, when you know it was filtered.
-func (f FilteredServiceInfoSnapshot) GetFilteredRate() (db.Rate, bool) {
-	serviceType, ok := f.filter.ServiceType.Unpack()
-	if !ok {
-		return db.Rate{}, false
-	}
-	rateName, ok := f.filter.RateName.Unpack()
-	if !ok {
-		return db.Rate{}, false
-	}
-	rate, ok := f.snapshot.rates[serviceType][rateName]
-	return rate, ok
+// FilterIsEmpty returns whether all optional filters are empty.
+// As the FilteredServiceInfoSnapshot get's re-used for applying parsed API
+// options to the ServiceInfoSnapshot, the filter can also be empty.
+func (f FilteredServiceInfoSnapshot) FilterIsEmpty() bool {
+	return f.filter.isEmpty()
 }
 
 // GetServices implements the [ServiceInfoReader] interface.

--- a/internal/core/service_info_cache_test.go
+++ b/internal/core/service_info_cache_test.go
@@ -66,9 +66,6 @@ func TestServiceInfoSnapshotFilter(t *testing.T) {
 	assert.Equal(t, ok, false)
 	_, ok = filtered.GetRatesForType("first")
 	assert.Equal(t, ok, false)
-	service, ok := filtered.GetFilteredService()
-	assert.Equal(t, ok, true)
-	assert.Equal(t, service.DisplayName, "Second")
 
 	// filter by ServiceArea
 	filtered = sis.Filter(core.ServiceInfoFilter{ServiceArea: Some("shared")})
@@ -90,12 +87,6 @@ func TestServiceInfoSnapshotFilter(t *testing.T) {
 	assert.Equal(t, ok, true)
 	_, ok = resources["things"]
 	assert.Equal(t, ok, false)
-	_, ok = filtered.GetFilteredResource()
-	assert.Equal(t, ok, false) // ServiceType not set
-	filtered2 := sis.Filter(core.ServiceInfoFilter{ServiceType: Some[db.ServiceType]("second"), ResourceName: Some[liquid.ResourceName]("capacity")})
-	resource, ok := filtered2.GetFilteredResource()
-	assert.Equal(t, ok, true)
-	assert.Equal(t, resource.DisplayName, "Capacity")
 
 	// filter by Category
 	filtered = sis.Filter(core.ServiceInfoFilter{Category: Some[liquid.CategoryName]("foo_category")})
@@ -108,6 +99,16 @@ func TestServiceInfoSnapshotFilter(t *testing.T) {
 	_, ok = filtered.GetServiceForType("first")
 	assert.Equal(t, ok, false)
 
+	// filter by Category matching the serviceType yields entries which have no explicit category
+	filtered = sis.Filter(core.ServiceInfoFilter{Category: Some[liquid.CategoryName]("second")})
+	resources, ok = filtered.GetResourcesForType("second")
+	assert.Equal(t, ok, true)
+	assert.Equal(t, len(resources), 1)
+	_, ok = resources["things"]
+	assert.Equal(t, ok, true)
+	_, ok = resources["capacity"]
+	assert.Equal(t, ok, false)
+
 	// filter by RateName
 	filtered = sis.Filter(core.ServiceInfoFilter{RateName: Some[liquid.RateName]("objects:create")})
 	rates, ok = filtered.GetRatesForType("first")
@@ -115,12 +116,6 @@ func TestServiceInfoSnapshotFilter(t *testing.T) {
 	assert.Equal(t, len(rates), 1)
 	_, ok = rates["objects:create"]
 	assert.Equal(t, ok, true)
-	_, ok = filtered.GetFilteredRate()
-	assert.Equal(t, ok, false) // ServiceType not set
-	filtered2 = sis.Filter(core.ServiceInfoFilter{ServiceType: Some[db.ServiceType]("first"), RateName: Some[liquid.RateName]("objects:create")})
-	rate, ok := filtered2.GetFilteredRate()
-	assert.Equal(t, ok, true)
-	assert.Equal(t, rate.DisplayName, "Object Creations")
 
 	// snapshot immutability: mutations on returned maps don't affect snapshot
 	services := sis.GetServices()

--- a/internal/test/mock_enforcer.go
+++ b/internal/test/mock_enforcer.go
@@ -22,6 +22,8 @@ type PolicyEnforcer struct {
 	AllowUncommit     bool
 	// flags by v2 action
 	AllowInfo             bool
+	AllowReportSingle     bool
+	AllowReportMultiple   bool
 	AllowCommitmentCreate bool
 	// v2:level:role
 	IsDomainRole  bool
@@ -79,6 +81,10 @@ func (e *PolicyEnforcer) allowAction(action string) bool {
 		return e.AllowUncommit
 	case "info":
 		return e.AllowInfo
+	case "report_single":
+		return e.AllowReportSingle
+	case "report_multiple":
+		return e.AllowReportMultiple
 	case "commitment_create":
 		return e.AllowCommitmentCreate
 	case "block_commitments":

--- a/internal/test/mock_enforcer.go
+++ b/internal/test/mock_enforcer.go
@@ -23,6 +23,9 @@ type PolicyEnforcer struct {
 	// flags by v2 action
 	AllowInfo             bool
 	AllowCommitmentCreate bool
+	// v2:level:role
+	IsDomainRole  bool
+	IsProjectRole bool
 	// match by request attribute
 	RejectServiceType string
 }
@@ -31,6 +34,12 @@ type PolicyEnforcer struct {
 func (e *PolicyEnforcer) Enforce(rule string, ctx policy.Context) bool {
 	if e.RejectServiceType != "" && ctx.Request["service_type"] == e.RejectServiceType {
 		return false
+	}
+	switch rule {
+	case "v2:domain:role":
+		return e.IsDomainRole
+	case "v2:project:role":
+		return e.IsProjectRole
 	}
 	fields := strings.Split(rule, ":")
 	// for the v2 api we are introducing a new scheme of v2:scope:endpoint

--- a/internal/test/setup.go
+++ b/internal/test/setup.go
@@ -280,6 +280,9 @@ func NewSetup(t *testing.T, opts ...SetupOption) Setup {
 		// v2 actions
 		AllowInfo:             true,
 		AllowCommitmentCreate: true,
+		// v2:level:role
+		IsDomainRole:  false,
+		IsProjectRole: false,
 	}
 	s.mockUserIdentity = map[string]string{
 		"user_id":             "uuid-for-alice",

--- a/internal/test/setup.go
+++ b/internal/test/setup.go
@@ -279,6 +279,8 @@ func NewSetup(t *testing.T, opts ...SetupOption) Setup {
 		AllowUncommit:     true,
 		// v2 actions
 		AllowInfo:             true,
+		AllowReportSingle:     true,
+		AllowReportMultiple:   true,
 		AllowCommitmentCreate: true,
 		// v2:level:role
 		IsDomainRole:  false,

--- a/internal/util/datatypes.go
+++ b/internal/util/datatypes.go
@@ -51,3 +51,6 @@ func FromUnixEncodedTime(t limes.UnixEncodedTime) time.Time {
 // CommitmentStatusDeleted is used for soft-deleting commitments before they get hard-deleted after a grace period.
 // It is defined here instead of in the liquid package, because in liquid we model deletions as status=None.
 const CommitmentStatusDeleted liquid.CommitmentStatus = "deleted"
+
+// util.SQLFilterNoop is used to replace a filter string in an SQL with a noop.
+const SQLFilterNoop = "TRUE = TRUE"


### PR DESCRIPTION
Finally the start of the implementation of the v2 report APIs.
Please review commit by commit, then it should be easily digestible.

Good to know for reviewing: We decided to rename `project_id` to `project_uuid` consistently in the API, likewise for domain.
This makes some changes necessary for the `policy.json`.
I am not 100% certain about the new structuring of that yet.