### PR TITLE
config: replace CatalogURL with APIDomainNames

### DIFF
--- a/docs/operators/config.md
+++ b/docs/operators/config.md
@@ -30,6 +30,8 @@ on the top left corner of this document to get to a specific section of this gui
 
 | Variable | Default | Description |
 | --- | --- | --- |
+| `LIMES_API_DOMAIN_NAME_V1` | *(required)* | Domain name of Limes v1 API as it appears in the Keystone service catalog for this cluster. The public endpoint URL in the catalog entry for service type `resources` must be `https://THIS_VALUE`. |
+| `LIMES_API_DOMAIN_NAME_V2` | *(required)* | Domain name of Limes v2 API as it appears in the Keystone service catalog for this cluster. The public endpoint URLs in the catalog entries for service types `limitas-resources` and `limitas-rates` must be `https://THIS_VALUE/resources` and `https://THIS_VALUE/rates`, respectively. |
 | `LIMES_API_LISTEN_ADDRESS` | `:80` | Bind address for the HTTP API exposed by this service, e.g. `127.0.0.1:80` to bind only on one IP, or `:80` to bind on all interfaces and addresses. |
 | `LIMES_API_POLICY_PATH` | `/etc/limes/policy.json` | Path to the oslo.policy file that describes authorization behavior for this service. Please refer to the [OpenStack documentation on policies][policy] for syntax reference. This repository includes an [example policy][ex-pol] that can be used for development setups, or as a basis for writing your own policy. For `:set_rate_limit` policies, the object attribute `%(service_type)s` is available to restrict editing to certain service types. |
 
@@ -128,7 +130,6 @@ The following fields and sections are supported:
 | Field | Required | Description |
 | --- | --- | --- |
 | `availability_zones` | yes | List of availability zones in this cluster. |
-| `catalog_url` | no | URL of Limes API service as it appears in the Keystone service catalog for this cluster. This is only used for version advertisements, and can be omitted if no client relies on the URLs in these version advertisements. |
 | `discovery.method` | no | Defines which method to use to discover Keystone domains and projects in this cluster. If not given, the default value is `list`. |
 | `discovery.except_domains` | no | May contain a regex. Domains whose names match the regex will not be considered by Limes. |
 | `discovery.only_domains` | no | May contain a regex. If given, only domains whose names match the regex will be considered by Limes. If `except_domains` is also given, it takes precedence over `only_domains`. |

--- a/internal/api/api_v2/version_provider.go
+++ b/internal/api/api_v2/version_provider.go
@@ -6,11 +6,12 @@ package api_v2
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"slices"
-	"strings"
 
 	"github.com/gorilla/mux"
 	"github.com/sapcc/go-bits/httpapi"
+	"github.com/sapcc/go-bits/osext"
 	"github.com/sapcc/go-bits/respondwith"
 
 	"github.com/sapcc/limes/internal/core"
