### PR TITLE
api: simplify VersionProvider, enforce configured domain names for v1/v2 API

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1755,7 +1755,7 @@ func TestDomainNameSeparation(t *testing.T) {
 	)
 
 	for _, format := range []string{"http://%s", "http://%s:8080", "https://%s", "https://%s:4443"} {
-		t.Run(fmt.Sprintf("format=%s", format), func(t *testing.T) {
+		t.Run("format="+format, func(t *testing.T) {
 			s.Handler.RespondTo(ctx, fmt.Sprintf(`GET %s/v1/clusters/current`, fmt.Sprintf(format, "limes.example.com"))).
 				ExpectStatus(t, http.StatusOK)
 			s.Handler.RespondTo(ctx, fmt.Sprintf(`GET %s/v1/clusters/current`, fmt.Sprintf(format, "limitas.example.com"))).

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -27,6 +27,7 @@ import (
 	"go.xyrillian.de/gg/assert"
 	. "go.xyrillian.de/gg/option"
 
+	"github.com/sapcc/limes/internal/api/api_v2"
 	"github.com/sapcc/limes/internal/collector"
 	"github.com/sapcc/limes/internal/core"
 	"github.com/sapcc/limes/internal/db"
@@ -1738,4 +1739,27 @@ func Test_SeparatedTopologyOperations(t *testing.T) {
 		ExpectHeader: map[string]string{"Content-Type": collector.ContentTypeForPrometheusMetrics},
 		ExpectBody:   oldassert.FixtureFile("fixtures/separated_topology_operations_metrics.prom"),
 	}.Check(t, promhttp.HandlerFor(s.Registry, promhttp.HandlerOpts{}))
+}
+
+func TestDomainNameSeparation(t *testing.T) {
+	ctx := t.Context()
+	s := test.NewSetup(t,
+		test.WithConfig(testAZSeparatedConfigJSON),
+		test.WithAPIDomainNames(api_v2.DomainNames{
+			V1: "limes.example.com",
+			V2: "limitas.example.com",
+		}),
+		test.WithPersistedServiceInfo("shared", test.DefaultLiquidServiceInfo("Shared")),
+		test.WithInitialDiscovery,
+		test.WithEmptyResourceRecordsAsNeeded,
+	)
+
+	for _, format := range []string{"http://%s", "http://%s:8080", "https://%s", "https://%s:4443"} {
+		t.Run(fmt.Sprintf("format=%s", format), func(t *testing.T) {
+			s.Handler.RespondTo(ctx, fmt.Sprintf(`GET %s/v1/clusters/current`, fmt.Sprintf(format, "limes.example.com"))).
+				ExpectStatus(t, http.StatusOK)
+			s.Handler.RespondTo(ctx, fmt.Sprintf(`GET %s/v1/clusters/current`, fmt.Sprintf(format, "limitas.example.com"))).
+				ExpectText(t, http.StatusBadRequest, "endpoint /v1/clusters/current cannot be accessed on limitas.example.com\n")
+		})
+	}
 }

--- a/internal/api/api_v2/core.go
+++ b/internal/api/api_v2/core.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sapcc/go-bits/gopherpolicy"
 	"github.com/sapcc/go-bits/httpapi"
 	"github.com/sapcc/go-bits/respondwith"
+	. "go.xyrillian.de/gg/option"
 
 	"github.com/sapcc/limes/internal/core"
 	"github.com/sapcc/limes/internal/db"
@@ -29,6 +30,7 @@ import (
 type v2Provider struct {
 	Cluster        *core.Cluster
 	DB             *gorp.DbMap
+	DomainNames    Option[DomainNames]
 	tokenValidator gopherpolicy.Validator
 	auditor        audittools.Auditor
 
@@ -39,16 +41,25 @@ type v2Provider struct {
 // NewV2API creates an httpapi.API that serves the Limes v2 API.
 // It also returns the VersionData for this API version which is needed for the
 // version advertisement on "GET /".
-func NewV2API(cluster *core.Cluster, tokenValidator gopherpolicy.Validator, auditor audittools.Auditor, timeNow func() time.Time) httpapi.API {
-	return &v2Provider{Cluster: cluster, DB: cluster.DB, tokenValidator: tokenValidator, auditor: auditor, timeNow: timeNow}
+func NewV2API(cluster *core.Cluster, domainNames Option[DomainNames], tokenValidator gopherpolicy.Validator, auditor audittools.Auditor, timeNow func() time.Time) httpapi.API {
+	return &v2Provider{Cluster: cluster, DB: cluster.DB, DomainNames: domainNames, tokenValidator: tokenValidator, auditor: auditor, timeNow: timeNow}
 }
 
 // AddTo implements the httpapi.API interface.
 func (p *v2Provider) AddTo(r *mux.Router) {
+	resRouter := r.PathPrefix("/resources/v2/").Subrouter()
+	ratesRouter := r.PathPrefix("/rates/v2/").Subrouter()
+
+	if apiDomainNames, ok := p.DomainNames.Unpack(); ok {
+		mw := EnforceDomainName(apiDomainNames.V2)
+		resRouter.Use(mw)
+		ratesRouter.Use(mw)
+	}
+
 	tv := p.tokenValidator
-	r.Methods("GET").Path("/resources/v2/info").HandlerFunc(handlerFunc(http.StatusOK, tv, p.handleGetResourcesInfo))
-	r.Methods("GET").Path("/rates/v2/info").HandlerFunc(handlerFunc(http.StatusOK, tv, p.handleGetRatesInfo))
-	r.Methods("POST").Path("/resources/v2/commitments/new").HandlerFunc(handlerFunc(http.StatusCreated, tv, p.handlePostNewCommitment))
+	resRouter.Methods("GET").Path("/info").HandlerFunc(handlerFunc(http.StatusOK, tv, p.handleGetResourcesInfo))
+	ratesRouter.Methods("GET").Path("/info").HandlerFunc(handlerFunc(http.StatusOK, tv, p.handleGetRatesInfo))
+	resRouter.Methods("POST").Path("/commitments/new").HandlerFunc(handlerFunc(http.StatusCreated, tv, p.handlePostNewCommitment))
 }
 
 // Wrapper for request handlers that enforces a structure,

--- a/internal/api/api_v2/core_test.go
+++ b/internal/api/api_v2/core_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sapcc/go-bits/httptest"
 
+	"github.com/sapcc/limes/internal/api/api_v2"
 	"github.com/sapcc/limes/internal/test"
 )
 
@@ -44,4 +45,27 @@ func TestRequestBodyParsing(t *testing.T) {
 		httptest.WithHeader("Content-Type", "application/json"),
 		httptest.WithBody(strings.NewReader(`{"service_type":"first"}{"service_type":"second"}`)),
 	).ExpectText(t, http.StatusBadRequest, "request body contains 25 unexpected bytes after the JSON payload\n")
+}
+
+func TestDomainNameSeparation(t *testing.T) {
+	ctx := t.Context()
+	s := test.NewSetup(t,
+		test.WithConfig(commitmentCreateConfigJSON),
+		test.WithAPIDomainNames(api_v2.DomainNames{
+			V1: "limes.example.com",
+			V2: "limitas.example.com",
+		}),
+		test.WithPersistedServiceInfo("first", test.DefaultLiquidServiceInfo("First")),
+		test.WithInitialDiscovery,
+		test.WithEmptyResourceRecordsAsNeeded,
+	)
+
+	for _, format := range []string{"http://%s", "http://%s:8080", "https://%s", "https://%s:4443"} {
+		t.Run(fmt.Sprintf("format=%s", format), func(t *testing.T) {
+			s.Handler.RespondTo(ctx, fmt.Sprintf(`GET %s/resources/v2/info`, fmt.Sprintf(format, "limes.example.com"))).
+				ExpectText(t, http.StatusBadRequest, "endpoint /resources/v2/info cannot be accessed on limes.example.com\n")
+			s.Handler.RespondTo(ctx, fmt.Sprintf(`GET %s/resources/v2/info`, fmt.Sprintf(format, "limitas.example.com"))).
+				ExpectStatus(t, http.StatusOK)
+		})
+	}
 }

--- a/internal/api/api_v2/core_test.go
+++ b/internal/api/api_v2/core_test.go
@@ -61,7 +61,7 @@ func TestDomainNameSeparation(t *testing.T) {
 	)
 
 	for _, format := range []string{"http://%s", "http://%s:8080", "https://%s", "https://%s:4443"} {
-		t.Run(fmt.Sprintf("format=%s", format), func(t *testing.T) {
+		t.Run("format="+format, func(t *testing.T) {
 			s.Handler.RespondTo(ctx, fmt.Sprintf(`GET %s/resources/v2/info`, fmt.Sprintf(format, "limes.example.com"))).
 				ExpectText(t, http.StatusBadRequest, "endpoint /resources/v2/info cannot be accessed on limes.example.com\n")
 			s.Handler.RespondTo(ctx, fmt.Sprintf(`GET %s/resources/v2/info`, fmt.Sprintf(format, "limitas.example.com"))).

--- a/internal/api/api_v2/version_provider.go
+++ b/internal/api/api_v2/version_provider.go
@@ -9,110 +9,53 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"slices"
 
 	"github.com/gorilla/mux"
 	"github.com/sapcc/go-bits/httpapi"
 	"github.com/sapcc/go-bits/osext"
-	"github.com/sapcc/go-bits/respondwith"
-
-	"github.com/sapcc/limes/internal/core"
 )
 
 type versionProvider struct {
-	Cluster                *core.Cluster
-	DomainNames            DomainNames
-	currentVersion         string
-	experimentalVersions   []string
-	otherSupportedVersions []string
-}
-
-// VersionData is used by version advertisement API.
-type VersionData struct {
-	Status string            `json:"status"`
-	ID     string            `json:"id"`
-	Links  []VersionLinkData `json:"links"`
-}
-
-// VersionLinkData is used by version advertisement API, as part of the
-// VersionData struct.
-type VersionLinkData struct {
-	URL      string `json:"href"`
-	Relation string `json:"rel"`
-	Type     string `json:"type,omitempty"`
+	DomainNames DomainNames
 }
 
 // NewVersionProviderAPI creates an httpapi.API that serves the version advertisement API.
-func NewVersionProviderAPI(cluster *core.Cluster, domainNames DomainNames) httpapi.API {
+func NewVersionProviderAPI(domainNames DomainNames) httpapi.API {
 	return &versionProvider{
-		Cluster:              cluster,
-		DomainNames:          domainNames,
-		currentVersion:       "v1",
-		experimentalVersions: []string{"v2"},
-	}
-}
-
-func (p *versionProvider) generateVersionData(version string) VersionData {
-	status := "SUPPORTED"
-	if version == p.currentVersion {
-		status = "CURRENT"
-	} else if slices.Contains(p.experimentalVersions, version) {
-		status = "EXPERIMENTAL"
-	}
-	return VersionData{
-		Status: status,
-		ID:     version,
-		Links: []VersionLinkData{
-			{
-				Relation: "self",
-				URL:      p.Path(version),
-			},
-			{
-				Relation: "describedby",
-				URL:      fmt.Sprintf("https://github.com/sapcc/limes/blob/master/docs/users/api-%s-specification.md", version),
-				Type:     "text/html",
-			},
-		},
+		DomainNames: domainNames,
 	}
 }
 
 // AddTo implements the httpapi.API interface.
 func (p *versionProvider) AddTo(r *mux.Router) {
-	allVersions := []string{p.currentVersion}
-	allVersions = append(allVersions, p.experimentalVersions...)
-	allVersions = append(allVersions, p.otherSupportedVersions...)
-	allVersionData := make([]VersionData, len(allVersions))
-	for i, version := range allVersions {
-		allVersionData[i] = p.generateVersionData(version)
-	}
+	// NOTE: The intent of this is to provide a minimal response on every URL
+	//       that appears in the Keystone catalog. These are, by service type:
+	//
+	// - resources:         https://$LIMES_API_DOMAIN_NAME_V1/
+	// - limitas-resources: https://$LIMES_API_DOMAIN_NAME_V2/resources/v2/
+	// - limitas-rates:     https://$LIMES_API_DOMAIN_NAME_V2/rates/v2/
+	//
+	// Also, for maximum backwards compatibility, https://$LIMES_API_DOMAIN_NAME_V1/v1/ is also understood.
 
-	r.Methods("HEAD", "GET").Path("/").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		httpapi.IdentifyEndpoint(r, "/")
-		httpapi.SkipRequestLog(r)
-		respondwith.JSON(w, 300, map[string]any{"versions": allVersionData})
-	})
+	enforceV1 := EnforceDomainName(p.DomainNames.V1)
+	enforceV2 := EnforceDomainName(p.DomainNames.V2)
 
-	for i, versionData := range allVersionData {
-		version := allVersions[i]
-		r.Methods("GET").Path("/" + version + "/").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			httpapi.IdentifyEndpoint(r, "/"+version+"/")
-			httpapi.SkipRequestLog(r)
-			respondwith.JSON(w, 200, map[string]any{"version": versionData})
-		})
+	for _, v1Path := range []string{"/", "/v1/"} {
+		r.Methods("HEAD", "GET").Path(v1Path).Handler(enforceV1(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			httpapi.IdentifyEndpoint(r, v1Path)
+			http.Redirect(w, r, "https://github.com/sapcc/limes/blob/master/docs/users/api-v1-specification.md", http.StatusSeeOther)
+		})))
 	}
-}
-
-// Path constructs a full URL for the respective /v[version]/ endpoint.
-func (p *versionProvider) Path(version string) string {
-	u := url.URL{
-		Scheme: "https",
-		Host:   p.DomainNames.V2,
-		Path:   version + "/",
-	}
-	if version == "v1" {
-		u.Host = p.DomainNames.V1
-	}
-	return u.String()
+	r.Methods("HEAD", "GET").Path("/resources/v2/").Handler(enforceV2(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		httpapi.IdentifyEndpoint(r, "/resources/v2/")
+		// TODO: replace with link to pkg.go.dev of the resource API spec
+		http.Redirect(w, r, "https://github.com/sapcc/limes/blob/master/docs/users/api-v2-specification.md", http.StatusSeeOther)
+	})))
+	r.Methods("HEAD", "GET").Path("/rates/v2/").Handler(enforceV2(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		httpapi.IdentifyEndpoint(r, "/rates/v2/")
+		// TODO: replace with link to pkg.go.dev of the rate API spec
+		http.Redirect(w, r, "https://github.com/sapcc/limes/blob/master/docs/users/api-v2-specification.md", http.StatusSeeOther)
+	})))
 }
 
 // DomainNames holds the domain names used by Limes's APIs.

--- a/internal/api/api_v2/version_provider.go
+++ b/internal/api/api_v2/version_provider.go
@@ -4,7 +4,9 @@
 package api_v2
 
 import (
+	"cmp"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"slices"
@@ -140,4 +142,30 @@ func CollectDomainNamesFromEnv() (result DomainNames, err error) {
 	}
 	result.V2, err = getAndCheck("LIMES_API_DOMAIN_NAME_V2")
 	return
+}
+
+// EnforceDomainName returns a middleware that rejects requests where
+// the hostname in the request URL does not match the given value.
+func EnforceDomainName(domainName string) mux.MiddlewareFunc {
+	return func(inner http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			hostName := getHostNameFor(r)
+			if hostName == domainName {
+				inner.ServeHTTP(w, r)
+			} else {
+				msg := fmt.Sprintf("endpoint %s cannot be accessed on %s", r.URL.EscapedPath(), hostName)
+				http.Error(w, msg, http.StatusBadRequest)
+			}
+		})
+	}
+}
+
+func getHostNameFor(r *http.Request) string {
+	hostAndMaybePort := cmp.Or(r.Header.Get("X-Forwarded-Host"), r.Host)
+	host, _, err := net.SplitHostPort(hostAndMaybePort)
+	if err == nil {
+		return host
+	} else {
+		return hostAndMaybePort // no port to split off
+	}
 }

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -27,7 +27,9 @@ import (
 	"github.com/sapcc/go-bits/httpapi"
 	"github.com/sapcc/go-bits/osext"
 	"github.com/sapcc/go-bits/respondwith"
+	. "go.xyrillian.de/gg/option"
 
+	"github.com/sapcc/limes/internal/api/api_v2"
 	"github.com/sapcc/limes/internal/core"
 	"github.com/sapcc/limes/internal/db"
 	"github.com/sapcc/limes/internal/reports"
@@ -36,6 +38,7 @@ import (
 type v1Provider struct {
 	Cluster        *core.Cluster
 	DB             *gorp.DbMap
+	DomainNames    Option[api_v2.DomainNames]
 	tokenValidator gopherpolicy.Validator
 	auditor        audittools.Auditor
 	// see comment in ListProjects() for details
@@ -51,10 +54,11 @@ type v1Provider struct {
 // NewV1API creates an httpapi.API that serves the Limes v1 API.
 // It also returns the VersionData for this API version which is needed for the
 // version advertisement on "GET /".
-func NewV1API(cluster *core.Cluster, tokenValidator gopherpolicy.Validator, auditor audittools.Auditor, timeNow func() time.Time, generateTransferToken func() string, generateProjectCommitmentUUID func() liquid.CommitmentUUID, registerer prometheus.Registerer) httpapi.API {
+func NewV1API(cluster *core.Cluster, domainNames Option[api_v2.DomainNames], tokenValidator gopherpolicy.Validator, auditor audittools.Auditor, timeNow func() time.Time, generateTransferToken func() string, generateProjectCommitmentUUID func() liquid.CommitmentUUID, registerer prometheus.Registerer) httpapi.API {
 	p := &v1Provider{
 		Cluster:                       cluster,
 		DB:                            cluster.DB,
+		DomainNames:                   domainNames,
 		tokenValidator:                tokenValidator,
 		auditor:                       auditor,
 		timeNow:                       timeNow,
@@ -92,52 +96,63 @@ func NewTokenValidator(provider *gophercloud.ProviderClient, eo gophercloud.Endp
 
 // AddTo implements the httpapi.API interface.
 func (p *v1Provider) AddTo(r *mux.Router) {
-	r.Methods("GET").Path("/v1/clusters/current").HandlerFunc(p.GetCluster)
-	r.Methods("GET").Path("/rates/v1/clusters/current").HandlerFunc(p.GetClusterRates)
+	resRouter := r.PathPrefix("/v1/").Subrouter()
+	ratesRouter := r.PathPrefix("/rates/v1/").Subrouter()
+	adminRouter := r.PathPrefix("/admin/").Subrouter()
 
-	r.Methods("GET").Path("/v1/inconsistencies").HandlerFunc(p.ListInconsistencies)
-	r.Methods("GET").Path("/v1/admin/scrape-errors").HandlerFunc(p.ListScrapeErrors)
-	r.Methods("GET").Path("/rates/v1/admin/scrape-errors").HandlerFunc(p.ListRateScrapeErrors)
+	if apiDomainNames, ok := p.DomainNames.Unpack(); ok {
+		mw := api_v2.EnforceDomainName(apiDomainNames.V1)
+		resRouter.Use(mw)
+		ratesRouter.Use(mw)
+		adminRouter.Use(mw)
+	}
 
-	r.Methods("GET").Path("/v1/domains").HandlerFunc(p.ListDomains)
-	r.Methods("GET").Path("/v1/domains/{domain_id}").HandlerFunc(p.GetDomain)
-	r.Methods("POST").Path("/v1/domains/discover").HandlerFunc(p.DiscoverDomains)
-	r.Methods("POST").Path("/v1/domains/{domain_id}/simulate-put").HandlerFunc(p.SimulatePutDomain)
-	r.Methods("PUT").Path("/v1/domains/{domain_id}").HandlerFunc(p.PutDomain)
+	resRouter.Methods("GET").Path("/clusters/current").HandlerFunc(p.GetCluster)
+	ratesRouter.Methods("GET").Path("/clusters/current").HandlerFunc(p.GetClusterRates)
 
-	r.Methods("GET").Path("/v1/domains/{domain_id}/projects").HandlerFunc(p.ListProjects)
-	r.Methods("GET").Path("/v1/domains/{domain_id}/projects/{project_id}").HandlerFunc(p.GetProject)
-	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/discover").HandlerFunc(p.DiscoverProjects)
-	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/sync").HandlerFunc(p.SyncProject)
-	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/simulate-put").HandlerFunc(p.SimulatePutProject)
-	r.Methods("PUT").Path("/v1/domains/{domain_id}/projects/{project_id}").HandlerFunc(p.PutProject)
-	r.Methods("PUT").Path("/v1/domains/{domain_id}/projects/{project_id}/max-quota").HandlerFunc(p.PutProjectMaxQuota)
-	r.Methods("PUT").Path("/v1/domains/{domain_id}/projects/{project_id}/forbid-autogrowth").HandlerFunc(p.PutQuotaAutogrowth)
-	r.Methods("GET").Path("/rates/v1/domains/{domain_id}/projects").HandlerFunc(p.ListProjectRates)
-	r.Methods("GET").Path("/rates/v1/domains/{domain_id}/projects/{project_id}").HandlerFunc(p.GetProjectRates)
-	r.Methods("POST").Path("/rates/v1/domains/{domain_id}/projects/{project_id}/sync").HandlerFunc(p.SyncProjectRates)
-	r.Methods("POST").Path("/rates/v1/domains/{domain_id}/projects/{project_id}/simulate-put").HandlerFunc(p.SimulatePutProjectRates)
-	r.Methods("PUT").Path("/rates/v1/domains/{domain_id}/projects/{project_id}").HandlerFunc(p.PutProjectRates)
+	resRouter.Methods("GET").Path("/inconsistencies").HandlerFunc(p.ListInconsistencies)
+	resRouter.Methods("GET").Path("/admin/scrape-errors").HandlerFunc(p.ListScrapeErrors)
+	ratesRouter.Methods("GET").Path("/admin/scrape-errors").HandlerFunc(p.ListRateScrapeErrors)
 
-	r.Methods("GET").Path("/v1/public-commitments").HandlerFunc(p.GetPublicCommitments)
-	r.Methods("GET").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments").HandlerFunc(p.GetProjectCommitments)
-	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments/new").HandlerFunc(p.CreateProjectCommitment)
-	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments/merge").HandlerFunc(p.MergeProjectCommitments)
-	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments/can-confirm").HandlerFunc(p.CanConfirmNewProjectCommitment)
-	r.Methods("DELETE").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments/{id}").HandlerFunc(p.DeleteProjectCommitment)
-	r.Methods("DELETE").Path("/v1/commitments/{id}").HandlerFunc(p.DeleteProjectCommitmentAsCloudAdmin)
-	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments/{id}/renew").HandlerFunc(p.RenewProjectCommitments)
-	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments/{id}/start-transfer").HandlerFunc(p.StartCommitmentTransfer)
-	r.Methods("POST").Path("/v1/commitments/{id}/start-transfer").HandlerFunc(p.StartCommitmentTransferAsCloudAdmin)
-	r.Methods("GET").Path("/v1/commitments/{token}").HandlerFunc(p.GetCommitmentByTransferToken)
-	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/transfer-commitment/{id}").HandlerFunc(p.TransferCommitment)
-	r.Methods("GET").Path("/v1/commitment-conversion/{service_type}/{resource_name}").HandlerFunc(p.GetCommitmentConversions)
-	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments/{commitment_id}/convert").HandlerFunc(p.ConvertCommitment)
-	r.Methods("POST").Path("/v1/domains/{domain_id}/projects/{project_id}/commitments/{commitment_id}/update-duration").HandlerFunc(p.UpdateCommitmentDuration)
+	resRouter.Methods("GET").Path("/domains").HandlerFunc(p.ListDomains)
+	resRouter.Methods("GET").Path("/domains/{domain_id}").HandlerFunc(p.GetDomain)
+	resRouter.Methods("POST").Path("/domains/discover").HandlerFunc(p.DiscoverDomains)
+	resRouter.Methods("POST").Path("/domains/{domain_id}/simulate-put").HandlerFunc(p.SimulatePutDomain)
+	resRouter.Methods("PUT").Path("/domains/{domain_id}").HandlerFunc(p.PutDomain)
 
-	r.Methods("GET").Path("/admin/liquid/service-capacity-request").HandlerFunc(p.GetServiceCapacityRequest)
-	r.Methods("GET").Path("/admin/liquid/service-usage-request").HandlerFunc(p.GetServiceUsageRequest)
-	r.Methods("GET").Path("/admin/mail/render").HandlerFunc(p.RenderMailTemplate)
+	resRouter.Methods("GET").Path("/domains/{domain_id}/projects").HandlerFunc(p.ListProjects)
+	resRouter.Methods("GET").Path("/domains/{domain_id}/projects/{project_id}").HandlerFunc(p.GetProject)
+	resRouter.Methods("POST").Path("/domains/{domain_id}/projects/discover").HandlerFunc(p.DiscoverProjects)
+	resRouter.Methods("POST").Path("/domains/{domain_id}/projects/{project_id}/sync").HandlerFunc(p.SyncProject)
+	resRouter.Methods("POST").Path("/domains/{domain_id}/projects/{project_id}/simulate-put").HandlerFunc(p.SimulatePutProject)
+	resRouter.Methods("PUT").Path("/domains/{domain_id}/projects/{project_id}").HandlerFunc(p.PutProject)
+	resRouter.Methods("PUT").Path("/domains/{domain_id}/projects/{project_id}/max-quota").HandlerFunc(p.PutProjectMaxQuota)
+	resRouter.Methods("PUT").Path("/domains/{domain_id}/projects/{project_id}/forbid-autogrowth").HandlerFunc(p.PutQuotaAutogrowth)
+	ratesRouter.Methods("GET").Path("/domains/{domain_id}/projects").HandlerFunc(p.ListProjectRates)
+	ratesRouter.Methods("GET").Path("/domains/{domain_id}/projects/{project_id}").HandlerFunc(p.GetProjectRates)
+	ratesRouter.Methods("POST").Path("/domains/{domain_id}/projects/{project_id}/sync").HandlerFunc(p.SyncProjectRates)
+	ratesRouter.Methods("POST").Path("/domains/{domain_id}/projects/{project_id}/simulate-put").HandlerFunc(p.SimulatePutProjectRates)
+	ratesRouter.Methods("PUT").Path("/domains/{domain_id}/projects/{project_id}").HandlerFunc(p.PutProjectRates)
+
+	resRouter.Methods("GET").Path("/public-commitments").HandlerFunc(p.GetPublicCommitments)
+	resRouter.Methods("GET").Path("/domains/{domain_id}/projects/{project_id}/commitments").HandlerFunc(p.GetProjectCommitments)
+	resRouter.Methods("POST").Path("/domains/{domain_id}/projects/{project_id}/commitments/new").HandlerFunc(p.CreateProjectCommitment)
+	resRouter.Methods("POST").Path("/domains/{domain_id}/projects/{project_id}/commitments/merge").HandlerFunc(p.MergeProjectCommitments)
+	resRouter.Methods("POST").Path("/domains/{domain_id}/projects/{project_id}/commitments/can-confirm").HandlerFunc(p.CanConfirmNewProjectCommitment)
+	resRouter.Methods("DELETE").Path("/domains/{domain_id}/projects/{project_id}/commitments/{id}").HandlerFunc(p.DeleteProjectCommitment)
+	resRouter.Methods("DELETE").Path("/commitments/{id}").HandlerFunc(p.DeleteProjectCommitmentAsCloudAdmin)
+	resRouter.Methods("POST").Path("/domains/{domain_id}/projects/{project_id}/commitments/{id}/renew").HandlerFunc(p.RenewProjectCommitments)
+	resRouter.Methods("POST").Path("/domains/{domain_id}/projects/{project_id}/commitments/{id}/start-transfer").HandlerFunc(p.StartCommitmentTransfer)
+	resRouter.Methods("POST").Path("/commitments/{id}/start-transfer").HandlerFunc(p.StartCommitmentTransferAsCloudAdmin)
+	resRouter.Methods("GET").Path("/commitments/{token}").HandlerFunc(p.GetCommitmentByTransferToken)
+	resRouter.Methods("POST").Path("/domains/{domain_id}/projects/{project_id}/transfer-commitment/{id}").HandlerFunc(p.TransferCommitment)
+	resRouter.Methods("GET").Path("/commitment-conversion/{service_type}/{resource_name}").HandlerFunc(p.GetCommitmentConversions)
+	resRouter.Methods("POST").Path("/domains/{domain_id}/projects/{project_id}/commitments/{commitment_id}/convert").HandlerFunc(p.ConvertCommitment)
+	resRouter.Methods("POST").Path("/domains/{domain_id}/projects/{project_id}/commitments/{commitment_id}/update-duration").HandlerFunc(p.UpdateCommitmentDuration)
+
+	adminRouter.Methods("GET").Path("/liquid/service-capacity-request").HandlerFunc(p.GetServiceCapacityRequest)
+	adminRouter.Methods("GET").Path("/liquid/service-usage-request").HandlerFunc(p.GetServiceUsageRequest)
+	adminRouter.Methods("GET").Path("/mail/render").HandlerFunc(p.RenderMailTemplate)
 }
 
 // RequireJSON will parse the request body into the given data structure, or

--- a/internal/test/setup.go
+++ b/internal/test/setup.go
@@ -40,6 +40,7 @@ import (
 
 type setupParams struct {
 	ConfigJSON                       string
+	APIDomainNames                   Option[api_v2.DomainNames]
 	APIMiddlewares                   []httpapi.API
 	WithInitialDiscovery             bool
 	WithEmptyResourceRecordsAsNeeded bool
@@ -80,6 +81,17 @@ func RemoveCommentsFromJSON(jsonStr string) string {
 func WithAPIMiddleware(mw func(http.Handler) http.Handler) SetupOption {
 	return func(params *setupParams) {
 		params.APIMiddlewares = append(params.APIMiddlewares, httpapi.WithGlobalMiddleware(mw))
+	}
+}
+
+// WithAPIDomainNames is a SetupOption for supplying domain name configuration to the
+// HTTP handler providing the Limes API within the test.
+//
+// By default, `s.Handler` does not care about domain names.
+// This is intended for testing domain name matching only.
+func WithAPIDomainNames(domainNames api_v2.DomainNames) SetupOption {
+	return func(params *setupParams) {
+		params.APIDomainNames = Some(domainNames)
 	}
 }
 
@@ -286,13 +298,16 @@ func NewSetup(t *testing.T, opts ...SetupOption) Setup {
 	transferTokenGenerator, currentTransferTokenNumber := transferTokenGenerator()
 	s.CurrentProjectCommitmentID = currentProjectCommitmentID
 	s.CurrentTransferTokenNumber = currentTransferTokenNumber
-	s.Handler = httptest.NewHandler(httpapi.Compose(
-		append(params.APIMiddlewares,
-			api.NewV1API(s.Cluster, s.TokenValidator, s.Auditor, s.Clock.Now, transferTokenGenerator, projectCommitmentUUIDGenerator, s.Registry),
-			api_v2.NewV2API(s.Cluster, s.TokenValidator, s.Auditor, s.Clock.Now),
-			httpapi.WithoutLogging(),
-		)...,
-	))
+
+	apis := append(slices.Clone(params.APIMiddlewares),
+		api.NewV1API(s.Cluster, params.APIDomainNames, s.TokenValidator, s.Auditor, s.Clock.Now, transferTokenGenerator, projectCommitmentUUIDGenerator, s.Registry),
+		api_v2.NewV2API(s.Cluster, params.APIDomainNames, s.TokenValidator, s.Auditor, s.Clock.Now),
+		httpapi.WithoutLogging(),
+	)
+	if apiDomainNames, ok := params.APIDomainNames.Unpack(); ok {
+		apis = append(apis, api_v2.NewVersionProviderAPI(s.Cluster, apiDomainNames))
+	}
+	s.Handler = httptest.NewHandler(httpapi.Compose(apis...))
 
 	s.Collector = &collector.Collector{
 		Cluster:     s.Cluster,

--- a/internal/test/setup.go
+++ b/internal/test/setup.go
@@ -305,7 +305,7 @@ func NewSetup(t *testing.T, opts ...SetupOption) Setup {
 		httpapi.WithoutLogging(),
 	)
 	if apiDomainNames, ok := params.APIDomainNames.Unpack(); ok {
-		apis = append(apis, api_v2.NewVersionProviderAPI(s.Cluster, apiDomainNames))
+		apis = append(apis, api_v2.NewVersionProviderAPI(apiDomainNames))
 	}
 	s.Handler = httptest.NewHandler(httpapi.Compose(apis...))
 

--- a/main.go
+++ b/main.go
@@ -296,7 +296,7 @@ func taskServe(ctx context.Context, cluster *core.Cluster, args []string, provid
 	commonAuditor := generateAuditor(ctx)
 	apiDomainNames := must.Return(api_v2.CollectDomainNamesFromEnv())
 	mux.Handle("/", httpapi.Compose(
-		api_v2.NewVersionProviderAPI(cluster, apiDomainNames),
+		api_v2.NewVersionProviderAPI(apiDomainNames),
 		api.NewV1API(cluster, Some(apiDomainNames), tokenValidator, commonAuditor, time.Now, datamodel.GenerateTransferToken, datamodel.GenerateProjectCommitmentUUID, nil),
 		api_v2.NewV2API(cluster, Some(apiDomainNames), tokenValidator, commonAuditor, time.Now),
 		pprofapi.API{IsAuthorized: pprofapi.IsRequestFromLocalhost},

--- a/main.go
+++ b/main.go
@@ -294,10 +294,11 @@ func taskServe(ctx context.Context, cluster *core.Cluster, args []string, provid
 	})
 	mux := http.NewServeMux()
 	commonAuditor := generateAuditor(ctx)
+	apiDomainNames := must.Return(api_v2.CollectDomainNamesFromEnv())
 	mux.Handle("/", httpapi.Compose(
-		api_v2.NewVersionProviderAPI(cluster, must.Return(api_v2.CollectDomainNamesFromEnv())),
-		api.NewV1API(cluster, tokenValidator, commonAuditor, time.Now, datamodel.GenerateTransferToken, datamodel.GenerateProjectCommitmentUUID, nil),
-		api_v2.NewV2API(cluster, tokenValidator, commonAuditor, time.Now),
+		api_v2.NewVersionProviderAPI(cluster, apiDomainNames),
+		api.NewV1API(cluster, Some(apiDomainNames), tokenValidator, commonAuditor, time.Now, datamodel.GenerateTransferToken, datamodel.GenerateProjectCommitmentUUID, nil),
+		api_v2.NewV2API(cluster, Some(apiDomainNames), tokenValidator, commonAuditor, time.Now),
 		pprofapi.API{IsAuthorized: pprofapi.IsRequestFromLocalhost},
 		httpapi.HealthCheckAPI{
 			SkipRequestLog: true,


### PR DESCRIPTION
The domain name enforcement ensures that the v1 API is served from the "Limes"-named domain name only, and v2 only from the "Limitas"-named domain name.

Regarding the VersionProvider simplification: The initial implementation of `GET /` and `GET /v1/`, nearly a decade ago, was based on my cargo-culting of generic recommendations for REST APIs, but the discoverability angle is significantly less important in OpenStack because APIs are discovered via the Keystone catalog. Really the only thing that we could be said to need is a link from the base URL (as entered in the Keystone catalog) to the API documentation, so we do just that: straight redirects without any JSON payload shenanigans.