### PR TITLE
switch DB connection handling from easypg to gg/pgruntime

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/sapcc/go-api-declarations v1.24.0
 	github.com/sapcc/go-bits v0.0.0-20260730170321-f6f727520601
 	github.com/sergi/go-diff v1.4.0
-	go.xyrillian.de/gg v1.13.0
+	go.xyrillian.de/gg v1.13.2
 	go.xyrillian.de/oblast v0.13.2
 	go.xyrillian.de/schwift/v2 v2.2.1
 )

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/sapcc/go-api-declarations v1.24.0
 	github.com/sapcc/go-bits v0.0.0-20260730170321-f6f727520601
 	github.com/sergi/go-diff v1.4.0
-	go.xyrillian.de/gg v1.12.0
+	go.xyrillian.de/gg v1.13.0
 	go.xyrillian.de/oblast v0.13.2
 	go.xyrillian.de/schwift/v2 v2.2.1
 )

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/sapcc/go-api-declarations v1.24.0
 	github.com/sapcc/go-bits v0.0.0-20260730170321-f6f727520601
 	github.com/sergi/go-diff v1.4.0
-	go.xyrillian.de/gg v1.13.2
+	go.xyrillian.de/gg v1.13.3
 	go.xyrillian.de/oblast v0.13.2
 	go.xyrillian.de/schwift/v2 v2.2.1
 )

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,8 @@ go.opentelemetry.io/otel/trace v1.37.0 h1:HLdcFNbRQBE2imdSEgm/kwqmQj1Or1l/7bW6mx
 go.opentelemetry.io/otel/trace v1.37.0/go.mod h1:TlgrlQ+PtQO5XFerSPUYG0JSgGyryXewPGyayAWSBS0=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
-go.xyrillian.de/gg v1.13.2 h1:A+eUQvHU5upT1fzsOzZZl51e8R6v5k+1ZHoRJftgnv4=
-go.xyrillian.de/gg v1.13.2/go.mod h1:DoO4fQSWIrBRlNlCjVyrYM0kAEBt/Jg2GkMH+cGRZ0k=
+go.xyrillian.de/gg v1.13.3 h1:Ulz3+eZnO2OUl7Bv+SWaA5ufDmjeLwwmICPP4dCurxA=
+go.xyrillian.de/gg v1.13.3/go.mod h1:DoO4fQSWIrBRlNlCjVyrYM0kAEBt/Jg2GkMH+cGRZ0k=
 go.xyrillian.de/oblast v0.13.2 h1:ICx20hOIfx8ff0xCYYanerJYBbmnw5kbF74yQzHz4FA=
 go.xyrillian.de/oblast v0.13.2/go.mod h1:EztRDtKccAN1Dfuva0XeADnaCNFo8Ew3r8RUxm2Z1s8=
 go.xyrillian.de/schwift/v2 v2.2.1 h1:uzw9Fe2ftiB4oUiEfxh2zTWxBRwFOAtVuyGZwAaAnNQ=

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,8 @@ go.opentelemetry.io/otel/trace v1.37.0 h1:HLdcFNbRQBE2imdSEgm/kwqmQj1Or1l/7bW6mx
 go.opentelemetry.io/otel/trace v1.37.0/go.mod h1:TlgrlQ+PtQO5XFerSPUYG0JSgGyryXewPGyayAWSBS0=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
-go.xyrillian.de/gg v1.12.0 h1:oW9S91y36lS72D3p9a4axqjkD9zkkjkNZ12+PaZHpos=
-go.xyrillian.de/gg v1.12.0/go.mod h1:DoO4fQSWIrBRlNlCjVyrYM0kAEBt/Jg2GkMH+cGRZ0k=
+go.xyrillian.de/gg v1.13.0 h1:K1RlyRxe2+7oaXALZBtuJqqwSEPneTjH1gPD18WuSaU=
+go.xyrillian.de/gg v1.13.0/go.mod h1:DoO4fQSWIrBRlNlCjVyrYM0kAEBt/Jg2GkMH+cGRZ0k=
 go.xyrillian.de/oblast v0.13.2 h1:ICx20hOIfx8ff0xCYYanerJYBbmnw5kbF74yQzHz4FA=
 go.xyrillian.de/oblast v0.13.2/go.mod h1:EztRDtKccAN1Dfuva0XeADnaCNFo8Ew3r8RUxm2Z1s8=
 go.xyrillian.de/schwift/v2 v2.2.1 h1:uzw9Fe2ftiB4oUiEfxh2zTWxBRwFOAtVuyGZwAaAnNQ=

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,8 @@ go.opentelemetry.io/otel/trace v1.37.0 h1:HLdcFNbRQBE2imdSEgm/kwqmQj1Or1l/7bW6mx
 go.opentelemetry.io/otel/trace v1.37.0/go.mod h1:TlgrlQ+PtQO5XFerSPUYG0JSgGyryXewPGyayAWSBS0=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
-go.xyrillian.de/gg v1.13.0 h1:K1RlyRxe2+7oaXALZBtuJqqwSEPneTjH1gPD18WuSaU=
-go.xyrillian.de/gg v1.13.0/go.mod h1:DoO4fQSWIrBRlNlCjVyrYM0kAEBt/Jg2GkMH+cGRZ0k=
+go.xyrillian.de/gg v1.13.2 h1:A+eUQvHU5upT1fzsOzZZl51e8R6v5k+1ZHoRJftgnv4=
+go.xyrillian.de/gg v1.13.2/go.mod h1:DoO4fQSWIrBRlNlCjVyrYM0kAEBt/Jg2GkMH+cGRZ0k=
 go.xyrillian.de/oblast v0.13.2 h1:ICx20hOIfx8ff0xCYYanerJYBbmnw5kbF74yQzHz4FA=
 go.xyrillian.de/oblast v0.13.2/go.mod h1:EztRDtKccAN1Dfuva0XeADnaCNFo8Ew3r8RUxm2Z1s8=
 go.xyrillian.de/schwift/v2 v2.2.1 h1:uzw9Fe2ftiB4oUiEfxh2zTWxBRwFOAtVuyGZwAaAnNQ=

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -27,6 +27,7 @@ import (
 	"go.xyrillian.de/gg/assert"
 	"go.xyrillian.de/gg/gsql"
 	. "go.xyrillian.de/gg/option"
+	"go.xyrillian.de/gg/pgruntime"
 
 	"github.com/sapcc/limes/internal/api/api_v2"
 	"github.com/sapcc/limes/internal/collector"
@@ -38,7 +39,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	easypg.WithTestDB(m, func() int { return m.Run() })
+	pgruntime.WithTestDB(m, m.Run)
 }
 
 // NOTE: MiB makes no sense for a deletion rate, but I want to test as many

