### PR TITLE
add `service_id` attribute to `categories` table 

### DIFF
--- a/internal/api/reports_v2/info.go
+++ b/internal/api/reports_v2/info.go
@@ -89,10 +89,10 @@ func GetResourcesInfo(cluster *core.Cluster, token *gopherpolicy.Token, timeNow 
 		Areas:  make(map[string]resourcesv2.AreaInfoReport),
 	}
 	services := sis.GetServices()
-	categories := sis.GetCategories()
 
 	for _, serviceType := range slices.Sorted(maps.Keys(services)) {
 		service := services[serviceType]
+		categories := sis.GetCategoriesForType(serviceType)
 		resources, _ := sis.GetResourcesForType(serviceType) // can have no resources
 		// skip non-allowed resources for this user, if any
 		allowedResources, serviceTypeOK := allowedResourcesByService[serviceType]
@@ -179,10 +179,10 @@ func GetRatesInfo(cluster *core.Cluster, token *gopherpolicy.Token, sis core.Ser
 		Areas:  make(map[string]ratesv2.AreaInfoReport),
 	}
 	services := sis.GetServices()
-	categories := sis.GetCategories()
 
 	for _, serviceType := range slices.Sorted(maps.Keys(services)) {
 		service := services[serviceType]
+		categories := sis.GetCategoriesForType(serviceType)
 		rates, _ := sis.GetRatesForType(serviceType) // can have no rates
 		config := cluster.Config.Liquids[serviceType]
 		area := config.Area

--- a/internal/collector/capacity_scrape_test.go
+++ b/internal/collector/capacity_scrape_test.go
@@ -694,7 +694,7 @@ func Test_ScanManualCapacity(t *testing.T) {
 		INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (5, 1, 'unknown', 0, 'shared/capacity/unknown');
 		INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (6, 2, 'any', 0, 'shared/things/any');
 		INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (7, 2, 'total', 0, 'shared/things/total');
-		INSERT INTO categories (id, name, display_name) VALUES (1, 'foo_category', 'Foo Category');
+		INSERT INTO categories (id, name, display_name, service_id) VALUES (1, 'foo_category', 'Foo Category', 1);
 		INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, needs_resource_demand, has_quota, path, display_name, category_id) VALUES (1, 1, 'capacity', 1, 'B', 'az-aware', TRUE, TRUE, TRUE, 'shared/capacity', 'Capacity', 1);
 		INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_quota, path, display_name) VALUES (2, 1, 'things', 1, 'piece', 'flat', TRUE, 'shared/things', 'Things');
 		INSERT INTO services (id, type, next_scrape_at, liquid_version, display_name) VALUES (1, 'shared', %[1]d, 1, 'Shared');

--- a/internal/collector/fixtures/checkconsistency0.sql
+++ b/internal/collector/fixtures/checkconsistency0.sql
@@ -13,7 +13,8 @@ INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (7, 2,
 INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (8, 3, 'any', 0, 'unshared/capacity/any');
 INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (9, 3, 'az-one', 0, 'unshared/capacity/az-one');
 
-INSERT INTO categories (id, name, display_name) VALUES (1, 'foo_category', 'Foo Category');
+INSERT INTO categories (id, name, display_name, service_id) VALUES (1, 'foo_category', 'Foo Category', 1);
+INSERT INTO categories (id, name, display_name, service_id) VALUES (2, 'foo_category', 'Foo Category', 2);
 
 INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
 INSERT INTO domains (id, name, uuid) VALUES (2, 'france', 'uuid-for-france');
@@ -31,7 +32,7 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (3, 2, 'par
 
 INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, needs_resource_demand, has_quota, path, display_name, category_id) VALUES (1, 1, 'capacity', 1, 'B', 'az-aware', TRUE, TRUE, TRUE, 'shared/capacity', 'Capacity', 1);
 INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_quota, path, display_name) VALUES (2, 1, 'things', 1, 'piece', 'flat', TRUE, 'shared/things', 'Things');
-INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, needs_resource_demand, has_quota, path, display_name, category_id) VALUES (3, 2, 'capacity', 1, 'B', 'az-aware', TRUE, TRUE, TRUE, 'unshared/capacity', 'Capacity', 1);
+INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, needs_resource_demand, has_quota, path, display_name, category_id) VALUES (3, 2, 'capacity', 1, 'B', 'az-aware', TRUE, TRUE, TRUE, 'unshared/capacity', 'Capacity', 2);
 INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_quota, path, display_name) VALUES (4, 2, 'things', 1, 'piece', 'flat', TRUE, 'unshared/things', 'Things');
 
 INSERT INTO services (id, type, next_scrape_at, liquid_version, display_name) VALUES (1, 'shared', 0, 1, 'Shared');

