### PR TITLE
V2 resource apis

### DIFF
--- a/docs/example-policy.json
+++ b/docs/example-policy.json
@@ -37,6 +37,9 @@
     "v2:project:info": "rule:'v2:domain:info' or rule:'v2:project:role'",
     "v2:project:report_single": "rule:'v2:project:report_multiple' or (rule:'v2:project:scope' and rule:'v2:project:role')",
     "v2:project:report_multiple": "rule:cluster_viewer or (rule:'v2:domain:scope' and rule:'v2:domain:role')",
+    "v2:project:with_subresources": "rule:cluster_admin or rule:cluster_viewer",
+    "v2:project:with_historical_usage": "rule:cluster_admin or rule:cluster_viewer",
+    "v2:project:with_timing": "rule:cluster_admin or rule:cluster_viewer",
     "v2:project:commitment_create": "rule:cluster_admin or (rule:'v2:domain:scope' and role:resource_admin) or (rule:'v2:project:scope' and role:admin)",
 
     "v2:domain:info": "rule:'v2:cluster:info' or rule:'v2:domain:role'",

--- a/internal/api/api_v2/cluster.go
+++ b/internal/api/api_v2/cluster.go
@@ -29,11 +29,15 @@ func (p *v2Provider) handleGetResourcesCluster(r *http.Request, token *gopherpol
 	if err != nil {
 		return none, err
 	}
-	_, err = reports_v2.FilterFromResourceOpts(p.Cluster, options.ResourceReportOpts)
+	filter, err := reports_v2.FilterFromResourceOpts(p.Cluster, options.ResourceReportOpts)
 	if err != nil {
 		return none, err
 	}
-	return none, nil
+	result, err := reports_v2.GetClusterResources(p.Cluster, token, filter, options, p.timeNow())
+	if err != nil {
+		return none, err
+	}
+	return result, nil
 }
 
 // handleGetRatesCluster handles GET /rates/v2/cluster.

--- a/internal/api/api_v2/cluster_test.go
+++ b/internal/api/api_v2/cluster_test.go
@@ -4,18 +4,205 @@
 package api_v2_test
 
 import (
+	"encoding/json"
 	"net/http"
 	"testing"
+	"time"
 
+	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
 	"github.com/sapcc/go-api-declarations/liquid"
 	"github.com/sapcc/go-bits/httptest"
 	"github.com/sapcc/go-bits/must"
 
 	. "go.xyrillian.de/gg/option"
 
+	"github.com/sapcc/limes/internal/db"
 	"github.com/sapcc/limes/internal/test"
 	"github.com/sapcc/limes/internal/test/common_fixtures"
+	"github.com/sapcc/limes/internal/util"
 )
