### PR TITLE
SaveServiceInfo: fix SQL error when deleting categories

### DIFF
--- a/internal/core/cluster.go
+++ b/internal/core/cluster.go
@@ -4,7 +4,9 @@
 package core
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
@@ -355,37 +357,31 @@ func SaveServiceInfoToDB(ctx context.Context, serviceType db.ServiceType, servic
 	}
 	srv := dbServices[0]
 
-	// collect existing and wanted categories
-	dbCategories, err := db.CategoryStore.SelectWhere(ctx, tx, `service_id = $1`, srv.ID).Collect()
+	// create or update wanted categories (cannot delete unnecessary categories yet,
+	// we need to update `resources.category_id` or `rates.category_id` first)
+	categoryMergeQuery := sqlext.SimplifyWhitespace(`
+		MERGE INTO categories AS c
+		USING json_each($1::json) AS src
+		   ON c.name = src.key AND c.service_id = $2
+		 WHEN NOT MATCHED BY TARGET THEN INSERT (name, display_name, service_id)
+		      VALUES (src.key, src.value ->> 'displayName', $2)
+		 WHEN MATCHED THEN UPDATE set display_name = src.value ->> 'displayName';
+	`)
+	categoriesJSON, err := json.Marshal(serviceInfo.Categories)
+	if err != nil {
+		return fmt.Errorf("cannot serialize serviceInfo.Categories for %s to JSON: %w", serviceType, err)
+	}
+	if bytes.Equal(categoriesJSON, []byte(`null`)) {
+		categoriesJSON = []byte(`{}`)
+	}
+	_, err = tx.ExecContext(ctx, categoryMergeQuery, categoriesJSON, srv.ID)
+	if err != nil {
+		return fmt.Errorf("cannot create/update categories for %s: %w", serviceType, err)
+	}
+	categoryByName, err := db.CategoryByNameIndex.IndexFrom(db.CategoryStore.SelectWhere(ctx, tx, `service_id = $1`, srv.ID))
 	if err != nil {
 		return fmt.Errorf("cannot inspect existing categories for %s: %w", serviceType, err)
 	}
-	wantedCategories := slices.Collect(maps.Keys(serviceInfo.Categories))
-	dbCategories, err = db.SetUpdate[db.Category, liquid.CategoryName]{
-		ExistingRecords: dbCategories,
-		WantedKeys:      wantedCategories,
-		KeyForRecord:    func(c db.Category) liquid.CategoryName { return c.Name },
-		Create: func(categoryName liquid.CategoryName) (db.Category, error) {
-			if !ReduceLogSpam {
-				logg.Info("SaveServiceInfoToDB: creating Category %s/%s with LiquidVersion = %d", serviceType, categoryName, serviceInfo.Version)
-			}
-			categoryInfo := serviceInfo.Categories[categoryName]
-			return db.Category{
-				ServiceID:   srv.ID,
-				Name:        categoryName,
-				DisplayName: categoryInfo.DisplayName,
-			}, nil
-		},
-		Update: func(category *db.Category) error {
-			categoryInfo := serviceInfo.Categories[category.Name]
-			category.DisplayName = categoryInfo.DisplayName
-			return nil
-		},
-	}.Execute(ctx, tx, db.CategoryStore)
-	if err != nil {
-		return fmt.Errorf("update categories failed for %s: %w", serviceType, err)
-	}
-	categoryByName := db.CategoryByNameIndex.Index(dbCategories)
 
 	// collect existing resources and the wanted resources
 	dbResources, err := db.ResourceStore.SelectWhere(ctx, tx, `service_id = $1`, srv.ID).Collect()
@@ -673,6 +669,19 @@ func SaveServiceInfoToDB(ctx context.Context, serviceType db.ServiceType, servic
 		if err != nil {
 			return fmt.Errorf("error while updating project_rates with rate_id %d when changing unit from %q to %q: %w", rateID, units.oldUnit, units.newUnit, err)
 		}
+	}
+
+	// remove unneeded categories (could not be done earlier because of `resources.category_id` and `rates.category_id` foreign keys)
+	// TODO: remove the `AND category_id IS NOT NULL` part once we add NOT NULL constraints on these columns
+	_, err = tx.ExecContext(ctx, sqlext.SimplifyWhitespace(`
+		DELETE FROM categories WHERE service_id = $1 AND id NOT IN (
+			SELECT DISTINCT category_id FROM resources WHERE service_id = $1 AND category_id IS NOT NULL
+			UNION
+			SELECT DISTINCT category_id FROM rates WHERE service_id = $1 AND category_id IS NOT NULL
+		)
+	`), srv.ID)
+	if err != nil {
+		return fmt.Errorf("while cleaning up unneeded categories for %s: %w", serviceType, err)
 	}
 
 	return tx.Commit()