--- a/internal/collector/fixtures/scandomains1.sql
+++ b/internal/collector/fixtures/scandomains1.sql
@@ -13,7 +13,8 @@ INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (7, 2,
 INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (8, 3, 'any', 0, 'unshared/capacity/any');
 INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (9, 3, 'az-one', 0, 'unshared/capacity/az-one');
 
-INSERT INTO categories (id, name, display_name) VALUES (1, 'foo_category', 'Foo Category');
+INSERT INTO categories (id, name, display_name, service_id) VALUES (1, 'foo_category', 'Foo Category', 1);
+INSERT INTO categories (id, name, display_name, service_id) VALUES (2, 'foo_category', 'Foo Category', 2);
 
 INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
 INSERT INTO domains (id, name, uuid) VALUES (2, 'france', 'uuid-for-france');
@@ -31,7 +32,7 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (3, 2, 'par
 
 INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, needs_resource_demand, has_quota, path, display_name, category_id) VALUES (1, 1, 'capacity', 1, 'B', 'az-aware', TRUE, TRUE, TRUE, 'shared/capacity', 'Capacity', 1);
 INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_quota, path, display_name) VALUES (2, 1, 'things', 1, 'piece', 'flat', TRUE, 'shared/things', 'Things');
-INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, needs_resource_demand, has_quota, path, display_name, category_id) VALUES (3, 2, 'capacity', 1, 'B', 'az-aware', TRUE, TRUE, TRUE, 'unshared/capacity', 'Capacity', 1);
+INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, needs_resource_demand, has_quota, path, display_name, category_id) VALUES (3, 2, 'capacity', 1, 'B', 'az-aware', TRUE, TRUE, TRUE, 'unshared/capacity', 'Capacity', 2);
 INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_quota, path, display_name) VALUES (4, 2, 'things', 1, 'piece', 'flat', TRUE, 'unshared/things', 'Things');
 
 INSERT INTO services (id, type, next_scrape_at, liquid_version, display_name) VALUES (1, 'shared', 0, 1, 'Shared');