@@ -18,6 +19,7 @@ import (
 
 type versionProvider struct {
 	Cluster                *core.Cluster
+	DomainNames            DomainNames
 	currentVersion         string
 	experimentalVersions   []string
 	otherSupportedVersions []string
@@ -39,9 +41,10 @@ type VersionLinkData struct {
 }
 
 // NewVersionProviderAPI creates an httpapi.API that serves the version advertisement API.
-func NewVersionProviderAPI(cluster *core.Cluster) httpapi.API {
+func NewVersionProviderAPI(cluster *core.Cluster, domainNames DomainNames) httpapi.API {
 	return &versionProvider{
 		Cluster:              cluster,
+		DomainNames:          domainNames,
 		currentVersion:       "v1",
 		experimentalVersions: []string{"v2"},
 	}
@@ -97,9 +100,44 @@ func (p *versionProvider) AddTo(r *mux.Router) {
 	}
 }
 
-// Path constructs a full URL for a given URL path below the respective /v[version]/ endpoint.
-func (p *versionProvider) Path(version string, elements ...string) string {
-	parts := []string{strings.TrimSuffix(p.Cluster.Config.CatalogURL, "/"), version}
-	parts = append(parts, elements...)
-	return strings.Join(parts, "/") + "/"
+// Path constructs a full URL for the respective /v[version]/ endpoint.
+func (p *versionProvider) Path(version string) string {
+	u := url.URL{
+		Scheme: "https",
+		Host:   p.DomainNames.V2,
+		Path:   version + "/",
+	}
+	if version == "v1" {
+		u.Host = p.DomainNames.V1
+	}
+	return u.String()
+}
+
+// DomainNames holds the domain names used by Limes's APIs.
+type DomainNames struct {
+	V1 string `json:"v1"`
+	V2 string `json:"v2"`
+}
+
+// CollectDomainNamesFromEnv constructs a [DomainNames] instance.
+func CollectDomainNamesFromEnv() (result DomainNames, err error) {
+	getAndCheck := func(key string) (string, error) {
+		value, err := osext.NeedGetenv(key)
+		if err != nil {
+			return "", err
+		}
+		// check that `value` is a hostname and nothing else
+		testURL, err := url.Parse("https://" + value)
+		if err != nil || testURL.Host != value {
+			return "", fmt.Errorf("invalid value for %s: expected a hostname, but got %q", key, value)
+		}
+		return value, nil
+	}
+
+	result.V1, err = getAndCheck("LIMES_API_DOMAIN_NAME_V1")
+	if err != nil {
+		return
+	}
+	result.V2, err = getAndCheck("LIMES_API_DOMAIN_NAME_V2")
+	return
 }

--- a/internal/api/api_v2/version_provider_test.go
+++ b/internal/api/api_v2/version_provider_test.go
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package api_v2_test
+
+import (
+	"testing"
+
+	"go.xyrillian.de/gg/assert"
+
+	"github.com/sapcc/limes/internal/api/api_v2"
+)
+
+func TestParseDomainNames(t *testing.T) {
+	t.Setenv("LIMES_API_DOMAIN_NAME_V1", "https://limes.example.com")
+	t.Setenv("LIMES_API_DOMAIN_NAME_V2", "limitas.example.com")
+	_, err := api_v2.CollectDomainNamesFromEnv()
+	assert.ErrEqual(t, err, `invalid value for LIMES_API_DOMAIN_NAME_V1: expected a hostname, but got "https://limes.example.com"`)
+
+	t.Setenv("LIMES_API_DOMAIN_NAME_V1", "limes.example.com")
+	t.Setenv("LIMES_API_DOMAIN_NAME_V2", "limitas.example.com/v2")
+	_, err = api_v2.CollectDomainNamesFromEnv()
+	assert.ErrEqual(t, err, `invalid value for LIMES_API_DOMAIN_NAME_V2: expected a hostname, but got "limitas.example.com/v2"`)
+
+	t.Setenv("LIMES_API_DOMAIN_NAME_V1", "limes.example.com")
+	t.Setenv("LIMES_API_DOMAIN_NAME_V2", "limitas.example.com")
+	names, err := api_v2.CollectDomainNamesFromEnv()
+	if assert.ErrEqual(t, err, nil) {
+		assert.Equal(t, names, api_v2.DomainNames{
+			V1: "limes.example.com",
+			V2: "limitas.example.com",
+		})
+	}
+}

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -29,7 +29,6 @@ import (
 // Cluster during the startup phase.
 type ClusterConfiguration struct {
 	AvailabilityZones        []limes.AvailabilityZone               `json:"availability_zones"`
-	CatalogURL               string                                 `json:"catalog_url"`
 	Discovery                DiscoveryConfiguration                 `json:"discovery"`
 	Areas                    map[string]AreaInfo                    `json:"areas"`
 	Liquids                  map[db.ServiceType]LiquidConfiguration `json:"liquids"`

--- a/main.go
+++ b/main.go
@@ -295,7 +295,7 @@ func taskServe(ctx context.Context, cluster *core.Cluster, args []string, provid
 	mux := http.NewServeMux()
 	commonAuditor := generateAuditor(ctx)
 	mux.Handle("/", httpapi.Compose(
-		api_v2.NewVersionProviderAPI(cluster),
+		api_v2.NewVersionProviderAPI(cluster, must.Return(api_v2.CollectDomainNamesFromEnv())),
 		api.NewV1API(cluster, tokenValidator, commonAuditor, time.Now, datamodel.GenerateTransferToken, datamodel.GenerateProjectCommitmentUUID, nil),
 		api_v2.NewV2API(cluster, tokenValidator, commonAuditor, time.Now),
 		pprofapi.API{IsAuthorized: pprofapi.IsRequestFromLocalhost},

--- a/main.go
+++ b/main.go
@@ -299,6 +299,12 @@ func taskServe(ctx context.Context, cluster *core.Cluster, args []string, provid
 		api.NewV1API(cluster, tokenValidator, commonAuditor, time.Now, datamodel.GenerateTransferToken, datamodel.GenerateProjectCommitmentUUID, nil),
 		api_v2.NewV2API(cluster, tokenValidator, commonAuditor, time.Now),
 		pprofapi.API{IsAuthorized: pprofapi.IsRequestFromLocalhost},
+		httpapi.HealthCheckAPI{
+			SkipRequestLog: true,
+			Check: func() error {
+				return cluster.DB.Db.PingContext(ctx)
+			},
+		},
 		httpapi.WithGlobalMiddleware(api.ForbidClusterIDHeader),
 		httpapi.WithGlobalMiddleware(corsMiddleware.Handler),
 	))


### PR DESCRIPTION
I want to set up the API such that v1 endpoints can only be queried with the v1 domain name (the one that says "Limes" in it) and v2 endpoints can only be queried with a separate domain name (which will say "Limitas" instead). Therefore, this new configuration section, unlike CatalogURL before it, is required, and the bulk of the diff is to add it to all test configs.

The actual change to inspect the Host/X-Forwarded-Host of requests will follow in a later branch. I'm only setting up infrastructure for now.

Also, I want to get rid of or at least rework the `GET /` endpoint, which is currently also used as the target for the liveness/readiness probes of API pods. To untangle this, this PR adds the conventional `GET /healthcheck` endpoint.

**Please do not merge without the respective helm-charts and secrets PR reviewed and approved.**