--- a/internal/core/cluster_test.go
+++ b/internal/core/cluster_test.go
@@ -60,7 +60,7 @@ func generateNewClusterWithPersistingServiceInfo(t *testing.T, s test.Setup, fai
 	}
 	connectErrs = s.Cluster.Connect(s.Ctx, nil, gophercloud.EndpointOpts{}, liquidClientFactory, None[pgruntime.ConnectionTarget]())
 	if failOnConnectError {
-		for _, err := range errs {
+		for _, err := range connectErrs {
 			t.Fatal(err)
 		}
 	}
@@ -152,18 +152,17 @@ func Test_ClusterSaveServiceInfo(t *testing.T) {
 	`)
 
 	// now we want to do an update of some categories:
-	newCategories := srvInfoUnshared.Categories
-	newCategories["bar_category"] = liquid.CategoryInfo{
-		DisplayName: "Foo Category",
-	}
-	srvInfoUnshared.Categories = newCategories
-	srvInfoUnshared.Rates["only_usage"] = liquid.RateInfo{Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: true, Category: Some(liquid.CategoryName("bar_category"))}
-	srvInfoUnshared.Rates["with_global_limit"] = liquid.RateInfo{Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: false, Category: Some(liquid.CategoryName("foo_category"))}
-	srvInfoUnshared.Version = 2
-	s.LiquidClients["unshared"].ServiceInfo.Set(srvInfoUnshared)
+	s.LiquidClients["unshared"].ServiceInfo.Modify(func(info *liquid.ServiceInfo) {
+		info.Categories["bar_category"] = liquid.CategoryInfo{
+			DisplayName: "Bar Category",
+		}
+		info.Rates["only_usage"] = liquid.RateInfo{Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: true, Category: Some(liquid.CategoryName("bar_category"))}
+		info.Rates["with_global_limit"] = liquid.RateInfo{Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: false, Category: Some(liquid.CategoryName("foo_category"))}
+		info.Version = 2
+	})
 	generateNewClusterWithPersistingServiceInfo(t, s, true)
 	tr.DBChanges().AssertEqual(`
-		INSERT INTO categories (id, name, display_name, service_id) VALUES (3, 'bar_category', 'Foo Category', 2);
+		INSERT INTO categories (id, name, display_name, service_id) VALUES (3, 'bar_category', 'Bar Category', 2);
 		UPDATE rates SET liquid_version = 2, category_id = 3 WHERE id = 1 AND service_id = 2 AND name = 'only_usage' AND path = 'unshared/only_usage';
 		UPDATE rates SET liquid_version = 2, category_id = 2 WHERE id = 2 AND service_id = 2 AND name = 'with_global_limit' AND path = 'unshared/with_global_limit';
 		UPDATE rates SET liquid_version = 2 WHERE id = 3 AND service_id = 2 AND name = 'with_project_limit' AND path = 'unshared/with_project_limit';
@@ -171,6 +170,32 @@ func Test_ClusterSaveServiceInfo(t *testing.T) {
 		UPDATE resources SET liquid_version = 2 WHERE id = 4 AND service_id = 2 AND name = 'things' AND path = 'unshared/things';
 		DELETE FROM services WHERE id = 2 AND type = 'unshared' AND liquid_version = 1;
 		INSERT INTO services (id, type, next_scrape_at, liquid_version, display_name) VALUES (2, 'unshared', 0, 2, 'Unshared');
+	`)
+
+	// rename a category: this will check that deleting the old category and inserting the new category works without conflict
+	// (this used to break because we would first delete the old category, which would leave the resource dangling without a valid category;
+	// this fails even if the foreign-key constraint from resources -> categories is DEFERRABLE INITIALLY DEFERRED)
+	s.LiquidClients["unshared"].ServiceInfo.Modify(func(info *liquid.ServiceInfo) {
+		info.Categories["bar_category_renamed"] = liquid.CategoryInfo{
+			DisplayName: "Bar Category",
+		}
+		delete(info.Categories, "bar_category")
+		rateInfo := info.Rates["only_usage"]
+		rateInfo.Category = Some(liquid.CategoryName("bar_category_renamed"))
+		info.Rates["only_usage"] = rateInfo
+		info.Version = 3
+	})
+	generateNewClusterWithPersistingServiceInfo(t, s, true)
+	tr.DBChanges().AssertEqual(`
+		DELETE FROM categories WHERE id = 3 AND name = 'bar_category' AND service_id = 2;
+		INSERT INTO categories (id, name, display_name, service_id) VALUES (4, 'bar_category_renamed', 'Bar Category', 2);
+		UPDATE rates SET liquid_version = 3, category_id = 4 WHERE id = 1 AND service_id = 2 AND name = 'only_usage' AND path = 'unshared/only_usage';
+		UPDATE rates SET liquid_version = 3 WHERE id = 2 AND service_id = 2 AND name = 'with_global_limit' AND path = 'unshared/with_global_limit';
+		UPDATE rates SET liquid_version = 3 WHERE id = 3 AND service_id = 2 AND name = 'with_project_limit' AND path = 'unshared/with_project_limit';
+		UPDATE resources SET liquid_version = 3 WHERE id = 3 AND service_id = 2 AND name = 'capacity' AND path = 'unshared/capacity';
+		UPDATE resources SET liquid_version = 3 WHERE id = 4 AND service_id = 2 AND name = 'things' AND path = 'unshared/things';
+		DELETE FROM services WHERE id = 2 AND type = 'unshared' AND liquid_version = 2;
+		INSERT INTO services (id, type, next_scrape_at, liquid_version, display_name) VALUES (2, 'unshared', 0, 3, 'Unshared');
 	`)
 
 	// When we remove a resource for which commitments exist, we want to fail
@@ -198,7 +223,7 @@ func Test_ClusterSaveServiceInfo(t *testing.T) {
 	})
 	tr.DBChanges().Ignore()
 	generateNewClusterWithPersistingServiceInfo(t, s, true)
-	tr.DBChanges().AssertEqual("")
+	tr.DBChanges().AssertEmpty()
 }
 
 func Test_ClusterServiceInfoUnitsChange(t *testing.T) {


### PR DESCRIPTION
I implemented the SetUpdate under the assumption that the foreign-key constraints would not be a problem because they are DEFERRABLE INITIALLY DEFERRED, but they do not actually work that way. The test added in this commit fails without the code change.