--- a/internal/core/cluster.go
+++ b/internal/core/cluster.go
@@ -396,23 +396,24 @@ func SaveServiceInfoToDB(ctx context.Context, serviceType db.ServiceType, servic
 			if !ReduceLogSpam {
 				logg.Info("SaveServiceInfoToDB: creating Resource %s/%s with LiquidVersion = %d", serviceType, resourceName, serviceInfo.Version)
 			}
-			categoryID := options.Map(serviceInfo.Resources[resourceName].Category,
+			resInfo := serviceInfo.Resources[resourceName]
+			categoryID := options.Map(resInfo.Category,
 				func(cn liquid.CategoryName) db.CategoryID { return categoryByName[cn].ID })
 			return db.Resource{
 				ServiceID:   srv.ID,
 				Name:        resourceName,
-				DisplayName: serviceInfo.Resources[resourceName].DisplayName,
+				DisplayName: resInfo.DisplayName,
 				// TODO: consider serializing empty categories as serviceType here, instead at the consumers
 				CategoryID:          categoryID,
 				Path:                db.ResourcePath{ServiceType: serviceType, ResourceName: resourceName},
 				LiquidVersion:       serviceInfo.Version,
-				Unit:                serviceInfo.Resources[resourceName].Unit,
-				Topology:            serviceInfo.Resources[resourceName].Topology,
-				HasCapacity:         serviceInfo.Resources[resourceName].HasCapacity,
-				NeedsResourceDemand: serviceInfo.Resources[resourceName].NeedsResourceDemand,
-				HasQuota:            serviceInfo.Resources[resourceName].HasQuota,
-				AttributesJSON:      string(serviceInfo.Resources[resourceName].Attributes),
-				HandlesCommitments:  serviceInfo.Resources[resourceName].HandlesCommitments,
+				Unit:                resInfo.Unit,
+				Topology:            resInfo.Topology,
+				HasCapacity:         resInfo.HasCapacity,
+				NeedsResourceDemand: resInfo.NeedsResourceDemand,
+				HasQuota:            resInfo.HasQuota,
+				AttributesJSON:      string(resInfo.Attributes),
+				HandlesCommitments:  resInfo.HandlesCommitments,
 			}, nil
 		},
 		Update: func(res *db.Resource) (err error) {
@@ -420,23 +421,24 @@ func SaveServiceInfoToDB(ctx context.Context, serviceType db.ServiceType, servic
 				logg.Info("SaveServiceInfoToDB: updating Resource %s/%s from LiquidVersion = %d to %d", serviceType, res.Name, res.LiquidVersion, serviceInfo.Version)
 			}
 			res.LiquidVersion = serviceInfo.Version
-			if res.Unit != serviceInfo.Resources[res.Name].Unit {
+			resInfo := serviceInfo.Resources[res.Name]
+			if res.Unit != resInfo.Unit {
 				unitChangesByResourceID[res.ID] = unitChange{
 					oldUnit: res.Unit,
-					newUnit: serviceInfo.Resources[res.Name].Unit,
+					newUnit: resInfo.Unit,
 				}
 			}
-			res.DisplayName = serviceInfo.Resources[res.Name].DisplayName
+			res.DisplayName = resInfo.DisplayName
 			// TODO: consider serializing empty categories as serviceType here, instead at the consumers
-			res.CategoryID = options.Map(serviceInfo.Resources[res.Name].Category,
+			res.CategoryID = options.Map(resInfo.Category,
 				func(cn liquid.CategoryName) db.CategoryID { return categoryByName[cn].ID })
-			res.Unit = serviceInfo.Resources[res.Name].Unit
-			res.Topology = serviceInfo.Resources[res.Name].Topology
-			res.HasCapacity = serviceInfo.Resources[res.Name].HasCapacity
-			res.NeedsResourceDemand = serviceInfo.Resources[res.Name].NeedsResourceDemand
-			res.HasQuota = serviceInfo.Resources[res.Name].HasQuota
-			res.AttributesJSON = string(serviceInfo.Resources[res.Name].Attributes)
-			res.HandlesCommitments = serviceInfo.Resources[res.Name].HandlesCommitments
+			res.Unit = resInfo.Unit
+			res.Topology = resInfo.Topology
+			res.HasCapacity = resInfo.HasCapacity
+			res.NeedsResourceDemand = resInfo.NeedsResourceDemand
+			res.HasQuota = resInfo.HasQuota
+			res.AttributesJSON = string(resInfo.Attributes)
+			res.HandlesCommitments = resInfo.HandlesCommitments
 			return nil
 		},
 		PreDelete: Some(generateDeleteFunc(dbm, func(r db.Resource) string { return r.Path.String() + "/%" })),

--- a/internal/core/cluster.go
+++ b/internal/core/cluster.go
@@ -355,19 +355,37 @@ func SaveServiceInfoToDB(ctx context.Context, serviceType db.ServiceType, servic
 	}
 	srv := dbServices[0]
 
-	// The categories don't have a reference to the service, so we just add all categories which are new
-	// and delete the one's which are unused after the resources for this service were reconciled.
-	categoryByName, err := db.CategoryByNameIndex.IndexFrom(db.CategoryStore.Select(ctx, tx, `SELECT * FROM categories`))
-	for name, categoryInfo := range serviceInfo.Categories {
-		if _, exists := categoryByName[name]; !exists {
-			newCategory := db.Category{Name: name, DisplayName: categoryInfo.DisplayName}
-			err = db.CategoryStore.Insert(ctx, tx, &newCategory)
-			if err != nil {
-				return fmt.Errorf("cannot insert category %s for %s: %w", name, serviceType, err)
-			}
-			categoryByName[name] = newCategory
-		}
+	// collect existing and wanted categories
+	dbCategories, err := db.CategoryStore.SelectWhere(ctx, tx, `service_id = $1`, srv.ID).Collect()
+	if err != nil {
+		return fmt.Errorf("cannot inspect existing categories for %s: %w", serviceType, err)
 	}
+	wantedCategories := slices.Collect(maps.Keys(serviceInfo.Categories))
+	dbCategories, err = db.SetUpdate[db.Category, liquid.CategoryName]{
+		ExistingRecords: dbCategories,
+		WantedKeys:      wantedCategories,
+		KeyForRecord:    func(c db.Category) liquid.CategoryName { return c.Name },
+		Create: func(categoryName liquid.CategoryName) (db.Category, error) {
+			if !ReduceLogSpam {
+				logg.Info("SaveServiceInfoToDB: creating Category %s/%s with LiquidVersion = %d", serviceType, categoryName, serviceInfo.Version)
+			}
+			categoryInfo := serviceInfo.Categories[categoryName]
+			return db.Category{
+				ServiceID:   srv.ID,
+				Name:        categoryName,
+				DisplayName: categoryInfo.DisplayName,
+			}, nil
+		},
+		Update: func(category *db.Category) error {
+			categoryInfo := serviceInfo.Categories[category.Name]
+			category.DisplayName = categoryInfo.DisplayName
+			return nil
+		},
+	}.Execute(ctx, tx, db.CategoryStore)
+	if err != nil {
+		return fmt.Errorf("update categories failed for %s: %w", serviceType, err)
+	}
+	categoryByName := db.CategoryByNameIndex.Index(dbCategories)
 
 	// collect existing resources and the wanted resources
 	dbResources, err := db.ResourceStore.SelectWhere(ctx, tx, `service_id = $1`, srv.ID).Collect()
@@ -446,12 +464,6 @@ func SaveServiceInfoToDB(ctx context.Context, serviceType db.ServiceType, servic
 	dbResources, err = resourceUpdate.Execute(ctx, tx, db.ResourceStore)
 	if err != nil {
 		return err
-	}
-
-	// remove unused categories (categories which are not referenced by any resource anymore)
-	_, err = tx.Exec(`DELETE FROM categories WHERE id NOT IN (SELECT DISTINCT category_id FROM resources)`)
-	if err != nil {
-		return fmt.Errorf("cannot delete unused categories for %s: %w", serviceType, err)
 	}
 
 	// do resource unit updates if applicable

--- a/internal/core/cluster_test.go
+++ b/internal/core/cluster_test.go
@@ -100,10 +100,11 @@ func Test_ClusterSaveServiceInfo(t *testing.T) {
 		INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (14, 4, 'total', 0, 'unshared/things/total');
 		INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (8, 3, 'any', 0, 'unshared/capacity/any');
 		INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (9, 3, 'az-one', 0, 'unshared/capacity/az-one');
-		INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, has_usage, path, category_id) VALUES (1, 2, 'only_usage', 1, 'MiB', 'flat', TRUE, 'unshared/only_usage', 1);
+		INSERT INTO categories (id, name, display_name, service_id) VALUES (2, 'foo_category', 'Foo Category', 2);
+		INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, has_usage, path, category_id) VALUES (1, 2, 'only_usage', 1, 'MiB', 'flat', TRUE, 'unshared/only_usage', 2);
 		INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, path) VALUES (2, 2, 'with_global_limit', 1, 'MiB', 'flat', 'unshared/with_global_limit');
 		INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, path) VALUES (3, 2, 'with_project_limit', 1, 'piece', 'flat', 'unshared/with_project_limit');
-		INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, needs_resource_demand, has_quota, path, display_name, category_id) VALUES (3, 2, 'capacity', 1, 'B', 'az-aware', TRUE, TRUE, TRUE, 'unshared/capacity', 'Capacity', 1);
+		INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, needs_resource_demand, has_quota, path, display_name, category_id) VALUES (3, 2, 'capacity', 1, 'B', 'az-aware', TRUE, TRUE, TRUE, 'unshared/capacity', 'Capacity', 2);
 		INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_quota, path, display_name) VALUES (4, 2, 'things', 1, 'piece', 'flat', TRUE, 'unshared/things', 'Things');
 		INSERT INTO services (id, type, next_scrape_at, liquid_version, display_name) VALUES (2, 'unshared', 0, 1, 'Unshared');
 	`)
@@ -162,9 +163,9 @@ func Test_ClusterSaveServiceInfo(t *testing.T) {
 	s.LiquidClients["unshared"].ServiceInfo.Set(srvInfoUnshared)
 	generateNewClusterWithPersistingServiceInfo(t, s, true)
 	tr.DBChanges().AssertEqual(`