--- a/internal/api/api_v2/info_test.go
+++ b/internal/api/api_v2/info_test.go
@@ -9,17 +9,17 @@ import (
 	"testing"
 
 	"github.com/sapcc/go-api-declarations/liquid"
-	"github.com/sapcc/go-bits/easypg"
 	"github.com/sapcc/go-bits/httptest"
 	"github.com/sapcc/go-bits/must"
 	. "go.xyrillian.de/gg/option"
+	"go.xyrillian.de/gg/pgruntime"
 
 	"github.com/sapcc/limes/internal/test"
 	"github.com/sapcc/limes/internal/test/common_fixtures"
 )
 
 func TestMain(m *testing.M) {
-	easypg.WithTestDB(m, func() int { return m.Run() })
+	pgruntime.WithTestDB(m, m.Run)
 }
 
 var infoConfigJSON = string(must.Return(httptest.NewJQModifiableJSONString(`

--- a/internal/api/reports_v2/scope_test.go
+++ b/internal/api/reports_v2/scope_test.go
@@ -10,11 +10,11 @@ import (
 	"testing"
 
 	"github.com/gorilla/mux"
-	"github.com/sapcc/go-bits/easypg"
 	"github.com/sapcc/go-bits/httptest"
 	"github.com/sapcc/go-bits/must"
 	"go.xyrillian.de/gg/assert"
 	. "go.xyrillian.de/gg/option"
+	"go.xyrillian.de/gg/pgruntime"
 
 	"github.com/sapcc/limes/internal/api/reports_v2"
 	"github.com/sapcc/limes/internal/db"
@@ -23,7 +23,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	easypg.WithTestDB(m, func() int { return m.Run() })
+	pgruntime.WithTestDB(m, m.Run)
 }
 
 var scopeConfigJSON = string(must.Return(httptest.NewJQModifiableJSONString("{}", "scopeConfigJSON").

--- a/internal/collector/shared_test.go
+++ b/internal/collector/shared_test.go
@@ -6,9 +6,9 @@ package collector_test
 import (
 	"testing"
 
-	"github.com/sapcc/go-bits/easypg"
+	"go.xyrillian.de/gg/pgruntime"
 )
 
 func TestMain(m *testing.M) {
-	easypg.WithTestDB(m, func() int { return m.Run() })
+	pgruntime.WithTestDB(m, m.Run)
 }

--- a/internal/core/cluster.go
+++ b/internal/core/cluster.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"maps"
-	"net/url"
 	"slices"
 	"time"
 
@@ -25,6 +24,7 @@ import (
 	"go.xyrillian.de/gg/gsql"
 	. "go.xyrillian.de/gg/option"
 	"go.xyrillian.de/gg/options"
+	"go.xyrillian.de/gg/pgruntime"
 
 	"github.com/sapcc/limes/internal/db"
 	"github.com/sapcc/limes/internal/util"
@@ -103,8 +103,8 @@ func NewCluster(config ClusterConfiguration, timeNow func() time.Time, dbm *gsql
 // We cannot do any of this earlier because we only know all resources after calling Init() on all LiquidConnections.
 //
 // The ServiceInfoCache is assembled here, because we need to use the Config in the test setup before Connect.
-// A dbURL needs to be provided when c.LiquidConnections is empty, to ensure ServiceInfo stays up to date.
-func (c *Cluster) Connect(ctx context.Context, provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, liquidClientFactory func(db.ServiceType) (LiquidClient, error), dbURL Option[url.URL]) (errs errext.ErrorSet) {
+// A [pgruntime.ConnectionTarget] needs to be provided when c.LiquidConnections is empty, to ensure ServiceInfo stays up to date.
+func (c *Cluster) Connect(ctx context.Context, provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, liquidClientFactory func(db.ServiceType) (LiquidClient, error), connTarget Option[pgruntime.ConnectionTarget]) (errs errext.ErrorSet) {
 	// save factory for possible later use
 	c.LiquidClientFactory = liquidClientFactory
 
@@ -115,7 +115,7 @@ func (c *Cluster) Connect(ctx context.Context, provider *gophercloud.ProviderCli
 	}
 
 	// initialize SIC
-	c.SIC, err = NewServiceInfoCache(ctx, c.DB, c.Config, dbURL)
+	c.SIC, err = NewServiceInfoCache(ctx, c.DB, c.Config, connTarget)
 	if err != nil {
 		errs.Addf("could not create service info cache: %w", err)
 		return errs

--- a/internal/core/cluster_test.go
+++ b/internal/core/cluster_test.go
@@ -5,7 +5,6 @@ package core_test
 
 import (
 	"encoding/json"
-	"net/url"
 	"testing"
 	"time"
 
@@ -19,6 +18,7 @@ import (
 	"github.com/sapcc/go-bits/must"
 	"go.xyrillian.de/gg/assert"
 	. "go.xyrillian.de/gg/option"
+	"go.xyrillian.de/gg/pgruntime"
 
 	"github.com/sapcc/limes/internal/core"
 	"github.com/sapcc/limes/internal/db"
@@ -58,7 +58,7 @@ func generateNewClusterWithPersistingServiceInfo(t *testing.T, s test.Setup, fai
 	for _, err := range errs {
 		t.Fatal(err)
 	}
-	connectErrs = s.Cluster.Connect(s.Ctx, nil, gophercloud.EndpointOpts{}, liquidClientFactory, None[url.URL]())
+	connectErrs = s.Cluster.Connect(s.Ctx, nil, gophercloud.EndpointOpts{}, liquidClientFactory, None[pgruntime.ConnectionTarget]())
 	if failOnConnectError {
 		for _, err := range errs {
 			t.Fatal(err)
@@ -68,7 +68,7 @@ func generateNewClusterWithPersistingServiceInfo(t *testing.T, s test.Setup, fai
 }
 
 func TestMain(m *testing.M) {
-	easypg.WithTestDB(m, func() int { return m.Run() })
+	pgruntime.WithTestDB(m, m.Run)
 }
 
 func Test_ClusterSaveServiceInfo(t *testing.T) {

--- a/internal/core/service_info_cache.go
+++ b/internal/core/service_info_cache.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
-	"net/url"
 	"sync"
 	"time"
 
@@ -22,6 +21,7 @@ import (
 
 	"go.xyrillian.de/gg/gsql"
 	. "go.xyrillian.de/gg/option"
+	"go.xyrillian.de/gg/pgruntime"
 )
 
 ///////////////////////////////////////////////////////////////////////
@@ -582,7 +582,7 @@ type ServiceInfoCache struct {
 }
 
 // NewServiceInfoCache generates a ServiceInfoCache and fills all services' data.
-func NewServiceInfoCache(ctx context.Context, dbm *gsql.DB, config ClusterConfiguration, dbURL Option[url.URL]) (*ServiceInfoCache, error) {
+func NewServiceInfoCache(ctx context.Context, dbm *gsql.DB, config ClusterConfiguration, connTarget Option[pgruntime.ConnectionTarget]) (*ServiceInfoCache, error) {
 	sic := &ServiceInfoCache{
 		DB:     dbm,
 		config: config,
@@ -596,7 +596,11 @@ func NewServiceInfoCache(ctx context.Context, dbm *gsql.DB, config ClusterConfig
 	}
 
 	// set up NOTIFY listener if a DB URL was provided (disabled in tests)
-	if u, ok := dbURL.Unpack(); ok {
+	if t, ok := connTarget.Unpack(); ok {
+		u, err := t.IntoURL()
+		if err != nil {
+			return nil, err
+		}
 		ch := make(chan struct{}, 1)
 		sic.OnInvalidate = ch
 		sic.sendInvalidate = ch

--- a/internal/core/service_info_cache_test.go
+++ b/internal/core/service_info_cache_test.go
@@ -8,12 +8,10 @@ import (
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/sapcc/go-api-declarations/liquid"
-	"github.com/sapcc/go-bits/easypg"
 	"github.com/sapcc/go-bits/httptest"
 	"github.com/sapcc/go-bits/must"
 	"go.xyrillian.de/gg/assert"
 	. "go.xyrillian.de/gg/option"
-	"go.xyrillian.de/gg/options"
 
 	"github.com/sapcc/limes/internal/core"
 	"github.com/sapcc/limes/internal/db"
@@ -43,7 +41,7 @@ func TestServiceInfoSnapshotFilter(t *testing.T) {
 		test.WithPersistedServiceInfo("first", serviceInfoFirst),
 		test.WithPersistedServiceInfo("second", test.DefaultLiquidServiceInfo("Second")),
 	)
-	s.Cluster.Connect(s.Ctx, nil, gophercloud.EndpointOpts{}, func(serviceType db.ServiceType) (core.LiquidClient, error) { return nil, nil }, options.FromPointer(easypg.BuildDBURL(t)))
+	s.Cluster.Connect(s.Ctx, nil, gophercloud.EndpointOpts{}, func(serviceType db.ServiceType) (core.LiquidClient, error) { return nil, nil }, Some(s.DBConnectionTarget))
 	t.Cleanup(func() { s.Cluster.SIC.Close() })
 
 	sis := s.Cluster.SIC.GetSnapshot()
@@ -155,7 +153,7 @@ func TestServiceInfoCache(t *testing.T) {
 	secondCapacity := s.GetResourceID("second", "capacity")
 	firstObjectsCreate := s.GetRateID("first", "objects:create")
 	// by calling connect with a DB-URL, we register the service info listeners
-	s.Cluster.Connect(s.Ctx, nil, gophercloud.EndpointOpts{}, func(serviceType db.ServiceType) (core.LiquidClient, error) { return nil, nil }, options.FromPointer(easypg.BuildDBURL(t)))
+	s.Cluster.Connect(s.Ctx, nil, gophercloud.EndpointOpts{}, func(serviceType db.ServiceType) (core.LiquidClient, error) { return nil, nil }, Some(s.DBConnectionTarget))
 	t.Cleanup(func() { s.Cluster.SIC.Close() })
 
 	sis := s.Cluster.SIC.GetSnapshot()
@@ -217,7 +215,7 @@ func TestServiceInfoCacheGetByID(t *testing.T) {
 		test.WithPersistedServiceInfo("first", serviceInfoFirst),
 		test.WithPersistedServiceInfo("second", test.DefaultLiquidServiceInfo("Second")),
 	)
-	s.Cluster.Connect(s.Ctx, nil, gophercloud.EndpointOpts{}, func(serviceType db.ServiceType) (core.LiquidClient, error) { return nil, nil }, options.FromPointer(easypg.BuildDBURL(t)))
+	s.Cluster.Connect(s.Ctx, nil, gophercloud.EndpointOpts{}, func(serviceType db.ServiceType) (core.LiquidClient, error) { return nil, nil }, Some(s.DBConnectionTarget))
 	t.Cleanup(func() { s.Cluster.SIC.Close() })
 
 	sis := s.Cluster.SIC.GetSnapshot()

--- a/internal/datamodel/quota_overrides_test.go
+++ b/internal/datamodel/quota_overrides_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 
 	"github.com/sapcc/go-api-declarations/liquid"
-	"github.com/sapcc/go-bits/easypg"
 	"github.com/sapcc/go-bits/httptest"
 	"github.com/sapcc/go-bits/must"
 	"go.xyrillian.de/gg/assert"
+	"go.xyrillian.de/gg/pgruntime"
 
 	"github.com/sapcc/limes/internal/datamodel"
 	"github.com/sapcc/limes/internal/db"
@@ -19,7 +19,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	easypg.WithTestDB(m, func() int { return m.Run() })
+	pgruntime.WithTestDB(m, m.Run)
 }
 
 var testQuotaOverridesNoRenamingConfigJSON = string(must.Return(httptest.NewJQModifiableJSONString("{}", "testQuotaOverridesNoRenamingConfigJSON").

--- a/internal/db/connection.go
+++ b/internal/db/connection.go
@@ -14,6 +14,7 @@ import (
 	"go.xyrillian.de/gg/gsql"
 	"go.xyrillian.de/gg/pgruntime"
 
+	"github.com/sapcc/go-api-declarations/bininfo"
 	"github.com/sapcc/go-bits/must"
 	"github.com/sapcc/go-bits/osext"
 	"github.com/sapcc/go-bits/sqlext"
@@ -39,6 +40,7 @@ func Init(ctx context.Context) (*gsql.DB, pgruntime.ConnectionTarget, error) {
 		Password:          os.Getenv("LIMES_DB_PASSWORD"),
 		ConnectionOptions: os.Getenv("LIMES_DB_CONNECTION_OPTIONS"),
 		DatabaseName:      osext.GetenvOrDefault("LIMES_DB_NAME", "limes"),
+		ApplicationName:   bininfo.Component(),
 	}
 	dbConn := must.Return(pgruntime.StdConnector("postgres").Connect(ctx, target, Configuration()))
 	prometheus.MustRegister(sqlstats.NewStatsCollector(target.DatabaseName, dbConn))

--- a/internal/db/connection.go
+++ b/internal/db/connection.go
@@ -4,59 +4,49 @@
 package db
 
 import (
+	"context"
 	"fmt"
-	"net/url"
 	"os"
 	"strings"
 
 	"github.com/dlmiddlecote/sqlstats"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.xyrillian.de/gg/gsql"
+	"go.xyrillian.de/gg/pgruntime"
 
-	"github.com/sapcc/go-api-declarations/bininfo"
-	"github.com/sapcc/go-bits/easypg"
+	"github.com/sapcc/go-bits/must"
 	"github.com/sapcc/go-bits/osext"
 	"github.com/sapcc/go-bits/sqlext"
 	"github.com/sapcc/go-bits/syncext"
+
+	// import DB driver
+	_ "github.com/lib/pq"
 )
 
-// Configuration returns the easypg.Configuration object that func Init() needs to initialize the DB connection.
-func Configuration() easypg.Configuration {
-	return easypg.Configuration{
+// Configuration returns the [pgruntime.ConnectionBehavior] object that func Init() needs to initialize the DB connection.
+func Configuration() pgruntime.ConnectionBehavior {
+	return pgruntime.ConnectionBehavior{
 		Migrations: sqlMigrations,
 	}
 }
 
 // Init initializes the connection to the database.
-func Init() (dbConn *gsql.DB, dbURL url.URL, err error) {
-	extraConnectionOptions := make(map[string]string)
-	if bininfo.Component() == "limes-serve" {
-		// the API seems to have issues with connections getting stuck in "idle in transaction" during high load, not sure yet why
-		extraConnectionOptions["idle_in_transaction_session_timeout"] = "10000" // 10000 ms = 10 seconds
-	}
-
-	dbName := osext.GetenvOrDefault("LIMES_DB_NAME", "limes")
-	dbURL, err = easypg.URLFrom(easypg.URLParts{
+func Init(ctx context.Context) (*gsql.DB, pgruntime.ConnectionTarget, error) {
+	target := pgruntime.ConnectionTarget{
 		HostName:          osext.GetenvOrDefault("LIMES_DB_HOSTNAME", "localhost"),
 		Port:              osext.GetenvOrDefault("LIMES_DB_PORT", "5432"),
 		UserName:          osext.GetenvOrDefault("LIMES_DB_USERNAME", "postgres"),
 		Password:          os.Getenv("LIMES_DB_PASSWORD"),
 		ConnectionOptions: os.Getenv("LIMES_DB_CONNECTION_OPTIONS"),
-		DatabaseName:      dbName,
-	})
-	if err != nil {
-		return nil, dbURL, err
+		DatabaseName:      osext.GetenvOrDefault("LIMES_DB_NAME", "limes"),
 	}
-	dbConnRaw, err := easypg.Connect(dbURL, Configuration())
-	if err != nil {
-		return nil, dbURL, err
-	}
-	prometheus.MustRegister(sqlstats.NewStatsCollector(dbName, dbConnRaw))
+	dbConn := must.Return(pgruntime.StdConnector("postgres").Connect(ctx, target, Configuration()))
+	prometheus.MustRegister(sqlstats.NewStatsCollector(target.DatabaseName, dbConn))
 
 	// ensure that this process does not starve other Limes processes for DB connections
-	dbConnRaw.SetMaxOpenConns(16)
+	dbConn.SetMaxOpenConns(16)
 
-	return gsql.NewDB(dbConnRaw), dbURL, nil
+	return dbConn, target, nil
 }
 
 // Interface is implemented by both [*gsql.DB] and [*gsql.Tx].

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -8,34 +8,11 @@ import _ "embed"
 //go:embed baseline.sql
 var sqlBaseline string
 
-var sqlMigrations = map[string]string{
+var sqlMigrations = map[int64]string{
 	// NOTE: Migrations 1 through 75 have been rolled up into one at 2026-04-02
 	// to better represent the current baseline of the DB schema.
-	"075_rollup.up.sql": ExpandEnumPlaceholders(sqlBaseline),
-	"075_rollup.down.sql": `
-		DROP TRIGGER rates_check_path_values_trigger ON az_resources;
-		DROP TRIGGER az_resources_check_path_values_trigger ON az_resources;
-		DROP TRIGGER resources_check_path_values_trigger ON resources;
-		DROP TRIGGER services_check_path_values_trigger ON services;
-		DROP FUNCTION check_path_values_trigger_function;
-		DROP TRIGGER az_resources_project_commitments_trigger ON az_resources;
-		DROP FUNCTION az_resources_project_commitments_trigger_function;
-		DROP TABLE project_rates;
-		DROP TABLE project_mail_notifications;
-		DROP TABLE project_commitments;
-		DROP TABLE project_az_resources;
-		DROP TABLE project_resources;
-		DROP INDEX project_services_stale_idx;
-		DROP TABLE project_services;
-		DROP TABLE projects;
-		DROP TABLE domains;
-		DROP TABLE rates;
-		DROP TABLE az_resources;
-		DROP TABLE resources;
-		DROP TABLE categories;
-		DROP TABLE services;
-	`,
-	`076_notify_service_update.up.sql`: `
+	75: ExpandEnumPlaceholders(sqlBaseline),
+	76: `
 		CREATE OR REPLACE FUNCTION notify_service_update()
 			RETURNS trigger AS $$
 			DECLARE
@@ -87,55 +64,27 @@ var sqlMigrations = map[string]string{
 			AFTER INSERT OR UPDATE OR DELETE ON rates
 			FOR EACH ROW EXECUTE FUNCTION notify_service_update();
 	`,
-	`076_notify_service_update.down.sql`: `
-		DROP TRIGGER IF EXISTS rates_notify_update ON rates;
-		DROP TRIGGER IF EXISTS az_resources_notify_update ON az_resources;
-		DROP TRIGGER IF EXISTS resources_notify_update ON resources;
-		DROP TRIGGER IF EXISTS services_notify_update ON services;
-		DROP FUNCTION IF EXISTS notify_service_update;
-	`,
-	`077_rate_category.up.sql`: `
+	77: `
 		ALTER TABLE rates ADD COLUMN category_id BIGINT DEFAULT NULL REFERENCES categories ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED;
 	`,
-	`077_rate_category.down.sql`: `
-		ALTER TABLE rates DROP COLUMN category_id;
-	`,
-	`078_add_topology_check.up.sql`: `
+	78: `
 		ALTER TABLE resources ADD CONSTRAINT resources_topology_acceptable_values CHECK (topology IN ('flat', 'az-aware', 'az-separated'));
 		ALTER TABLE rates ADD CONSTRAINT rates_topology_acceptable_values CHECK (topology IN ('flat', 'az-aware', 'az-separated'));
 	`,
-	`078_add_topology_check.down.sql`: `
-		ALTER TABLE resources DROP CONSTRAINT resources_topology_acceptable_values;
-		ALTER TABLE rates DROP CONSTRAINT rates_topology_acceptable_values;
-	`,
-	`079_add_commitment_handling_needs_project_metadata.up.sql`: `
+	79: `
 		ALTER TABLE services ADD COLUMN commitment_handling_needs_project_metadata BOOLEAN NOT NULL DEFAULT FALSE;
 		ALTER TABLE rates ADD COLUMN from_liquid BOOLEAN NOT NULL DEFAULT FALSE;
 	`,
-	`079_add_commitment_handling_needs_project_metadata.down.sql`: `
-		ALTER TABLE services DROP COLUMN commitment_handling_needs_project_metadata;
+	80: `
 		ALTER TABLE rates DROP COLUMN from_liquid;
 	`,
-	`080_drop_rates_from_liquid.up.sql`: `
-		ALTER TABLE rates DROP COLUMN from_liquid;
-	`,
-	`080_drop_rates_from_liquid.down.sql`: `
-		ALTER TABLE rates ADD COLUMN from_liquid BOOLEAN NOT NULL DEFAULT FALSE;
-	`,
-	`081_add_project_commitments_updated_at.up.sql`: `
+	81: `
 		ALTER TABLE project_commitments ADD COLUMN updated_at TIMESTAMPTZ;
 		UPDATE project_commitments SET updated_at = COALESCE(deleted_at, superseded_at, transfer_started_at, confirmed_at, created_at);
 		ALTER TABLE project_commitments ALTER COLUMN updated_at SET NOT NULL;
 	`,
-	`081_add_project_commitments_updated_at.down.sql`: `
-		ALTER TABLE project_commitments DROP COLUMN updated_at;
-	`,
-	"082_rewrite_unitnone_into_unitpiece.up.sql": `
+	82: `
 		UPDATE resources SET unit = 'piece' WHERE unit = '';
 		UPDATE rates SET unit = 'piece' WHERE unit = '';
-	`,
-	"082_rewrite_unitnone_into_unitpiece.down.sql": `
-		UPDATE resources SET unit = '' WHERE unit = 'piece';
-		UPDATE rates SET unit = '' WHERE unit = 'piece';
 	`,
 }

--- a/internal/test/setup.go
+++ b/internal/test/setup.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"maps"
 	"net/http"
-	"net/url"
 	"regexp"
 	"slices"
 	"strconv"
@@ -20,7 +19,6 @@ import (
 	"github.com/sapcc/go-api-declarations/limes"
 	"github.com/sapcc/go-api-declarations/liquid"
 	"github.com/sapcc/go-bits/audittools"
-	"github.com/sapcc/go-bits/easypg"
 	"github.com/sapcc/go-bits/errext"
 	"github.com/sapcc/go-bits/httpapi"
 	"github.com/sapcc/go-bits/httptest"
@@ -30,6 +28,7 @@ import (
 	"github.com/sapcc/go-bits/osext"
 	"go.xyrillian.de/gg/gsql"
 	. "go.xyrillian.de/gg/option"
+	"go.xyrillian.de/gg/pgruntime"
 
 	"github.com/sapcc/limes/internal/api"
 	"github.com/sapcc/limes/internal/api/api_v2"
@@ -160,6 +159,7 @@ type Setup struct {
 	// fields that are always set
 	Ctx                        context.Context //nolint:containedctx // only used in tests
 	DB                         *gsql.DB
+	DBConnectionTarget         pgruntime.ConnectionTarget
 	Cluster                    *core.Cluster
 	Clock                      *mock.Clock
 	Registry                   *prometheus.Registry
@@ -225,15 +225,7 @@ func NewSetup(t *testing.T, opts ...SetupOption) Setup {
 	s.Clock = mock.NewClock()
 	s.t = t
 
-	s.DB = gsql.NewDB(easypg.ConnectForTest(t, db.Configuration(),
-		easypg.ClearTables("project_commitments", "services", "domains", "categories"),
-		easypg.ResetPrimaryKeys(
-			"services", "resources", "rates", "az_resources",
-			"domains", "projects", "project_commitments", "project_mail_notifications",
-			"project_services", "project_resources", "project_az_resources", "project_rates",
-			"categories",
-		),
-	))
+	s.DB, s.DBConnectionTarget = pgruntime.StdConnector("postgres").ConnectForTest(t, db.Configuration())
 
 	// Cluster.Connect() needs to use our MockLiquidClient instances instead of real LIQUID clients
 	s.LiquidClients = params.LiquidClients
@@ -261,7 +253,7 @@ func NewSetup(t *testing.T, opts ...SetupOption) Setup {
 		}
 		must.SucceedT(t, core.SaveServiceInfoToDB(s.Ctx, serviceType, serviceInfo, s.Cluster.Config.AvailabilityZones, rateLimits, s.Clock.Now(), s.DB))
 	}
-	errs = s.Cluster.Connect(s.Ctx, nil, gophercloud.EndpointOpts{}, liquidClientFactory, None[url.URL]())
+	errs = s.Cluster.Connect(s.Ctx, nil, gophercloud.EndpointOpts{}, liquidClientFactory, None[pgruntime.ConnectionTarget]())
 	failIfErrs(t, errs)
 
 	s.Registry = prometheus.NewPedanticRegistry()

--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"os"
 	"slices"
 	"strings"
@@ -30,6 +29,7 @@ import (
 	"github.com/sapcc/go-bits/must"
 	"github.com/sapcc/go-bits/osext"
 	. "go.xyrillian.de/gg/option"
+	"go.xyrillian.de/gg/pgruntime"
 
 	"github.com/sapcc/limes/internal/api"
 	"github.com/sapcc/limes/internal/api/api_v2"
@@ -148,18 +148,18 @@ func main() {
 	must.Succeed(err)
 
 	// load configuration and connect to cluster
-	dbm, dbURL, err := db.Init()
+	dbm, connTarget, err := db.Init(ctx)
 	if err != nil {
 		logg.Fatal(err.Error())
 	}
 	cluster, errs := core.NewClusterFromJSON(must.Return(os.ReadFile(configPath)), time.Now, dbm, taskName == "collect") // #nosec G703 -- configPath is from command-line argument, controlled by operator
 	errs.LogFatalIfError()
-	maybeDBURL := None[url.URL]()
+	maybeConnTarget := None[pgruntime.ConnectionTarget]()
 	if taskName != "collect" {
 		// background: the collector task explicitly updates the SIC after writing
-		maybeDBURL = Some(dbURL)
+		maybeConnTarget = Some(connTarget)
 	}
-	errs = cluster.Connect(ctx, provider, eo, core.LiquidClientFactory(provider, eo), maybeDBURL)
+	errs = cluster.Connect(ctx, provider, eo, core.LiquidClientFactory(provider, eo), maybeConnTarget)
 	errs.LogFatalIfError()
 	if cluster.SIC != nil {
 		defer cluster.SIC.Close()

--- a/vendor/go.xyrillian.de/gg/gsql/std.go
+++ b/vendor/go.xyrillian.de/gg/gsql/std.go
@@ -53,6 +53,15 @@ func (db *DB) Conn(ctx context.Context) (*Conn, error) {
 	return maybe(NewConn, conn), err
 }
 
+// WithinTransaction executes an action within a database transaction.
+// The transaction will be committed if the callback returns successfully, or rolled back otherwise.
+//
+// This is equivalent to the GSQLTransact() method of the DB's [ConnectionHandle] implementation,
+// but the callback receives the concrete type [*Tx] instead of a generic [Handle].
+func (db *DB) WithinTransaction(ctx context.Context, action func(*Tx) error) error {
+	return withinTransaction(ctx, db.DB, action)
+}
+
 // Conn wraps [*sql.Conn] into a [Handle].
 //
 // Because this type has [*sql.Conn] as an embedded field,
@@ -71,6 +80,15 @@ func NewConn(db *sql.Conn) *Conn {
 func (conn *Conn) BeginTx(ctx context.Context, opts *sql.TxOptions) (*Tx, error) {
 	tx, err := conn.Conn.BeginTx(ctx, opts)
 	return maybe(NewTx, tx), err
+}
+
+// WithinTransaction executes an action within a database transaction.
+// The transaction will be committed if the callback returns successfully, or rolled back otherwise.
+//
+// This is equivalent to the GSQLTransact() method of conn's [ConnectionHandle] implementation,
+// but the callback receives the concrete type [*Tx] instead of a generic [Handle].
+func (conn *Conn) WithinTransaction(ctx context.Context, action func(*Tx) error) error {
+	return withinTransaction(ctx, conn.Conn, action)
 }
 
 // Tx wraps [*sql.Tx] into a [Handle].
@@ -191,7 +209,14 @@ func (h sqlConnectionHandle[T]) GSQLClose(ctx context.Context) error {
 
 // GSQLTransact implements the [ConnectionHandle] interface.
 func (h sqlConnectionHandle[T]) GSQLTransact(ctx context.Context, action func(tx Handle) error) error {
-	tx, err := h.Base.BeginTx(ctx, nil)
+	return withinTransaction(ctx, h.Base, func(tx *Tx) error {
+		return action(tx)
+	})
+}
+
+// withinTransaction implements the method of that name that exists on all types based on [sqlConnectionHandle].
+func withinTransaction(ctx context.Context, conn sqlConnection, action func(*Tx) error) error {
+	tx, err := conn.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}

--- a/vendor/go.xyrillian.de/gg/pgruntime/behavior.go
+++ b/vendor/go.xyrillian.de/gg/pgruntime/behavior.go
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: 2026 Stefan Majewsky <majewsky@gmx.net>
+// SPDX-License-Identifier: Apache-2.0
+
+package pgruntime
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"go.xyrillian.de/gg/gsql"
+)
+
+// ConnectionBehavior contains configuration for [Connector.Connect] and [Connector.ConnectForTest].
+//
+// If Migrations is not nil, pgruntime will perform very basic handling for schema migrations.
+// Migrations must be given with the version number as key, and one or several DDL queries needed to reach that version from the previous version.
+// For example:
+//
+//	behavior.Migrations = map[int]string{
+//		1: `
+//			CREATE TABLE assets (
+//				id   BIGSERIAL PRIMARY KEY,
+//				name TEXT
+//			);
+//		`,
+//		2: `
+//			UPDATE assets SET name = 'unknown' WHERE name IS NULL;
+//			ALTER TABLE assets ALTER COLUMN name SET NOT NULL;
+//		`,
+//	}
+//
+// Versions need not start at 1 and need not be contiguous (so e.g. UNIX timestamps can be used as schema versions).
+// Schema migrations will be executed as follows:
+//
+//   - The table "schema_migrations" will be created with the same schema as used by [golang-migrate] if it does not exists (see [MigrationsSchema]).
+//     It will only ever contain one record, initially with version 0.
+//   - If Migrations contains entries with a version number larger than the one recorded in the database,
+//     pgruntime picks the first such migration by ascending version number, executes the DDL query, and increases the version number in "schema_migrations" accordingly.
+//
+// [golang-migrate]: https://pkg.go.dev/github.com/golang-migrate/migrate
+type ConnectionBehavior struct {
+	Migrations map[int64]string // or nil to skip schema_migrations
+}
+
+// MigrationsSchema defines the structure of the "schema_migrations" table used by pgruntime's schema migration handling.
+// It is the same table schema as used by [golang-migrate]'s postgres driver, to enable seamless migration from that library to pgruntime.
+// The "dirty" column is not used by pgruntime, and will always be set to FALSE for compatibility with golang-migrate.
+//
+// [golang-migrate]: https://pkg.go.dev/github.com/golang-migrate/migrate
+const MigrationsSchema = `CREATE TABLE IF NOT EXISTS schema_migrations (version BIGINT NOT NULL PRIMARY KEY, dirty BOOLEAN NOT NULL)`
+
+func (b ConnectionBehavior) applyTo(ctx context.Context, db gsql.ConnectionHandle) error {
+	if len(b.Migrations) > 0 {
+		err := applyMigrations(ctx, db, b.Migrations)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func applyMigrations(ctx context.Context, db gsql.ConnectionHandle, migrations map[int64]string) error {
+	// apply schema_migrations table schema
+	_, err := execQuery(ctx, db, MigrationsSchema, nil)
+	if err != nil {
+		return fmt.Errorf("could not apply schema_migrations table schema: %w", err)
+	}
+
+	// read schema_migrations table
+	rowCount, err := selectOneValue[int64](ctx, db, `SELECT COUNT(*) FROM schema_migrations`)
+	if err != nil {
+		return fmt.Errorf("could not check row count for schema_migrations: %w", err)
+	}
+	var (
+		currentVersion int64
+		dirty          bool
+	)
+	switch rowCount {
+	case 0:
+		currentVersion = 0
+		_, err = execQuery(ctx, db, `INSERT INTO schema_migrations (version, dirty) VALUES (0, FALSE)`, nil)
+		if err != nil {
+			return fmt.Errorf("could not initialize schema_migrations record: %w", err)
+		}
+	case 1:
+		err = queryRow(ctx, db, `SELECT version, dirty FROM schema_migrations`, nil, []any{&currentVersion, &dirty})
+		if err != nil {
+			return fmt.Errorf("could not read schema_migrations record: %w", err)
+		}
+	default:
+		if err != nil {
+			return fmt.Errorf("expected 1 record in schema_migrations table, but found %d records", rowCount)
+		}
+	}
+	if dirty {
+		// NOTE: defense in depth: this can never occur when only using pgruntime, but may occur when migrating from golang-migrate
+		return fmt.Errorf("schema_migrations is marked as dirty (version = %d)", currentVersion)
+	}
+
+	// find migrations to apply
+	var pendingVersions []int64
+	for version := range migrations {
+		if version > currentVersion {
+			pendingVersions = append(pendingVersions, version)
+		}
+	}
+	slices.Sort(pendingVersions)
+
+	// apply migrations
+	for _, version := range pendingVersions {
+		err := db.GSQLTransact(ctx, func(tx gsql.Handle) error {
+			_, err := execQuery(ctx, db, migrations[version], nil)
+			if err != nil {
+				return fmt.Errorf("could not execute schema migration: %w", err)
+			}
+			_, err = execQuery(ctx, db, `UPDATE schema_migrations SET version = $1, dirty = FALSE`, []any{version})
+			if err != nil {
+				return fmt.Errorf("could not update schema_migrations record: %w", err)
+			}
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("while migrating to schema version %d: %w", version, err)
+		}
+	}
+
+	return nil
+}

--- a/vendor/go.xyrillian.de/gg/pgruntime/behavior.go
+++ b/vendor/go.xyrillian.de/gg/pgruntime/behavior.go
@@ -110,7 +110,22 @@ func applyMigrations(ctx context.Context, db gsql.ConnectionHandle, migrations m
 	// apply migrations
 	for _, version := range pendingVersions {
 		err := db.GSQLTransact(ctx, func(tx gsql.Handle) error {
-			_, err := execQuery(ctx, db, migrations[version], nil)
+			// ensure that nobody else is migrating until we are done
+			var actualVersion int64
+			err := queryRow(ctx, db, `SELECT version FROM schema_migrations FOR UPDATE`, nil, []any{&actualVersion})
+			if err != nil {
+				return fmt.Errorf("could not obtain lock for schema migration: %w", err)
+			}
+
+			// ensure that nobody else migrated just before we started our transaction block
+			if version <= actualVersion {
+				return fmt.Errorf("tried to perform migration to version %d, but schema is already at version %d (multiple migrations might be running concurrently)",
+					version, actualVersion,
+				)
+			}
+
+			// perform the next migration
+			_, err = execQuery(ctx, db, migrations[version], nil)
 			if err != nil {
 				return fmt.Errorf("could not execute schema migration: %w", err)
 			}

--- a/vendor/go.xyrillian.de/gg/pgruntime/connector.go
+++ b/vendor/go.xyrillian.de/gg/pgruntime/connector.go
@@ -1,0 +1,176 @@
+// SPDX-FileCopyrightText: 2026 Stefan Majewsky <majewsky@gmx.net>
+// SPDX-License-Identifier: Apache-2.0
+
+package pgruntime
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/base32"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"go.xyrillian.de/gg/assert"
+	"go.xyrillian.de/gg/errext"
+	"go.xyrillian.de/gg/gsql"
+)
+
+// Connector describes how to connect to a PostgreSQL database given a [libpq-style connection URI].
+// This type acts as a dependency injection surface, abstracting the different ways in which different database drivers and libraries perform connection.
+//
+// [libpq-style connection URI]: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS
+type Connector[T gsql.ConnectionHandle] func(context.Context, ConnectionTarget) (T, error)
+
+// StdConnector returns a [Connector] for database/sql drivers.
+// When used with [lib/pq], the driver name must be "postgres".
+func StdConnector(driverName string) Connector[*gsql.DB] {
+	return func(ctx context.Context, target ConnectionTarget) (*gsql.DB, error) {
+		u, err := target.IntoURL()
+		if err != nil {
+			return nil, err
+		}
+		db, err := sql.Open(driverName, u.String())
+		if err != nil {
+			return nil, err
+		}
+		return gsql.NewDB(db), nil
+	}
+}
+
+// Connect connects to a PostgreSQL database.
+func (c Connector[T]) Connect(ctx context.Context, target ConnectionTarget, behavior ConnectionBehavior) (T, error) {
+	var none T // shorthand for error return paths
+
+	db, err := c(ctx, target)
+	if err != nil {
+		return none, err
+	}
+	err = behavior.applyTo(ctx, db)
+	if err != nil {
+		return none, errext.WithCleanup(err, "db.Close", db.GSQLClose(ctx))
+	}
+	return db, nil
+}
+
+// TestSetupOption is an optional behavior that can be given to [Connector.ConnectForTest].
+type TestSetupOption func(*testSetupParams)
+
+type testSetupParams struct {
+	DatabaseName string
+}
+
+// OverrideDatabaseName is a [TestSetupOption] that picks a different database name than the default of t.Name().
+//
+// This is only necessary if a single test needs to use multiple database connections at the same time,
+// e.g. to simulate two separate deployments of the application next to each other.
+func OverrideDatabaseName(dbName string) TestSetupOption {
+	return func(params *testSetupParams) {
+		params.DatabaseName = dbName
+	}
+}
+
+// ConnectForTest connects to the test database server managed by [WithTestDB].
+//
+// Each test will run in its own separate database (whose name is the same as t.Name()),
+// so it is safe to mark tests as t.Parallel() to run multiple tests within the same package concurrently.
+// ConnectForTest will always drop and recreate the database to ensure deterministic test behavior.
+//
+// Some tests require setting up multiple separate connections to the same database.
+// The second return argument can be be used with [Connector.Connect] to obtain additional connections as needed.
+func (c Connector[T]) ConnectForTest(t assert.TestingTB, behavior ConnectionBehavior, opts ...TestSetupOption) (T, ConnectionTarget) {
+	t.Helper()
+	ctx := t.Context()
+
+	params := testSetupParams{
+		DatabaseName: t.Name(),
+	}
+	for _, opt := range opts {
+		opt(&params)
+	}
+
+	// normalize t.Name() into an acceptable database name for PostgreSQL
+	//   - only alphanumerics and underscore -> replace all other symbols with _
+	//   - max 63 chars -> if overflown, truncate and append a short digest to hopefully make it unique
+	dbName := strings.ToLower(params.DatabaseName)
+	dbName = regexp.MustCompile(`[^a-z_]`).ReplaceAllString(dbName, "_")
+	if len(dbName) > 63 {
+		digest := sha256.Sum256([]byte(params.DatabaseName))
+		encoded := base32.HexEncoding.EncodeToString(digest[:])
+		dbName = dbName[0:53] + "__" + strings.ToLower(encoded[0:8])
+	}
+
+	// connect to "postgres" database for the CREATE DATABASE query (if necessary)
+	target := ConnectionTarget{
+		HostName:          "127.0.0.1",
+		Port:              testdbPort,
+		UserName:          testdbUserName,
+		DatabaseName:      "postgres",
+		ConnectionOptions: "sslmode=disable",
+	}
+	adminDB, err := c(ctx, target)
+	if err != nil {
+		t.Fatal(err.Error() + " (if this error is about the database server not running, check if your TestMain() calls pgruntime.WithTestDB())")
+	}
+	err = createDatabaseIfMissing(ctx, adminDB, dbName)
+	err = errext.WithCleanup(err, "db.Close", adminDB.GSQLClose(ctx))
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	// connect to actual test database
+	target.DatabaseName = dbName
+	testDB, err := c.Connect(ctx, target, behavior)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	err = resetTestDatabase(ctx, testDB, params, behavior)
+	if err != nil {
+		err = errext.WithCleanup(err, "db.Close", testDB.GSQLClose(ctx))
+		t.Fatal(err.Error())
+	}
+	return testDB, target
+}
+
+func createDatabaseIfMissing(ctx context.Context, db gsql.Handle, dbName string) error {
+	// check if database exists
+	exists, err := selectOneValue[bool](ctx, db, `SELECT COUNT(*) > 0 FROM pg_catalog.pg_database WHERE datname = $1`, dbName)
+	if err != nil {
+		return fmt.Errorf("while reading from pg_catalog.pg_database: %w", err)
+	}
+
+	// create database if necessary
+	if !exists {
+		_, err = execQuery(ctx, db, "CREATE DATABASE "+quoteIdentifier(dbName), nil)
+		if err != nil {
+			return fmt.Errorf("during CREATE DATABASE: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func resetTestDatabase(ctx context.Context, db gsql.Handle, params testSetupParams, behavior ConnectionBehavior) error {
+	// enumerate all tables that need to be truncated (all tables that are not managed by pgruntime)
+	condition := `table_schema = 'public' AND table_type = 'BASE TABLE'`
+	if len(behavior.Migrations) > 0 {
+		condition += ` AND table_name != 'schema_migrations'`
+	}
+	query := fmt.Sprintf(`SELECT quote_ident(table_name) FROM information_schema.tables WHERE %s ORDER BY table_name`, condition)
+	quotedTableNames, err := selectSeveralValues[string](ctx, db, query)
+	if err != nil {
+		return fmt.Errorf("while listing tables to truncate: %w", err)
+	}
+
+	// truncate all tables at once
+	if len(quotedTableNames) > 0 {
+		query = fmt.Sprintf(`TRUNCATE %s RESTART IDENTITY CASCADE`, strings.Join(quotedTableNames, ", "))
+		_, err = execQuery(ctx, db, query, nil)
+		if err != nil {
+			return fmt.Errorf("during %s: %w", query, err)
+		}
+	}
+
+	return nil
+}

--- a/vendor/go.xyrillian.de/gg/pgruntime/helpers.go
+++ b/vendor/go.xyrillian.de/gg/pgruntime/helpers.go
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2026 Stefan Majewsky <majewsky@gmx.net>
+// SPDX-License-Identifier: Apache-2.0
+
+package pgruntime
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+
+	"go.xyrillian.de/gg/errext"
+	"go.xyrillian.de/gg/gsql"
+)
+
+// Convenience function for executing a one-off SQL query returning no rows.
+// TODO: move to gsql
+func execQuery(ctx context.Context, db gsql.Handle, query string, args []any) (sql.Result, error) {
+	stmt, err := db.GSQLPrepare(ctx, query, false)
+	if err != nil {
+		return nil, err
+	}
+	result, err := stmt.Exec(ctx, args)
+	return result, errext.WithCleanup(err, "stmt.Close", stmt.Close())
+}
+
+// Convenience function for executing a one-off SQL query returning one row.
+func queryRow(ctx context.Context, db gsql.Handle, query string, args, slots []any) error {
+	stmt, err := db.GSQLPrepare(ctx, query, false)
+	if err != nil {
+		return err
+	}
+	err = stmt.QueryRow(ctx, args, slots)
+	return errext.WithCleanup(err, "stmt.Close", stmt.Close())
+}
+
+// Convenience function for executing a one-off SQL query returning one value.
+// TODO: move to gsql
+func selectOneValue[T any](ctx context.Context, db gsql.Handle, query string, args ...any) (T, error) {
+	stmt, err := db.GSQLPrepare(ctx, query, false)
+	if err != nil {
+		var none T
+		return none, err
+	}
+
+	var result T
+	err = stmt.QueryRow(ctx, args, []any{&result})
+	return result, errext.WithCleanup(err, "stmt.Close", stmt.Close())
+}
+
+// Convenience function for executing a one-off SQL query returning several single-column rows.
+// TODO: move to gsql (and also add ForeachValue with a callback instead of a slice return, maybe even ForeachPair and ForeachTriple)
+func selectSeveralValues[T any](ctx context.Context, db gsql.Handle, query string, args ...any) ([]T, error) {
+	rows, err := db.GSQLQuery(ctx, query, args)
+	if err != nil {
+		return nil, err
+	}
+	var result []T
+	for rows.Next() {
+		// TODO: this should share growRecordSlice() from Oblast to optimize allocations
+		var value T
+		err := rows.Scan(&value)
+		if err != nil {
+			return nil, errext.WithCleanup(err, "rows.Close", rows.Close())
+		}
+		result = append(result, value)
+	}
+	return result, errext.WithCleanup(nil, "rows.Err", rows.Err())
+}
+
+// Convenience function for preparing an identifier that needs to be inserted into a query verbatim
+// (e.g. a database name for CREATE DATABASE).
+func quoteIdentifier(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}

--- a/vendor/go.xyrillian.de/gg/pgruntime/pgruntime.go
+++ b/vendor/go.xyrillian.de/gg/pgruntime/pgruntime.go
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2026 Stefan Majewsky <majewsky@gmx.net>
+// SPDX-License-Identifier: Apache-2.0
+
+// Package pgruntime provides connection handling for PostgreSQL databases,
+// including optional support for database migrations and self-contained test DB instances.
+// It can be used with any PostgreSQL data driver, including [lib/pq] and [pgx].
+//
+// # Basic usage
+//
+// In productive scenarios, build a [ConnectionTarget] instance from configuration values or command-line arguments, and call [Connector.Connect].
+// In test scenarios, call [Connector.ConnectForTest].
+//
+// Both situations require a [Connector] instance:
+// When using an std-compatible driver like [lib/pq], use [StdConnector].
+// Otherwise, a custom [Connector] implementation must be supplied.
+// For [pgx], the connectors from [gg-pgx] may be used.
+//
+// # Legacy
+//
+// This is a clean-room reimplementation of one half of [easypg] with several interface improvements and cleanups, most notably:
+//   - The hard dependency on lib/pq has been removed.
+//   - Support for creating databases on first use has been removed (except in ConnectForTest).
+//   - The reset logic in ConnectForTest is completely reworked and massively simplified.
+//
+// [easypg]: https://pkg.go.dev/github.com/sapcc/go-bits/easypg
+// [lib/pq]: https://pkg.go.dev/github.com/lib/pq
+// [pgx]: https://pkg.go.dev/github.com/jackc/pgx/v5
+// [gg-pgx]: https://pkg.go.dev/go.xyrillian.de/gg-pgx
+package pgruntime

--- a/vendor/go.xyrillian.de/gg/pgruntime/target.go
+++ b/vendor/go.xyrillian.de/gg/pgruntime/target.go
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: 2026 Stefan Majewsky <majewsky@gmx.net>
+// SPDX-License-Identifier: Apache-2.0
+
+package pgruntime
+
+import (
+	"fmt"
+	"maps"
+	"net"
+	"net/url"
+	"strings"
+)
+
+// ConnectionTarget describes the location of and credentials and other connection options for the database server that [Connector.Connect] connects to.
+//
+//   - The HostName, UserName and DatabaseName fields are required. All other fields are optional.
+//   - The ConnectionOptions field is intended for options coming in via config.
+//     Its value must be formatted in the syntax accepted by [url.ParseQuery].
+//   - The ExtraConnectionOptions field is intended for options coming in via code.
+//   - Both ConnectionOptions fields accept all query parameters that are allowed in [libpq-style connection URIs].
+//
+// This type is intended to be retrieved from environment variables, for example:
+//
+//	ct := pgruntime.ConnectionTarget{
+//		HostName:          cmp.Or(os.Getenv("FOOBAR_DB_HOSTNAME"), "localhost"),
+//		Port:              cmp.Or(os.Getenv("FOOBAR_DB_PORT"), "5432"),
+//		UserName:          cmp.Or(os.Getenv("FOOBAR_DB_USERNAME"), "postgres"),
+//		Password:          os.Getenv("FOOBAR_DB_PASSWORD"),
+//		ConnectionOptions: os.Getenv("FOOBAR_DB_CONNECTION_OPTIONS"),
+//		DatabaseName:      cmp.Or(os.Getenv("FOOBAR_DB_NAME"), "foobar"),
+//	}))
+//
+// [libpq-style connection URIs]: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS
+type ConnectionTarget struct {
+	HostName               string
+	Port                   string
+	UserName               string
+	Password               string // default: <no password>
+	DatabaseName           string
+	ConnectionOptions      string
+	ExtraConnectionOptions url.Values
+}
+
+const (
+	connectionURISchemeShort = "postgres"
+	connectionURISchemeLong  = "postgresql"
+)
+
+// ParseConnectionTargetFromURL parses a [libpq-style connection URI] into a [ConnectionTarget] instance.
+// If there are connection options, they will be placed in the ConnectionOptions field, not in ExtraConnectionOptions.
+//
+// The special libpq syntax with multiple host:port pairs is not supported by this function and will result in an error.
+//
+// [libpq-style connection URI]: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS
+func ParseConnectionTargetFromURL(u *url.URL) (ConnectionTarget, error) {
+	var (
+		result ConnectionTarget
+		none   ConnectionTarget // shorthand for error return paths
+	)
+
+	if u.Scheme != connectionURISchemeShort && u.Scheme != connectionURISchemeLong {
+		return none, fmt.Errorf(`in ParseConnectionTargetFromURL: expected scheme %q or %q, but got %q`, connectionURISchemeShort, connectionURISchemeLong, u.Scheme)
+	}
+	if u.Opaque != "" {
+		return none, fmt.Errorf(`in ParseConnectionTargetFromURL: expected authority component, but got rootless path %q`, u.Opaque)
+	}
+	if u.Fragment != "" {
+		return none, fmt.Errorf(`in ParseConnectionTargetFromURL: unexpected fragment %q`, u.Fragment)
+	}
+
+	var err error
+	if strings.Contains(u.Host, ":") {
+		result.HostName, result.Port, err = net.SplitHostPort(u.Host)
+		if err != nil {
+			return none, fmt.Errorf(`in ParseConnectionTargetFromURL: malformed host %q`, u.Host)
+		}
+	} else {
+		result.HostName = u.Host
+	}
+	result.UserName = u.User.Username()
+	result.Password, _ = u.User.Password()
+
+	result.DatabaseName = strings.TrimPrefix(u.Path, "/")
+	if strings.Contains(result.DatabaseName, "/") {
+		return none, fmt.Errorf(`in ParseConnectionTargetFromURL: malformed database name %q`, result.DatabaseName)
+	}
+
+	if u.RawQuery != "" {
+		_, err := url.ParseQuery(u.RawQuery)
+		if err != nil {
+			return none, fmt.Errorf(`in ParseConnectionTargetFromURL: malformed connection options: %w`, err)
+		}
+		result.ConnectionOptions = u.RawQuery
+	}
+
+	return result, nil
+}
+
+// IntoURL formats the ConnectionTarget as a libpq-style connection URI.
+func (t ConnectionTarget) IntoURL() (*url.URL, error) {
+	rawQuery, err := mergeConnectionOptions(t.ConnectionOptions, t.ExtraConnectionOptions)
+	if err != nil {
+		return nil, fmt.Errorf("in ConnectionTarget.IntoURL: malformed connection options: %w", err)
+	}
+	return &url.URL{
+		Scheme:   connectionURISchemeShort, // could also use `connectionURISchemeLong`, but go-bits/easypg made this choice
+		User:     t.buildUserInfo(),
+		Host:     t.buildHostPort(),
+		Path:     "/" + t.DatabaseName,
+		RawQuery: rawQuery,
+	}, nil
+}
+
+func (t ConnectionTarget) buildUserInfo() *url.Userinfo {
+	if t.Password == "" {
+		return url.User(t.UserName)
+	} else {
+		return url.UserPassword(t.UserName, t.Password)
+	}
+}
+
+func (t ConnectionTarget) buildHostPort() string {
+	if t.Port == "" {
+		return t.HostName
+	} else {
+		return net.JoinHostPort(t.HostName, t.Port)
+	}
+}
+
+func mergeConnectionOptions(opts string, extraOpts url.Values) (string, error) {
+	if len(extraOpts) == 0 {
+		return opts, nil
+	}
+	if opts == "" {
+		return extraOpts.Encode(), nil
+	}
+
+	values, err := url.ParseQuery(opts)
+	if err != nil {
+		return "", err
+	}
+	maps.Copy(values, extraOpts)
+	return values.Encode(), nil
+}

--- a/vendor/go.xyrillian.de/gg/pgruntime/target.go
+++ b/vendor/go.xyrillian.de/gg/pgruntime/target.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"net"
 	"net/url"
+	"os"
 	"strings"
 )
 
@@ -18,6 +19,9 @@ import (
 //     Its value must be formatted in the syntax accepted by [url.ParseQuery].
 //   - The ExtraConnectionOptions field is intended for options coming in via code.
 //   - Both ConnectionOptions fields accept all query parameters that are allowed in [libpq-style connection URIs].
+//   - ApplicationName is an alternative way of setting ExtraConnectionOptions["fallback_application_name"].
+//     If filled, pgruntime will also try to automatically append the hostname if available.
+//     An explicit "application_name" setting in either ConnectionOptions or ExtraConnectionOptions takes precedence over this setting.
 //
 // This type is intended to be retrieved from environment variables, for example:
 //
@@ -39,6 +43,7 @@ type ConnectionTarget struct {
 	DatabaseName           string
 	ConnectionOptions      string
 	ExtraConnectionOptions url.Values
+	ApplicationName        string
 }
 
 const (
@@ -47,7 +52,7 @@ const (
 )
 
 // ParseConnectionTargetFromURL parses a [libpq-style connection URI] into a [ConnectionTarget] instance.
-// If there are connection options, they will be placed in the ConnectionOptions field, not in ExtraConnectionOptions.
+// If there are connection options, they will be placed in the ConnectionOptions field, not in ExtraConnectionOptions or ApplicationName.
 //
 // The special libpq syntax with multiple host:port pairs is not supported by this function and will result in an error.
 //
@@ -96,9 +101,20 @@ func ParseConnectionTargetFromURL(u *url.URL) (ConnectionTarget, error) {
 	return result, nil
 }
 
+// dependency injection slot to insert a double during tests
+var osHostname = os.Hostname
+
 // IntoURL formats the ConnectionTarget as a libpq-style connection URI.
 func (t ConnectionTarget) IntoURL() (*url.URL, error) {
-	rawQuery, err := mergeConnectionOptions(t.ConnectionOptions, t.ExtraConnectionOptions)
+	appName := t.ApplicationName
+	if appName != "" {
+		hostname, err := osHostname()
+		if err == nil {
+			appName += "@" + hostname
+		}
+	}
+
+	rawQuery, err := mergeConnectionOptions(t.ConnectionOptions, t.ExtraConnectionOptions, appName)
 	if err != nil {
 		return nil, fmt.Errorf("in ConnectionTarget.IntoURL: malformed connection options: %w", err)
 	}
@@ -127,12 +143,21 @@ func (t ConnectionTarget) buildHostPort() string {
 	}
 }
 
-func mergeConnectionOptions(opts string, extraOpts url.Values) (string, error) {
-	if len(extraOpts) == 0 {
+func mergeConnectionOptions(opts string, extraOpts url.Values, appName string) (string, error) {
+	if len(extraOpts) == 0 && appName == "" {
 		return opts, nil
 	}
 	if opts == "" {
-		return extraOpts.Encode(), nil
+		if appName == "" {
+			return extraOpts.Encode(), nil
+		} else {
+			cloned := maps.Clone(extraOpts)
+			if cloned == nil {
+				cloned = make(url.Values)
+			}
+			cloned.Set("fallback_application_name", appName)
+			return cloned.Encode(), nil
+		}
 	}
 
 	values, err := url.ParseQuery(opts)
@@ -140,5 +165,8 @@ func mergeConnectionOptions(opts string, extraOpts url.Values) (string, error) {
 		return "", err
 	}
 	maps.Copy(values, extraOpts)
+	if appName != "" {
+		values.Set("fallback_application_name", appName)
+	}
 	return values.Encode(), nil
 }

--- a/vendor/go.xyrillian.de/gg/pgruntime/testdb.go
+++ b/vendor/go.xyrillian.de/gg/pgruntime/testdb.go
@@ -1,0 +1,313 @@
+// SPDX-FileCopyrightText: 2026 Stefan Majewsky <majewsky@gmx.net>
+// SPDX-License-Identifier: Apache-2.0
+
+package pgruntime
+
+import (
+	"bytes"
+	_ "embed"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime/debug"
+	"strings"
+	"testing"
+	"time"
+
+	. "go.xyrillian.de/gg/option"
+)
+
+const (
+	// ConnectionTarget attributes for test DB
+	testdbUserName = "postgres"
+	testdbPort     = "54320"
+
+	// paths below $MODULE_ROOT/.testdb
+	testdbDatadirLocation = "datadir"
+	testdbVersionLocation = "datadir/PG_VERSION"
+	testdbRuntimeLocation = "run"
+	testdbLogfileLocation = "run/postgresql.log"
+	testdbPidfileLocation = "run/pid"
+)
+
+//go:embed tool_template.sh
+var toolScriptTemplate []byte
+
+// WithTestDB spawns a PostgreSQL database for the duration of a `go test` run.
+// Its data directory, configuration and logs are stored in the ".testdb" directory below the module root dir (next to the "go.mod" file).
+//   - To inspect it manually, use one of the helper scripts in the ".testdb" directory, e.g. ".testdb/psql.sh".
+//   - It is currently not supported to run tests for multiple packages concurrently. Run "go test" with "-p 1" when running tests for multiple packages.
+//   - The "/.testdb" directory should be added to your repository's .gitignore rules.
+//
+// This function takes a [testing.M] because it is supposed to be called from TestMain().
+// This ensures that its cleanup phase shuts down the database server after all tests have been executed.
+// Add a TestMain() like this to each package that calls [Connector.ConnectForTest]:
+//
+//	func TestMain(m *testing.M) {
+//		pgruntime.WithTestDB(m, m.Run)
+//	}
+//
+// If the environment variable PGRUNTIME_TESTDB_PATH is set, this path will be used instead of ".testdb" below the module root dir.
+// This can be used e.g. to place the testdb on a tmpfs to avoid slow disk IO.
+// Doing so can reduce test execution times in realistic scenarios by as much as two thirds.
+// For clarity, a symlink will be created at the usual ".testdb" location, pointing to the actual path.
+//
+// If the value of $PGRUNTIME_TESTDB_PATH contains the string "%MODULE%" (e.g. "/tmp/testdb/%MODULE%"),
+// this string will be replaced by the name of the main module.
+// Using this placeholder, you can set this variable in your shell rc file once,
+// but the test databases of different applications will still be neatly separated.
+func WithTestDB(m *testing.M, action func() int) int {
+	// NOTE: Lifting the "-p 1" restriction is tough because tests for multiple packages are
+	//       compiled into one test binary per package, and thus execute in separate processes.
+	//       We would need some way for all these binaries to coordinate on only shutting down
+	//       the server once everyone is finished with their tests. The obvious choices for
+	//       coordination mechanisms (IPC or file locking) are platform-specific and would
+	//       require introducing dependencies (ugh) or adding platform-specific code (ugh).
+
+	result, err := withTestDB(m, action)
+	if err == nil {
+		return result
+	} else {
+		panic(err.Error())
+	}
+}
+
+func withTestDB(m *testing.M, action func() int) (_ int, returnedError error) {
+	testdbPath, err := findTestdbPath()
+	if err != nil {
+		return 0, err
+	}
+	err = stopDBIfLingering(testdbPath)
+	if err != nil {
+		return 0, err
+	}
+	err = wipeDBIfMajorUpgrade(testdbPath)
+	if err != nil {
+		return 0, err
+	}
+	err = initDBIfNecessary(testdbPath)
+	if err != nil {
+		return 0, err
+	}
+	err = startDB(testdbPath)
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		returnedError = stopDB(testdbPath)
+	}()
+	return action(), nil
+}
+
+func findTestdbPath() (string, error) {
+	// find `$REPO_ROOT/.testdb`
+	cwd, err := os.Getwd()
+	if err == nil {
+		cwd, err = filepath.Abs(cwd)
+	}
+	if err != nil {
+		return "", fmt.Errorf("could not find working directory: %w", err)
+	}
+	result, err := findModuleRootDir(cwd)
+	if err != nil {
+		return "", fmt.Errorf("could not find module root directory: %w", err)
+	}
+	rootPath, ok := result.Unpack()
+	if !ok {
+		return "", fmt.Errorf("neither the working directory %q nor any of its parents contain a go.mod file", cwd)
+	}
+	testdbPath := filepath.Join(rootPath, ".testdb")
+
+	// find override path, if any
+	overridePath := os.Getenv("PGRUNTIME_TESTDB_PATH")
+	if overridePath == "" {
+		return testdbPath, nil
+	}
+	if strings.Contains(overridePath, "%MODULE%") {
+		info, ok := debug.ReadBuildInfo()
+		if !ok {
+			panic("$PGRUNTIME_TESTDB_PATH contains %MODULE% placeholder, but binary was not built with module support")
+		}
+		overridePath = strings.ReplaceAll(overridePath, "%MODULE%", info.Main.Path)
+	}
+
+	// if there is an override path, report the override path (so that initDBIfNecessary can create it),
+	// but put a symlink at the standard path for convenient access
+	err = os.Symlink(overridePath, testdbPath)
+	if os.IsExist(err) {
+		// do not complain if the symlink already exists
+		err = nil
+	}
+	return overridePath, err
+}
+
+func findModuleRootDir(dirPath string) (Option[string], error) {
+	_, err := os.Stat(filepath.Join(dirPath, "go.mod"))
+	switch {
+	case err == nil:
+		return Some(dirPath), nil
+	case os.IsNotExist(err):
+		parentPath := filepath.Dir(dirPath)
+		if parentPath == dirPath {
+			return None[string](), nil
+		} else {
+			return findModuleRootDir(parentPath)
+		}
+	default:
+		return None[string](), err
+	}
+}
+
+func wipeDBIfMajorUpgrade(testdbPath string) error {
+	// check datadir/PG_VERSION for test database
+	buf, err := os.ReadFile(filepath.Join(testdbPath, testdbVersionLocation))
+	switch {
+	case err == nil:
+		// continue below
+	case os.IsNotExist(err):
+		// DB not initialized yet -> nothing to do
+		return nil
+	default:
+		return err
+	}
+	serverVersion := strings.TrimSpace(string(buf))
+
+	// check installed PostgreSQL version via `psql --version`
+	cmd := exec.Command("psql", "--version")
+	cmd.Stderr = os.Stderr
+	buf, err = cmd.Output()
+	if err != nil {
+		return fmt.Errorf("could not run `psql --version`: %w", err)
+	}
+
+	// output from `psql --version` should look like e.g. "psql (PostgreSQL) 18.4" -> we want just the version number part
+	clientOutput := strings.TrimSpace(string(buf))
+	fields := strings.Fields(clientOutput)
+	if len(fields) != 3 || fields[0] != "psql" || fields[1] != "(PostgreSQL)" {
+		return fmt.Errorf("unexpected output from `psql --version`: %q", clientOutput)
+	}
+	clientVersion := fields[2]
+
+	// wipe DB on version mismatch (`serverVersion` will be a major version like "18", and `clientVersion` a minor version like "18.4")
+	if strings.HasPrefix(clientVersion, serverVersion) {
+		return nil
+	}
+	return os.RemoveAll(testdbPath) // wipe everything, including the .testdb folder, to make initDBIfNecessary() work
+}
+
+func initDBIfNecessary(testdbPath string) error {
+	// check if already initialized
+	fi, err := os.Stat(testdbPath)
+	switch {
+	case err == nil:
+		if fi.IsDir() {
+			return nil
+		} else {
+			return fmt.Errorf("unexpected type of filesystem entry on %q (expected a directory)", testdbPath)
+		}
+	case os.IsNotExist(err):
+		// need to run initdb, continue below
+	default:
+		return err
+	}
+
+	// create scaffold
+	var (
+		datadirPath = filepath.Join(testdbPath, testdbDatadirLocation)
+		runtimePath = filepath.Join(testdbPath, testdbRuntimeLocation)
+	)
+	err = os.MkdirAll(datadirPath, 0777)
+	if err != nil {
+		return err
+	}
+	err = os.MkdirAll(runtimePath, 0777)
+	if err != nil {
+		return err
+	}
+	for _, toolName := range []string{"pgcli", "pg_dump", "psql"} {
+		buf := bytes.ReplaceAll(toolScriptTemplate, []byte("$COMMAND"), []byte(toolName))
+		err := os.WriteFile(filepath.Join(testdbPath, toolName+".sh"), buf, 0777)
+		if err != nil {
+			return err
+		}
+	}
+
+	// run initdb
+	cmd := exec.Command("initdb",
+		"--pgdata="+datadirPath,
+		"--no-locale",
+		"--auth=trust", "--username="+testdbUserName,
+		"--set", "external_pid_file="+filepath.Join(testdbPath, testdbPidfileLocation),
+		"--set", "max_connections=250",
+		"--set", "port="+testdbPort,
+		"--set", "unix_socket_directories="+runtimePath,
+	)
+	cmd.Dir = testdbPath
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("could not run `initdb`: %w", err)
+	}
+	return nil
+}
+
+func startDB(testdbPath string) error {
+	// truncate logfile
+	logfilePath := filepath.Join(testdbPath, testdbLogfileLocation)
+	err := os.Remove(logfilePath)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	// run `pg_ctl start`
+	cmd := exec.Command("pg_ctl",
+		"start", "--wait", "--silent",
+		"-D", filepath.Join(testdbPath, testdbDatadirLocation),
+		"-l", logfilePath,
+	)
+	cmd.Dir = testdbPath
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("could not run `pg_ctl start`: %w", err)
+	}
+	return nil
+}
+
+func stopDB(testdbPath string) error {
+	cmd := exec.Command("pg_ctl",
+		"stop", "--wait", "--silent",
+		"-D", filepath.Join(testdbPath, testdbDatadirLocation),
+	)
+	cmd.Dir = testdbPath
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("could not run `pg_ctl stop`: %w", err)
+	}
+	return nil
+}
+
+func stopDBIfLingering(testdbPath string) error {
+	_, err := os.Stat(filepath.Join(testdbPath, testdbPidfileLocation))
+	switch {
+	case err == nil:
+		// looks like a previous instance of this DB is still running -> restart it
+		// (we do not just reuse an instance started by someone else because they might terminate it at any point;
+		// better to make them fail loudly right now)
+		err = stopDB(testdbPath)
+		if err != nil {
+			return err
+		}
+		time.Sleep(time.Second / 2) // give them some time to blow up before starting the DB back up
+		return nil
+	case os.IsNotExist(err):
+		return nil // nothing to do, DB is not running
+	default:
+		return err
+	}
+}

--- a/vendor/go.xyrillian.de/gg/pgruntime/testdb.go
+++ b/vendor/go.xyrillian.de/gg/pgruntime/testdb.go
@@ -181,10 +181,13 @@ func wipeDBIfMajorUpgrade(testdbPath string) error {
 		return fmt.Errorf("could not run `psql --version`: %w", err)
 	}
 
-	// output from `psql --version` should look like e.g. "psql (PostgreSQL) 18.4" -> we want just the version number part
+	// output from `psql --version` should look like e.g.
+	//   "psql (PostgreSQL) 18.4"                                (seen on Arch Linux)
+	//   "psql (PostgreSQL) 18.4 (Ubuntu 18.4-0ubuntu0.26.04.1)" (seen on Ubuntu)
+	// -> we want just the version number part
 	clientOutput := strings.TrimSpace(string(buf))
 	fields := strings.Fields(clientOutput)
-	if len(fields) != 3 || fields[0] != "psql" || fields[1] != "(PostgreSQL)" {
+	if len(fields) < 3 || fields[0] != "psql" || fields[1] != "(PostgreSQL)" {
 		return fmt.Errorf("unexpected output from `psql --version`: %q", clientOutput)
 	}
 	clientVersion := fields[2]

--- a/vendor/go.xyrillian.de/gg/pgruntime/tool_template.sh
+++ b/vendor/go.xyrillian.de/gg/pgruntime/tool_template.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+
+stop_postgres() {
+	EXIT_CODE=$?
+	pg_ctl stop --wait --silent -D datadir
+	exit "${EXIT_CODE}"
+}
+trap stop_postgres EXIT INT TERM
+
+rm -f -- run/postgresql.log
+pg_ctl start --wait --silent -D datadir -l run/postgresql.log
+$COMMAND -U postgres -h 127.0.0.1 -p 54320 "$@"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -178,7 +178,7 @@ github.com/sapcc/go-bits/syncext
 # github.com/sergi/go-diff v1.4.0
 ## explicit; go 1.13
 github.com/sergi/go-diff/diffmatchpatch
-# go.xyrillian.de/gg v1.12.0
+# go.xyrillian.de/gg v1.13.0
 ## explicit; go 1.26
 go.xyrillian.de/gg/assert
 go.xyrillian.de/gg/errext
@@ -188,6 +188,7 @@ go.xyrillian.de/gg/is
 go.xyrillian.de/gg/jsonmatch
 go.xyrillian.de/gg/option
 go.xyrillian.de/gg/options
+go.xyrillian.de/gg/pgruntime
 # go.xyrillian.de/oblast v0.13.2
 ## explicit; go 1.26
 go.xyrillian.de/oblast

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -178,7 +178,7 @@ github.com/sapcc/go-bits/syncext
 # github.com/sergi/go-diff v1.4.0
 ## explicit; go 1.13
 github.com/sergi/go-diff/diffmatchpatch
-# go.xyrillian.de/gg v1.13.0
+# go.xyrillian.de/gg v1.13.2
 ## explicit; go 1.26
 go.xyrillian.de/gg/assert
 go.xyrillian.de/gg/errext

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -178,7 +178,7 @@ github.com/sapcc/go-bits/syncext
 # github.com/sergi/go-diff v1.4.0
 ## explicit; go 1.13
 github.com/sergi/go-diff/diffmatchpatch
-# go.xyrillian.de/gg v1.13.2
+# go.xyrillian.de/gg v1.13.3
 ## explicit; go 1.26
 go.xyrillian.de/gg/assert
 go.xyrillian.de/gg/errext


### PR DESCRIPTION
pgruntime is a clean-room reimplementation of the respective part of easypg, with several improvements:

- Down migrations are removed, because there was no way to invoke them anyway (except by applying them to the DB manually). They are also not really relevant for PostgreSQL anyway, because PostgreSQL can execute DDL in transactions, and so a faulty migration cannot leave the DB in a dirty state.
- Nearly all TestSetupOptions are removed. All the "clever" logic for wiping test databases from easypg turns out to not really be necessary; pgruntime just runs `TRUNCATE ... RESTART IDENTITY` on all tables instead.
- The `.testdb` directory can be [redirected] to a path of the user's choosing. Not sure if this is going to be interesting for the macOS users here, but as a Linux user, I found that putting my testdb on tmpfs speeds up my `make check` by a solid 30-40%.
- Unlike easypg, which depends on golang-migrate, a library with tons and tons of dependencies, pgruntime has zero non-std dependencies. You cannot see it in this commit yet because easypg is still used for DB test assertions, but once we can get rid of the golang-migrate dependency within go-bits/easypg, we will see `vendor/` shrink by about 4 KLOC and `go.sum` by about 20%.

[redirected]: https://pkg.go.dev/go.xyrillian.de/gg/pgruntime#WithTestDB