+
+var resourceReportConfigJSON = string(must.Return(httptest.NewJQModifiableJSONString(test.RemoveCommentsFromJSON(`
+	{
+		"liquids": {
+			"first": {
+				"area": "first",
+				"commitment_behavior_per_resource": [
+					{"key": "capacity", "value": {"durations_per_domain": [{"key": ".*", "value": ["1 year", "3 years"]}]}}
+				]
+			},
+			"second": {
+				"area": "second",
+				"commitment_behavior_per_resource": [
+					{"key": "capacity", "value": {"durations_per_domain": [{"key": ".*", "value": ["1 year", "3 years"]}]}}
+				]
+			}
+		},
+		"resource_behavior": [
+			{"resource": "first/capacity", "overcommit_factor": 2}	
+		]
+	}`), "resourceReportConfigJSON").
+	ModifyWithVariable(".discovery = $ref", common_fixtures.DiscoveryBerlinDresdenParis).
+	ModifyWithVariable(".areas = $ref", common_fixtures.AreasFirstSecond).
+	ModifyWithVariable(".availability_zones = $ref", common_fixtures.AZsOneTwo).
+	MarshalJSON()))
+
+func TestV2ClusterResourceReport(t *testing.T) {
+	s := test.NewSetup(t,
+		test.WithConfig(resourceReportConfigJSON),
+		test.WithPersistedServiceInfo("first", test.DefaultLiquidServiceInfo("First")),
+		test.WithPersistedServiceInfo("second", test.DefaultLiquidServiceInfo("Second")),
+		test.WithInitialDiscovery,
+		test.WithEmptyResourceRecordsAsNeeded,
+	)
+	fixturePath := "./fixtures/resource-cluster.json"
+
+	s.Clock.StepBy(time.Hour)
+
+	// set up some capacity and usage data
+	// "first/capacity" is AZ-aware with has_capacity=true: set raw_capacity on az_resources
+	s.MustDBExec(`UPDATE az_resources SET raw_capacity = 1000, usage = 500 WHERE path LIKE 'first/capacity/az-%'`)
+	s.MustDBExec(`UPDATE az_resources SET raw_capacity = 500 WHERE path LIKE 'second/capacity/az-%'`)
+	// set usage on project_az_resources (3 projects, each gets 10 usage for capacity in each AZ)
+	s.MustDBExec(`UPDATE project_az_resources SET usage = 10 WHERE az_resource_id IN (SELECT id FROM az_resources WHERE path LIKE '%/capacity/%')`)
+	// set usage for "things" (flat topology, so only "any" AZ)
+	s.MustDBExec(`UPDATE project_az_resources SET usage = 5, physical_usage = 2 WHERE az_resource_id IN (SELECT id FROM az_resources WHERE path LIKE '%/things/%')`)
+	// set subcapacities on one AZ resource for testing with=subcapacities
+	s.MustDBExec(`UPDATE az_resources SET subcapacities = '[{"foo":"bar"},{"foo":"baz"}]' WHERE path = 'first/capacity/az-one'`)
+	// scraped_at
+	s.MustDBExec(`UPDATE services SET scraped_at = $1`, s.Clock.Now().UTC())
+
+	// setup some commitments in all states to check the filtering and produce committed_confirmed_unutilized
+	berlin := s.GetProjectID("berlin")
+	firstCapacityAZOne := s.GetAZResourceID("first", "capacity", "az-one")
+	firstCapacityAZTwo := s.GetAZResourceID("first", "capacity", "az-two")
+	for i, config := range []struct {
+		status      liquid.CommitmentStatus
+		confirmedAt Option[time.Time]
+	}{
+		{liquid.CommitmentStatusPlanned, None[time.Time]()},
+		{liquid.CommitmentStatusPending, None[time.Time]()},
+		{liquid.CommitmentStatusConfirmed, Some(s.Clock.Now())},
+		{liquid.CommitmentStatusSuperseded, Some(s.Clock.Now())},
+		{liquid.CommitmentStatusExpired, Some(s.Clock.Now())},
+		{util.CommitmentStatusDeleted, Some(s.Clock.Now())},
+	} {
+		s.MustDBInsert(&db.ProjectCommitment{
+			UUID:                test.GenerateDummyCommitmentUUID(uint64(i + 1)),
+			ProjectID:           berlin,
+			AZResourceID:        firstCapacityAZOne,
+			Amount:              10,
+			Duration:            must.ReturnT(limesresources.ParseCommitmentDuration("1 year"))(t),
+			CreatedAt:           s.Clock.Now(),
+			UpdatedAt:           s.Clock.Now(),
+			CreatorUUID:         "dummy",
+			CreatorName:         "dummy",
+			ConfirmedAt:         config.confirmedAt,
+			ExpiresAt:           s.Clock.Now().AddDate(1, 0, 0),
+			Status:              config.status,
+			CreationContextJSON: json.RawMessage(`{}`),
+		})
+	}
+	// create some committed_confirmed_unutilized
+	s.MustDBInsert(&db.ProjectCommitment{
+		UUID:                test.GenerateDummyCommitmentUUID(7),
+		ProjectID:           berlin,
+		AZResourceID:        firstCapacityAZTwo,
+		Amount:              50,
+		Duration:            must.ReturnT(limesresources.ParseCommitmentDuration("1 year"))(t),
+		CreatedAt:           s.Clock.Now(),
+		UpdatedAt:           s.Clock.Now(),
+		CreatorUUID:         "dummy",
+		CreatorName:         "dummy",
+		ConfirmedAt:         Some(s.Clock.Now()),
+		ExpiresAt:           s.Clock.Now().AddDate(1, 0, 0),
+		Status:              liquid.CommitmentStatusConfirmed,
+		CreationContextJSON: json.RawMessage(`{}`),
+	})
+
+	// permission check
+	s.TokenValidator.Enforcer.AllowReportSingle = false
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/cluster").
+		ExpectText(t, http.StatusForbidden, "Forbidden\n")
+	s.TokenValidator.Enforcer.AllowReportSingle = true
+
+	// full result with all options
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/cluster?with=info&with=subcapacities&with=commitment_stats&with=timing").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "all options"))
+
+	var (
+		withoutInfoMods            = []string{"del(.info)"}
+		withoutTimingMods          = []string{`walk(if type == "object" then del(.scraped_at) else . end)`}
+		withoutSubcapacitiesMods   = []string{`walk(if type == "object" then del(.subcapacities) else . end)`}
+		withoutCommitmentStatsMods = []string{`walk(if type == "object" then del(.committed) else . end)`, `walk(if type == "object" then del(.committed_confirmed_unutilized) else . end)`,
+			`walk(if type == "object" then del(.usage_uncommitted) else . end)`}
+	)
+
+	// without any extras
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/cluster").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "no params").
+			Modify(withoutInfoMods...).
+			Modify(withoutTimingMods...).
+			Modify(withoutSubcapacitiesMods...).
+			Modify(withoutCommitmentStatsMods...))
+
+	// just one extra at a time
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/cluster?with=subcapacities").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "no params").
+			Modify(withoutInfoMods...).
+			Modify(withoutTimingMods...).
+			Modify(withoutCommitmentStatsMods...))
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/cluster?with=commitment_stats").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "no params").
+			Modify(withoutInfoMods...).
+			Modify(withoutTimingMods...).
+			Modify(withoutSubcapacitiesMods...))
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/cluster?with=timing").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "no params").
+			Modify(withoutInfoMods...).
+			Modify(withoutSubcapacitiesMods...).
+			Modify(withoutCommitmentStatsMods...))
+
+	// filter by area (second area has resources)
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/cluster?with=info&area=second").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "area filter").
+			Modify("del(.info.service_areas.first)").
+			Modify("del(.cluster_report.service_areas.first)").
+			Modify(withoutTimingMods...).
+			Modify(withoutSubcapacitiesMods...).
+			Modify(withoutCommitmentStatsMods...))
+
+	// filter by service
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/cluster?with=info&service=first").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "service filter").
+			Modify("del(.info.service_areas.second)").
+			Modify("del(.cluster_report.service_areas.second)").
+			Modify(withoutTimingMods...).
+			Modify(withoutSubcapacitiesMods...).
+			Modify(withoutCommitmentStatsMods...))
+
+	// filter by resource
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/cluster?with=info&resource=capacity").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "resource filter").
+			Modify("del(.info.service_areas.first.services.first.categories.first)").
+			Modify("del(.info.service_areas.second.services.second.categories.second)").
+			Modify("del(.cluster_report.service_areas.first.services.first.categories.first)").
+			Modify("del(.cluster_report.service_areas.second.services.second.categories.second)").
+			Modify(withoutTimingMods...).
+			Modify(withoutSubcapacitiesMods...).
+			Modify(withoutCommitmentStatsMods...))
+
+	// filter by category
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/cluster?with=info&category=foo_category").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "category filter").
+			Modify("del(.info.service_areas.first.services.first.categories.first)").
+			Modify("del(.info.service_areas.second.services.second.categories.second)").
+			Modify("del(.cluster_report.service_areas.first.services.first.categories.first)").
+			Modify("del(.cluster_report.service_areas.second.services.second.categories.second)").
+			Modify(withoutTimingMods...).
+			Modify(withoutSubcapacitiesMods...).
+			Modify(withoutCommitmentStatsMods...))
+}
 
 var rateReportConfigJSON = string(must.Return(httptest.NewJQModifiableJSONString(test.RemoveCommentsFromJSON(`
 	{

--- a/internal/api/api_v2/cluster_test.go
+++ b/internal/api/api_v2/cluster_test.go
@@ -40,6 +40,16 @@ var resourceReportConfigJSON = string(must.Return(httptest.NewJQModifiableJSONSt
 		},
 		"resource_behavior": [
 			{"resource": "first/capacity", "overcommit_factor": 2}	
+		],
+		"quota_distribution_configs": [
+			{
+				"resource": "first/capacity",
+				"model": "autogrow",
+				"autogrow": {
+					"growth_multiplier": 1.0,
+					"usage_data_retention_period": "48h"
+				}
+			}
 		]
 	}`), "resourceReportConfigJSON").
 	ModifyWithVariable(".discovery = $ref", common_fixtures.DiscoveryBerlinDresdenParis).

--- a/internal/api/api_v2/domain.go
+++ b/internal/api/api_v2/domain.go
@@ -21,37 +21,24 @@ import (
 // handleGetResourcesDomains handles GET /resources/v2/domains.
 func (p *v2Provider) handleGetResourcesDomains(r *http.Request, token *gopherpolicy.Token) (_ resourcesv2.DomainGetResponse, err error) {
 	httpapi.IdentifyEndpoint(r, "/resources/v2/domains")
-	none := resourcesv2.DomainGetResponse{}
-
-	err = token.Enforce("v2:domain:report_multiple")
-	if err != nil {
-		return none, err
-	}
-	_, err = reports_v2.NewScope(false, r, None[string](), token, p.DB)
-	if err != nil {
-		return none, err
-	}
-	options, err := opts.ParseQueryString[common.DomainResourceReportOpts](r.URL.Query())
-	if err != nil {
-		return none, err
-	}
-	_, err = reports_v2.FilterFromResourceOpts(p.Cluster, options.ResourceReportOpts)
-	if err != nil {
-		return none, err
-	}
-	return none, nil
+	return p.commonHandleGetResourcesDomain(r, token, "v2:domain:report_multiple")
 }
 
 // handleGetResourcesDomain handles GET /resources/v2/domains/:domain_uuid.
 func (p *v2Provider) handleGetResourcesDomain(r *http.Request, token *gopherpolicy.Token) (_ resourcesv2.DomainGetResponse, err error) {
 	httpapi.IdentifyEndpoint(r, "/resources/v2/domains/:domain_uuid")
+	return p.commonHandleGetResourcesDomain(r, token, "v2:domain:report_single")
+}
+
+// commonHandleGetResourcesDomain handles single- and multi-domain resource calls.
+func (p *v2Provider) commonHandleGetResourcesDomain(r *http.Request, token *gopherpolicy.Token, rule string) (_ resourcesv2.DomainGetResponse, err error) {
 	none := resourcesv2.DomainGetResponse{}
 
-	err = token.Enforce("v2:domain:report_single")
+	err = token.Enforce(rule)
 	if err != nil {
 		return none, err
 	}
-	_, err = reports_v2.NewScope(false, r, None[string](), token, p.DB)
+	scope, err := reports_v2.NewScope(false, r, None[string](), token, p.DB)
 	if err != nil {
 		return none, err
 	}
@@ -59,11 +46,15 @@ func (p *v2Provider) handleGetResourcesDomain(r *http.Request, token *gopherpoli
 	if err != nil {
 		return none, err
 	}
-	_, err = reports_v2.FilterFromResourceOpts(p.Cluster, options.ResourceReportOpts)
+	filter, err := reports_v2.FilterFromResourceOpts(p.Cluster, options.ResourceReportOpts)
 	if err != nil {
 		return none, err
 	}
-	return none, nil
+	result, err := reports_v2.GetDomainResources(p.Cluster, token, filter, options, scope, p.timeNow())
+	if err != nil {
+		return none, err
+	}
+	return result, nil
 }
 
 // handleGetRatesDomains handles GET /rates/v2/domains.

--- a/internal/api/api_v2/domain_test.go
+++ b/internal/api/api_v2/domain_test.go
@@ -4,16 +4,165 @@
 package api_v2_test
 
 import (
+	"encoding/json"
 	"net/http"
 	"testing"
+	"time"
 
+	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
 	"github.com/sapcc/go-api-declarations/liquid"
 	"github.com/sapcc/go-bits/httptest"
+	"github.com/sapcc/go-bits/must"
 
 	. "go.xyrillian.de/gg/option"
 
+	"github.com/sapcc/limes/internal/db"
 	"github.com/sapcc/limes/internal/test"
+	"github.com/sapcc/limes/internal/util"
 )
+
+func TestV2DomainResourceReport(t *testing.T) {
+	s := test.NewSetup(t,
+		test.WithConfig(resourceReportConfigJSON),
+		test.WithPersistedServiceInfo("first", test.DefaultLiquidServiceInfo("First")),
+		test.WithPersistedServiceInfo("second", test.DefaultLiquidServiceInfo("Second")),
+		test.WithInitialDiscovery,
+		test.WithEmptyResourceRecordsAsNeeded,
+	)
+	fixturePath := "./fixtures/resource-domains.json"
+
+	s.Clock.StepBy(time.Hour)
+
+	// set up usage on project_az_resources
+	// germany has 2 projects (berlin, dresden), france has 1 (paris)
+	s.MustDBExec(`UPDATE project_az_resources SET usage = 10 WHERE az_resource_id IN (SELECT id FROM az_resources WHERE path LIKE '%/capacity/%')`)
+	s.MustDBExec(`UPDATE project_az_resources SET usage = 5, physical_usage = 2 WHERE az_resource_id IN (SELECT id FROM az_resources WHERE path LIKE '%/things/%')`)
+
+	// setup commitments for commitment_stats testing
+	berlin := s.GetProjectID("berlin")
+	firstCapacityAZOne := s.GetAZResourceID("first", "capacity", "az-one")
+	firstCapacityAZTwo := s.GetAZResourceID("first", "capacity", "az-two")
+	for i, config := range []struct {
+		status      liquid.CommitmentStatus
+		confirmedAt Option[time.Time]
+	}{
+		{liquid.CommitmentStatusPlanned, None[time.Time]()},
+		{liquid.CommitmentStatusPending, None[time.Time]()},
+		{liquid.CommitmentStatusConfirmed, Some(s.Clock.Now())},
+		{liquid.CommitmentStatusSuperseded, Some(s.Clock.Now())},
+		{liquid.CommitmentStatusExpired, Some(s.Clock.Now())},
+		{util.CommitmentStatusDeleted, Some(s.Clock.Now())},
+	} {
+		s.MustDBInsert(&db.ProjectCommitment{
+			UUID:                test.GenerateDummyCommitmentUUID(uint64(i + 1)),
+			ProjectID:           berlin,
+			AZResourceID:        firstCapacityAZOne,
+			Amount:              10,
+			Duration:            must.ReturnT(limesresources.ParseCommitmentDuration("1 year"))(t),
+			CreatedAt:           s.Clock.Now(),
+			UpdatedAt:           s.Clock.Now(),
+			CreatorUUID:         "dummy",
+			CreatorName:         "dummy",
+			ConfirmedAt:         config.confirmedAt,
+			ExpiresAt:           s.Clock.Now().AddDate(1, 0, 0),
+			Status:              config.status,
+			CreationContextJSON: json.RawMessage(`{}`),
+		})
+	}
+	// create some committed_confirmed_unutilized
+	s.MustDBInsert(&db.ProjectCommitment{
+		UUID:                test.GenerateDummyCommitmentUUID(7),
+		ProjectID:           berlin,
+		AZResourceID:        firstCapacityAZTwo,
+		Amount:              50,
+		Duration:            must.ReturnT(limesresources.ParseCommitmentDuration("1 year"))(t),
+		CreatedAt:           s.Clock.Now(),
+		UpdatedAt:           s.Clock.Now(),
+		CreatorUUID:         "dummy",
+		CreatorName:         "dummy",
+		ConfirmedAt:         Some(s.Clock.Now()),
+		ExpiresAt:           s.Clock.Now().AddDate(1, 0, 0),
+		Status:              liquid.CommitmentStatusConfirmed,
+		CreationContextJSON: json.RawMessage(`{}`),
+	})
+
+	// permission checks
+	s.TokenValidator.Enforcer.AllowReportMultiple = false
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/domains").
+		ExpectText(t, http.StatusForbidden, "Forbidden\n")
+	s.TokenValidator.Enforcer.AllowReportMultiple = true
+	s.TokenValidator.Enforcer.AllowReportSingle = false
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/domains/uuid-for-france").
+		ExpectText(t, http.StatusForbidden, "Forbidden\n")
+	s.TokenValidator.Enforcer.AllowReportSingle = true
+
+	// full result with all options
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/domains?with=info&with=commitment_stats").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "all options"))
+
+	var (
+		withoutInfoMods            = []string{"del(.info)"}
+		withoutCommitmentStatsMods = []string{
+			`walk(if type == "object" then del(.committed) else . end)`,
+			`walk(if type == "object" then del(.committed_confirmed_unutilized) else . end)`,
+			`walk(if type == "object" then del(.usage_uncommitted) else . end)`,
+		}
+	)
+
+	// without any extras
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/domains").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "no params").
+			Modify(withoutInfoMods...).
+			Modify(withoutCommitmentStatsMods...))
+
+	// with=commitment_stats only
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/domains?with=commitment_stats").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "commitment_stats only").
+			Modify(withoutInfoMods...))
+
+	// single domain
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/domains/uuid-for-france?with=info&with=commitment_stats").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "domain filter france").
+			Modify(`del(.domains["uuid-for-germany"])`))
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/domains/uuid-for-germany?with=info&with=commitment_stats").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "domain filter germany").
+			Modify(`del(.domains["uuid-for-france"])`))
+
+	// filter by area
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/domains?with=info&area=second").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "area filter").
+			Modify("del(.info.service_areas.first)").
+			Modify("del(.domains[].service_areas.first)").
+			Modify(withoutCommitmentStatsMods...))
+
+	// filter by service
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/domains?with=info&service=first").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "service filter").
+			Modify("del(.info.service_areas.second)").
+			Modify("del(.domains[].service_areas.second)").
+			Modify(withoutCommitmentStatsMods...))
+
+	// filter by resource
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/domains?with=info&resource=capacity").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "resource filter").
+			Modify("del(.info.service_areas.first.services.first.categories.first)").
+			Modify("del(.info.service_areas.second.services.second.categories.second)").
+			Modify("del(.domains[].service_areas.first.services.first.categories.first)").
+			Modify("del(.domains[].service_areas.second.services.second.categories.second)").
+			Modify(withoutCommitmentStatsMods...))
+
+	// filter by category
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/domains?with=info&category=foo_category").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "category filter").
+			Modify("del(.info.service_areas.first.services.first.categories.first)").
+			Modify("del(.info.service_areas.second.services.second.categories.second)").
+			Modify("del(.domains[].service_areas.first.services.first.categories.first)").
+			Modify("del(.domains[].service_areas.second.services.second.categories.second)").
+			Modify(withoutCommitmentStatsMods...))
+
+	// unknown domain
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/domains/does-not-exist").ExpectText(t, http.StatusNotFound, "no such domain (UUID = does-not-exist)\n")
+}
 
 func TestV2DomainRateReport(t *testing.T) {
 	srvInfoFirst := test.DefaultLiquidServiceInfo("First")

--- a/internal/api/api_v2/fixtures/resource-cluster.json
+++ b/internal/api/api_v2/fixtures/resource-cluster.json
@@ -1,0 +1,240 @@
+{
+  "info": {
+    "all_azs": [
+      "az-one",
+      "az-two"
+    ],
+    "service_areas": {
+      "first": {
+        "display_name": "First",
+        "services": {
+          "first": {
+            "version": 1,
+            "display_name": "First",
+            "categories": {
+              "first": {
+                "display_name": "First",
+                "resources": {
+                  "things": {
+                    "display_name": "Things",
+                    "unit": "piece",
+                    "topology": "flat",
+                    "has_capacity": false,
+                    "has_quota": true
+                  }
+                }
+              },
+              "foo_category": {
+                "display_name": "Foo Category",
+                "resources": {
+                  "capacity": {
+                    "display_name": "Capacity",
+                    "unit": "B",
+                    "topology": "az-aware",
+                    "has_capacity": true,
+                    "has_quota": true,
+                    "commitment_config": {
+                      "durations": [
+                        "1 year",
+                        "3 years"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "second": {
+        "display_name": "Second",
+        "services": {
+          "second": {
+            "version": 1,
+            "display_name": "Second",
+            "categories": {
+              "foo_category": {
+                "display_name": "Foo Category",
+                "resources": {
+                  "capacity": {
+                    "display_name": "Capacity",
+                    "unit": "B",
+                    "topology": "az-aware",
+                    "has_capacity": true,
+                    "has_quota": true,
+                    "commitment_config": {
+                      "durations": [
+                        "1 year",
+                        "3 years"
+                      ]
+                    }
+                  }
+                }
+              },
+              "second": {
+                "display_name": "Second",
+                "resources": {
+                  "things": {
+                    "display_name": "Things",
+                    "unit": "piece",
+                    "topology": "flat",
+                    "has_capacity": false,
+                    "has_quota": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "cluster_report": {
+    "service_areas": {
+      "first": {
+        "services": {
+          "first": {
+            "scraped_at": 3600,
+            "categories": {
+              "first": {
+                "resources": {
+                  "things": {
+                    "availability_zones": {
+                      "any": {
+                        "capacity": 0,
+                        "raw_capacity": 0,
+                        "usage": 15,
+                        "physical_usage": 6
+                      }
+                    }
+                  }
+                }
+              },
+              "foo_category": {
+                "resources": {
+                  "capacity": {
+                    "availability_zones": {
+                      "any": {
+                        "capacity": 0,
+                        "raw_capacity": 0,
+                        "usage": 30,
+                        "usage_uncommitted": 30,
+                        "committed_confirmed_unutilized": 0
+                      },
+                      "az-one": {
+                        "capacity": 2000,
+                        "raw_capacity": 1000,
+                        "overall_usage": 500,
+                        "usage": 30,
+                        "usage_uncommitted": 20,
+                        "committed_confirmed_unutilized": 0,
+                        "subcapacities": [
+                          {
+                            "foo": "bar"
+                          },
+                          {
+                            "foo": "baz"
+                          }
+                        ],
+                        "committed": {
+                          "confirmed": {
+                            "1 year": 10
+                          },
+                          "pending": {
+                            "1 year": 10
+                          },
+                          "planned": {
+                            "1 year": 10
+                          }
+                        }
+                      },
+                      "az-two": {
+                        "capacity": 2000,
+                        "raw_capacity": 1000,
+                        "overall_usage": 500,
+                        "usage": 30,
+                        "usage_uncommitted": 20,
+                        "committed_confirmed_unutilized": 40,
+                        "committed": {
+                          "confirmed": {
+                            "1 year": 50
+                          }
+                        }
+                      },
+                      "unknown": {
+                        "capacity": 0,
+                        "raw_capacity": 0,
+                        "usage": 30,
+                        "usage_uncommitted": 30,
+                        "committed_confirmed_unutilized": 0
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "second": {
+        "services": {
+          "second": {
+            "scraped_at": 3600,
+            "categories": {
+              "foo_category": {
+                "resources": {
+                  "capacity": {
+                    "availability_zones": {
+                      "any": {
+                        "capacity": 0,
+                        "raw_capacity": 0,
+                        "usage": 30,
+                        "usage_uncommitted": 30,
+                        "committed_confirmed_unutilized": 0
+                      },
+                      "az-one": {
+                        "capacity": 500,
+                        "raw_capacity": 500,
+                        "usage": 30,
+                        "usage_uncommitted": 30,
+                        "committed_confirmed_unutilized": 0
+                      },
+                      "az-two": {
+                        "capacity": 500,
+                        "raw_capacity": 500,
+                        "usage": 30,
+                        "usage_uncommitted": 30,
+                        "committed_confirmed_unutilized": 0
+                      },
+                      "unknown": {
+                        "capacity": 0,
+                        "raw_capacity": 0,
+                        "usage": 30,
+                        "usage_uncommitted": 30,
+                        "committed_confirmed_unutilized": 0
+                      }
+                    }
+                  }
+                }
+              },
+              "second": {
+                "resources": {
+                  "things": {
+                    "availability_zones": {
+                      "any": {
+                        "capacity": 0,
+                        "raw_capacity": 0,
+                        "usage": 15,
+                        "physical_usage": 6
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/api/api_v2/fixtures/resource-domains.json
+++ b/internal/api/api_v2/fixtures/resource-domains.json
@@ -1,0 +1,314 @@
+{
+  "info": {
+    "all_azs": [
+      "az-one",
+      "az-two"
+    ],
+    "service_areas": {
+      "first": {
+        "display_name": "First",
+        "services": {
+          "first": {
+            "version": 1,
+            "display_name": "First",
+            "categories": {
+              "first": {
+                "display_name": "First",
+                "resources": {
+                  "things": {
+                    "display_name": "Things",
+                    "unit": "piece",
+                    "topology": "flat",
+                    "has_capacity": false,
+                    "has_quota": true
+                  }
+                }
+              },
+              "foo_category": {
+                "display_name": "Foo Category",
+                "resources": {
+                  "capacity": {
+                    "display_name": "Capacity",
+                    "unit": "B",
+                    "topology": "az-aware",
+                    "has_capacity": true,
+                    "has_quota": true,
+                    "commitment_config": {
+                      "durations": [
+                        "1 year",
+                        "3 years"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "second": {
+        "display_name": "Second",
+        "services": {
+          "second": {
+            "version": 1,
+            "display_name": "Second",
+            "categories": {
+              "foo_category": {
+                "display_name": "Foo Category",
+                "resources": {
+                  "capacity": {
+                    "display_name": "Capacity",
+                    "unit": "B",
+                    "topology": "az-aware",
+                    "has_capacity": true,
+                    "has_quota": true,
+                    "commitment_config": {
+                      "durations": [
+                        "1 year",
+                        "3 years"
+                      ]
+                    }
+                  }
+                }
+              },
+              "second": {
+                "display_name": "Second",
+                "resources": {
+                  "things": {
+                    "display_name": "Things",
+                    "unit": "piece",
+                    "topology": "flat",
+                    "has_capacity": false,
+                    "has_quota": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "domains": {
+    "uuid-for-france": {
+      "uuid": "uuid-for-france",
+      "name": "france",
+      "service_areas": {
+        "first": {
+          "services": {
+            "first": {
+              "categories": {
+                "first": {
+                  "resources": {
+                    "things": {
+                      "availability_zones": {
+                        "any": {
+                          "usage": 5,
+                          "physical_usage": 2
+                        }
+                      }
+                    }
+                  }
+                },
+                "foo_category": {
+                  "resources": {
+                    "capacity": {
+                      "availability_zones": {
+                        "any": {
+                          "usage": 10,
+                          "committed_confirmed_unutilized": 0,
+                          "usage_uncommitted": 10
+                        },
+                        "az-one": {
+                          "usage": 10,
+                          "committed_confirmed_unutilized": 0,
+                          "usage_uncommitted": 10
+                        },
+                        "az-two": {
+                          "usage": 10,
+                          "committed_confirmed_unutilized": 0,
+                          "usage_uncommitted": 10
+                        },
+                        "unknown": {
+                          "usage": 10,
+                          "committed_confirmed_unutilized": 0,
+                          "usage_uncommitted": 10
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "second": {
+          "services": {
+            "second": {
+              "categories": {
+                "foo_category": {
+                  "resources": {
+                    "capacity": {
+                      "availability_zones": {
+                        "any": {
+                          "usage": 10,
+                          "committed_confirmed_unutilized": 0,
+                          "usage_uncommitted": 10
+                        },
+                        "az-one": {
+                          "usage": 10,
+                          "committed_confirmed_unutilized": 0,
+                          "usage_uncommitted": 10
+                        },
+                        "az-two": {
+                          "usage": 10,
+                          "committed_confirmed_unutilized": 0,
+                          "usage_uncommitted": 10
+                        },
+                        "unknown": {
+                          "usage": 10,
+                          "committed_confirmed_unutilized": 0,
+                          "usage_uncommitted": 10
+                        }
+                      }
+                    }
+                  }
+                },
+                "second": {
+                  "resources": {
+                    "things": {
+                      "availability_zones": {
+                        "any": {
+                          "usage": 5,
+                          "physical_usage": 2
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "uuid-for-germany": {
+      "uuid": "uuid-for-germany",
+      "name": "germany",
+      "service_areas": {
+        "first": {
+          "services": {
+            "first": {
+              "categories": {
+                "first": {
+                  "resources": {
+                    "things": {
+                      "availability_zones": {
+                        "any": {
+                          "usage": 10,
+                          "physical_usage": 4
+                        }
+                      }
+                    }
+                  }
+                },
+                "foo_category": {
+                  "resources": {
+                    "capacity": {
+                      "availability_zones": {
+                        "any": {
+                          "usage": 20,
+                          "committed_confirmed_unutilized": 0,
+                          "usage_uncommitted": 20
+                        },
+                        "az-one": {
+                          "usage": 20,
+                          "committed": {
+                            "confirmed": {
+                              "1 year": 10
+                            },
+                            "pending": {
+                              "1 year": 10
+                            },
+                            "planned": {
+                              "1 year": 10
+                            }
+                          },
+                          "committed_confirmed_unutilized": 0,
+                          "usage_uncommitted": 10
+                        },
+                        "az-two": {
+                          "usage": 20,
+                          "committed_confirmed_unutilized": 40,
+                          "usage_uncommitted": 10,
+                          "committed": {
+                            "confirmed": {
+                              "1 year": 50
+                            }
+                          }
+                        },
+                        "unknown": {
+                          "usage": 20,
+                          "committed_confirmed_unutilized": 0,
+                          "usage_uncommitted": 20
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "second": {
+          "services": {
+            "second": {
+              "categories": {
+                "foo_category": {
+                  "resources": {
+                    "capacity": {
+                      "availability_zones": {
+                        "any": {
+                          "usage": 20,
+                          "committed_confirmed_unutilized": 0,
+                          "usage_uncommitted": 20
+                        },
+                        "az-one": {
+                          "usage": 20,
+                          "committed_confirmed_unutilized": 0,
+                          "usage_uncommitted": 20
+                        },
+                        "az-two": {
+                          "usage": 20,
+                          "committed_confirmed_unutilized": 0,
+                          "usage_uncommitted": 20
+                        },
+                        "unknown": {
+                          "usage": 20,
+                          "committed_confirmed_unutilized": 0,
+                          "usage_uncommitted": 20
+                        }
+                      }
+                    }
+                  }
+                },
+                "second": {
+                  "resources": {
+                    "things": {
+                      "availability_zones": {
+                        "any": {
+                          "usage": 10,
+                          "physical_usage": 4
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/api/api_v2/fixtures/resource-projects.json
+++ b/internal/api/api_v2/fixtures/resource-projects.json
@@ -1,0 +1,608 @@
+{
+  "info": {
+    "all_azs": [
+      "az-one",
+      "az-two"
+    ],
+    "service_areas": {
+      "first": {
+        "display_name": "First",
+        "services": {
+          "first": {
+            "version": 1,
+            "display_name": "First",
+            "categories": {
+              "first": {
+                "display_name": "First",
+                "resources": {
+                  "things": {
+                    "display_name": "Things",
+                    "unit": "piece",
+                    "topology": "flat",
+                    "has_capacity": false,
+                    "has_quota": true
+                  }
+                }
+              },
+              "foo_category": {
+                "display_name": "Foo Category",
+                "resources": {
+                  "capacity": {
+                    "display_name": "Capacity",
+                    "unit": "B",
+                    "topology": "az-aware",
+                    "has_capacity": true,
+                    "has_quota": true,
+                    "commitment_config": {
+                      "durations": [
+                        "1 year",
+                        "3 years"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "second": {
+        "display_name": "Second",
+        "services": {
+          "second": {
+            "version": 1,
+            "display_name": "Second",
+            "categories": {
+              "foo_category": {
+                "display_name": "Foo Category",
+                "resources": {
+                  "capacity": {
+                    "display_name": "Capacity",
+                    "unit": "B",
+                    "topology": "az-aware",
+                    "has_capacity": true,
+                    "has_quota": true,
+                    "commitment_config": {
+                      "durations": [
+                        "1 year",
+                        "3 years"
+                      ]
+                    }
+                  }
+                }
+              },
+              "second": {
+                "display_name": "Second",
+                "resources": {
+                  "things": {
+                    "display_name": "Things",
+                    "unit": "piece",
+                    "topology": "flat",
+                    "has_capacity": false,
+                    "has_quota": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "domains": {
+    "uuid-for-france": {
+      "projects": {
+        "uuid-for-paris": {
+          "uuid": "uuid-for-paris",
+          "name": "paris",
+          "parent_uuid": "uuid-for-france",
+          "domain": {
+            "uuid": "uuid-for-france",
+            "name": "france"
+          },
+          "service_areas": {
+            "first": {
+              "services": {
+                "first": {
+                  "scraped_at": 3600,
+                  "categories": {
+                    "first": {
+                      "resources": {
+                        "things": {
+                          "availability_zones": {
+                            "any": {
+                              "usage": 5,
+                              "quota": 50,
+                              "physical_usage": 2,
+                              "historical_usage": {
+                                "min_usage": 0,
+                                "max_usage": 0,
+                                "duration": "1s"
+                              }
+                            }
+                          },
+                          "forbid_autogrowth": false
+                        }
+                      }
+                    },
+                    "foo_category": {
+                      "resources": {
+                        "capacity": {
+                          "availability_zones": {
+                            "any": {
+                              "usage": 10,
+                              "quota": 100,
+                              "historical_usage": {
+                                "min_usage": 0,
+                                "max_usage": 0,
+                                "duration": "48h"
+                              }
+                            },
+                            "az-one": {
+                              "usage": 10,
+                              "quota": 100,
+                              "historical_usage": {
+                                "min_usage": 5,
+                                "max_usage": 10,
+                                "duration": "48h"
+                              },
+                              "subresources": [
+                                {
+                                  "name": "sub1"
+                                },
+                                {
+                                  "name": "sub2"
+                                }
+                              ]
+                            },
+                            "az-two": {
+                              "usage": 10,
+                              "quota": 100,
+                              "historical_usage": {
+                                "min_usage": 5,
+                                "max_usage": 10,
+                                "duration": "48h"
+                              }
+                            },
+                            "unknown": {
+                              "usage": 10,
+                              "quota": 100,
+                              "historical_usage": {
+                                "min_usage": 0,
+                                "max_usage": 0,
+                                "duration": "48h"
+                              }
+                            }
+                          },
+                          "forbid_autogrowth": false
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "second": {
+              "services": {
+                "second": {
+                  "scraped_at": 3600,
+                  "categories": {
+                    "foo_category": {
+                      "resources": {
+                        "capacity": {
+                          "availability_zones": {
+                            "any": {
+                              "usage": 10,
+                              "quota": 100,
+                              "historical_usage": {
+                                "min_usage": 0,
+                                "max_usage": 0,
+                                "duration": "1s"
+                              }
+                            },
+                            "az-one": {
+                              "usage": 10,
+                              "quota": 100,
+                              "historical_usage": {
+                                "min_usage": 0,
+                                "max_usage": 0,
+                                "duration": "1s"
+                              }
+                            },
+                            "az-two": {
+                              "usage": 10,
+                              "quota": 100,
+                              "historical_usage": {
+                                "min_usage": 0,
+                                "max_usage": 0,
+                                "duration": "1s"
+                              }
+                            },
+                            "unknown": {
+                              "usage": 10,
+                              "quota": 100,
+                              "historical_usage": {
+                                "min_usage": 0,
+                                "max_usage": 0,
+                                "duration": "1s"
+                              }
+                            }
+                          },
+                          "forbid_autogrowth": false
+                        }
+                      }
+                    },
+                    "second": {
+                      "resources": {
+                        "things": {
+                          "availability_zones": {
+                            "any": {
+                              "usage": 5,
+                              "quota": 50,
+                              "physical_usage": 2,
+                              "historical_usage": {
+                                "min_usage": 0,
+                                "max_usage": 0,
+                                "duration": "1s"
+                              }
+                            }
+                          },
+                          "forbid_autogrowth": false
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "uuid-for-germany": {
+      "projects": {
+        "uuid-for-berlin": {
+          "uuid": "uuid-for-berlin",
+          "name": "berlin",
+          "parent_uuid": "uuid-for-germany",
+          "domain": {
+            "uuid": "uuid-for-germany",
+            "name": "germany"
+          },
+          "service_areas": {
+            "first": {
+              "services": {
+                "first": {
+                  "scraped_at": 3600,
+                  "categories": {
+                    "first": {
+                      "resources": {
+                        "things": {
+                          "availability_zones": {
+                            "any": {
+                              "usage": 5,
+                              "quota": 50,
+                              "physical_usage": 2,
+                              "historical_usage": {
+                                "min_usage": 0,
+                                "max_usage": 0,
+                                "duration": "1s"
+                              }
+                            }
+                          },
+                          "forbid_autogrowth": false
+                        }
+                      }
+                    },
+                    "foo_category": {
+                      "resources": {
+                        "capacity": {
+                          "availability_zones": {
+                            "any": {
+                              "usage": 10,
+                              "quota": 100,
+                              "historical_usage": {
+                                "min_usage": 0,
+                                "max_usage": 0,
+                                "duration": "48h"
+                              }
+                            },
+                            "az-one": {
+                              "usage": 10,
+                              "quota": 100,
+                              "committed": {
+                                "confirmed": {
+                                  "1 year": 10
+                                },
+                                "pending": {
+                                  "1 year": 10
+                                },
+                                "planned": {
+                                  "1 year": 10
+                                }
+                              },
+                              "historical_usage": {
+                                "min_usage": 5,
+                                "max_usage": 10,
+                                "duration": "48h"
+                              },
+                              "subresources": [
+                                {
+                                  "name": "sub1"
+                                },
+                                {
+                                  "name": "sub2"
+                                }
+                              ]
+                            },
+                            "az-two": {
+                              "usage": 10,
+                              "quota": 100,
+                              "historical_usage": {
+                                "min_usage": 5,
+                                "max_usage": 10,
+                                "duration": "48h"
+                              }
+                            },
+                            "unknown": {
+                              "usage": 10,
+                              "quota": 100,
+                              "historical_usage": {
+                                "min_usage": 0,
+                                "max_usage": 0,
+                                "duration": "48h"
+                              }
+                            }
+                          },
+                          "forbid_autogrowth": false
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "second": {
+              "services": {
+                "second": {
+                  "scraped_at": 3600,
+                  "categories": {
+                    "foo_category": {
+                      "resources": {
+                        "capacity": {
+                          "availability_zones": {
+                            "any": {
+                              "usage": 10,
+                              "quota": 100,
+                              "historical_usage": {
+                                "min_usage": 0,
+                                "max_usage": 0,
+                                "duration": "1s"
+                              }
+                            },
+                            "az-one": {
+                              "usage": 10,
+                              "quota": 100,
+                              "historical_usage": {
+                                "min_usage": 0,
+                                "max_usage": 0,
+                                "duration": "1s"
+                              }
+                            },
+                            "az-two": {
+                              "usage": 10,
+                              "quota": 100,
+                              "historical_usage": {
+                                "min_usage": 0,
+                                "max_usage": 0,
+                                "duration": "1s"
+                              }
+                            },
+                            "unknown": {
+                              "usage": 10,
+                              "quota": 100,
+                              "historical_usage": {
+                                "min_usage": 0,
+                                "max_usage": 0,
+                                "duration": "1s"
+                              }
+                            }
+                          },
+                          "forbid_autogrowth": false
+                        }
+                      }
+                    },
+                    "second": {
+                      "resources": {
+                        "things": {
+                          "availability_zones": {
+                            "any": {
+                              "usage": 5,
+                              "quota": 50,
+                              "physical_usage": 2,
+                              "historical_usage": {
+                                "min_usage": 0,
+                                "max_usage": 0,
+                                "duration": "1s"
+                              }
+                            }
+                          },
+                          "forbid_autogrowth": false
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "uuid-for-dresden": {
+          "uuid": "uuid-for-dresden",
+          "name": "dresden",
+          "parent_uuid": "uuid-for-berlin",
+          "domain": {
+            "uuid": "uuid-for-germany",
+            "name": "germany"
+          },
+          "service_areas": {
+            "first": {
+              "services": {
+                "first": {
+                  "scraped_at": 3600,
+                  "categories": {
+                    "first": {
+                      "resources": {
+                        "things": {
+                          "availability_zones": {
+                            "any": {
+                              "usage": 5,
+                              "quota": 50,
+                              "physical_usage": 2,
+                              "historical_usage": {
+                                "min_usage": 0,
+                                "max_usage": 0,
+                                "duration": "1s"
+                              }
+                            }
+                          },
+                          "forbid_autogrowth": false
+                        }
+                      }
+                    },
+                    "foo_category": {
+                      "resources": {
+                        "capacity": {
+                          "availability_zones": {
+                            "any": {
+                              "usage": 10,
+                              "quota": 100,
+                              "historical_usage": {
+                                "min_usage": 0,
+                                "max_usage": 0,
+                                "duration": "48h"
+                              }
+                            },
+                            "az-one": {
+                              "usage": 10,
+                              "quota": 100,
+                              "historical_usage": {
+                                "min_usage": 5,
+                                "max_usage": 10,
+                                "duration": "48h"
+                              },
+                              "subresources": [
+                                {
+                                  "name": "sub1"
+                                },
+                                {
+                                  "name": "sub2"
+                                }
+                              ]
+                            },
+                            "az-two": {
+                              "usage": 10,
+                              "quota": 100,
+                              "historical_usage": {
+                                "min_usage": 5,
+                                "max_usage": 10,
+                                "duration": "48h"
+                              }
+                            },
+                            "unknown": {
+                              "usage": 10,
+                              "quota": 100,
+                              "historical_usage": {
+                                "min_usage": 0,
+                                "max_usage": 0,
+                                "duration": "48h"
+                              }
+                            }
+                          },
+                          "forbid_autogrowth": false
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "second": {
+              "services": {
+                "second": {
+                  "scraped_at": 3600,
+                  "categories": {
+                    "foo_category": {
+                      "resources": {
+                        "capacity": {
+                          "availability_zones": {
+                            "any": {
+                              "usage": 10,
+                              "quota": 100,
+                              "historical_usage": {
+                                "min_usage": 0,
+                                "max_usage": 0,
+                                "duration": "1s"
+                              }
+                            },
+                            "az-one": {
+                              "usage": 10,
+                              "quota": 100,
+                              "historical_usage": {
+                                "min_usage": 0,
+                                "max_usage": 0,
+                                "duration": "1s"
+                              }
+                            },
+                            "az-two": {
+                              "usage": 10,
+                              "quota": 100,
+                              "historical_usage": {
+                                "min_usage": 0,
+                                "max_usage": 0,
+                                "duration": "1s"
+                              }
+                            },
+                            "unknown": {
+                              "usage": 10,
+                              "quota": 100,
+                              "historical_usage": {
+                                "min_usage": 0,
+                                "max_usage": 0,
+                                "duration": "1s"
+                              }
+                            }
+                          },
+                          "forbid_autogrowth": false
+                        }
+                      }
+                    },
+                    "second": {
+                      "resources": {
+                        "things": {
+                          "availability_zones": {
+                            "any": {
+                              "usage": 5,
+                              "quota": 50,
+                              "physical_usage": 2,
+                              "historical_usage": {
+                                "min_usage": 0,
+                                "max_usage": 0,
+                                "duration": "1s"
+                              }
+                            }
+                          },
+                          "forbid_autogrowth": false
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/api/api_v2/project.go
+++ b/internal/api/api_v2/project.go
@@ -19,31 +19,17 @@ import (
 // handleGetResourcesProjects handles GET /resources/v2/projects.
 func (p *v2Provider) handleGetResourcesProjects(r *http.Request, token *gopherpolicy.Token) (_ resourcesv2.ProjectGetResponse, err error) {
 	httpapi.IdentifyEndpoint(r, "/resources/v2/projects")
-	none := resourcesv2.ProjectGetResponse{}
-
-	// important: validate scope before token.Enforce, so that projects domain_uuid is written back to token scope
-	options, err := opts.ParseQueryString[common.ProjectResourceReportOpts](r.URL.Query())
-	if err != nil {
-		return none, err
-	}
-	_, err = reports_v2.NewScope(true, r, options.DomainUUID, token, p.DB)
-	if err != nil {
-		return none, err
-	}
-	err = token.Enforce("v2:project:report_multiple")
-	if err != nil {
-		return none, err
-	}
-	_, err = reports_v2.FilterFromResourceOpts(p.Cluster, options.ResourceReportOpts)
-	if err != nil {
-		return none, err
-	}
-	return none, nil
+	return p.commonHandleGetResourcesProject(r, token, "v2:project:report_multiple")
 }
 
 // handleGetResourcesProject handles GET /resources/v2/projects/:project_uuid.
 func (p *v2Provider) handleGetResourcesProject(r *http.Request, token *gopherpolicy.Token) (_ resourcesv2.ProjectGetResponse, err error) {
 	httpapi.IdentifyEndpoint(r, "/resources/v2/projects/:project_uuid")
+	return p.commonHandleGetResourcesProject(r, token, "v2:project:report_single")
+}
+
+// commonHandleGetResourcesProject handles single- and multi-project rate calls.
+func (p *v2Provider) commonHandleGetResourcesProject(r *http.Request, token *gopherpolicy.Token, rule string) (_ resourcesv2.ProjectGetResponse, err error) {
 	none := resourcesv2.ProjectGetResponse{}
 
 	// important: validate scope before token.Enforce, so that projects domain_uuid is written back to token scope
@@ -51,19 +37,45 @@ func (p *v2Provider) handleGetResourcesProject(r *http.Request, token *gopherpol
 	if err != nil {
 		return none, err
 	}
-	_, err = reports_v2.NewScope(true, r, options.DomainUUID, token, p.DB)
+	scope, err := reports_v2.NewScope(true, r, options.DomainUUID, token, p.DB)
 	if err != nil {
 		return none, err
 	}
-	err = token.Enforce("v2:project:report_single")
+
+	err = token.Enforce(rule)
 	if err != nil {
 		return none, err
 	}
-	_, err = reports_v2.FilterFromResourceOpts(p.Cluster, options.ResourceReportOpts)
+	// important: project-resources have special ?with= params which are subject to special permissions
+	// we can only return one error, so
+	if options.WithTiming {
+		err = token.Enforce("v2:project:with_timing")
+		if err != nil {
+			return none, err
+		}
+	}
+	if options.WithSubresources {
+		err = token.Enforce("v2:project:with_subresources")
+		if err != nil {
+			return none, err
+		}
+	}
+	if options.WithHistoricalUsage {
+		err = token.Enforce("v2:project:with_historical_usage")
+		if err != nil {
+			return none, err
+		}
+	}
+
+	filter, err := reports_v2.FilterFromResourceOpts(p.Cluster, options.ResourceReportOpts)
 	if err != nil {
 		return none, err
 	}
-	return none, nil
+	result, err := reports_v2.GetProjectResources(p.Cluster, token, filter, options, scope, p.timeNow())
+	if err != nil {
+		return none, err
+	}
+	return result, nil
 }
 
 // handleGetRatesProjects handles GET /rates/v2/projects.

--- a/internal/api/api_v2/project_test.go
+++ b/internal/api/api_v2/project_test.go
@@ -4,16 +4,260 @@
 package api_v2_test
 
 import (
+	"encoding/json"
 	"net/http"
 	"testing"
+	"time"
 
+	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
 	"github.com/sapcc/go-api-declarations/liquid"
 	"github.com/sapcc/go-bits/httptest"
+	"github.com/sapcc/go-bits/must"
 
 	. "go.xyrillian.de/gg/option"
 
+	"github.com/sapcc/limes/internal/db"
 	"github.com/sapcc/limes/internal/test"
+	"github.com/sapcc/limes/internal/util"
 )
+
+func TestV2ProjectResourceReport(t *testing.T) {
+	s := test.NewSetup(t,
+		test.WithConfig(resourceReportConfigJSON),
+		test.WithPersistedServiceInfo("first", test.DefaultLiquidServiceInfo("First")),
+		test.WithPersistedServiceInfo("second", test.DefaultLiquidServiceInfo("Second")),
+		test.WithInitialDiscovery,
+		test.WithEmptyResourceRecordsAsNeeded,
+	)
+	fixturePath := "./fixtures/resource-projects.json"
+
+	s.Clock.StepBy(time.Hour)
+
+	// set up usage on project_az_resources
+	// germany has 2 projects (berlin, dresden), france has 1 (paris)
+	s.MustDBExec(`UPDATE project_az_resources SET usage = 10 WHERE az_resource_id IN (SELECT id FROM az_resources WHERE path LIKE '%/capacity/%')`)
+	s.MustDBExec(`UPDATE project_az_resources SET usage = 5, physical_usage = 2 WHERE az_resource_id IN (SELECT id FROM az_resources WHERE path LIKE '%/things/%')`)
+	// set some quota values
+	s.MustDBExec(`UPDATE project_az_resources SET quota = 100 WHERE az_resource_id IN (SELECT id FROM az_resources WHERE path LIKE '%/capacity/%')`)
+	s.MustDBExec(`UPDATE project_az_resources SET quota = 50 WHERE az_resource_id IN (SELECT id FROM az_resources WHERE path LIKE '%/things/%')`)
+	// set subresources for testing with=subresources
+	s.MustDBExec(`UPDATE project_az_resources SET subresources = '[{"name":"sub1"},{"name":"sub2"}]' WHERE az_resource_id IN (SELECT id FROM az_resources WHERE path = 'first/capacity/az-one')`)
+	// scraped_at for timing
+	s.MustDBExec(`UPDATE project_services SET scraped_at = $1`, s.Clock.Now().UTC())
+	// historical_usage for testing with=historical_usage (only rendered for resources with autogrow quota distribution)
+	// The format is {"t":[unix_seconds...],"v":[usage_values...]}
+	historicalUsageJSON := `{"t":[3000,3300,3600],"v":[5,8,10]}`
+	s.MustDBExec(`UPDATE project_az_resources SET historical_usage = $1 WHERE az_resource_id IN (SELECT id FROM az_resources WHERE path LIKE 'first/capacity/az-%')`, historicalUsageJSON)
+
+	// setup commitments for commitment_stats testing
+	berlin := s.GetProjectID("berlin")
+	firstCapacityAZOne := s.GetAZResourceID("first", "capacity", "az-one")
+	for i, config := range []struct {
+		status      liquid.CommitmentStatus
+		confirmedAt Option[time.Time]
+	}{
+		{liquid.CommitmentStatusPlanned, None[time.Time]()},
+		{liquid.CommitmentStatusPending, None[time.Time]()},
+		{liquid.CommitmentStatusConfirmed, Some(s.Clock.Now())},
+		{liquid.CommitmentStatusSuperseded, Some(s.Clock.Now())},
+		{liquid.CommitmentStatusExpired, Some(s.Clock.Now())},
+		{util.CommitmentStatusDeleted, Some(s.Clock.Now())},
+	} {
+		s.MustDBInsert(&db.ProjectCommitment{
+			UUID:                test.GenerateDummyCommitmentUUID(uint64(i + 1)),
+			ProjectID:           berlin,
+			AZResourceID:        firstCapacityAZOne,
+			Amount:              10,
+			Duration:            must.ReturnT(limesresources.ParseCommitmentDuration("1 year"))(t),
+			CreatedAt:           s.Clock.Now(),
+			UpdatedAt:           s.Clock.Now(),
+			CreatorUUID:         "dummy",
+			CreatorName:         "dummy",
+			ConfirmedAt:         config.confirmedAt,
+			ExpiresAt:           s.Clock.Now().AddDate(1, 0, 0),
+			Status:              config.status,
+			CreationContextJSON: json.RawMessage(`{}`),
+		})
+	}
+
+	// permission checks
+	s.TokenValidator.Enforcer.AllowReportMultiple = false
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/projects").
+		ExpectText(t, http.StatusForbidden, "Forbidden\n")
+	s.TokenValidator.Enforcer.AllowReportMultiple = true
+	s.TokenValidator.Enforcer.AllowReportSingle = false
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/projects/uuid-for-paris").
+		ExpectText(t, http.StatusForbidden, "Forbidden\n")
+	s.TokenValidator.Enforcer.AllowReportSingle = true
+
+	// permission checks for with= params that require special permissions
+	s.TokenValidator.Enforcer.ForbidWithTiming = true
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/projects?with=timing").
+		ExpectText(t, http.StatusForbidden, "Forbidden\n")
+	s.TokenValidator.Enforcer.ForbidWithTiming = false
+
+	s.TokenValidator.Enforcer.ForbidWithSubresources = true
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/projects?with=subresources").
+		ExpectText(t, http.StatusForbidden, "Forbidden\n")
+	s.TokenValidator.Enforcer.ForbidWithSubresources = false
+
+	s.TokenValidator.Enforcer.ForbidWithHistoricalUsage = true
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/projects?with=historical_usage").
+		ExpectText(t, http.StatusForbidden, "Forbidden\n")
+	s.TokenValidator.Enforcer.ForbidWithHistoricalUsage = false
+
+	// full result with all options
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/projects?with=info&with=commitment_stats&with=timing&with=subresources&with=historical_usage&with=constraints").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "all options"))
+
+	var (
+		withoutInfoMods            = []string{"del(.info)"}
+		withoutTimingMods          = []string{`walk(if type == "object" then del(.scraped_at) else . end)`}
+		withoutSubresourcesMods    = []string{`walk(if type == "object" then del(.subresources) else . end)`}
+		withoutHistoricalUsageMods = []string{`walk(if type == "object" then del(.historical_usage) else . end)`}
+		withoutCommitmentStatsMods = []string{
+			`walk(if type == "object" then del(.committed) else . end)`,
+			`walk(if type == "object" then del(.committed_confirmed_unutilized) else . end)`,
+			`walk(if type == "object" then del(.usage_uncommitted) else . end)`,
+		}
+		withoutConstraintsMods = []string{
+			`walk(if type == "object" then del(.max_quota) else . end)`,
+			`walk(if type == "object" then del(.forbid_autogrowth) else . end)`,
+		}
+	)
+
+	// without any extras
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/projects").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "no params").
+			Modify(withoutInfoMods...).
+			Modify(withoutTimingMods...).
+			Modify(withoutSubresourcesMods...).
+			Modify(withoutHistoricalUsageMods...).
+			Modify(withoutCommitmentStatsMods...).
+			Modify(withoutConstraintsMods...))
+
+	// individual with= params
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/projects?with=commitment_stats").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "no params").
+			Modify(withoutInfoMods...).
+			Modify(withoutTimingMods...).
+			Modify(withoutSubresourcesMods...).
+			Modify(withoutHistoricalUsageMods...).
+			Modify(withoutConstraintsMods...))
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/projects?with=timing").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "no params").
+			Modify(withoutInfoMods...).
+			Modify(withoutSubresourcesMods...).
+			Modify(withoutHistoricalUsageMods...).
+			Modify(withoutCommitmentStatsMods...).
+			Modify(withoutConstraintsMods...))
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/projects?with=subresources").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "no params").
+			Modify(withoutInfoMods...).
+			Modify(withoutTimingMods...).
+			Modify(withoutHistoricalUsageMods...).
+			Modify(withoutCommitmentStatsMods...).
+			Modify(withoutConstraintsMods...))
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/projects?with=historical_usage").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "no params").
+			Modify(withoutInfoMods...).
+			Modify(withoutTimingMods...).
+			Modify(withoutSubresourcesMods...).
+			Modify(withoutCommitmentStatsMods...).
+			Modify(withoutConstraintsMods...))
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/projects?with=constraints").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "no params").
+			Modify(withoutInfoMods...).
+			Modify(withoutTimingMods...).
+			Modify(withoutSubresourcesMods...).
+			Modify(withoutHistoricalUsageMods...).
+			Modify(withoutCommitmentStatsMods...))
+
+	// single project
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/projects/uuid-for-paris?with=info&with=commitment_stats").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "project filter paris").
+			Modify(`del(.domains["uuid-for-germany"])`).
+			Modify(withoutTimingMods...).
+			Modify(withoutSubresourcesMods...).
+			Modify(withoutHistoricalUsageMods...).
+			Modify(withoutConstraintsMods...))
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/projects/uuid-for-berlin?with=info&with=commitment_stats").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "project filter berlin").
+			Modify(`del(.domains["uuid-for-france"])`).
+			Modify(`del(.domains["uuid-for-germany"].projects["uuid-for-dresden"])`).
+			Modify(withoutTimingMods...).
+			Modify(withoutSubresourcesMods...).
+			Modify(withoutHistoricalUsageMods...).
+			Modify(withoutConstraintsMods...))
+
+	// domain filter
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/projects?with=info&with=commitment_stats&domain_uuid=uuid-for-france").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "domain filter france").
+			Modify(`del(.domains["uuid-for-germany"])`).
+			Modify(withoutTimingMods...).
+			Modify(withoutSubresourcesMods...).
+			Modify(withoutHistoricalUsageMods...).
+			Modify(withoutConstraintsMods...))
+
+	// filter by area
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/projects?with=info&area=second").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "area filter").
+			Modify("del(.info.service_areas.first)").
+			Modify("del(.domains[].projects[].service_areas.first)").
+			Modify(withoutTimingMods...).
+			Modify(withoutSubresourcesMods...).
+			Modify(withoutHistoricalUsageMods...).
+			Modify(withoutCommitmentStatsMods...).
+			Modify(withoutConstraintsMods...))
+
+	// filter by service
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/projects?with=info&service=first").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "service filter").
+			Modify("del(.info.service_areas.second)").
+			Modify("del(.domains[].projects[].service_areas.second)").
+			Modify(withoutTimingMods...).
+			Modify(withoutSubresourcesMods...).
+			Modify(withoutHistoricalUsageMods...).
+			Modify(withoutCommitmentStatsMods...).
+			Modify(withoutConstraintsMods...))
+
+	// filter by resource
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/projects?with=info&resource=capacity").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "resource filter").
+			Modify("del(.info.service_areas.first.services.first.categories.first)").
+			Modify("del(.info.service_areas.second.services.second.categories.second)").
+			Modify("del(.domains[].projects[].service_areas.first.services.first.categories.first)").
+			Modify("del(.domains[].projects[].service_areas.second.services.second.categories.second)").
+			Modify(withoutTimingMods...).
+			Modify(withoutSubresourcesMods...).
+			Modify(withoutHistoricalUsageMods...).
+			Modify(withoutCommitmentStatsMods...).
+			Modify(withoutConstraintsMods...))
+
+	// filter by category
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/projects?with=info&category=foo_category").ExpectJSON(t, http.StatusOK,
+		httptest.NewJQModifiableJSONFixture(fixturePath, "category filter").
+			Modify("del(.info.service_areas.first.services.first.categories.first)").
+			Modify("del(.info.service_areas.second.services.second.categories.second)").
+			Modify("del(.domains[].projects[].service_areas.first.services.first.categories.first)").
+			Modify("del(.domains[].projects[].service_areas.second.services.second.categories.second)").
+			Modify(withoutTimingMods...).
+			Modify(withoutSubresourcesMods...).
+			Modify(withoutHistoricalUsageMods...).
+			Modify(withoutCommitmentStatsMods...).
+			Modify(withoutConstraintsMods...))
+
+	// scope errors
+	s.TokenValidator.Enforcer.IsDomainRole = true
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/projects").ExpectText(t, http.StatusBadRequest, "specify URL project_uuid or query domain_uuid\n")
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/projects/uuid-for-paris?domain_uuid=uuid-for-france").ExpectText(t, http.StatusBadRequest, "query domain_uuid cannot be set, when URL project_uuid is set\n")
+	s.TokenValidator.Enforcer.IsDomainRole = false
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/projects/uuid-for-paris?domain_uuid=uuid-for-france").ExpectText(t, http.StatusBadRequest, "query domain_uuid cannot be set, when URL project_uuid is set\n")
+
+	// unknown domain/project
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/projects?domain_uuid=does-not-exist").ExpectText(t, http.StatusNotFound, "no such domain (UUID = does-not-exist)\n")
+	s.Handler.RespondTo(s.Ctx, "GET /resources/v2/projects/does-not-exist").ExpectText(t, http.StatusNotFound, "no such project (UUID = does-not-exist)\n")
+}
 
 func TestV2ProjectRateReport(t *testing.T) {
 	srvInfoFirst := test.DefaultLiquidServiceInfo("First")

--- a/internal/api/reports_v2/cluster.go
+++ b/internal/api/reports_v2/cluster.go
@@ -143,30 +143,21 @@ func GetClusterResources(cluster *core.Cluster, token *gopherpolicy.Token, filte
 		}
 		overcommitFactor := cluster.BehaviorForResource(azResource.Path.ServiceType, azResource.Path.ResourceName).OvercommitFactor
 		capacity := overcommitFactor.ApplyTo(rawCapacity)
-
 		var committed map[liquid.CommitmentStatus]map[limesresources.CommitmentDuration]uint64
 		if opts.WithCommitmentStats {
-			// cancel out committed values when no commitments are configured for this resource in all projects
-			// the database cannot do this, because it does not know the allowed configurations
+			err = json.Unmarshal([]byte(committedJSON), &committed)
+			if err != nil {
+				return fmt.Errorf("while parsing DB commitment stats for %s: %w", azResource.Path, err)
+			}
+
+			// do not report commitment stats if the resource does not allow new commitments in any domains
+			// (however, if there are pre-existing commitments, report those in the usual way until they all expire or are deleted)
 			commitmentBehavior := cluster.CommitmentBehaviorForResource(azResource.Path.ServiceType, azResource.Path.ResourceName)
-			if len(commitmentBehavior.ForCluster().Durations) != 0 {
-				err = json.Unmarshal([]byte(committedJSON), &committed)
-				if err != nil {
-					return fmt.Errorf("while parsing DB commitment stats for %s: %w", azResource.Path, err)
-				}
-			} else {
+			if len(commitmentBehavior.ForCluster().Durations) == 0 && len(committed) == 0 {
+				committed = nil
 				usageUncommitted = None[uint64]()
 				committedConfirmedUnutilized = None[uint64]()
 			}
-		}
-
-		// cancel out committed values when no commitments are configured for this resource in all projects
-		// the database cannot do this, because it does not know the allowed configurations
-		commitmentBehavior := cluster.CommitmentBehaviorForResource(azResource.Path.ServiceType, azResource.Path.ResourceName)
-		if len(commitmentBehavior.ForCluster().Durations) == 0 {
-			committed = make(map[liquid.CommitmentStatus]map[limesresources.CommitmentDuration]uint64)
-			usageUncommitted = None[uint64]()
-			committedConfirmedUnutilized = None[uint64]()
 		}
 
 		scrapedAtUnix := options.Map(scrapedAt, util.IntoUnixEncodedTime)

--- a/internal/api/reports_v2/cluster.go
+++ b/internal/api/reports_v2/cluster.go
@@ -6,6 +6,7 @@ package reports_v2
 import (
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/sapcc/go-api-declarations/limes"
@@ -92,13 +93,13 @@ var clusterResourceReportQuery = sqlext.SimplifyWhitespace(db.ExpandEnumPlacehol
 
 // GetClusterResources returns a resourcesv2.ClusterGetResponse.
 func GetClusterResources(cluster *core.Cluster, token *gopherpolicy.Token, filter Filter, opts common.ClusterResourceReportOpts, timeNow time.Time) (resourcesv2.ClusterGetResponse, error) {
-	result := &resourcesv2.ClusterGetResponse{}
+	var result resourcesv2.ClusterGetResponse
 
 	// fill info report
 	if opts.WithInfo {
 		infoReport, err := GetResourcesInfo(cluster, token, timeNow, filter)
 		if err != nil {
-			return *result, err
+			return result, err
 		}
 		result.InfoReport = Some(infoReport)
 	}
@@ -151,7 +152,7 @@ func GetClusterResources(cluster *core.Cluster, token *gopherpolicy.Token, filte
 			if len(commitmentBehavior.ForCluster().Durations) != 0 {
 				err = json.Unmarshal([]byte(committedJSON), &committed)
 				if err != nil {
-					return err
+					return fmt.Errorf("while parsing DB commitment stats for %s: %w", azResource.Path, err)
 				}
 			} else {
 				usageUncommitted = None[uint64]()
@@ -170,7 +171,7 @@ func GetClusterResources(cluster *core.Cluster, token *gopherpolicy.Token, filte
 
 		scrapedAtUnix := options.Map(scrapedAt, util.IntoUnixEncodedTime)
 
-		setInClusterResourceReport(filter, cluster, result, azResourceID, resourcesv2.ClusterAvailabilityZoneReport{
+		setInClusterResourceReport(filter, cluster, &result, azResourceID, resourcesv2.ClusterAvailabilityZoneReport{
 			Capacity:                     capacity,
 			RawCapacity:                  rawCapacity,
 			OverallUsage:                 overallUsage,
@@ -184,10 +185,7 @@ func GetClusterResources(cluster *core.Cluster, token *gopherpolicy.Token, filte
 		return nil
 	})
 
-	if err != nil {
-		return *result, err
-	}
-	return *result, nil
+	return result, err
 }
 
 // setInClusterResourceReport creates or iterates higher level structs on the way to the nested
@@ -195,7 +193,7 @@ func GetClusterResources(cluster *core.Cluster, token *gopherpolicy.Token, filte
 func setInClusterResourceReport(filter Filter, cluster *core.Cluster, report *resourcesv2.ClusterGetResponse, azResourceID db.AZResourceID, value resourcesv2.ClusterAvailabilityZoneReport, scrapedAt Option[limes.UnixEncodedTime]) {
 	azResource, aExists := filter.GetAZResourceForID(azResourceID)
 	if !aExists {
-		// defense in depth: a rate was deleted in between, so we ignore the data
+		// defense in depth: an az_resource was deleted in between, so we ignore the data
 		return
 	}
 	// cannot be missing due to referential integrity
@@ -256,13 +254,13 @@ var clusterRateReportQuery = sqlext.SimplifyWhitespace(`
 
 // GetClusterRates returns a ratesv2.ClusterGetResponse.
 func GetClusterRates(cluster *core.Cluster, token *gopherpolicy.Token, filter Filter, opts common.ClusterRateReportOpts) (ratesv2.ClusterGetResponse, error) {
-	result := &ratesv2.ClusterGetResponse{}
+	var result ratesv2.ClusterGetResponse
 
 	// fill info report
 	if opts.WithInfo {
 		infoReport, err := GetRatesInfo(cluster, token, filter)
 		if err != nil {
-			return *result, err
+			return result, err
 		}
 		result.InfoReport = Some(infoReport)
 	}
@@ -278,14 +276,10 @@ func GetClusterRates(cluster *core.Cluster, token *gopherpolicy.Token, filter Fi
 		if err != nil {
 			return err
 		}
-		setInClusterRateReport(filter, cluster, result, rateID, ratesv2.ClusterRateReport{UsageAsBigint: usageAsBigint})
+		setInClusterRateReport(filter, cluster, &result, rateID, ratesv2.ClusterRateReport{UsageAsBigint: usageAsBigint})
 		return nil
 	})
-
-	if err != nil {
-		return *result, err
-	}
-	return *result, nil
+	return result, err
 }
 
 // setInClusterRateReport creates or iterates higher level structs on the way to the nested

--- a/internal/api/reports_v2/cluster.go
+++ b/internal/api/reports_v2/cluster.go
@@ -5,19 +5,247 @@ package reports_v2
 
 import (
 	"database/sql"
+	"encoding/json"
+	"time"
 
+	"github.com/sapcc/go-api-declarations/limes"
+	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
 	"github.com/sapcc/go-api-declarations/liquid"
 	"github.com/sapcc/go-bits/must"
 	"github.com/sapcc/go-bits/sqlext"
 	. "go.xyrillian.de/gg/option"
+	"go.xyrillian.de/gg/options"
 
 	"github.com/sapcc/go-bits/gopherpolicy"
 
 	"github.com/sapcc/limes/internal/apideclarations/apiv2/common"
 	ratesv2 "github.com/sapcc/limes/internal/apideclarations/apiv2/rates"
+	resourcesv2 "github.com/sapcc/limes/internal/apideclarations/apiv2/resources"
 	"github.com/sapcc/limes/internal/core"
 	"github.com/sapcc/limes/internal/db"
+	"github.com/sapcc/limes/internal/util"
 )
+
+var clusterResourceReportQuery = sqlext.SimplifyWhitespace(db.ExpandEnumPlaceholders(`
+	WITH 
+	$with_commitment_stats{{
+		project_commitment_sums AS (
+			SELECT az_resource_id,
+		  	json_object_agg(status, by_status) AS committed
+			FROM (
+		  		SELECT az_resource_id, status,
+				json_object_agg(duration, total_amount) AS by_status
+				FROM (
+					SELECT az_resource_id, status, duration, SUM(amount) AS total_amount
+					FROM project_commitments
+					WHERE {{az_resource_id = ANY($az_resource_id)}}
+					AND status NOT IN ({{liquid.CommitmentStatusSuperseded}}, {{liquid.CommitmentStatusExpired}}, {{util.CommitmentStatusDeleted}})
+					GROUP BY az_resource_id, status, duration
+		 		) inner_agg
+		  		GROUP BY az_resource_id, status
+			) outer_agg
+			GROUP BY az_resource_id
+		),
+		project_commitment_project_sums_confirmed AS (
+			SELECT az_resource_id, project_id, SUM(amount) as amount
+			FROM project_commitments
+			WHERE {{az_resource_id = ANY($az_resource_id)}}
+			AND status = {{liquid.CommitmentStatusConfirmed}}
+			GROUP BY az_resource_id, project_id
+		),
+	}}
+	project_sums AS (
+		SELECT pazr.az_resource_id, 
+		$with_commitment_stats{{
+			SUM(COALESCE(pcpsc.amount, 0)) as committed_confirmed,
+			SUM(GREATEST(COALESCE(pcpsc.AMOUNT-pazr.usage, 0), 0)) AS committed_confirmed_unutilized,
+		}}
+		SUM(pazr.usage) as usage,
+		SUM(pazr.physical_usage) as physical_usage
+		FROM project_az_resources pazr
+		$with_commitment_stats{{
+			LEFT JOIN project_commitment_project_sums_confirmed pcpsc
+			ON pcpsc.project_id = pazr.project_id AND pcpsc.az_resource_id = pazr.az_resource_id
+		}}
+		WHERE {{az_resource_id = ANY($az_resource_id)}}
+		GROUP BY pazr.az_resource_id
+	)
+	SELECT 
+		azr.id, azr.raw_capacity, azr.usage as overall_usage, ps.usage,
+		$with_timing{{s.scraped_at,}} 
+		$with_commitment_stats{{
+			COALESCE(pcs.committed, '{}') as committed,
+			ps.committed_confirmed_unutilized,
+			ps.usage - (ps.committed_confirmed - ps.committed_confirmed_unutilized) as usage_uncommitted, 
+		}}
+		$with_subcapacities{{azr.subcapacities,}}
+		ps.physical_usage
+	FROM services s
+	JOIN resources r ON r.service_id = s.id
+	JOIN az_resources azr ON azr.resource_id = r.id
+	JOIN project_sums ps ON ps.az_resource_id = azr.id
+	$with_commitment_stats{{
+		LEFT JOIN project_commitment_sums pcs ON pcs.az_resource_id = azr.id
+	}}
+	WHERE azr.az != {{liquid.AvailabilityZoneTotal}}
+`))
+
+// GetClusterResources returns a resourcesv2.ClusterGetResponse.
+func GetClusterResources(cluster *core.Cluster, token *gopherpolicy.Token, filter Filter, opts common.ClusterResourceReportOpts, timeNow time.Time) (resourcesv2.ClusterGetResponse, error) {
+	result := &resourcesv2.ClusterGetResponse{}
+
+	// fill info report
+	if opts.WithInfo {
+		infoReport, err := GetResourcesInfo(cluster, token, timeNow, filter)
+		if err != nil {
+			return *result, err
+		}
+		result.InfoReport = Some(infoReport)
+	}
+
+	query := EvalClusterResourceExtraProps(clusterResourceReportQuery, opts)
+	query, args := filter.ExpandServiceFilters(query)
+	err := sqlext.ForeachRow(cluster.DB, query, args, func(rows *sql.Rows) error {
+		var (
+			azResourceID                 db.AZResourceID
+			rawCapacity                  uint64
+			overallUsage                 Option[uint64]
+			usage                        uint64
+			scrapedAt                    Option[time.Time]
+			committedJSON                string
+			committedConfirmedUnutilized Option[uint64]
+			usageUncommitted             Option[uint64]
+			subcapacities                string
+			physicalUsage                Option[uint64]
+		)
+		columns := []any{&azResourceID, &rawCapacity, &overallUsage, &usage}
+		if opts.WithTiming {
+			columns = append(columns, &scrapedAt)
+		}
+		if opts.WithCommitmentStats {
+			columns = append(columns, &committedJSON, &committedConfirmedUnutilized, &usageUncommitted)
+		}
+		if opts.WithSubcapacities {
+			columns = append(columns, &subcapacities)
+		}
+		columns = append(columns, &physicalUsage)
+		err := rows.Scan(columns...)
+		if err != nil {
+			return err
+		}
+
+		// do some computations on the resulting values
+		azResource, aExists := filter.GetAZResourceForID(azResourceID)
+		if !aExists {
+			// defense in depth: an az_resource was deleted in between, so we ignore the data
+			return nil
+		}
+		overcommitFactor := cluster.BehaviorForResource(azResource.Path.ServiceType, azResource.Path.ResourceName).OvercommitFactor
+		capacity := overcommitFactor.ApplyTo(rawCapacity)
+
+		var committed map[liquid.CommitmentStatus]map[limesresources.CommitmentDuration]uint64
+		if opts.WithCommitmentStats {
+			// cancel out committed values when no commitments are configured for this resource in all projects
+			// the database cannot do this, because it does not know the allowed configurations
+			commitmentBehavior := cluster.CommitmentBehaviorForResource(azResource.Path.ServiceType, azResource.Path.ResourceName)
+			if len(commitmentBehavior.ForCluster().Durations) != 0 {
+				err = json.Unmarshal([]byte(committedJSON), &committed)
+				if err != nil {
+					return err
+				}
+			} else {
+				usageUncommitted = None[uint64]()
+				committedConfirmedUnutilized = None[uint64]()
+			}
+		}
+
+		// cancel out committed values when no commitments are configured for this resource in all projects
+		// the database cannot do this, because it does not know the allowed configurations
+		commitmentBehavior := cluster.CommitmentBehaviorForResource(azResource.Path.ServiceType, azResource.Path.ResourceName)
+		if len(commitmentBehavior.ForCluster().Durations) == 0 {
+			committed = make(map[liquid.CommitmentStatus]map[limesresources.CommitmentDuration]uint64)
+			usageUncommitted = None[uint64]()
+			committedConfirmedUnutilized = None[uint64]()
+		}
+
+		scrapedAtUnix := options.Map(scrapedAt, util.IntoUnixEncodedTime)
+
+		setInClusterResourceReport(filter, cluster, result, azResourceID, resourcesv2.ClusterAvailabilityZoneReport{
+			Capacity:                     capacity,
+			RawCapacity:                  rawCapacity,
+			OverallUsage:                 overallUsage,
+			Usage:                        usage,
+			Committed:                    committed,
+			CommittedConfirmedUnutilized: committedConfirmedUnutilized,
+			UsageUncommitted:             usageUncommitted,
+			PhysicalUsage:                physicalUsage,
+			Subcapacities:                json.RawMessage(subcapacities),
+		}, scrapedAtUnix)
+		return nil
+	})
+
+	if err != nil {
+		return *result, err
+	}
+	return *result, nil
+}
+
+// setInClusterResourceReport creates or iterates higher level structs on the way to the nested
+// location of the db.AZResourceID in the report and assigns the value for resourcesv2.ClusterAvailabilityZoneReport.
+func setInClusterResourceReport(filter Filter, cluster *core.Cluster, report *resourcesv2.ClusterGetResponse, azResourceID db.AZResourceID, value resourcesv2.ClusterAvailabilityZoneReport, scrapedAt Option[limes.UnixEncodedTime]) {
+	azResource, aExists := filter.GetAZResourceForID(azResourceID)
+	if !aExists {
+		// defense in depth: a rate was deleted in between, so we ignore the data
+		return
+	}
+	// cannot be missing due to referential integrity
+	resource := must.BeOK(filter.GetResourceForID(azResource.ResourceID))
+	service := must.BeOK(filter.GetServiceForID(resource.ServiceID))
+
+	config := cluster.Config.Liquids[service.Type]
+	area := config.Area
+	// defense in depth: config should be in sync with serviceInfo
+	if area == "" {
+		return
+	}
+
+	// check area level (might be uninitialized)
+	if report.ClusterReport.Areas == nil {
+		report.ClusterReport.Areas = make(map[string]resourcesv2.ClusterAreaReport)
+	}
+	if _, exists := report.ClusterReport.Areas[area]; !exists {
+		report.ClusterReport.Areas[area] = resourcesv2.ClusterAreaReport{Services: make(map[db.ServiceType]resourcesv2.ClusterServiceReport)}
+	}
+	areaReport := report.ClusterReport.Areas[area]
+
+	// check service level
+	if _, exists := areaReport.Services[service.Type]; !exists {
+		areaReport.Services[service.Type] = resourcesv2.ClusterServiceReport{
+			ScrapedAt:  scrapedAt,
+			Categories: make(map[liquid.CategoryName]resourcesv2.ClusterCategoryReport),
+		}
+	}
+	serviceReport := areaReport.Services[service.Type]
+
+	// check category level
+	category := liquid.CategoryName(service.Type)
+	if categoryID, exists := resource.CategoryID.Unpack(); exists {
+		category = must.BeOK(filter.GetCategoryForID(categoryID)).Name
+	}
+	if _, exists := serviceReport.Categories[category]; !exists {
+		serviceReport.Categories[category] = resourcesv2.ClusterCategoryReport{Resources: make(map[liquid.ResourceName]resourcesv2.ClusterResourceReport)}
+	}
+	categoryReport := serviceReport.Categories[category]
+
+	// check resource level
+	if _, exists := categoryReport.Resources[resource.Name]; !exists {
+		categoryReport.Resources[resource.Name] = resourcesv2.ClusterResourceReport{AvailabilityZones: make(map[limes.AvailabilityZone]resourcesv2.ClusterAvailabilityZoneReport)}
+	}
+	azReport := categoryReport.Resources[resource.Name]
+
+	// check AZ level
+	azReport.AvailabilityZones[azResource.AvailabilityZone] = value
+}
 
 var clusterRateReportQuery = sqlext.SimplifyWhitespace(`
 	SELECT pra.rate_id, SUM(pra.usage_as_bigint::BIGINT)::TEXT AS usage_as_bigint

--- a/internal/api/reports_v2/cluster.go
+++ b/internal/api/reports_v2/cluster.go
@@ -5,10 +5,9 @@ package reports_v2
 
 import (
 	"database/sql"
-	"maps"
-	"slices"
 
 	"github.com/sapcc/go-api-declarations/liquid"
+	"github.com/sapcc/go-bits/must"
 	"github.com/sapcc/go-bits/sqlext"
 	. "go.xyrillian.de/gg/option"
 
@@ -65,55 +64,49 @@ func GetClusterRates(cluster *core.Cluster, token *gopherpolicy.Token, filter Fi
 // location of the db.RateID in the report and assigns the value for ratesv2.ClusterRateReport.
 // If this rate should not get set because it does not have usage, this is a no-op.
 func setInClusterRateReport(filter Filter, cluster *core.Cluster, report *ratesv2.ClusterGetResponse, rateID db.RateID, value ratesv2.ClusterRateReport) {
-	services := filter.GetServices()
-	categories := filter.GetCategories()
-
-	for _, serviceType := range slices.Sorted(maps.Keys(services)) {
-		rates, _ := filter.GetRatesForType(serviceType) // can have no resources
-		for _, rateName := range slices.Sorted(maps.Keys(rates)) {
-			rate := rates[rateName]
-			if rate.ID != rateID {
-				continue
-			}
-			if !rate.HasUsage {
-				return
-			}
-
-			config := cluster.Config.Liquids[serviceType]
-			area := config.Area
-			// defense in depth: config should be in sync with serviceInfo
-			if area == "" {
-				return
-			}
-
-			// check area level (might be uninitialized)
-			if report.ClusterReport.Areas == nil {
-				report.ClusterReport.Areas = make(map[string]ratesv2.ClusterAreaReport)
-			}
-			if _, exists := report.ClusterReport.Areas[area]; !exists {
-				report.ClusterReport.Areas[area] = ratesv2.ClusterAreaReport{Services: make(map[db.ServiceType]ratesv2.ClusterServiceReport)}
-			}
-			areaReport := report.ClusterReport.Areas[area]
-
-			// check service level
-			if _, exists := areaReport.Services[serviceType]; !exists {
-				areaReport.Services[serviceType] = ratesv2.ClusterServiceReport{Categories: make(map[liquid.CategoryName]ratesv2.ClusterCategoryReport)}
-			}
-			serviceReport := areaReport.Services[serviceType]
-
-			// check category level
-			category := liquid.CategoryName(serviceType)
-			if categoryID, exists := rate.CategoryID.Unpack(); exists {
-				category = categories[categoryID].Name
-			}
-			if _, exists := serviceReport.Categories[category]; !exists {
-				serviceReport.Categories[category] = ratesv2.ClusterCategoryReport{Rates: make(map[liquid.RateName]ratesv2.ClusterRateReport)}
-			}
-			categoryReport := serviceReport.Categories[category]
-
-			// check rate level
-			categoryReport.Rates[rate.Name] = value
-			return
-		}
+	rate, rExists := filter.GetRateForID(rateID)
+	if !rExists {
+		// defense in depth: a rate was deleted in between, so we ignore the data
+		return
 	}
+	// cannot be missing due to referential integrity
+	service := must.BeOK(filter.GetServiceForID(rate.ServiceID))
+	if !rate.HasUsage {
+		return
+	}
+
+	config := cluster.Config.Liquids[service.Type]
+	area := config.Area
+	// defense in depth: config should be in sync with serviceInfo
+	if area == "" {
+		return
+	}
+
+	// check area level (might be uninitialized)
+	if report.ClusterReport.Areas == nil {
+		report.ClusterReport.Areas = make(map[string]ratesv2.ClusterAreaReport)
+	}
+	if _, exists := report.ClusterReport.Areas[area]; !exists {
+		report.ClusterReport.Areas[area] = ratesv2.ClusterAreaReport{Services: make(map[db.ServiceType]ratesv2.ClusterServiceReport)}
+	}
+	areaReport := report.ClusterReport.Areas[area]
+
+	// check service level
+	if _, exists := areaReport.Services[service.Type]; !exists {
+		areaReport.Services[service.Type] = ratesv2.ClusterServiceReport{Categories: make(map[liquid.CategoryName]ratesv2.ClusterCategoryReport)}
+	}
+	serviceReport := areaReport.Services[service.Type]
+
+	// check category level
+	category := liquid.CategoryName(service.Type)
+	if categoryID, exists := rate.CategoryID.Unpack(); exists {
+		category = must.BeOK(filter.GetCategoryForID(categoryID)).Name
+	}
+	if _, exists := serviceReport.Categories[category]; !exists {
+		serviceReport.Categories[category] = ratesv2.ClusterCategoryReport{Rates: make(map[liquid.RateName]ratesv2.ClusterRateReport)}
+	}
+	categoryReport := serviceReport.Categories[category]
+
+	// check rate level
+	categoryReport.Rates[rate.Name] = value
 }

--- a/internal/api/reports_v2/cluster.go
+++ b/internal/api/reports_v2/cluster.go
@@ -27,11 +27,11 @@ var clusterRateReportQuery = sqlext.SimplifyWhitespace(`
 `)
 
 // GetClusterRates returns a ratesv2.ClusterGetResponse.
-func GetClusterRates(cluster *core.Cluster, token *gopherpolicy.Token, filter Filter, options common.ClusterRateReportOpts) (ratesv2.ClusterGetResponse, error) {
+func GetClusterRates(cluster *core.Cluster, token *gopherpolicy.Token, filter Filter, opts common.ClusterRateReportOpts) (ratesv2.ClusterGetResponse, error) {
 	result := &ratesv2.ClusterGetResponse{}
 
 	// fill info report
-	if options.WithInfo {
+	if opts.WithInfo {
 		infoReport, err := GetRatesInfo(cluster, token, filter)
 		if err != nil {
 			return *result, err

--- a/internal/api/reports_v2/domain.go
+++ b/internal/api/reports_v2/domain.go
@@ -141,15 +141,16 @@ func GetDomainResources(cluster *core.Cluster, token *gopherpolicy.Token, filter
 		}
 		var committed map[liquid.CommitmentStatus]map[limesresources.CommitmentDuration]uint64
 		if opts.WithCommitmentStats {
-			// cancel out committed values when no commitments are configured for this resource in all projects
-			// the database cannot do this, because it does not know the allowed configurations
+			err = json.Unmarshal([]byte(committedJSON), &committed)
+			if err != nil {
+				return fmt.Errorf("while parsing DB commitment stats for %s: %w", azResource.Path, err)
+			}
+
+			// do not report commitment stats if the resource does not allow new commitments in this domain
+			// (however, if there are pre-existing commitments, report those in the usual way until they all expire or are deleted)
 			commitmentBehavior := cluster.CommitmentBehaviorForResource(azResource.Path.ServiceType, azResource.Path.ResourceName)
-			if len(commitmentBehavior.ForDomain(domainName).Durations) != 0 {
-				err = json.Unmarshal([]byte(committedJSON), &committed)
-				if err != nil {
-					return fmt.Errorf("while parsing DB commitment stats for %s: %w", azResource.Path, err)
-				}
-			} else {
+			if len(commitmentBehavior.ForDomain(domainName).Durations) == 0 && len(committed) == 0 {
+				committed = nil
 				usageUncommitted = None[uint64]()
 				committedConfirmedUnutilized = None[uint64]()
 			}

--- a/internal/api/reports_v2/domain.go
+++ b/internal/api/reports_v2/domain.go
@@ -6,6 +6,7 @@ package reports_v2
 import (
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/sapcc/go-api-declarations/limes"
@@ -97,13 +98,13 @@ var domainResourceReportQuery = sqlext.SimplifyWhitespace(db.ExpandEnumPlacehold
 
 // GetDomainResources returns a resourcesv2.DomainGetResponse.
 func GetDomainResources(cluster *core.Cluster, token *gopherpolicy.Token, filter Filter, opts common.DomainResourceReportOpts, scope Scope, timeNow time.Time) (resourcesv2.DomainGetResponse, error) {
-	result := &resourcesv2.DomainGetResponse{}
+	var result resourcesv2.DomainGetResponse
 
 	// fill info report
 	if opts.WithInfo {
 		infoReport, err := GetResourcesInfo(cluster, token, timeNow, filter)
 		if err != nil {
-			return *result, err
+			return result, err
 		}
 		result.InfoReport = Some(infoReport)
 	}
@@ -146,7 +147,7 @@ func GetDomainResources(cluster *core.Cluster, token *gopherpolicy.Token, filter
 			if len(commitmentBehavior.ForDomain(domainName).Durations) != 0 {
 				err = json.Unmarshal([]byte(committedJSON), &committed)
 				if err != nil {
-					return err
+					return fmt.Errorf("while parsing DB commitment stats for %s: %w", azResource.Path, err)
 				}
 			} else {
 				usageUncommitted = None[uint64]()
@@ -154,7 +155,7 @@ func GetDomainResources(cluster *core.Cluster, token *gopherpolicy.Token, filter
 			}
 		}
 
-		setInDomainResourceReport(filter, cluster, result, azResourceID, common.DomainMetadata{
+		setInDomainResourceReport(filter, cluster, &result, azResourceID, common.DomainMetadata{
 			UUID: domainUUID,
 			Name: domainName,
 		}, resourcesv2.DomainAvailabilityZoneReport{
@@ -166,11 +167,7 @@ func GetDomainResources(cluster *core.Cluster, token *gopherpolicy.Token, filter
 		})
 		return nil
 	})
-
-	if err != nil {
-		return *result, err
-	}
-	return *result, nil
+	return result, err
 }
 
 // setInDomainResourceReport creates or iterates higher level structs on the way to the nested
@@ -178,7 +175,7 @@ func GetDomainResources(cluster *core.Cluster, token *gopherpolicy.Token, filter
 func setInDomainResourceReport(filter Filter, cluster *core.Cluster, report *resourcesv2.DomainGetResponse, azResourceID db.AZResourceID, domain common.DomainMetadata, value resourcesv2.DomainAvailabilityZoneReport) {
 	azResource, aExists := filter.GetAZResourceForID(azResourceID)
 	if !aExists {
-		// defense in depth: a rate was deleted in between, so we ignore the data
+		// defense in depth: an az_resource was deleted in between, so we ignore the data
 		return
 	}
 	// cannot be missing due to referential integrity
@@ -252,13 +249,13 @@ var domainRateReportQuery = sqlext.SimplifyWhitespace(`
 
 // GetDomainRates returns a ratesv2.DomainGetResponse.
 func GetDomainRates(cluster *core.Cluster, token *gopherpolicy.Token, filter Filter, opts common.DomainRateReportOpts, scope Scope) (ratesv2.DomainGetResponse, error) {
-	result := &ratesv2.DomainGetResponse{}
+	var result ratesv2.DomainGetResponse
 
 	// fill info report
 	if opts.WithInfo {
 		infoReport, err := GetRatesInfo(cluster, token, filter)
 		if err != nil {
-			return *result, err
+			return result, err
 		}
 		result.InfoReport = Some(infoReport)
 	}
@@ -277,7 +274,7 @@ func GetDomainRates(cluster *core.Cluster, token *gopherpolicy.Token, filter Fil
 		if err != nil {
 			return err
 		}
-		setInDomainRateReport(filter, cluster, result, rateID, common.DomainMetadata{
+		setInDomainRateReport(filter, cluster, &result, rateID, common.DomainMetadata{
 			UUID: domainUUID,
 			Name: domainName,
 		}, ratesv2.DomainRateReport{
@@ -285,11 +282,7 @@ func GetDomainRates(cluster *core.Cluster, token *gopherpolicy.Token, filter Fil
 		})
 		return nil
 	})
-
-	if err != nil {
-		return *result, err
-	}
-	return *result, nil
+	return result, err
 }
 
 // setInDomainReport creates or iterates higher level structs on the way to the nested

--- a/internal/api/reports_v2/domain.go
+++ b/internal/api/reports_v2/domain.go
@@ -5,9 +5,8 @@ package reports_v2
 
 import (
 	"database/sql"
-	"maps"
-	"slices"
 
+	"github.com/sapcc/go-bits/must"
 	. "go.xyrillian.de/gg/option"
 
 	"github.com/sapcc/go-api-declarations/liquid"
@@ -78,64 +77,58 @@ func GetDomainRates(cluster *core.Cluster, token *gopherpolicy.Token, filter Fil
 // location of the db.RateID in the report and assigns the value for ratesv2.DomainRateReport.
 // If this rate should not get set because it does not have usage, this is a no-op.
 func setInDomainRateReport(filter Filter, cluster *core.Cluster, report *ratesv2.DomainGetResponse, rateID db.RateID, domain common.DomainMetadata, value ratesv2.DomainRateReport) {
-	services := filter.GetServices()
-	categories := filter.GetCategories()
+	rate, rExists := filter.GetRateForID(rateID)
+	if !rExists {
+		// defense in depth: a rate was deleted in between, so we ignore the data
+		return
+	}
+	// cannot be missing due to referential integrity
+	service := must.BeOK(filter.GetServiceForID(rate.ServiceID))
+	if !rate.HasUsage {
+		return
+	}
 
-	for _, serviceType := range slices.Sorted(maps.Keys(services)) {
-		rates, _ := filter.GetRatesForType(serviceType) // can have no resources
-		for _, rateName := range slices.Sorted(maps.Keys(rates)) {
-			rate := rates[rateName]
-			if rate.ID != rateID {
-				continue
-			}
-			if !rate.HasUsage {
-				return
-			}
+	config := cluster.Config.Liquids[service.Type]
+	area := config.Area
+	// defense in depth: config should be in sync with serviceInfo
+	if area == "" {
+		return
+	}
 
-			config := cluster.Config.Liquids[serviceType]
-			area := config.Area
-			// defense in depth: config should be in sync with serviceInfo
-			if area == "" {
-				return
-			}
-
-			// check domain level (might be uninitialized)
-			if report.DomainReports == nil {
-				report.DomainReports = make(map[string]ratesv2.DomainReport)
-			}
-			if _, exists := report.DomainReports[domain.UUID]; !exists {
-				report.DomainReports[domain.UUID] = ratesv2.DomainReport{
-					DomainMetadata: domain,
-					Areas:          make(map[string]ratesv2.DomainAreaReport),
-				}
-			}
-			domainReport := report.DomainReports[domain.UUID]
-
-			// check area level
-			if _, exists := domainReport.Areas[area]; !exists {
-				domainReport.Areas[area] = ratesv2.DomainAreaReport{Services: make(map[db.ServiceType]ratesv2.DomainServiceReport)}
-			}
-			areaReport := domainReport.Areas[area]
-
-			// check service level
-			if _, exists := areaReport.Services[serviceType]; !exists {
-				areaReport.Services[serviceType] = ratesv2.DomainServiceReport{Categories: make(map[liquid.CategoryName]ratesv2.DomainCategoryReport)}
-			}
-			serviceReport := areaReport.Services[serviceType]
-
-			// check category level
-			category := liquid.CategoryName(serviceType)
-			if categoryID, exists := rate.CategoryID.Unpack(); exists {
-				category = categories[categoryID].Name
-			}
-			if _, exists := serviceReport.Categories[category]; !exists {
-				serviceReport.Categories[category] = ratesv2.DomainCategoryReport{Rates: make(map[liquid.RateName]ratesv2.DomainRateReport)}
-			}
-			categoryReport := serviceReport.Categories[category]
-
-			// check rate level
-			categoryReport.Rates[rate.Name] = value
-			return
+	// check domain level (might be uninitialized)
+	if report.DomainReports == nil {
+		report.DomainReports = make(map[string]ratesv2.DomainReport)
+	}
+	if _, exists := report.DomainReports[domain.UUID]; !exists {
+		report.DomainReports[domain.UUID] = ratesv2.DomainReport{
+			DomainMetadata: domain,
+			Areas:          make(map[string]ratesv2.DomainAreaReport),
 		}
 	}
+	domainReport := report.DomainReports[domain.UUID]
+
+	// check area level
+	if _, exists := domainReport.Areas[area]; !exists {
+		domainReport.Areas[area] = ratesv2.DomainAreaReport{Services: make(map[db.ServiceType]ratesv2.DomainServiceReport)}
+	}
+	areaReport := domainReport.Areas[area]
+
+	// check service level
+	if _, exists := areaReport.Services[service.Type]; !exists {
+		areaReport.Services[service.Type] = ratesv2.DomainServiceReport{Categories: make(map[liquid.CategoryName]ratesv2.DomainCategoryReport)}
+	}
+	serviceReport := areaReport.Services[service.Type]
+
+	// check category level
+	category := liquid.CategoryName(service.Type)
+	if categoryID, exists := rate.CategoryID.Unpack(); exists {
+		category = must.BeOK(filter.GetCategoryForID(categoryID)).Name
+	}
+	if _, exists := serviceReport.Categories[category]; !exists {
+		serviceReport.Categories[category] = ratesv2.DomainCategoryReport{Rates: make(map[liquid.RateName]ratesv2.DomainRateReport)}
+	}
+	categoryReport := serviceReport.Categories[category]
+
+	// check rate level
+	categoryReport.Rates[rate.Name] = value
 }

--- a/internal/api/reports_v2/domain.go
+++ b/internal/api/reports_v2/domain.go
@@ -27,7 +27,7 @@ var domainRateReportQuery = sqlext.SimplifyWhitespace(`
 	JOIN domains d
 	ON d.id = p.domain_id
 	WHERE {{pra.rate_id = ANY($rate_id)}}
-	AND {{d.id = $domain_id}}
+	AND {{d.id = ANY($domain_id)}}
 	GROUP BY d.uuid, d.name, pra.rate_id
 `)
 

--- a/internal/api/reports_v2/domain.go
+++ b/internal/api/reports_v2/domain.go
@@ -5,19 +5,238 @@ package reports_v2
 
 import (
 	"database/sql"
+	"encoding/json"
+	"time"
 
-	"github.com/sapcc/go-bits/must"
-	. "go.xyrillian.de/gg/option"
-
+	"github.com/sapcc/go-api-declarations/limes"
+	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
 	"github.com/sapcc/go-api-declarations/liquid"
 	"github.com/sapcc/go-bits/gopherpolicy"
+	"github.com/sapcc/go-bits/must"
 	"github.com/sapcc/go-bits/sqlext"
+	. "go.xyrillian.de/gg/option"
 
 	"github.com/sapcc/limes/internal/apideclarations/apiv2/common"
 	ratesv2 "github.com/sapcc/limes/internal/apideclarations/apiv2/rates"
+	resourcesv2 "github.com/sapcc/limes/internal/apideclarations/apiv2/resources"
 	"github.com/sapcc/limes/internal/core"
 	"github.com/sapcc/limes/internal/db"
 )
+
+var domainResourceReportQuery = sqlext.SimplifyWhitespace(db.ExpandEnumPlaceholders(`
+	WITH 
+	$with_commitment_stats{{
+		project_commitment_domain_sums AS (
+			SELECT az_resource_id, domain_id,
+		  	json_object_agg(status, by_status) AS committed
+			FROM (
+		  		SELECT az_resource_id, domain_id, status,
+				json_object_agg(duration, total_amount) AS by_status
+				FROM (
+					SELECT az_resource_id, domain_id, status, duration, SUM(amount) AS total_amount
+					FROM project_commitments pc
+					JOIN projects p 
+					ON pc.project_id = p.id 
+					WHERE {{az_resource_id = ANY($az_resource_id)}}
+					AND {{p.domain_id = ANY($domain_id)}}
+					AND status NOT IN ({{liquid.CommitmentStatusSuperseded}}, {{liquid.CommitmentStatusExpired}}, {{util.CommitmentStatusDeleted}})
+					GROUP BY az_resource_id, domain_id, status, duration
+		 		) inner_agg
+		  		GROUP BY az_resource_id, domain_id, status
+			) outer_agg
+			GROUP BY az_resource_id, domain_id
+		),
+		project_commitment_project_sums_confirmed AS (
+			SELECT az_resource_id, project_id, SUM(amount) as amount
+			FROM project_commitments pc
+			JOIN projects p 
+			ON pc.project_id = p.id
+			WHERE {{az_resource_id = ANY($az_resource_id)}}
+			AND {{p.domain_id = ANY($domain_id)}}
+			AND status = {{liquid.CommitmentStatusConfirmed}}
+			GROUP BY az_resource_id, project_id
+		),
+	}}
+	domain_sums AS (
+		SELECT pazr.az_resource_id, domain_id,
+		$with_commitment_stats{{
+			SUM(COALESCE(pcpsc.amount, 0)) as committed_confirmed,
+			SUM(GREATEST(COALESCE(pcpsc.AMOUNT-pazr.usage, 0), 0)) AS committed_confirmed_unutilized,
+		}}
+		SUM(pazr.usage) as usage,
+		SUM(pazr.physical_usage) as physical_usage
+		FROM project_az_resources pazr
+		JOIN projects p 
+		ON pazr.project_id = p.id
+		$with_commitment_stats{{
+			LEFT JOIN project_commitment_project_sums_confirmed pcpsc
+			ON pcpsc.project_id = pazr.project_id AND pcpsc.az_resource_id = pazr.az_resource_id
+		}}
+		WHERE {{pazr.az_resource_id = ANY($az_resource_id)}}
+		AND {{p.domain_id = ANY($domain_id)}}
+		GROUP BY pazr.az_resource_id, domain_id
+	)
+	SELECT 
+		d.uuid, d.name, azr.id, ds.usage,
+		$with_commitment_stats{{
+			COALESCE(pcds.committed, '{}') as committed,
+			ds.committed_confirmed_unutilized,
+			ds.usage - (ds.committed_confirmed - ds.committed_confirmed_unutilized) as usage_uncommitted, 
+		}}
+		ds.physical_usage
+	FROM services s
+	JOIN resources r ON r.service_id = s.id
+	JOIN az_resources azr ON azr.resource_id = r.id
+	JOIN domain_sums ds ON ds.az_resource_id = azr.id
+	JOIN domains d ON d.id = ds.domain_id
+	$with_commitment_stats{{
+		LEFT JOIN project_commitment_domain_sums pcds ON pcds.az_resource_id = azr.id AND pcds.domain_id = ds.domain_id
+	}}
+	WHERE azr.az != {{liquid.AvailabilityZoneTotal}}
+`))
+
+// GetDomainResources returns a resourcesv2.DomainGetResponse.
+func GetDomainResources(cluster *core.Cluster, token *gopherpolicy.Token, filter Filter, opts common.DomainResourceReportOpts, scope Scope, timeNow time.Time) (resourcesv2.DomainGetResponse, error) {
+	result := &resourcesv2.DomainGetResponse{}
+
+	// fill info report
+	if opts.WithInfo {
+		infoReport, err := GetResourcesInfo(cluster, token, timeNow, filter)
+		if err != nil {
+			return *result, err
+		}
+		result.InfoReport = Some(infoReport)
+	}
+
+	query := EvalDomainResourceExtraProps(domainResourceReportQuery, opts)
+	query, args := filter.ExpandServiceFilters(query)
+	query, args = scope.ExpandScopeFilters(query, args...)
+	err := sqlext.ForeachRow(cluster.DB, query, args, func(rows *sql.Rows) error {
+		var (
+			domainUUID                   string
+			domainName                   string
+			azResourceID                 db.AZResourceID
+			usage                        uint64
+			committedJSON                string
+			committedConfirmedUnutilized Option[uint64]
+			usageUncommitted             Option[uint64]
+			physicalUsage                Option[uint64]
+		)
+		columns := []any{&domainUUID, &domainName, &azResourceID, &usage}
+		if opts.WithCommitmentStats {
+			columns = append(columns, &committedJSON, &committedConfirmedUnutilized, &usageUncommitted)
+		}
+		columns = append(columns, &physicalUsage)
+		err := rows.Scan(columns...)
+		if err != nil {
+			return err
+		}
+
+		// do some computations on the resulting values
+		azResource, aExists := filter.GetAZResourceForID(azResourceID)
+		if !aExists {
+			// defense in depth: an az_resource was deleted in between, so we ignore the data
+			return nil
+		}
+		var committed map[liquid.CommitmentStatus]map[limesresources.CommitmentDuration]uint64
+		if opts.WithCommitmentStats {
+			// cancel out committed values when no commitments are configured for this resource in all projects
+			// the database cannot do this, because it does not know the allowed configurations
+			commitmentBehavior := cluster.CommitmentBehaviorForResource(azResource.Path.ServiceType, azResource.Path.ResourceName)
+			if len(commitmentBehavior.ForDomain(domainName).Durations) != 0 {
+				err = json.Unmarshal([]byte(committedJSON), &committed)
+				if err != nil {
+					return err
+				}
+			} else {
+				usageUncommitted = None[uint64]()
+				committedConfirmedUnutilized = None[uint64]()
+			}
+		}
+
+		setInDomainResourceReport(filter, cluster, result, azResourceID, common.DomainMetadata{
+			UUID: domainUUID,
+			Name: domainName,
+		}, resourcesv2.DomainAvailabilityZoneReport{
+			Usage:                        usage,
+			Committed:                    committed,
+			CommittedConfirmedUnutilized: committedConfirmedUnutilized,
+			UsageUncommitted:             usageUncommitted,
+			PhysicalUsage:                physicalUsage,
+		})
+		return nil
+	})
+
+	if err != nil {
+		return *result, err
+	}
+	return *result, nil
+}
+
+// setInDomainResourceReport creates or iterates higher level structs on the way to the nested
+// location of the db.AZResourceID in the report and assigns the value for resourcesv2.DomainAvailabilityZoneReport.
+func setInDomainResourceReport(filter Filter, cluster *core.Cluster, report *resourcesv2.DomainGetResponse, azResourceID db.AZResourceID, domain common.DomainMetadata, value resourcesv2.DomainAvailabilityZoneReport) {
+	azResource, aExists := filter.GetAZResourceForID(azResourceID)
+	if !aExists {
+		// defense in depth: a rate was deleted in between, so we ignore the data
+		return
+	}
+	// cannot be missing due to referential integrity
+	resource := must.BeOK(filter.GetResourceForID(azResource.ResourceID))
+	service := must.BeOK(filter.GetServiceForID(resource.ServiceID))
+
+	config := cluster.Config.Liquids[service.Type]
+	area := config.Area
+	// defense in depth: config should be in sync with serviceInfo
+	if area == "" {
+		return
+	}
+
+	// check domain level (might be uninitialized)
+	if report.DomainReports == nil {
+		report.DomainReports = make(map[string]resourcesv2.DomainReport)
+	}
+	if _, exists := report.DomainReports[domain.UUID]; !exists {
+		report.DomainReports[domain.UUID] = resourcesv2.DomainReport{
+			DomainMetadata: domain,
+			Areas:          make(map[string]resourcesv2.DomainAreaReport),
+		}
+	}
+	domainReport := report.DomainReports[domain.UUID]
+
+	// check area level
+	if _, exists := domainReport.Areas[area]; !exists {
+		domainReport.Areas[area] = resourcesv2.DomainAreaReport{Services: make(map[db.ServiceType]resourcesv2.DomainServiceReport)}
+	}
+	areaReport := domainReport.Areas[area]
+
+	// check service level
+	if _, exists := areaReport.Services[service.Type]; !exists {
+		areaReport.Services[service.Type] = resourcesv2.DomainServiceReport{
+			Categories: make(map[liquid.CategoryName]resourcesv2.DomainCategoryReport),
+		}
+	}
+	serviceReport := areaReport.Services[service.Type]
+
+	// check category level
+	category := liquid.CategoryName(service.Type)
+	if categoryID, exists := resource.CategoryID.Unpack(); exists {
+		category = must.BeOK(filter.GetCategoryForID(categoryID)).Name
+	}
+	if _, exists := serviceReport.Categories[category]; !exists {
+		serviceReport.Categories[category] = resourcesv2.DomainCategoryReport{Resources: make(map[liquid.ResourceName]resourcesv2.DomainResourceReport)}
+	}
+	categoryReport := serviceReport.Categories[category]
+
+	// check resource level
+	if _, exists := categoryReport.Resources[resource.Name]; !exists {
+		categoryReport.Resources[resource.Name] = resourcesv2.DomainResourceReport{AvailabilityZones: make(map[limes.AvailabilityZone]resourcesv2.DomainAvailabilityZoneReport)}
+	}
+	azReport := categoryReport.Resources[resource.Name]
+
+	// check AZ level
+	azReport.AvailabilityZones[azResource.AvailabilityZone] = value
+}
 
 var domainRateReportQuery = sqlext.SimplifyWhitespace(`
 	SELECT d.uuid, d.name, pra.rate_id, SUM(pra.usage_as_bigint::BIGINT)::TEXT AS usage_as_bigint

--- a/internal/api/reports_v2/domain.go
+++ b/internal/api/reports_v2/domain.go
@@ -32,11 +32,11 @@ var domainRateReportQuery = sqlext.SimplifyWhitespace(`
 `)
 
 // GetDomainRates returns a ratesv2.DomainGetResponse.
-func GetDomainRates(cluster *core.Cluster, token *gopherpolicy.Token, filter Filter, options common.DomainRateReportOpts, scope Scope) (ratesv2.DomainGetResponse, error) {
+func GetDomainRates(cluster *core.Cluster, token *gopherpolicy.Token, filter Filter, opts common.DomainRateReportOpts, scope Scope) (ratesv2.DomainGetResponse, error) {
 	result := &ratesv2.DomainGetResponse{}
 
 	// fill info report
-	if options.WithInfo {
+	if opts.WithInfo {
 		infoReport, err := GetRatesInfo(cluster, token, filter)
 		if err != nil {
 			return *result, err

--- a/internal/api/reports_v2/extra_props.go
+++ b/internal/api/reports_v2/extra_props.go
@@ -41,6 +41,7 @@ func EvalProjectResourceExtraProps(sql string, opts common.ProjectResourceReport
 		"commitment_stats": opts.WithCommitmentStats,
 		"timing":           opts.WithTiming,
 		"subresources":     opts.WithSubresources,
+		"historical_usage": opts.WithHistoricalUsage,
 	}
 	return handleProps(sql, optSettings)
 }

--- a/internal/api/reports_v2/extra_props.go
+++ b/internal/api/reports_v2/extra_props.go
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package reports_v2
+
+import (
+	"strings"
+
+	"github.com/sapcc/limes/internal/apideclarations/apiv2/common"
+)
+
+// EvalClusterResourceExtraProps can validate common.ClusterResourceReportOpts and
+// remove unchecked options tagged in the following style, named
+// similarly to the opts query string param from the sql string:
+// $with_[opt]{{[optional sql]}}
+// If the option is checked (true), the [optional sql] is retained.
+// If an unknown [opt] is found, the function panics.
+func EvalClusterResourceExtraProps(sql string, opts common.ClusterResourceReportOpts) string {
+	optSettings := map[string]bool{
+		"commitment_stats": opts.WithCommitmentStats,
+		"timing":           opts.WithTiming,
+		"subcapacities":    opts.WithSubcapacities,
+	}
+	return handleProps(sql, optSettings)
+}
+
+// EvalDomainResourceExtraProps works like EvalClusterResourceExtraProps but with
+// common.DomainResourceReportOpts.
+func EvalDomainResourceExtraProps(sql string, opts common.DomainResourceReportOpts) string {
+	optSettings := map[string]bool{
+		"commitment_stats": opts.WithCommitmentStats,
+	}
+	return handleProps(sql, optSettings)
+}
+
+// EvalProjectResourceExtraProps works like EvalClusterResourceExtraProps but with
+// common.ProjectResourceReportOpts.
+func EvalProjectResourceExtraProps(sql string, opts common.ProjectResourceReportOpts) string {
+	optSettings := map[string]bool{
+		"constraints":      opts.WithUserSpecifiedConstraints,
+		"commitment_stats": opts.WithCommitmentStats,
+		"timing":           opts.WithTiming,
+		"subresources":     opts.WithSubresources,
+	}
+	return handleProps(sql, optSettings)
+}
+
+// handleProps is the generic, unexported function which takes an array of
+// optStrings and does the replacement according to the chosen options.
+// It panics when $with_[opt]{{...}} is found in the sql string, but not in the optSettings array.
+// It counts nested {{ and }} to find the correct matching closing delimiter.
+func handleProps(sql string, optSettings map[string]bool) string {
+	for {
+		idx := strings.Index(sql, "$with_")
+		if idx == -1 {
+			return sql
+		}
+		nameEnd := strings.Index(sql[idx:], "{{")
+		optName := sql[idx+len("$with_") : idx+nameEnd]
+		contentStart := idx + nameEnd + 2
+
+		// find matching }} by counting nested braces
+		depth, pos := 1, contentStart
+		for pos < len(sql)-1 && depth > 0 {
+			switch {
+			case sql[pos] == '{' && sql[pos+1] == '{':
+				depth++
+				pos += 2
+			case sql[pos] == '}' && sql[pos+1] == '}':
+				depth--
+				pos += 2
+			default:
+				pos++
+			}
+		}
+
+		checked, ok := optSettings[optName]
+		if !ok {
+			panic("unknown $with_ option: " + optName)
+		}
+		if checked {
+			sql = sql[:idx] + sql[contentStart:pos-2] + sql[pos:]
+		} else {
+			sql = sql[:idx] + sql[pos:]
+		}
+	}
+}

--- a/internal/api/reports_v2/extra_props_test.go
+++ b/internal/api/reports_v2/extra_props_test.go
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package reports_v2
+
+import (
+	"testing"
+
+	"go.xyrillian.de/gg/assert"
+)
+
+func TestHandleProps_AllEnabled(t *testing.T) {
+	input := `SELECT col1, $with_timing{{col2,}} $with_stats{{col3,}} col4 FROM table`
+	opts := map[string]bool{"timing": true, "stats": true}
+	result := handleProps(input, opts)
+	assert.Equal(t, result, `SELECT col1, col2, col3, col4 FROM table`)
+}
+
+func TestHandleProps_AllDisabled(t *testing.T) {
+	input := `SELECT col1, $with_timing{{col2,}} $with_stats{{col3,}} col4 FROM table`
+	opts := map[string]bool{"timing": false, "stats": false}
+	result := handleProps(input, opts)
+	assert.Equal(t, result, `SELECT col1,   col4 FROM table`)
+}
+
+func TestHandleProps_Mixed(t *testing.T) {
+	input := `SELECT col1, $with_timing{{col2,}} $with_stats{{col3,}} col4 FROM table`
+	opts := map[string]bool{"timing": true, "stats": false}
+	result := handleProps(input, opts)
+	assert.Equal(t, result, `SELECT col1, col2,  col4 FROM table`)
+}
+
+func TestHandleProps_NestedBraces(t *testing.T) {
+	input := `WITH $with_commitment_stats{{cte AS (SELECT x FROM t WHERE {{az_resource_id = ANY($az_resource_id)}} GROUP BY x),}} main AS (SELECT 1)`
+	opts := map[string]bool{"commitment_stats": true}
+	result := handleProps(input, opts)
+	assert.Equal(t, result, `WITH cte AS (SELECT x FROM t WHERE {{az_resource_id = ANY($az_resource_id)}} GROUP BY x), main AS (SELECT 1)`)
+}
+
+func TestHandleProps_NestedBracesDisabled(t *testing.T) {
+	input := `WITH $with_commitment_stats{{cte AS (SELECT x FROM t WHERE {{az_resource_id = ANY($az_resource_id)}} GROUP BY x),}} main AS (SELECT 1)`
+	opts := map[string]bool{"commitment_stats": false}
+	result := handleProps(input, opts)
+	assert.Equal(t, result, `WITH  main AS (SELECT 1)`)
+}
+
+func TestHandleProps_MultipleNestedBlocks(t *testing.T) {
+	input := `SELECT $with_a{{col_a,}} $with_b{{col_b, {{inner}},}} col_c FROM $with_a{{table_a JOIN}} table_b`
+	opts := map[string]bool{"a": true, "b": false}
+	result := handleProps(input, opts)
+	assert.Equal(t, result, `SELECT col_a,  col_c FROM table_a JOIN table_b`)
+}
+
+func TestHandleProps_NoMarkers(t *testing.T) {
+	input := `SELECT col1, col2 FROM table`
+	opts := map[string]bool{}
+	result := handleProps(input, opts)
+	assert.Equal(t, result, `SELECT col1, col2 FROM table`)
+}
+
+func TestHandleProps_UnknownOptionPanics(t *testing.T) {
+	input := `SELECT $with_unknown{{col1}} FROM table`
+	opts := map[string]bool{"timing": true}
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic for unknown option, but did not panic")
+		}
+		msg, ok := r.(string)
+		if !ok || msg != "unknown $with_ option: unknown" {
+			t.Fatalf("unexpected panic value: %v", r)
+		}
+	}()
+	handleProps(input, opts)
+}

--- a/internal/api/reports_v2/filter.go
+++ b/internal/api/reports_v2/filter.go
@@ -76,7 +76,7 @@ func FilterFromRateOpts(cluster *core.Cluster, opts common.RateReportOpts) (f Fi
 	return f, nil
 }
 
-var filterReplaceRx = regexp.MustCompile(`{{(.*?) = ANY\(\$(service_id|resource_id|rate_id)\)}}`)
+var filterReplaceRx = regexp.MustCompile(`{{(\S+?) = ANY\(\$(service_id|resource_id|az_resource_id|rate_id)\)}}`)
 
 // ExpandServiceFilters takes an SQL query string with curly-bracketed
 // where-clauses and will replace each one with an arg position and return the
@@ -84,7 +84,7 @@ var filterReplaceRx = regexp.MustCompile(`{{(.*?) = ANY\(\$(service_id|resource_
 // The expressions must be of the form "{{[filter-field] = ANY($[id-field])}}"
 // where filter-field can be a primary key column or a foreign key and id-field
 // is the name of the entity whose ID-column values are used.
-// It supports service_id, resource_id and rate_id.
+// It supports service_id, resource_id, az_resource_id and rate_id.
 // On unknown keywords it will panic.
 func (f Filter) ExpandServiceFilters(originalQuery string, originalArgs ...any) (query string, args []any) {
 	// get current highest index
@@ -113,6 +113,8 @@ func (f Filter) ExpandServiceFilters(originalQuery string, originalArgs ...any) 
 			args = append(args, pq.Array(f.getServiceIDs()))
 		case "resource_id":
 			args = append(args, pq.Array(f.getResourceIDs()))
+		case "az_resource_id":
+			args = append(args, pq.Array(f.getAZResourceIDs()))
 		case "rate_id":
 			args = append(args, pq.Array(f.getRateIDs()))
 		default:
@@ -135,6 +137,17 @@ func (f Filter) getResourceIDs() (ids []db.ResourceID) {
 	for _, resources := range f.GetResources() {
 		for _, resource := range resources {
 			ids = append(ids, resource.ID)
+		}
+	}
+	return ids
+}
+
+func (f Filter) getAZResourceIDs() (ids []db.AZResourceID) {
+	for _, azResources := range f.GetAZResources() {
+		for _, azResourcesByAZ := range azResources {
+			for _, azResource := range azResourcesByAZ {
+				ids = append(ids, azResource.ID)
+			}
 		}
 	}
 	return ids

--- a/internal/api/reports_v2/project.go
+++ b/internal/api/reports_v2/project.go
@@ -5,10 +5,9 @@ package reports_v2
 
 import (
 	"database/sql"
-	"maps"
-	"slices"
 
 	limesrates "github.com/sapcc/go-api-declarations/limes/rates"
+	"github.com/sapcc/go-bits/must"
 	. "go.xyrillian.de/gg/option"
 
 	"github.com/sapcc/go-api-declarations/liquid"
@@ -92,76 +91,70 @@ func GetProjectRates(cluster *core.Cluster, token *gopherpolicy.Token, filter Fi
 // location of the db.RateID in the report and assigns the value for ratesv2.ProjectRateReport.
 // If this rate should not get set because it does not have usage, this is a no-op.
 func setInProjectRateReport(filter Filter, cluster *core.Cluster, report *ratesv2.ProjectGetResponse, rateID db.RateID, project common.ProjectMetadata, value ratesv2.ProjectRateReport) {
-	services := filter.GetServices()
-	categories := filter.GetCategories()
+	rate, rExists := filter.GetRateForID(rateID)
+	if !rExists {
+		// defense in depth: a rate was deleted in between, so we ignore the data
+		return
+	}
+	// cannot be missing due to referential integrity
+	service := must.BeOK(filter.GetServiceForID(rate.ServiceID))
+	if !rate.HasUsage && value.ProjectLimit.IsNone() && value.ProjectWindow.IsNone() {
+		return
+	}
+	// note: the database has a non-null constraint here, so we correct this after the fact
+	if !rate.HasUsage {
+		value.UsageAsBigint = None[string]()
+	}
 
-	for _, serviceType := range slices.Sorted(maps.Keys(services)) {
-		rates, _ := filter.GetRatesForType(serviceType) // can have no resources
-		for _, rateName := range slices.Sorted(maps.Keys(rates)) {
-			rate := rates[rateName]
-			if rate.ID != rateID {
-				continue
-			}
-			if !rate.HasUsage && value.ProjectLimit.IsNone() && value.ProjectWindow.IsNone() {
-				return
-			}
-			// note: the database has a non-null constraint here, so we correct this after the fact
-			if !rate.HasUsage {
-				value.UsageAsBigint = None[string]()
-			}
+	config := cluster.Config.Liquids[service.Type]
+	area := config.Area
+	// defense in depth: config should be in sync with serviceInfo
+	if area == "" {
+		return
+	}
 
-			config := cluster.Config.Liquids[serviceType]
-			area := config.Area
-			// defense in depth: config should be in sync with serviceInfo
-			if area == "" {
-				return
-			}
-
-			// check domain level (might be uninitialized)
-			if report.DomainReports == nil {
-				report.DomainReports = make(map[string]ratesv2.ProjectsByDomainReport)
-			}
-			if _, exists := report.DomainReports[project.DomainInfo.UUID]; !exists {
-				report.DomainReports[project.DomainInfo.UUID] = ratesv2.ProjectsByDomainReport{
-					ProjectReports: make(map[string]ratesv2.ProjectReport),
-				}
-			}
-			domainReport := report.DomainReports[project.DomainInfo.UUID]
-
-			// check project level
-			if _, exists := domainReport.ProjectReports[project.UUID]; !exists {
-				domainReport.ProjectReports[project.UUID] = ratesv2.ProjectReport{
-					ProjectMetadata: project,
-					Areas:           make(map[string]ratesv2.ProjectAreaReport),
-				}
-			}
-			projectReport := domainReport.ProjectReports[project.UUID]
-
-			// check area level
-			if _, exists := projectReport.Areas[area]; !exists {
-				projectReport.Areas[area] = ratesv2.ProjectAreaReport{Services: make(map[db.ServiceType]ratesv2.ProjectServiceReport)}
-			}
-			areaReport := projectReport.Areas[area]
-
-			// check service level
-			if _, exists := areaReport.Services[serviceType]; !exists {
-				areaReport.Services[serviceType] = ratesv2.ProjectServiceReport{Categories: make(map[liquid.CategoryName]ratesv2.ProjectCategoryReport)}
-			}
-			serviceReport := areaReport.Services[serviceType]
-
-			// check category level
-			category := liquid.CategoryName(serviceType)
-			if categoryID, exists := rate.CategoryID.Unpack(); exists {
-				category = categories[categoryID].Name
-			}
-			if _, exists := serviceReport.Categories[category]; !exists {
-				serviceReport.Categories[category] = ratesv2.ProjectCategoryReport{Rates: make(map[liquid.RateName]ratesv2.ProjectRateReport)}
-			}
-			categoryReport := serviceReport.Categories[category]
-
-			// check rate level
-			categoryReport.Rates[rate.Name] = value
-			return
+	// check domain level (might be uninitialized)
+	if report.DomainReports == nil {
+		report.DomainReports = make(map[string]ratesv2.ProjectsByDomainReport)
+	}
+	if _, exists := report.DomainReports[project.DomainInfo.UUID]; !exists {
+		report.DomainReports[project.DomainInfo.UUID] = ratesv2.ProjectsByDomainReport{
+			ProjectReports: make(map[string]ratesv2.ProjectReport),
 		}
 	}
+	domainReport := report.DomainReports[project.DomainInfo.UUID]
+
+	// check project level
+	if _, exists := domainReport.ProjectReports[project.UUID]; !exists {
+		domainReport.ProjectReports[project.UUID] = ratesv2.ProjectReport{
+			ProjectMetadata: project,
+			Areas:           make(map[string]ratesv2.ProjectAreaReport),
+		}
+	}
+	projectReport := domainReport.ProjectReports[project.UUID]
+
+	// check area level
+	if _, exists := projectReport.Areas[area]; !exists {
+		projectReport.Areas[area] = ratesv2.ProjectAreaReport{Services: make(map[db.ServiceType]ratesv2.ProjectServiceReport)}
+	}
+	areaReport := projectReport.Areas[area]
+
+	// check service level
+	if _, exists := areaReport.Services[service.Type]; !exists {
+		areaReport.Services[service.Type] = ratesv2.ProjectServiceReport{Categories: make(map[liquid.CategoryName]ratesv2.ProjectCategoryReport)}
+	}
+	serviceReport := areaReport.Services[service.Type]
+
+	// check category level
+	category := liquid.CategoryName(service.Type)
+	if categoryID, exists := rate.CategoryID.Unpack(); exists {
+		category = must.BeOK(filter.GetCategoryForID(categoryID)).Name
+	}
+	if _, exists := serviceReport.Categories[category]; !exists {
+		serviceReport.Categories[category] = ratesv2.ProjectCategoryReport{Rates: make(map[liquid.RateName]ratesv2.ProjectRateReport)}
+	}
+	categoryReport := serviceReport.Categories[category]
+
+	// check rate level
+	categoryReport.Rates[rate.Name] = value
 }

--- a/internal/api/reports_v2/project.go
+++ b/internal/api/reports_v2/project.go
@@ -83,13 +83,13 @@ var projectResourceReportQuery = sqlext.SimplifyWhitespace(db.ExpandEnumPlacehol
 
 // GetProjectResources returns a resourcesv2.ProjectGetResponse.
 func GetProjectResources(cluster *core.Cluster, token *gopherpolicy.Token, filter Filter, opts common.ProjectResourceReportOpts, scope Scope, timeNow time.Time) (resourcesv2.ProjectGetResponse, error) {
-	result := &resourcesv2.ProjectGetResponse{}
+	var result resourcesv2.ProjectGetResponse
 
 	// fill info report
 	if opts.WithInfo {
 		infoReport, err := GetResourcesInfo(cluster, token, timeNow, filter)
 		if err != nil {
-			return *result, err
+			return result, err
 		}
 		result.InfoReport = Some(infoReport)
 	}
@@ -168,14 +168,14 @@ func GetProjectResources(cluster *core.Cluster, token *gopherpolicy.Token, filte
 			if len(commitmentBehavior.ForDomain(domainName).Durations) != 0 {
 				err = json.Unmarshal([]byte(committedJSON), &committed)
 				if err != nil {
-					return err
+					return fmt.Errorf("while parsing DB commitment stats for %s: %w", azResource.Path, err)
 				}
 			}
 		}
 
 		scrapedAtUnix := options.Map(scrapedAt, util.IntoUnixEncodedTime)
 
-		setInProjectResourceReport(filter, cluster, result, azResourceID, common.ProjectMetadata{
+		setInProjectResourceReport(filter, cluster, &result, azResourceID, common.ProjectMetadata{
 			UUID:       projectUUID,
 			Name:       projectName,
 			ParentUUID: projectParentUUID,
@@ -193,11 +193,7 @@ func GetProjectResources(cluster *core.Cluster, token *gopherpolicy.Token, filte
 		}, scrapedAtUnix, constraints)
 		return nil
 	})
-
-	if err != nil {
-		return *result, err
-	}
-	return *result, nil
+	return result, err
 }
 
 // setInProjectResourceReport creates or iterates higher level structs on the way to the nested
@@ -209,7 +205,7 @@ func setInProjectResourceReport(filter Filter, cluster *core.Cluster, report *re
 
 	azResource, aExists := filter.GetAZResourceForID(azResourceID)
 	if !aExists {
-		// defense in depth: a rate was deleted in between, so we ignore the data
+		// defense in depth: an az_resource was deleted in between, so we ignore the data
 		return
 	}
 	// cannot be missing due to referential integrity
@@ -296,13 +292,13 @@ var projectRateReportQuery = sqlext.SimplifyWhitespace(`
 
 // GetProjectRates returns a ratesv2.ProjectGetResponse.
 func GetProjectRates(cluster *core.Cluster, token *gopherpolicy.Token, filter Filter, opts common.ProjectRateReportOpts, scope Scope) (ratesv2.ProjectGetResponse, error) {
-	result := &ratesv2.ProjectGetResponse{}
+	var result ratesv2.ProjectGetResponse
 
 	// fill info report
 	if opts.WithInfo {
 		infoReport, err := GetRatesInfo(cluster, token, filter)
 		if err != nil {
-			return *result, err
+			return result, err
 		}
 		result.InfoReport = Some(infoReport)
 	}
@@ -327,7 +323,7 @@ func GetProjectRates(cluster *core.Cluster, token *gopherpolicy.Token, filter Fi
 		if err != nil {
 			return err
 		}
-		setInProjectRateReport(filter, cluster, result, rateID, common.ProjectMetadata{
+		setInProjectRateReport(filter, cluster, &result, rateID, common.ProjectMetadata{
 			UUID:       projectUUID,
 			Name:       projectName,
 			ParentUUID: projectParentUUID,
@@ -342,11 +338,7 @@ func GetProjectRates(cluster *core.Cluster, token *gopherpolicy.Token, filter Fi
 		})
 		return nil
 	})
-
-	if err != nil {
-		return *result, err
-	}
-	return *result, nil
+	return result, err
 }
 
 // setInProjectRateReport creates or iterates higher level structs on the way to the nested

--- a/internal/api/reports_v2/project.go
+++ b/internal/api/reports_v2/project.go
@@ -162,14 +162,16 @@ func GetProjectResources(cluster *core.Cluster, token *gopherpolicy.Token, filte
 
 		var committed map[liquid.CommitmentStatus]map[limesresources.CommitmentDuration]uint64
 		if opts.WithCommitmentStats {
-			// cancel out committed values when no commitments are configured for this resource in all projects
-			// the database cannot do this, because it does not know the allowed configurations
+			err = json.Unmarshal([]byte(committedJSON), &committed)
+			if err != nil {
+				return fmt.Errorf("while parsing DB commitment stats for %s: %w", azResource.Path, err)
+			}
+
+			// do not report commitment stats if the resource does not allow new commitments in this domain
+			// (however, if there are pre-existing commitments, report those in the usual way until they all expire or are deleted)
 			commitmentBehavior := cluster.CommitmentBehaviorForResource(azResource.Path.ServiceType, azResource.Path.ResourceName)
-			if len(commitmentBehavior.ForDomain(domainName).Durations) != 0 {
-				err = json.Unmarshal([]byte(committedJSON), &committed)
-				if err != nil {
-					return fmt.Errorf("while parsing DB commitment stats for %s: %w", azResource.Path, err)
-				}
+			if len(commitmentBehavior.ForDomain(domainName).Durations) == 0 && len(committed) == 0 {
+				committed = nil
 			}
 		}
 

--- a/internal/api/reports_v2/project.go
+++ b/internal/api/reports_v2/project.go
@@ -28,8 +28,8 @@ var projectRateReportQuery = sqlext.SimplifyWhitespace(`
 	JOIN domains d
 	ON d.id = p.domain_id
 	WHERE {{pra.rate_id = ANY($rate_id)}}
-	AND {{d.id = $domain_id}}
-	AND {{p.id = $project_id}}
+	AND {{d.id = ANY($domain_id)}}
+	AND {{p.id = ANY($project_id)}}
 `)
 
 // GetProjectRates returns a ratesv2.ProjectGetResponse.

--- a/internal/api/reports_v2/project.go
+++ b/internal/api/reports_v2/project.go
@@ -5,10 +5,16 @@ package reports_v2
 
 import (
 	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
 
+	"github.com/sapcc/go-api-declarations/limes"
 	limesrates "github.com/sapcc/go-api-declarations/limes/rates"
+	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
 	"github.com/sapcc/go-bits/must"
 	. "go.xyrillian.de/gg/option"
+	"go.xyrillian.de/gg/options"
 
 	"github.com/sapcc/go-api-declarations/liquid"
 	"github.com/sapcc/go-bits/gopherpolicy"
@@ -16,9 +22,265 @@ import (
 
 	"github.com/sapcc/limes/internal/apideclarations/apiv2/common"
 	ratesv2 "github.com/sapcc/limes/internal/apideclarations/apiv2/rates"
+	resourcesv2 "github.com/sapcc/limes/internal/apideclarations/apiv2/resources"
 	"github.com/sapcc/limes/internal/core"
 	"github.com/sapcc/limes/internal/db"
+	"github.com/sapcc/limes/internal/util"
 )
+
+var projectResourceReportQuery = sqlext.SimplifyWhitespace(db.ExpandEnumPlaceholders(`
+	$with_commitment_stats{{
+		WITH
+		project_commitment_project_sums AS (
+			SELECT az_resource_id, project_id,
+		  	json_object_agg(status, by_status) AS committed
+			FROM (
+		  		SELECT az_resource_id, project_id, status,
+				json_object_agg(duration, total_amount) AS by_status
+				FROM (
+					SELECT az_resource_id, project_id, status, duration, SUM(amount) AS total_amount
+					FROM project_commitments pc
+					JOIN projects p
+					ON pc.project_id = p.id
+					WHERE {{az_resource_id = ANY($az_resource_id)}}
+					AND {{p.domain_id = ANY($domain_id)}}
+					AND {{p.id = ANY($project_id)}}
+					AND status NOT IN ({{liquid.CommitmentStatusSuperseded}}, {{liquid.CommitmentStatusExpired}}, {{util.CommitmentStatusDeleted}})
+					GROUP BY az_resource_id, project_id, status, duration
+		 		) inner_agg
+		  		GROUP BY az_resource_id, project_id, status
+			) outer_agg
+			GROUP BY az_resource_id, project_id
+		)
+	}}
+	SELECT 
+		d.uuid, d.name, p.uuid, p.name, p.parent_uuid, azr.id, pazr.usage, pazr.quota,
+		$with_timing{{ps.scraped_at,}}
+		$with_commitment_stats{{COALESCE(pcps.committed, '{}') as committed,}}
+		$with_historical_usage{{pazr.historical_usage,}}
+		$with_subresources{{pazr.subresources,}}
+		$with_constraints{{pr.forbid_autogrowth, pr.max_quota_from_outside_admin,}}
+		pazr.physical_usage
+	FROM services s
+	JOIN resources r ON r.service_id = s.id
+	JOIN az_resources azr ON azr.resource_id = r.id
+	JOIN project_az_resources pazr ON pazr.az_resource_id = azr.id
+	$with_constraints{{
+		JOIN project_resources pr ON pr.resource_id = r.id AND pazr.project_id = pr.project_id
+	}}
+	$with_timing{{
+		JOIN project_services ps ON ps.service_id = s.id AND pazr.project_id = ps.project_id
+	}}
+	JOIN projects p ON p.id = pazr.project_id
+	JOIN domains d ON d.id = p.domain_id
+	$with_commitment_stats{{
+		LEFT JOIN project_commitment_project_sums pcps ON pcps.az_resource_id = azr.id AND pcps.project_id = p.id
+	}}
+	WHERE {{d.id = ANY($domain_id)}}
+	AND {{p.id = ANY($project_id)}}
+	AND azr.az != {{liquid.AvailabilityZoneTotal}}
+`))
+
+// GetProjectResources returns a resourcesv2.ProjectGetResponse.
+func GetProjectResources(cluster *core.Cluster, token *gopherpolicy.Token, filter Filter, opts common.ProjectResourceReportOpts, scope Scope, timeNow time.Time) (resourcesv2.ProjectGetResponse, error) {
+	result := &resourcesv2.ProjectGetResponse{}
+
+	// fill info report
+	if opts.WithInfo {
+		infoReport, err := GetResourcesInfo(cluster, token, timeNow, filter)
+		if err != nil {
+			return *result, err
+		}
+		result.InfoReport = Some(infoReport)
+	}
+
+	query := EvalProjectResourceExtraProps(projectResourceReportQuery, opts)
+	query, args := filter.ExpandServiceFilters(query)
+	query, args = scope.ExpandScopeFilters(query, args...)
+	err := sqlext.ForeachRow(cluster.DB, query, args, func(rows *sql.Rows) error {
+		var (
+			domainUUID          string
+			domainName          string
+			projectUUID         string
+			projectName         string
+			projectParentUUID   string
+			azResourceID        db.AZResourceID
+			usage               uint64
+			quota               Option[uint64]
+			scrapedAt           Option[time.Time]
+			committedJSON       string
+			historicalUsageJSON string
+			subresources        string
+			constraints         struct {
+				forbidAutogrowth         Option[bool]
+				maxQuotaFromOutsideAdmin Option[uint64]
+			}
+			physicalUsage Option[uint64]
+		)
+		columns := []any{&domainUUID, &domainName, &projectUUID, &projectName, &projectParentUUID, &azResourceID, &usage, &quota}
+		if opts.WithTiming {
+			columns = append(columns, &scrapedAt)
+		}
+		if opts.WithCommitmentStats {
+			columns = append(columns, &committedJSON)
+		}
+		if opts.WithHistoricalUsage {
+			columns = append(columns, &historicalUsageJSON)
+		}
+		if opts.WithSubresources {
+			columns = append(columns, &subresources)
+		}
+		if opts.WithUserSpecifiedConstraints {
+			columns = append(columns, &constraints.forbidAutogrowth, &constraints.maxQuotaFromOutsideAdmin)
+		}
+		columns = append(columns, &physicalUsage)
+		err := rows.Scan(columns...)
+		if err != nil {
+			return err
+		}
+
+		// do some computations on the resulting values
+		azResource, aExists := filter.GetAZResourceForID(azResourceID)
+		if !aExists {
+			// defense in depth: an az_resource was deleted in between, so we ignore the data
+			return nil
+		}
+		historicalUsage := None[resourcesv2.ProjectHistoricalReport]()
+		quotaDistConfig := cluster.QuotaDistributionConfigForResource(azResource.Path.ServiceType, azResource.Path.ResourceName)
+		if opts.WithHistoricalUsage && quotaDistConfig.Model == limesresources.AutogrowQuotaDistribution {
+			autogrowConfig := must.BeOK(quotaDistConfig.Autogrow.Unpack()) // safe because model=autogrow
+			ts, err := util.ParseTimeSeries[uint64](historicalUsageJSON)
+			if err != nil {
+				return fmt.Errorf("while parsing historical_usage for project %s: %w", projectName, err)
+			}
+			historicalUsage = Some(resourcesv2.ProjectHistoricalReport{
+				MinUsage: ts.MinOr(0),
+				MaxUsage: ts.MaxOr(0),
+				Duration: limesrates.Window(max(autogrowConfig.UsageDataRetentionPeriod.Into(), 0)),
+			})
+		}
+
+		var committed map[liquid.CommitmentStatus]map[limesresources.CommitmentDuration]uint64
+		if opts.WithCommitmentStats {
+			// cancel out committed values when no commitments are configured for this resource in all projects
+			// the database cannot do this, because it does not know the allowed configurations
+			commitmentBehavior := cluster.CommitmentBehaviorForResource(azResource.Path.ServiceType, azResource.Path.ResourceName)
+			if len(commitmentBehavior.ForDomain(domainName).Durations) != 0 {
+				err = json.Unmarshal([]byte(committedJSON), &committed)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		scrapedAtUnix := options.Map(scrapedAt, util.IntoUnixEncodedTime)
+
+		setInProjectResourceReport(filter, cluster, result, azResourceID, common.ProjectMetadata{
+			UUID:       projectUUID,
+			Name:       projectName,
+			ParentUUID: projectParentUUID,
+			DomainInfo: common.DomainMetadata{
+				UUID: domainUUID,
+				Name: domainName,
+			},
+		}, resourcesv2.ProjectAvailabilityZoneReport{
+			Usage:           usage,
+			Quota:           quota,
+			Committed:       committed,
+			PhysicalUsage:   physicalUsage,
+			HistoricalUsage: historicalUsage,
+			Subresources:    json.RawMessage(subresources),
+		}, scrapedAtUnix, constraints)
+		return nil
+	})
+
+	if err != nil {
+		return *result, err
+	}
+	return *result, nil
+}
+
+// setInProjectResourceReport creates or iterates higher level structs on the way to the nested
+// location of the db.AZResourceID in the report and assigns the value for resourcesv2.ProjectAvailabilityZoneReport.
+func setInProjectResourceReport(filter Filter, cluster *core.Cluster, report *resourcesv2.ProjectGetResponse, azResourceID db.AZResourceID, project common.ProjectMetadata, value resourcesv2.ProjectAvailabilityZoneReport, scrapedAt Option[limes.UnixEncodedTime], constraints struct {
+	forbidAutogrowth         Option[bool]
+	maxQuotaFromOutsideAdmin Option[uint64]
+}) {
+
+	azResource, aExists := filter.GetAZResourceForID(azResourceID)
+	if !aExists {
+		// defense in depth: a rate was deleted in between, so we ignore the data
+		return
+	}
+	// cannot be missing due to referential integrity
+	resource := must.BeOK(filter.GetResourceForID(azResource.ResourceID))
+	service := must.BeOK(filter.GetServiceForID(resource.ServiceID))
+
+	config := cluster.Config.Liquids[service.Type]
+	area := config.Area
+	// defense in depth: config should be in sync with serviceInfo
+	if area == "" {
+		return
+	}
+
+	// check domain level (might be uninitialized)
+	if report.DomainReports == nil {
+		report.DomainReports = make(map[string]resourcesv2.ProjectsByDomainReport)
+	}
+	if _, exists := report.DomainReports[project.DomainInfo.UUID]; !exists {
+		report.DomainReports[project.DomainInfo.UUID] = resourcesv2.ProjectsByDomainReport{
+			ProjectReports: make(map[string]resourcesv2.ProjectReport),
+		}
+	}
+	domainReport := report.DomainReports[project.DomainInfo.UUID]
+
+	// check project level
+	if _, exists := domainReport.ProjectReports[project.UUID]; !exists {
+		domainReport.ProjectReports[project.UUID] = resourcesv2.ProjectReport{
+			ProjectMetadata: project,
+			Areas:           make(map[string]resourcesv2.ProjectAreaReport),
+		}
+	}
+	projectReport := domainReport.ProjectReports[project.UUID]
+
+	// check area level
+	if _, exists := projectReport.Areas[area]; !exists {
+		projectReport.Areas[area] = resourcesv2.ProjectAreaReport{Services: make(map[db.ServiceType]resourcesv2.ProjectServiceReport)}
+	}
+	areaReport := projectReport.Areas[area]
+
+	// check service level
+	if _, exists := areaReport.Services[service.Type]; !exists {
+		areaReport.Services[service.Type] = resourcesv2.ProjectServiceReport{
+			ScrapedAt:  scrapedAt,
+			Categories: make(map[liquid.CategoryName]resourcesv2.ProjectCategoryReport),
+		}
+	}
+	serviceReport := areaReport.Services[service.Type]
+
+	// check category level
+	category := liquid.CategoryName(service.Type)
+	if categoryID, exists := resource.CategoryID.Unpack(); exists {
+		category = must.BeOK(filter.GetCategoryForID(categoryID)).Name
+	}
+	if _, exists := serviceReport.Categories[category]; !exists {
+		serviceReport.Categories[category] = resourcesv2.ProjectCategoryReport{Resources: make(map[liquid.ResourceName]resourcesv2.ProjectResourceReport)}
+	}
+	categoryReport := serviceReport.Categories[category]
+
+	// check resource level
+	if _, exists := categoryReport.Resources[resource.Name]; !exists {
+		categoryReport.Resources[resource.Name] = resourcesv2.ProjectResourceReport{
+			AvailabilityZones: make(map[limes.AvailabilityZone]resourcesv2.ProjectAvailabilityZoneReport),
+			MaxQuota:          constraints.maxQuotaFromOutsideAdmin,
+			ForbidAutogrowth:  constraints.forbidAutogrowth,
+		}
+	}
+	azReport := categoryReport.Resources[resource.Name]
+
+	// check AZ level
+	azReport.AvailabilityZones[azResource.AvailabilityZone] = value
+}
 
 var projectRateReportQuery = sqlext.SimplifyWhitespace(`
 	SELECT d.uuid, d.name, p.uuid, p.name, p.parent_uuid, pra.rate_id, pra.usage_as_bigint, pra.rate_limit, pra.window_ns

--- a/internal/api/reports_v2/project.go
+++ b/internal/api/reports_v2/project.go
@@ -33,11 +33,11 @@ var projectRateReportQuery = sqlext.SimplifyWhitespace(`
 `)
 
 // GetProjectRates returns a ratesv2.ProjectGetResponse.
-func GetProjectRates(cluster *core.Cluster, token *gopherpolicy.Token, filter Filter, options common.ProjectRateReportOpts, scope Scope) (ratesv2.ProjectGetResponse, error) {
+func GetProjectRates(cluster *core.Cluster, token *gopherpolicy.Token, filter Filter, opts common.ProjectRateReportOpts, scope Scope) (ratesv2.ProjectGetResponse, error) {
 	result := &ratesv2.ProjectGetResponse{}
 
 	// fill info report
-	if options.WithInfo {
+	if opts.WithInfo {
 		infoReport, err := GetRatesInfo(cluster, token, filter)
 		if err != nil {
 			return *result, err

--- a/internal/api/reports_v2/scope.go
+++ b/internal/api/reports_v2/scope.go
@@ -110,7 +110,7 @@ func NewScope(forProject bool, r *http.Request, queryDomainUUID Option[string], 
 	return s, nil
 }
 
-var scopeFilterReplaceRx = regexp.MustCompile(`{{(.*?) = \$(domain_id|project_id)}}`)
+var scopeFilterReplaceRx = regexp.MustCompile(`{{(\S+?) = \$(domain_id|project_id)}}`)
 
 // ExpandScopeFilters takes an SQL query string with curly-bracketed
 // where-clauses and will replace each one with an arg position and return the

--- a/internal/api/reports_v2/scope.go
+++ b/internal/api/reports_v2/scope.go
@@ -110,7 +110,7 @@ func NewScope(forProject bool, r *http.Request, queryDomainUUID Option[string], 
 	return s, nil
 }
 
-var scopeFilterReplaceRx = regexp.MustCompile(`{{(\S+?) = \$(domain_id|project_id)}}`)
+var scopeFilterReplaceRx = regexp.MustCompile(`{{(\S+?) = ANY\(\$(domain_id|project_id)\)}}`)
 
 // ExpandScopeFilters takes an SQL query string with curly-bracketed
 // where-clauses and will replace each one with an arg position and return the

--- a/internal/api/reports_v2/scope_test.go
+++ b/internal/api/reports_v2/scope_test.go
@@ -216,7 +216,7 @@ func TestV2ExpandScopeFilters(t *testing.T) {
 	// empty scope: all placeholders become TRUE = TRUE
 	emptyScope := reports_v2.Scope{}
 	query, args := emptyScope.ExpandScopeFilters(
-		`SELECT * FROM t WHERE {{d.id = $domain_id}} AND {{p.id = $project_id}}`,
+		`SELECT * FROM t WHERE {{d.id = ANY($domain_id)}} AND {{p.id = ANY($project_id)}}`,
 	)
 	assert.Equal(t, query, `SELECT * FROM t WHERE TRUE = TRUE AND TRUE = TRUE`)
 	assert.Equal(t, len(args), 0)
@@ -226,7 +226,7 @@ func TestV2ExpandScopeFilters(t *testing.T) {
 		Domain: Some(domainFrance),
 	}
 	query, args = domainScope.ExpandScopeFilters(
-		`SELECT * FROM t WHERE {{d.id = $domain_id}} AND {{p.id = $project_id}}`,
+		`SELECT * FROM t WHERE {{d.id = ANY($domain_id)}} AND {{p.id = ANY($project_id)}}`,
 	)
 	assert.Equal(t, query, `SELECT * FROM t WHERE d.id = $1 AND TRUE = TRUE`)
 	assert.Equal(t, len(args), 1)
@@ -238,7 +238,7 @@ func TestV2ExpandScopeFilters(t *testing.T) {
 		Project: Some(projectParis),
 	}
 	query, args = projectScope.ExpandScopeFilters(
-		`SELECT * FROM t WHERE {{d.id = $domain_id}} AND {{p.id = $project_id}}`,
+		`SELECT * FROM t WHERE {{d.id = ANY($domain_id)}} AND {{p.id = ANY($project_id)}}`,
 	)
 	assert.Equal(t, query, `SELECT * FROM t WHERE d.id = $1 AND p.id = $2`)
 	assert.Equal(t, len(args), 2)
@@ -247,7 +247,7 @@ func TestV2ExpandScopeFilters(t *testing.T) {
 
 	// with pre-existing args: arg positions continue from the highest existing index
 	query, args = projectScope.ExpandScopeFilters(
-		`SELECT * FROM t WHERE t.name = $14 AND {{d.id = $domain_id}} AND {{p.id = $project_id}}`,
+		`SELECT * FROM t WHERE t.name = $14 AND {{d.id = ANY($domain_id)}} AND {{p.id = ANY($project_id)}}`,
 		"some-value",
 	)
 	assert.Equal(t, query, `SELECT * FROM t WHERE t.name = $14 AND d.id = $15 AND p.id = $16`)
@@ -258,7 +258,7 @@ func TestV2ExpandScopeFilters(t *testing.T) {
 
 	// only project_id placeholder in query with project scope
 	query, args = projectScope.ExpandScopeFilters(
-		`SELECT * FROM t WHERE {{p.id = $project_id}}`,
+		`SELECT * FROM t WHERE {{p.id = ANY($project_id)}}`,
 	)
 	assert.Equal(t, query, `SELECT * FROM t WHERE p.id = $1`)
 	assert.Equal(t, len(args), 1)

--- a/internal/apideclarations/apiv2/common/opts.go
+++ b/internal/apideclarations/apiv2/common/opts.go
@@ -4,8 +4,6 @@
 package common
 
 import (
-	"time"
-
 	"github.com/sapcc/go-api-declarations/liquid"
 	. "go.xyrillian.de/gg/option"
 
@@ -32,13 +30,8 @@ type ResourceReportOpts struct {
 	GenericReportOpts
 	// ResourceName filters resources by name
 	ResourceName Option[liquid.ResourceName] `q:"resource"`
-	// WithUserSpecifiedConstraints enriches the response with MaxQuota and ForbidAutogrowth values
-	WithUserSpecifiedConstraints bool `q:"with,value:constraints"`
 	// WithCommitmentStats enriches the response with Committed values
 	WithCommitmentStats bool `q:"with,value:commitment_stats"`
-	// MinScrapedAt and MaxScrapedAt allow to filter services by their latest successful scrape time
-	MinScrapedAt Option[time.Time] `q:"min_scraped_at"`
-	MaxScrapedAt Option[time.Time] `q:"max_scraped_at"`
 }
 
 // ClusterResourceReportOpts contains query parameter options for cluster
@@ -61,6 +54,8 @@ type DomainResourceReportOpts struct {
 // resource reports.
 type ProjectResourceReportOpts struct {
 	ResourceReportOpts
+	// WithUserSpecifiedConstraints enriches the response with MaxQuota and ForbidAutogrowth values
+	WithUserSpecifiedConstraints bool `q:"with,value:constraints"`
 	// WithTiming enriches the response with ScrapedAt values which is only allowed for users with certain permissions
 	WithTiming bool `q:"with,value:timing"`
 	// WithSubresources enriches the response with Subresources values which is only allowed for users with certain permissions

--- a/internal/apideclarations/apiv2/common/opts.go
+++ b/internal/apideclarations/apiv2/common/opts.go
@@ -40,7 +40,7 @@ type ClusterResourceReportOpts struct {
 	ResourceReportOpts
 	// WithTiming enriches the response with ScrapedAt values
 	WithTiming bool `q:"with,value:timing"`
-	// WithSubcapacities enriches the response with Subcapacities values which is only allowed for users with certain permissions
+	// WithSubcapacities enriches the response with Subcapacities values
 	WithSubcapacities bool `q:"with,value:subcapacities"`
 }
 
@@ -60,6 +60,8 @@ type ProjectResourceReportOpts struct {
 	WithTiming bool `q:"with,value:timing"`
 	// WithSubresources enriches the response with Subresources values which is only allowed for users with certain permissions
 	WithSubresources bool `q:"with,value:subresources"`
+	// WithHistoricalUsage enriches the response with HistoricalUsage values which is only allowed for users with certain permissions
+	WithHistoricalUsage bool `q:"with,value:historical_usage"`
 	// DomainUUID is a special entity filter which is only allowed for users with certain permissions
 	DomainUUID Option[string] `q:"domain_uuid"`
 }

--- a/internal/apideclarations/apiv2/resources/cluster.go
+++ b/internal/apideclarations/apiv2/resources/cluster.go
@@ -74,16 +74,20 @@ type ClusterAvailabilityZoneReport struct {
 	// Usage is the sum of the usages across all projects as reported by the service.
 	Usage uint64 `json:"usage"`
 	// Committed is the sum of committed amounts across all projects grouped by their Status and then CommitmentDuration.
+	// It is populated sparsely, so that only status and durations which exist will appear .
+	// It is only returned when the resource supports commitments.
 	// It is only returned when the respective query option with=commitment_stats is set.
 	Committed map[liquid.CommitmentStatus]map[limesresources.CommitmentDuration]uint64 `json:"committed,omitempty"`
 	// CommittedConfirmedUnutilized is the sum of CommittedConfirmed - Usage for each project in this cluster.
 	// If computed as sum of CommittedConfirmed - sum of Usage, the result is semantically wrong (commitments cannot cover other projects).
+	// It is only returned when the resource supports commitments.
 	// It is only returned when the respective query option with=commitment_stats is set.
 	CommittedConfirmedUnutilized Option[uint64] `json:"committed_confirmed_unutilized,omitzero"`
-	// UncommittedUsage can also be derived as sum of Usage - (Committed.Values().Sum() - CommittedConfirmedUnutilized).
+	// UsageUncommitted can also be derived as sum of Usage - (Committed.Values().Sum() - CommittedConfirmedUnutilized).
 	// so this is only reported for convenience purposes.
+	// It is only returned when the resource supports commitments.
 	// It is only returned when the respective query option with=commitment_stats is set.
-	UncommittedUsage Option[uint64] `json:"uncommitted_usage,omitzero"`
+	UsageUncommitted Option[uint64] `json:"usage_uncommitted,omitzero"`
 	// PhysicalUsage is collected per project and then summed, same as Usage.
 	PhysicalUsage Option[uint64] `json:"physical_usage,omitzero"`
 	// Subcapacities is formatted as json.RawMessage for convenience for reading from the database.

--- a/internal/apideclarations/apiv2/resources/domain.go
+++ b/internal/apideclarations/apiv2/resources/domain.go
@@ -63,16 +63,20 @@ type DomainAvailabilityZoneReport struct {
 	// Usage is the sum of the usages across projects in this domain as reported by the service.
 	Usage uint64 `json:"usage"`
 	// Committed is the sum of committed amounts across projects in this domain grouped by their Status and then CommitmentDuration.
+	// It is populated sparsely, so that only status and durations which exist will appear.
+	// It is only returned when the resource supports commitments.
 	// It is only returned when the respective query option with=commitment_stats is set.
 	Committed map[liquid.CommitmentStatus]map[limesresources.CommitmentDuration]uint64 `json:"committed,omitempty"`
 	// CommittedConfirmedUnutilized is the sum of CommittedConfirmed - Usage for each project in this domain.
 	// If computed as sum of CommittedConfirmed - sum of Usage, the result is semantically wrong (commitments cannot cover other projects).
+	// It is only returned when the resource supports commitments.
 	// It is only returned when the respective query option with=commitment_stats is set.
 	CommittedConfirmedUnutilized Option[uint64] `json:"committed_confirmed_unutilized,omitzero"`
-	// UncommittedUsage can also be derived as sum of Usage - (Committed.Values().Sum() - CommittedConfirmedUnutilized).
+	// UsageUncommitted can also be derived as sum of Usage - (Committed.Values().Sum() - CommittedConfirmedUnutilized).
 	// so this is only reported for convenience purposes.
+	// It is only returned when the resource supports commitments.
 	// It is only returned when the respective query option with=commitment_stats is set.
-	UncommittedUsage Option[uint64] `json:"uncommitted_usage,omitzero"`
+	UsageUncommitted Option[uint64] `json:"usage_uncommitted,omitzero"`
 	// PhysicalUsage is collected per project and then summed, same as Usage.
 	PhysicalUsage Option[uint64] `json:"physical_usage,omitzero"`
 }

--- a/internal/apideclarations/apiv2/resources/project.go
+++ b/internal/apideclarations/apiv2/resources/project.go
@@ -92,6 +92,7 @@ type ProjectAvailabilityZoneReport struct {
 	PhysicalUsage Option[uint64] `json:"physical_usage,omitzero"`
 	// HistoricalUsage are the statistics on which the automatic quota distribution is based on.
 	// It is only returned when automatic quota distribution is configured for this resource.
+	// It is only returned when the respective query option with=historical_usage is set.
 	HistoricalUsage Option[ProjectHistoricalReport] `json:"historical_usage,omitzero"`
 	// Subresources is formatted as json.RawMessage for convenience for reading from the database.
 	// The content will be a marshalled []liquid.Subresource.

--- a/internal/apideclarations/apiv2/resources/project.go
+++ b/internal/apideclarations/apiv2/resources/project.go
@@ -84,6 +84,7 @@ type ProjectAvailabilityZoneReport struct {
 	// It is only returned when the resource has quota.
 	Quota Option[uint64] `json:"quota,omitzero"`
 	// Committed is the sum of committed amounts grouped by their Status and then CommitmentDuration.
+	// It is populated sparsely, so that only status and durations which exist will appear.
 	// It is only returned when the respective query option with=commitment_stats is set.
 	Committed map[liquid.CommitmentStatus]map[limesresources.CommitmentDuration]uint64 `json:"committed,omitempty"`
 	// PhysicalUsage is usage of physical hardware resources which results from the Usage.

--- a/internal/core/service_info_cache.go
+++ b/internal/core/service_info_cache.go
@@ -51,12 +51,16 @@ type ServiceInfoReader interface {
 	GetServices() map[db.ServiceType]db.Service
 	// GetServiceForType returns the service for the given service type.
 	GetServiceForType(serviceType db.ServiceType) (db.Service, bool)
+	// GetServiceForID returns the service for the given service ID.
+	GetServiceForID(id db.ServiceID) (db.Service, bool)
 	// GetResources returns all resources.
 	GetResources() map[db.ServiceType]map[liquid.ResourceName]db.Resource
 	// GetResourcesForType returns all resources for the given service type.
 	GetResourcesForType(serviceType db.ServiceType) (map[liquid.ResourceName]db.Resource, bool)
 	// GetResourceForPath returns the resource for the given path.
 	GetResourceForPath(path db.ResourcePath) (db.Resource, bool)
+	// GetResourceForID returns the resource for the given resource ID.
+	GetResourceForID(id db.ResourceID) (db.Resource, bool)
 	// GetAZResources returns all AZ resources.
 	GetAZResources() map[db.ServiceType]map[liquid.ResourceName]map[limes.AvailabilityZone]db.AZResource
 	// GetAZResourcesForType returns all AZ resources for the given service type.
@@ -65,12 +69,16 @@ type ServiceInfoReader interface {
 	GetAZResourcesForPath(path db.ResourcePath) (map[limes.AvailabilityZone]db.AZResource, bool)
 	// GetAZResourceForPath returns the AZ resource for the given AZResourcePath.
 	GetAZResourceForPath(path db.AZResourcePath) (db.AZResource, bool)
+	// GetAZResourceForID returns the AZ resource for the given AZ resource ID.
+	GetAZResourceForID(id db.AZResourceID) (db.AZResource, bool)
 	// GetRates returns all rates.
 	GetRates() map[db.ServiceType]map[liquid.RateName]db.Rate
 	// GetRatesForType returns all rates for the given service type.
 	GetRatesForType(serviceType db.ServiceType) (map[liquid.RateName]db.Rate, bool)
 	// GetRateForPath returns the rate for the given service type and rate name.
 	GetRateForPath(path db.RatePath) (db.Rate, bool)
+	// GetRateForID returns the rate for the given rate ID.
+	GetRateForID(id db.RateID) (db.Rate, bool)
 	// GetCategories returns all categories.
 	GetCategories() map[db.CategoryID]db.Category
 	// GetCategoryForID returns the category for the given ID.
@@ -102,6 +110,11 @@ type (
 		azResources azResourcesByAZNameType
 		rates       ratesByNameType
 		categories  categoriesByID
+		// ID-based indexes for O(1) lookup by primary key
+		servicesByID    servicesByIDIndex
+		resourcesByID   resourcesByIDIndex
+		azResourcesByID azResourcesByIDIndex
+		ratesByID       ratesByIDIndex
 		// necessary for constructing filters by area
 		areaMapping map[db.ServiceType]string
 	}
@@ -116,12 +129,31 @@ type (
 	ratesByNameType         = map[db.ServiceType]ratesByName
 	ratesByName             = map[liquid.RateName]db.Rate
 	categoriesByID          = map[db.CategoryID]db.Category
+	servicesByIDIndex       = map[db.ServiceID]db.Service
+	resourcesByIDIndex      = map[db.ResourceID]db.Resource
+	azResourcesByIDIndex    = map[db.AZResourceID]db.AZResource
+	ratesByIDIndex          = map[db.RateID]db.Rate
 )
 
 // removeDataForType removes all data of a given serviceType, making the cache ready
 // for populating this serviceType from scratch. Categories are always flushed
 // completely.
 func (s ServiceInfoSnapshot) removeDataForType(serviceType db.ServiceType) ServiceInfoSnapshot {
+	// remove ID index entries for this service type
+	if svc, ok := s.services[serviceType]; ok {
+		delete(s.servicesByID, svc.ID)
+	}
+	for _, resource := range s.resources[serviceType] {
+		delete(s.resourcesByID, resource.ID)
+	}
+	for _, azResByAZ := range s.azResources[serviceType] {
+		for _, azRes := range azResByAZ {
+			delete(s.azResourcesByID, azRes.ID)
+		}
+	}
+	for _, rate := range s.rates[serviceType] {
+		delete(s.ratesByID, rate.ID)
+	}
 	delete(s.services, serviceType)
 	delete(s.resources, serviceType)
 	delete(s.azResources, serviceType)
@@ -141,9 +173,13 @@ func (s ServiceInfoSnapshot) deepClone() ServiceInfoSnapshot {
 		azResources: deepCloneMap(s.azResources, func(inner azResourcesByAZName) azResourcesByAZName {
 			return deepCloneMap(inner, maps.Clone)
 		}),
-		rates:       deepCloneMap(s.rates, maps.Clone),
-		categories:  maps.Clone(s.categories),
-		areaMapping: s.areaMapping, // should never get modified
+		rates:           deepCloneMap(s.rates, maps.Clone),
+		categories:      maps.Clone(s.categories),
+		servicesByID:    maps.Clone(s.servicesByID),
+		resourcesByID:   maps.Clone(s.resourcesByID),
+		azResourcesByID: maps.Clone(s.azResourcesByID),
+		ratesByID:       maps.Clone(s.ratesByID),
+		areaMapping:     s.areaMapping, // should never get modified
 	}
 }
 
@@ -249,6 +285,33 @@ func (s ServiceInfoSnapshot) Filter(filter ServiceInfoFilter) FilteredServiceInf
 			}
 		}
 	}
+
+	// rebuild ID indexes from the surviving path-based maps
+	f.snapshot.servicesByID = make(servicesByIDIndex, len(f.snapshot.services))
+	for _, svc := range f.snapshot.services {
+		f.snapshot.servicesByID[svc.ID] = svc
+	}
+	f.snapshot.resourcesByID = make(resourcesByIDIndex)
+	for _, resources := range f.snapshot.resources {
+		for _, resource := range resources {
+			f.snapshot.resourcesByID[resource.ID] = resource
+		}
+	}
+	f.snapshot.azResourcesByID = make(azResourcesByIDIndex)
+	for _, azResByAZName := range f.snapshot.azResources {
+		for _, azResByAZ := range azResByAZName {
+			for _, azRes := range azResByAZ {
+				f.snapshot.azResourcesByID[azRes.ID] = azRes
+			}
+		}
+	}
+	f.snapshot.ratesByID = make(ratesByIDIndex, len(f.snapshot.rates))
+	for _, rates := range f.snapshot.rates {
+		for _, rate := range rates {
+			f.snapshot.ratesByID[rate.ID] = rate
+		}
+	}
+
 	return f
 }
 
@@ -260,6 +323,12 @@ func (s ServiceInfoSnapshot) GetServices() servicesByType {
 // GetServiceForType implements the [ServiceInfoReader] interface.
 func (s ServiceInfoSnapshot) GetServiceForType(serviceType db.ServiceType) (db.Service, bool) {
 	val, ok := s.services[serviceType]
+	return val, ok
+}
+
+// GetServiceForID implements the [ServiceInfoReader] interface.
+func (s ServiceInfoSnapshot) GetServiceForID(id db.ServiceID) (db.Service, bool) {
+	val, ok := s.servicesByID[id]
 	return val, ok
 }
 
@@ -277,6 +346,12 @@ func (s ServiceInfoSnapshot) GetResourcesForType(serviceType db.ServiceType) (re
 // GetResourceForPath implements the [ServiceInfoReader] interface.
 func (s ServiceInfoSnapshot) GetResourceForPath(path db.ResourcePath) (db.Resource, bool) {
 	val, ok := s.resources[path.ServiceType][path.ResourceName]
+	return val, ok
+}
+
+// GetResourceForID implements the [ServiceInfoReader] interface.
+func (s ServiceInfoSnapshot) GetResourceForID(id db.ResourceID) (db.Resource, bool) {
+	val, ok := s.resourcesByID[id]
 	return val, ok
 }
 
@@ -305,6 +380,12 @@ func (s ServiceInfoSnapshot) GetAZResourceForPath(path db.AZResourcePath) (db.AZ
 	return val, ok
 }
 
+// GetAZResourceForID implements the [ServiceInfoReader] interface.
+func (s ServiceInfoSnapshot) GetAZResourceForID(id db.AZResourceID) (db.AZResource, bool) {
+	val, ok := s.azResourcesByID[id]
+	return val, ok
+}
+
 // GetRates implements the [ServiceInfoReader] interface.
 func (s ServiceInfoSnapshot) GetRates() ratesByNameType {
 	return deepCloneMap(s.rates, maps.Clone)
@@ -319,6 +400,12 @@ func (s ServiceInfoSnapshot) GetRatesForType(serviceType db.ServiceType) (ratesB
 // GetRateForPath implements the [ServiceInfoReader] interface.
 func (s ServiceInfoSnapshot) GetRateForPath(path db.RatePath) (db.Rate, bool) {
 	val, ok := s.rates[path.ServiceType][path.RateName]
+	return val, ok
+}
+
+// GetRateForID implements the [ServiceInfoReader] interface.
+func (s ServiceInfoSnapshot) GetRateForID(id db.RateID) (db.Rate, bool) {
+	val, ok := s.ratesByID[id]
 	return val, ok
 }
 
@@ -341,12 +428,16 @@ func newEmptyServiceInfoSnapshot(config ClusterConfiguration) ServiceInfoSnapsho
 		areaMapping[serviceType] = liquidConfiguration.Area
 	}
 	return ServiceInfoSnapshot{
-		services:    make(servicesByType),
-		resources:   make(resourcesByNameType),
-		azResources: make(azResourcesByAZNameType),
-		rates:       make(ratesByNameType),
-		categories:  make(categoriesByID),
-		areaMapping: areaMapping,
+		services:        make(servicesByType),
+		resources:       make(resourcesByNameType),
+		azResources:     make(azResourcesByAZNameType),
+		rates:           make(ratesByNameType),
+		categories:      make(categoriesByID),
+		servicesByID:    make(servicesByIDIndex),
+		resourcesByID:   make(resourcesByIDIndex),
+		azResourcesByID: make(azResourcesByIDIndex),
+		ratesByID:       make(ratesByIDIndex),
+		areaMapping:     areaMapping,
 	}
 }
 
@@ -377,6 +468,11 @@ func (f FilteredServiceInfoSnapshot) GetServiceForType(serviceType db.ServiceTyp
 	return f.snapshot.GetServiceForType(serviceType)
 }
 
+// GetServiceForID implements the [ServiceInfoReader] interface.
+func (f FilteredServiceInfoSnapshot) GetServiceForID(id db.ServiceID) (db.Service, bool) {
+	return f.snapshot.GetServiceForID(id)
+}
+
 // GetResources implements the [ServiceInfoReader] interface.
 func (f FilteredServiceInfoSnapshot) GetResources() resourcesByNameType {
 	return f.snapshot.GetResources()
@@ -390,6 +486,11 @@ func (f FilteredServiceInfoSnapshot) GetResourcesForType(serviceType db.ServiceT
 // GetResourceForPath implements the [ServiceInfoReader] interface.
 func (f FilteredServiceInfoSnapshot) GetResourceForPath(path db.ResourcePath) (db.Resource, bool) {
 	return f.snapshot.GetResourceForPath(path)
+}
+
+// GetResourceForID implements the [ServiceInfoReader] interface.
+func (f FilteredServiceInfoSnapshot) GetResourceForID(id db.ResourceID) (db.Resource, bool) {
+	return f.snapshot.GetResourceForID(id)
 }
 
 // GetAZResources implements the [ServiceInfoReader] interface.
@@ -412,6 +513,11 @@ func (f FilteredServiceInfoSnapshot) GetAZResourceForPath(path db.AZResourcePath
 	return f.snapshot.GetAZResourceForPath(path)
 }
 
+// GetAZResourceForID implements the [ServiceInfoReader] interface.
+func (f FilteredServiceInfoSnapshot) GetAZResourceForID(id db.AZResourceID) (db.AZResource, bool) {
+	return f.snapshot.GetAZResourceForID(id)
+}
+
 // GetRates implements the [ServiceInfoReader] interface.
 func (f FilteredServiceInfoSnapshot) GetRates() ratesByNameType {
 	return f.snapshot.GetRates()
@@ -425,6 +531,11 @@ func (f FilteredServiceInfoSnapshot) GetRatesForType(serviceType db.ServiceType)
 // GetRateForPath implements the [ServiceInfoReader] interface.
 func (f FilteredServiceInfoSnapshot) GetRateForPath(path db.RatePath) (db.Rate, bool) {
 	return f.snapshot.GetRateForPath(path)
+}
+
+// GetRateForID implements the [ServiceInfoReader] interface.
+func (f FilteredServiceInfoSnapshot) GetRateForID(id db.RateID) (db.Rate, bool) {
+	return f.snapshot.GetRateForID(id)
 }
 
 // GetCategories implements the [ServiceInfoReader] interface.
@@ -571,6 +682,9 @@ func (s *ServiceInfoCache) InvalidateService(serviceType Option[db.ServiceType])
 		return fmt.Errorf("while reading services for type(s) %v: %w", serviceType, err)
 	}
 	maps.Copy(s.data.services, servicesByType)
+	for _, svc := range servicesByType {
+		s.data.servicesByID[svc.ID] = svc
+	}
 
 	resourcesByPath, err := db.BuildIndexOfDBResult(
 		s.DB,
@@ -586,6 +700,7 @@ func (s *ServiceInfoCache) InvalidateService(serviceType Option[db.ServiceType])
 			s.data.resources[path.ServiceType] = make(resourcesByName)
 		}
 		s.data.resources[path.ServiceType][path.ResourceName] = resource
+		s.data.resourcesByID[resource.ID] = resource
 	}
 
 	azResourcesByPath, err := db.BuildIndexOfDBResult(
@@ -605,6 +720,7 @@ func (s *ServiceInfoCache) InvalidateService(serviceType Option[db.ServiceType])
 			s.data.azResources[path.ServiceType][path.ResourceName] = make(azResourcesByAZ)
 		}
 		s.data.azResources[path.ServiceType][path.ResourceName][path.AvailabilityZone] = azResource
+		s.data.azResourcesByID[azResource.ID] = azResource
 	}
 
 	ratesByPath, err := db.BuildIndexOfDBResult(
@@ -621,6 +737,7 @@ func (s *ServiceInfoCache) InvalidateService(serviceType Option[db.ServiceType])
 			s.data.rates[path.ServiceType] = make(ratesByName)
 		}
 		s.data.rates[path.ServiceType][path.RateName] = rate
+		s.data.ratesByID[rate.ID] = rate
 	}
 
 	s.data.categories, err = db.BuildIndexOfDBResult(

--- a/internal/core/service_info_cache_test.go
+++ b/internal/core/service_info_cache_test.go
@@ -203,3 +203,79 @@ func TestServiceInfoCache(t *testing.T) {
 	sis = s.Cluster.SIC.GetSnapshot()
 	assert.Equal(t, len(must.BeOKT(sis.GetRatesForType("first"))(t)), 3)
 }
+
+func TestServiceInfoCacheGetByID(t *testing.T) {
+	serviceInfoFirst := test.DefaultLiquidServiceInfo("First")
+	serviceInfoFirst.Rates = map[liquid.RateName]liquid.RateInfo{
+		"objects:create": {DisplayName: "Object Creations", Topology: liquid.FlatTopology, HasUsage: true},
+		"objects:delete": {DisplayName: "Object Deletions", Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: true},
+	}
+	serviceInfoFirst.Resources = map[liquid.ResourceName]liquid.ResourceInfo{}
+	serviceInfoFirst.Categories = map[liquid.CategoryName]liquid.CategoryInfo{}
+	s := test.NewSetup(t,
+		test.WithConfig(configJSON),
+		test.WithPersistedServiceInfo("first", serviceInfoFirst),
+		test.WithPersistedServiceInfo("second", test.DefaultLiquidServiceInfo("Second")),
+	)
+	s.Cluster.Connect(s.Ctx, nil, gophercloud.EndpointOpts{}, func(serviceType db.ServiceType) (core.LiquidClient, error) { return nil, nil }, options.FromPointer(easypg.BuildDBURL(t)))
+	t.Cleanup(func() { s.Cluster.SIC.Close() })
+
+	sis := s.Cluster.SIC.GetSnapshot()
+
+	// GetServiceForID
+	firstServiceID := s.GetServiceID("first")
+	svc, ok := sis.GetServiceForID(firstServiceID)
+	assert.Equal(t, ok, true)
+	assert.Equal(t, svc.Type, "first")
+	assert.Equal(t, svc.DisplayName, "First")
+	_, ok = sis.GetServiceForID(99999) // non-existent ID
+	assert.Equal(t, ok, false)
+
+	// GetResourceForID
+	secondCapacityID := s.GetResourceID("second", "capacity")
+	res, ok := sis.GetResourceForID(secondCapacityID)
+	assert.Equal(t, ok, true)
+	assert.Equal(t, res.Name, "capacity")
+	assert.Equal(t, res.DisplayName, "Capacity")
+	_, ok = sis.GetResourceForID(99999) // non-existent ID
+	assert.Equal(t, ok, false)
+
+	// GetAZResourceForID (already tested above but verify via index)
+	secondCapacityAZOne := s.GetAZResourceID("second", "capacity", "az-one")
+	azRes, ok := sis.GetAZResourceForID(secondCapacityAZOne)
+	assert.Equal(t, ok, true)
+	assert.Equal(t, azRes.Path.ServiceType, "second")
+	assert.Equal(t, azRes.Path.ResourceName, "capacity")
+	assert.Equal(t, azRes.Path.AvailabilityZone, "az-one")
+	_, ok = sis.GetAZResourceForID(99999) // non-existent ID
+	assert.Equal(t, ok, false)
+
+	// GetRateForID
+	firstObjectsCreateID := s.GetRateID("first", "objects:create")
+	rate, ok := sis.GetRateForID(firstObjectsCreateID)
+	assert.Equal(t, ok, true)
+	assert.Equal(t, rate.Name, "objects:create")
+	assert.Equal(t, rate.DisplayName, "Object Creations")
+	_, ok = sis.GetRateForID(99999) // non-existent ID
+	assert.Equal(t, ok, false)
+
+	// Verify ID indexes are updated after invalidation
+	s.MustDBExec("UPDATE services SET display_name = 'UpdatedFirst' WHERE id = $1", firstServiceID)
+	<-s.Cluster.SIC.OnInvalidate
+	sis = s.Cluster.SIC.GetSnapshot()
+	svc, ok = sis.GetServiceForID(firstServiceID)
+	assert.Equal(t, ok, true)
+	assert.Equal(t, svc.DisplayName, "UpdatedFirst")
+
+	// Verify FilteredServiceInfoSnapshot also delegates correctly
+	filtered := sis.Filter(core.ServiceInfoFilter{ServiceType: Some[db.ServiceType]("second")})
+	res, ok = filtered.GetResourceForID(secondCapacityID)
+	assert.Equal(t, ok, true)
+	assert.Equal(t, res.Name, "capacity")
+	// rate from "first" service should NOT be accessible when filtered to "second"
+	_, ok = filtered.GetRateForID(firstObjectsCreateID)
+	assert.Equal(t, ok, false)
+	// service "first" should NOT be accessible when filtered to "second"
+	_, ok = filtered.GetServiceForID(firstServiceID)
+	assert.Equal(t, ok, false)
+}

--- a/internal/test/mock_enforcer.go
+++ b/internal/test/mock_enforcer.go
@@ -25,6 +25,10 @@ type PolicyEnforcer struct {
 	AllowReportSingle     bool
 	AllowReportMultiple   bool
 	AllowCommitmentCreate bool
+	// flags for v2 project-level ?with= permissions (default: true via fallthrough)
+	ForbidWithTiming          bool
+	ForbidWithSubresources    bool
+	ForbidWithHistoricalUsage bool
 	// v2:level:role
 	IsDomainRole  bool
 	IsProjectRole bool
@@ -87,6 +91,12 @@ func (e *PolicyEnforcer) allowAction(action string) bool {
 		return e.AllowReportMultiple
 	case "commitment_create":
 		return e.AllowCommitmentCreate
+	case "with_timing":
+		return !e.ForbidWithTiming
+	case "with_subresources":
+		return !e.ForbidWithSubresources
+	case "with_historical_usage":
+		return !e.ForbidWithHistoricalUsage
 	case "block_commitments":
 		return false
 	default:


### PR DESCRIPTION
Current state:
* I introduced some simplifications compared to `/rates`, e.g. direct access to entities by ID from `ServiceInfoCache`
* all apis implemented, tests written
* I think that It can serve all data as we imagined when brainstorming a few months ago and that all `?with=` options exist that we needed
* the performance is as follows: `/resources/v2/project` with our largest domain in our largest region is 10s computation, with all projects of the region it's 30s computation. That's not great, but acceptable, considering that in v1 the iteration through all domains produces some overhead that we save in v2
* my main idea was to have 1 SQL result per innermost result object so that we don't have to loop over the result multiple times - this makes the SQL quite long, possibly it could be shortened through clever application of theory of sets?


TODO:
* look at streaming the results of `resources/v2/project`, because this is quite a large data amount. the streaming implementation of v1 only works with list currently, not with object, but we can most likely make this work
* please look at the oslo policy, whether that is how we want to check for special with-flags in `resources/v2/project`
* check that I did not forget any functionality (params, returned data)
* probably, some logic can be deduplicated when looking at it long enough. E.g. the `setIn...Report` functions have a lot of duplication. Maybe we should implement a generic `func Set(value any)` on all structs and do this recursive? That does not help for values which are set on a higher level in the structure though, like `scraped_at, forbid_autogrowth, max_quota, ...`...
* look at SQL for optimization potential