-		INSERT INTO categories (id, name, display_name) VALUES (2, 'bar_category', 'Foo Category');
-		UPDATE rates SET liquid_version = 2, category_id = 2 WHERE id = 1 AND service_id = 2 AND name = 'only_usage' AND path = 'unshared/only_usage';
-		UPDATE rates SET liquid_version = 2, category_id = 1 WHERE id = 2 AND service_id = 2 AND name = 'with_global_limit' AND path = 'unshared/with_global_limit';
+		INSERT INTO categories (id, name, display_name, service_id) VALUES (3, 'bar_category', 'Foo Category', 2);
+		UPDATE rates SET liquid_version = 2, category_id = 3 WHERE id = 1 AND service_id = 2 AND name = 'only_usage' AND path = 'unshared/only_usage';
+		UPDATE rates SET liquid_version = 2, category_id = 2 WHERE id = 2 AND service_id = 2 AND name = 'with_global_limit' AND path = 'unshared/with_global_limit';
 		UPDATE rates SET liquid_version = 2 WHERE id = 3 AND service_id = 2 AND name = 'with_project_limit' AND path = 'unshared/with_project_limit';
 		UPDATE resources SET liquid_version = 2 WHERE id = 3 AND service_id = 2 AND name = 'capacity' AND path = 'unshared/capacity';
 		UPDATE resources SET liquid_version = 2 WHERE id = 4 AND service_id = 2 AND name = 'things' AND path = 'unshared/things';

--- a/internal/core/service_info_cache.go
+++ b/internal/core/service_info_cache.go
@@ -22,6 +22,7 @@ import (
 	"go.xyrillian.de/gg/gsql"
 	. "go.xyrillian.de/gg/option"
 	"go.xyrillian.de/gg/pgruntime"
+	"go.xyrillian.de/oblast"
 )
 
 ///////////////////////////////////////////////////////////////////////
@@ -80,8 +81,8 @@ type ServiceInfoReader interface {
 	GetRateForPath(path db.RatePath) (db.Rate, bool)
 	// GetRateForID returns the rate for the given rate ID.
 	GetRateForID(id db.RateID) (db.Rate, bool)
-	// GetCategories returns all categories.
-	GetCategories() map[db.CategoryID]db.Category
+	// GetCategories returns all categories for the given service type.
+	GetCategoriesForType(serviceType db.ServiceType) map[db.CategoryID]db.Category
 	// GetCategoryForID returns the category for the given ID.
 	GetCategoryForID(categoryID db.CategoryID) (db.Category, bool)
 }
@@ -110,12 +111,13 @@ type (
 		resources   resourcesByNameType
 		azResources azResourcesByAZNameType
 		rates       ratesByNameType
-		categories  categoriesByID
+		categories  categoriesByIDType
 		// ID-based indexes for O(1) lookup by primary key
 		servicesByID    servicesByIDIndex
 		resourcesByID   resourcesByIDIndex
 		azResourcesByID azResourcesByIDIndex
 		ratesByID       ratesByIDIndex
+		categoriesByID  categoriesByID
 		// necessary for constructing filters by area
 		areaMapping map[db.ServiceType]string
 	}
@@ -129,16 +131,17 @@ type (
 	azResourcesByAZ         = map[limes.AvailabilityZone]db.AZResource
 	ratesByNameType         = map[db.ServiceType]ratesByName
 	ratesByName             = map[liquid.RateName]db.Rate
+	categoriesByIDType      = map[db.ServiceType]categoriesByID
 	categoriesByID          = map[db.CategoryID]db.Category
-	servicesByIDIndex       = map[db.ServiceID]db.Service
-	resourcesByIDIndex      = map[db.ResourceID]db.Resource
-	azResourcesByIDIndex    = map[db.AZResourceID]db.AZResource
-	ratesByIDIndex          = map[db.RateID]db.Rate
+
+	servicesByIDIndex    = map[db.ServiceID]db.Service
+	resourcesByIDIndex   = map[db.ResourceID]db.Resource
+	azResourcesByIDIndex = map[db.AZResourceID]db.AZResource
+	ratesByIDIndex       = map[db.RateID]db.Rate
 )
 
 // removeDataForType removes all data of a given serviceType, making the cache ready
-// for populating this serviceType from scratch. Categories are always flushed
-// completely.
+// for populating this serviceType from scratch.
 func (s ServiceInfoSnapshot) removeDataForType(serviceType db.ServiceType) ServiceInfoSnapshot {
 	// remove ID index entries for this service type
 	if svc, ok := s.services[serviceType]; ok {
@@ -155,11 +158,14 @@ func (s ServiceInfoSnapshot) removeDataForType(serviceType db.ServiceType) Servi
 	for _, rate := range s.rates[serviceType] {
 		delete(s.ratesByID, rate.ID)
 	}
+	for _, category := range s.categories[serviceType] {
+		delete(s.categoriesByID, category.ID)
+	}
 	delete(s.services, serviceType)
 	delete(s.resources, serviceType)
 	delete(s.azResources, serviceType)
 	delete(s.rates, serviceType)
-	s.categories = make(map[db.CategoryID]db.Category)
+	delete(s.categories, serviceType)
 	return s
 }
 
@@ -175,10 +181,11 @@ func (s ServiceInfoSnapshot) deepClone() ServiceInfoSnapshot {
 			return deepCloneMap(inner, maps.Clone)
 		}),
 		rates:           deepCloneMap(s.rates, maps.Clone),
-		categories:      maps.Clone(s.categories),
+		categories:      deepCloneMap(s.categories, maps.Clone),
 		servicesByID:    maps.Clone(s.servicesByID),
 		resourcesByID:   maps.Clone(s.resourcesByID),
 		azResourcesByID: maps.Clone(s.azResourcesByID),
+		categoriesByID:  maps.Clone(s.categoriesByID),
 		ratesByID:       maps.Clone(s.ratesByID),
 		areaMapping:     s.areaMapping, // should never get modified
 	}
@@ -202,6 +209,7 @@ func (s ServiceInfoSnapshot) Filter(filter ServiceInfoFilter) FilteredServiceInf
 			delete(f.snapshot.resources, serviceType)
 			delete(f.snapshot.azResources, serviceType)
 			delete(f.snapshot.rates, serviceType)
+			delete(f.snapshot.categories, serviceType)
 		}
 	}
 	// filter services by type
@@ -214,16 +222,20 @@ func (s ServiceInfoSnapshot) Filter(filter ServiceInfoFilter) FilteredServiceInf
 			delete(f.snapshot.azResources, serviceType)
 			delete(f.snapshot.resources, serviceType)
 			delete(f.snapshot.rates, serviceType)
+			delete(f.snapshot.categories, serviceType)
 		}
 	}
 	categoriesToRemove := make(map[db.CategoryID]struct{})
 	// find categories to remove
 	categoryFilter, categoryFilterExists := f.filter.Category.Unpack()
 	if categoryFilterExists {
-		for categoryID, info := range f.snapshot.categories {
-			if info.Name != categoryFilter {
-				delete(f.snapshot.categories, categoryID)
-				categoriesToRemove[categoryID] = struct{}{}
+		for serviceType, categories := range f.snapshot.categories {
+			_ = serviceType
+			for categoryID, info := range categories {
+				if info.Name != categoryFilter {
+					delete(categories, categoryID)
+					categoriesToRemove[categoryID] = struct{}{}
+				}
 			}
 		}
 	}
@@ -246,6 +258,7 @@ func (s ServiceInfoSnapshot) Filter(filter ServiceInfoFilter) FilteredServiceInf
 						delete(f.snapshot.resources, serviceType)
 						delete(f.snapshot.azResources, serviceType)
 						delete(f.snapshot.rates, serviceType)
+						delete(f.snapshot.categories, serviceType)
 					}
 				} else {
 					seenCategories[categoryID] = struct{}{}
@@ -270,6 +283,7 @@ func (s ServiceInfoSnapshot) Filter(filter ServiceInfoFilter) FilteredServiceInf
 						delete(f.snapshot.resources, serviceType)
 						delete(f.snapshot.azResources, serviceType)
 						delete(f.snapshot.rates, serviceType)
+						delete(f.snapshot.categories, serviceType)
 					}
 				} else {
 					seenCategories[categoryID] = struct{}{}
@@ -280,9 +294,14 @@ func (s ServiceInfoSnapshot) Filter(filter ServiceInfoFilter) FilteredServiceInf
 
 	// if we filtered by rate or service name, we must thin out the categories
 	if resourceFilterExists || rateFilterExists {
-		for categoryID := range f.snapshot.categories {
-			if _, ok := seenCategories[categoryID]; !ok {
-				delete(f.snapshot.categories, categoryID)
+		for serviceType, categories := range f.snapshot.categories {
+			for categoryID := range categories {
+				if _, ok := seenCategories[categoryID]; !ok {
+					delete(categories, categoryID)
+				}
+			}
+			if len(categories) == 0 {
+				delete(f.snapshot.categories, serviceType)
 			}
 		}
 	}
@@ -310,6 +329,12 @@ func (s ServiceInfoSnapshot) Filter(filter ServiceInfoFilter) FilteredServiceInf
 	for _, rates := range f.snapshot.rates {
 		for _, rate := range rates {
 			f.snapshot.ratesByID[rate.ID] = rate
+		}
+	}
+	f.snapshot.categoriesByID = make(categoriesByID, len(f.snapshot.categories))
+	for _, categories := range f.snapshot.categories {
+		for _, category := range categories {
+			f.snapshot.categoriesByID[category.ID] = category
 		}
 	}
 
@@ -410,14 +435,14 @@ func (s ServiceInfoSnapshot) GetRateForID(id db.RateID) (db.Rate, bool) {
 	return val, ok
 }
 
-// GetCategories implements the [ServiceInfoReader] interface.
-func (s ServiceInfoSnapshot) GetCategories() categoriesByID {
-	return maps.Clone(s.categories)
+// GetCategoriesForType implements the [ServiceInfoReader] interface.
+func (s ServiceInfoSnapshot) GetCategoriesForType(serviceType db.ServiceType) categoriesByID {
+	return maps.Clone(s.categories[serviceType])
 }
 
 // GetCategoryForID implements the [ServiceInfoReader] interface.
 func (s ServiceInfoSnapshot) GetCategoryForID(categoryID db.CategoryID) (db.Category, bool) {
-	val, ok := s.categories[categoryID]
+	val, ok := s.categoriesByID[categoryID]
 	return val, ok
 }
 
@@ -433,11 +458,12 @@ func newEmptyServiceInfoSnapshot(config ClusterConfiguration) ServiceInfoSnapsho
 		resources:       make(resourcesByNameType),
 		azResources:     make(azResourcesByAZNameType),
 		rates:           make(ratesByNameType),
-		categories:      make(categoriesByID),
+		categories:      make(categoriesByIDType),
 		servicesByID:    make(servicesByIDIndex),
 		resourcesByID:   make(resourcesByIDIndex),
 		azResourcesByID: make(azResourcesByIDIndex),
 		ratesByID:       make(ratesByIDIndex),
+		categoriesByID:  make(categoriesByID),
 		areaMapping:     areaMapping,
 	}
 }
@@ -539,9 +565,9 @@ func (f FilteredServiceInfoSnapshot) GetRateForID(id db.RateID) (db.Rate, bool) 
 	return f.snapshot.GetRateForID(id)
 }
 
-// GetCategories implements the [ServiceInfoReader] interface.
-func (f FilteredServiceInfoSnapshot) GetCategories() categoriesByID {
-	return f.snapshot.GetCategories()
+// GetCategoriesForType implements the [ServiceInfoReader] interface.
+func (f FilteredServiceInfoSnapshot) GetCategoriesForType(serviceType db.ServiceType) categoriesByID {
+	return f.snapshot.GetCategoriesForType(serviceType)
 }
 
 // GetCategoryForID implements the [ServiceInfoReader] interface.
@@ -691,6 +717,8 @@ func (s *ServiceInfoCache) InvalidateService(ctx context.Context, serviceType Op
 		s.data.servicesByID[svc.ID] = svc
 	}
 
+	// TODO: simplify queries below by using the ServiceID from the record that we just pulled
+
 	resourcesByPath, err := db.ResourceByPathIndex.IndexFrom(
 		db.ResourceStore.Select(ctx, s.DB, `SELECT r.* FROM resources r JOIN services s ON r.service_id = s.id WHERE s.type = $1 OR $1 IS NULL`, serviceType),
 	)
@@ -736,10 +764,24 @@ func (s *ServiceInfoCache) InvalidateService(ctx context.Context, serviceType Op
 		s.data.ratesByID[rate.ID] = rate
 	}
 
-	s.data.categories, err = db.CategoryByIDIndex.IndexFrom(db.CategoryStore.Select(ctx, s.DB, `SELECT * FROM categories`))
-	if err != nil {
-		return fmt.Errorf("while reading categories: %w", err)
+	type categoryRecord struct {
+		db.Category
+		ServiceType db.ServiceType `db:"service_type"`
 	}
+	categoryRecords, err := oblast.MustNewStore[categoryRecord](oblast.PostgresDialect()).Select(ctx, s.DB,
+		`SELECT c.*, s.type AS service_type FROM categories c JOIN services s ON c.service_id = s.id WHERE s.type = $1 OR $1 IS NULL`, serviceType,
+	).Collect()
+	if err != nil {
+		return fmt.Errorf("while reading categories for type(s) %v: %w", serviceType, err)
+	}
+	for _, record := range categoryRecords {
+		if _, ok := s.data.categories[record.ServiceType]; !ok {
+			s.data.categories[record.ServiceType] = make(categoriesByID)
+		}
+		s.data.categories[record.ServiceType][record.ID] = record.Category
+		s.data.categoriesByID[record.ID] = record.Category
+	}
+
 	return nil
 }
 
@@ -760,7 +802,7 @@ func (s *ServiceInfoCache) GetServiceInfo(serviceType db.ServiceType) (info liqu
 	service := s.data.services[serviceType]
 	resources := s.data.resources[serviceType]
 	rates := s.data.rates[serviceType]
-	categories := s.data.categories
+	categories := s.data.categoriesByID
 
 	capacityMetricFamilies, err := util.JSONToAny[map[liquid.MetricName]liquid.MetricFamilyInfo](service.CapacityMetricFamiliesJSON, "capacity_metric_families")
 	if err != nil {

--- a/internal/core/service_info_cache_test.go
+++ b/internal/core/service_info_cache_test.go
@@ -162,7 +162,8 @@ func TestServiceInfoCache(t *testing.T) {
 	assert.Equal(t, len(must.BeOKT(sis.GetResourcesForType("second"))(t)), 2)
 	assert.Equal(t, must.BeOKT(sis.GetResourceForPath(db.ResourcePath{ServiceType: "second", ResourceName: "capacity"}))(t).Name, "capacity")
 	must.NotBeOKT(sis.GetRatesForType("second"))(t)
-	assert.Equal(t, len(sis.GetCategories()), 1)
+	assert.Equal(t, len(sis.GetCategoriesForType("first")), 0)
+	assert.Equal(t, len(sis.GetCategoriesForType("second")), 1)
 
 	// check service update
 	assert.Equal(t, must.BeOKT(sis.GetServiceForType("first"))(t).DisplayName, "First")

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -114,4 +114,44 @@ var sqlMigrations = map[int64]string{
 
 		ALTER TABLE categories ALTER COLUMN service_id SET NOT NULL;
 	`,
+	84: `
+		CREATE OR REPLACE FUNCTION notify_service_update()
+			RETURNS trigger AS $$
+			DECLARE
+				service_type TEXT;
+			BEGIN
+				IF TG_TABLE_NAME = 'services' THEN
+					FOR service_type IN
+						SELECT s.type FROM services s
+							WHERE s.type = ANY(ARRAY[NEW.type, OLD.type])
+					LOOP
+						PERFORM pg_notify('limitas_service_update', service_type);
+					END LOOP;
+
+				ELSIF TG_TABLE_NAME = 'resources' OR TG_TABLE_NAME = 'rates' OR TG_TABLE_NAME = 'categories' THEN
+					FOR service_type IN
+						SELECT s.type FROM services s
+							WHERE s.id = ANY(ARRAY[NEW.service_id, OLD.service_id])
+					LOOP
+						PERFORM pg_notify('limitas_service_update', service_type);
+					END LOOP;
+
+				ELSIF TG_TABLE_NAME = 'az_resources' THEN
+					FOR service_type IN
+						SELECT DISTINCT s.type FROM services s
+							JOIN resources r ON r.service_id = s.id
+							WHERE r.id = ANY(ARRAY[NEW.resource_id, OLD.resource_id])
+					LOOP
+						PERFORM pg_notify('limitas_service_update', service_type);
+					END LOOP;
+				END IF;
+
+				RETURN COALESCE(NEW, OLD);
+			END;
+			$$ LANGUAGE plpgsql;
+
+		CREATE TRIGGER categories_notify_update
+			AFTER INSERT OR UPDATE OR DELETE ON categories
+			FOR EACH ROW EXECUTE FUNCTION notify_service_update();
+	`,
 }

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -87,4 +87,31 @@ var sqlMigrations = map[int64]string{
 		UPDATE resources SET unit = 'piece' WHERE unit = '';
 		UPDATE rates SET unit = 'piece' WHERE unit = '';
 	`,
+
+	// NOTE: This will fail if there are categories that belong to multiple services.
+	//       (The `INSERT INTO category_affinities` part will complain about its uniqueness constraint being violated.)
+	//       This is currently not the case in any of our real deployments, so this restriction ought to be acceptable;
+	//       but it fails for some test databases, so an `rm -rf .testdb` may be required if this migration fails.
+	//
+	// NOTE: The table `category_affinities` is set up as a materialized temporary table,
+	//       instead of just being a table expression within UPDATE,
+	//       to ensure the explicit error on uniqueness violation as described above.
+	83: `
+		ALTER TABLE categories ADD COLUMN service_id BIGINT REFERENCES services ON DELETE CASCADE;
+		ALTER TABLE categories DROP CONSTRAINT categories_name_key;
+		ALTER TABLE categories ADD UNIQUE (service_id, name);
+
+		CREATE TEMP TABLE category_affinities (category_id BIGINT UNIQUE, service_id BIGINT);
+		INSERT INTO category_affinities
+			SELECT DISTINCT category_id, service_id FROM (
+				SELECT category_id, service_id FROM resources WHERE category_id IS NOT NULL
+				UNION
+				SELECT category_id, service_id FROM rates WHERE category_id IS NOT NULL
+			);
+
+		UPDATE categories c SET service_id = ca.service_id FROM category_affinities ca WHERE ca.category_id = c.id;
+		DROP TABLE category_affinities;
+
+		ALTER TABLE categories ALTER COLUMN service_id SET NOT NULL;
+	`,
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -365,6 +365,7 @@ var MailNotificationStore = oblast.MustNewStore[MailNotification](oblast.Postgre
 // Category contains a record from the `categories` table.
 type Category struct {
 	ID          CategoryID          `db:"id,auto"`
+	ServiceID   ServiceID           `db:"service_id"`
 	Name        liquid.CategoryName `db:"name"`
 	DisplayName string              `db:"display_name"`
 }


### PR DESCRIPTION
Without this, two services declaring a category with the same name would enter into an edit war if they declare their category with different display names. (This issue would get worse if we added additional attributes to `liquid.CategoryInfo` in the future.)

This is not a problem in prod right now because our existing liquids _happen to_ use unique category names, but that may change in the future. I came across this topic because I wanted to materialize `CategoryID = nil` into implicitly-defined categories that actually exist in the DB (instead of just being constructed at view time in the api_v2 implementation), but implying category records like this feels risky without proper isolation between services.

The theme of the implementation is that categories are less special now: In SaveServiceInfoToDB(), they are maintained with a normal SetUpdate now. In ServiceInfoSnapshot, they are invalidated on the service level like everything else.

The TODO regarding query simplification is intended like this. I am leaving a note for myself later, but do not want to expand the scope of this PR further.