### PR TITLE
SaveServiceInfoToDB: materialize default categories

### DIFF
--- a/internal/api/reports_v2/filter_test.go
+++ b/internal/api/reports_v2/filter_test.go
@@ -123,20 +123,20 @@ func TestV2FilterCreation(t *testing.T) {
 	resourceFilter = must.ReturnT(reports_v2.FilterFromResourceOpts(s.Cluster, resourceOpts))(t)
 	assert.Equal(t, len(resourceFilter.GetServices()), 1)
 	assert.Equal(t, len(must.BeOK(resourceFilter.GetResourcesForType("first"))), 1)
-	assert.Equal(t, (must.BeOK(resourceFilter.GetResourcesForType("first")))["things"].CategoryID.IsSome(), false)
+	assert.Equal(t, (must.BeOK(resourceFilter.GetResourcesForType("first")))["things"].CategoryID.IsSome(), true) // not false anymore, refers to the materialized default category
 	assert.Equal(t, len(must.NotBeOK(resourceFilter.GetResourcesForType("second"))), 0)
 	assert.Equal(t, len(must.BeOK(resourceFilter.GetRatesForType("first"))), 1)
-	assert.Equal(t, (must.BeOK(resourceFilter.GetRatesForType("first")))["objects:update"].CategoryID.IsSome(), false)
+	assert.Equal(t, (must.BeOK(resourceFilter.GetRatesForType("first")))["objects:update"].CategoryID.IsSome(), true) // not false anymore, refers to the materialized default category
 	assert.Equal(t, len(must.NotBeOK(resourceFilter.GetRatesForType("second"))), 0)
 
 	rateOpts = common.RateReportOpts{GenericReportOpts: common.GenericReportOpts{Category: Some(liquid.CategoryName("first"))}}
 	rateFilter = must.ReturnT(reports_v2.FilterFromRateOpts(s.Cluster, rateOpts))(t)
 	assert.Equal(t, len(rateFilter.GetServices()), 1)
 	assert.Equal(t, len(must.BeOK(rateFilter.GetResourcesForType("first"))), 1)
-	assert.Equal(t, (must.BeOK(rateFilter.GetResourcesForType("first")))["things"].CategoryID.IsSome(), false)
+	assert.Equal(t, (must.BeOK(rateFilter.GetResourcesForType("first")))["things"].CategoryID.IsSome(), true) // not false anymore, refers to the materialized default category
 	assert.Equal(t, len(must.NotBeOK(rateFilter.GetResourcesForType("second"))), 0)
 	assert.Equal(t, len(must.BeOK(rateFilter.GetRatesForType("first"))), 1)
-	assert.Equal(t, (must.BeOK(rateFilter.GetRatesForType("first")))["objects:update"].CategoryID.IsSome(), false)
+	assert.Equal(t, (must.BeOK(rateFilter.GetRatesForType("first")))["objects:update"].CategoryID.IsSome(), true) // not false anymore, refers to the materialized default category
 	assert.Equal(t, len(must.NotBeOK(rateFilter.GetRatesForType("second"))), 0)
 
 	// resource filter

--- a/internal/collector/capacity_scrape_test.go
+++ b/internal/collector/capacity_scrape_test.go
@@ -119,8 +119,10 @@ func Test_ScanCapacity(t *testing.T) {
 		INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (2, 1, 'total', 0, 'shared/things/total');
 		INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (3, 2, 'any', 0, 'unshared/capacity/any');
 		INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (4, 2, 'total', 0, 'unshared/capacity/total');
-		INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, has_quota, path, display_name) VALUES (1, 1, 'things', 1, 'piece', 'flat', TRUE, TRUE, 'shared/things', 'Things');
-		INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, has_quota, path, display_name) VALUES (2, 2, 'capacity', 1, 'B', 'flat', TRUE, TRUE, 'unshared/capacity', 'Capacity');
+		INSERT INTO categories (id, name, display_name, service_id) VALUES (1, 'shared', 'Shared', 1);
+		INSERT INTO categories (id, name, display_name, service_id) VALUES (2, 'unshared', 'Unshared', 2);
+		INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, has_quota, path, display_name, category_id) VALUES (1, 1, 'things', 1, 'piece', 'flat', TRUE, TRUE, 'shared/things', 'Things', 1);
+		INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, has_quota, path, display_name, category_id) VALUES (2, 2, 'capacity', 1, 'B', 'flat', TRUE, TRUE, 'unshared/capacity', 'Capacity', 2);
 		INSERT INTO services (id, type, next_scrape_at, liquid_version, display_name) VALUES (1, 'shared', %[1]d, 1, 'Shared');
 		INSERT INTO services (id, type, next_scrape_at, liquid_version, display_name) VALUES (2, 'unshared', %[1]d, 1, 'Unshared');
 	`, s.Clock.Now().Unix())
@@ -203,7 +205,7 @@ func Test_ScanCapacity(t *testing.T) {
 		INSERT INTO az_resources (id, resource_id, az, raw_capacity, usage, path) VALUES (7, 4, 'total', 23, 4, 'shared/things/total');
 		UPDATE resources SET liquid_version = 2 WHERE id = 2 AND service_id = 2 AND name = 'capacity' AND path = 'unshared/capacity';
 		DELETE FROM resources WHERE id = 3 AND service_id = 2 AND name = 'unknown' AND path = 'unshared/unknown';
-		INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, has_quota, path, display_name) VALUES (4, 1, 'things', 2, 'piece', 'flat', TRUE, TRUE, 'shared/things', 'Things');
+		INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, has_quota, path, display_name, category_id) VALUES (4, 1, 'things', 2, 'piece', 'flat', TRUE, TRUE, 'shared/things', 'Things', 1);
 		DELETE FROM services WHERE id = 1 AND type = 'shared' AND liquid_version = 1;
 		INSERT INTO services (id, type, scraped_at, scrape_duration_secs, serialized_metrics, next_scrape_at, liquid_version, display_name) VALUES (1, 'shared', %d, 5, '{}', %d, 2, 'Shared');
 		DELETE FROM services WHERE id = 2 AND type = 'unshared' AND liquid_version = 1;
@@ -256,7 +258,8 @@ func Test_ScanCapacityWithSubcapacities(t *testing.T) {
 	tr0.AssertEqualf(`
 		INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (1, 1, 'any', 0, 'shared/things/any');
 		INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (2, 1, 'total', 0, 'shared/things/total');
-		INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, has_quota, path, display_name) VALUES (1, 1, 'things', 1, 'piece', 'flat', TRUE, TRUE, 'shared/things', 'Things');
+		INSERT INTO categories (id, name, display_name, service_id) VALUES (1, 'shared', 'Shared', 1);
+		INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, has_quota, path, display_name, category_id) VALUES (1, 1, 'things', 1, 'piece', 'flat', TRUE, TRUE, 'shared/things', 'Things', 1);
 		INSERT INTO services (id, type, next_scrape_at, liquid_version, capacity_metric_families_json, display_name) VALUES (1, 'shared', %[1]d, 1, '{"limes_unittest_capacity_larger_half":{"type":"gauge","help":"","labelKeys":null},"limes_unittest_capacity_smaller_half":{"type":"gauge","help":"","labelKeys":null}}', 'Shared');
 	`, s.Clock.Now().Unix())
 
@@ -367,7 +370,8 @@ func Test_ScanCapacityAZAware(t *testing.T) {
 		INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (3, 1, 'az-two', 0, 'shared/things/az-two');
 		INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (4, 1, 'total', 0, 'shared/things/total');
 		INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (5, 1, 'unknown', 0, 'shared/things/unknown');
-		INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, has_quota, path, display_name) VALUES (1, 1, 'things', 1, 'piece', 'az-aware', TRUE, TRUE, 'shared/things', 'Things');
+		INSERT INTO categories (id, name, display_name, service_id) VALUES (1, 'shared', 'Shared', 1);
+		INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, has_quota, path, display_name, category_id) VALUES (1, 1, 'things', 1, 'piece', 'az-aware', TRUE, TRUE, 'shared/things', 'Things', 1);
 		INSERT INTO services (id, type, next_scrape_at, liquid_version, display_name) VALUES (1, 'shared', %[1]d, 1, 'Shared');
 	`, s.Clock.Now().Unix())
 
@@ -695,8 +699,9 @@ func Test_ScanManualCapacity(t *testing.T) {
 		INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (6, 2, 'any', 0, 'shared/things/any');
 		INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (7, 2, 'total', 0, 'shared/things/total');
 		INSERT INTO categories (id, name, display_name, service_id) VALUES (1, 'foo_category', 'Foo Category', 1);
+		INSERT INTO categories (id, name, display_name, service_id) VALUES (2, 'shared', 'Shared', 1);
 		INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, needs_resource_demand, has_quota, path, display_name, category_id) VALUES (1, 1, 'capacity', 1, 'B', 'az-aware', TRUE, TRUE, TRUE, 'shared/capacity', 'Capacity', 1);
-		INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_quota, path, display_name) VALUES (2, 1, 'things', 1, 'piece', 'flat', TRUE, 'shared/things', 'Things');
+		INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_quota, path, display_name, category_id) VALUES (2, 1, 'things', 1, 'piece', 'flat', TRUE, 'shared/things', 'Things', 2);
 		INSERT INTO services (id, type, next_scrape_at, liquid_version, display_name) VALUES (1, 'shared', %[1]d, 1, 'Shared');
 	`,
 		s.Clock.Now().Unix(),

--- a/internal/collector/fixtures/checkconsistency0.sql
+++ b/internal/collector/fixtures/checkconsistency0.sql
@@ -14,7 +14,9 @@ INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (8, 3,
 INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (9, 3, 'az-one', 0, 'unshared/capacity/az-one');
 
 INSERT INTO categories (id, name, display_name, service_id) VALUES (1, 'foo_category', 'Foo Category', 1);
-INSERT INTO categories (id, name, display_name, service_id) VALUES (2, 'foo_category', 'Foo Category', 2);
+INSERT INTO categories (id, name, display_name, service_id) VALUES (2, 'shared', 'Shared', 1);
+INSERT INTO categories (id, name, display_name, service_id) VALUES (3, 'foo_category', 'Foo Category', 2);
+INSERT INTO categories (id, name, display_name, service_id) VALUES (4, 'unshared', 'Unshared', 2);
 
 INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
 INSERT INTO domains (id, name, uuid) VALUES (2, 'france', 'uuid-for-france');
@@ -31,9 +33,9 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (2, 1, 'dre
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (3, 2, 'paris', 'uuid-for-paris', 'uuid-for-france');
 
 INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, needs_resource_demand, has_quota, path, display_name, category_id) VALUES (1, 1, 'capacity', 1, 'B', 'az-aware', TRUE, TRUE, TRUE, 'shared/capacity', 'Capacity', 1);
-INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_quota, path, display_name) VALUES (2, 1, 'things', 1, 'piece', 'flat', TRUE, 'shared/things', 'Things');
-INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, needs_resource_demand, has_quota, path, display_name, category_id) VALUES (3, 2, 'capacity', 1, 'B', 'az-aware', TRUE, TRUE, TRUE, 'unshared/capacity', 'Capacity', 2);
-INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_quota, path, display_name) VALUES (4, 2, 'things', 1, 'piece', 'flat', TRUE, 'unshared/things', 'Things');
+INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_quota, path, display_name, category_id) VALUES (2, 1, 'things', 1, 'piece', 'flat', TRUE, 'shared/things', 'Things', 2);
+INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, needs_resource_demand, has_quota, path, display_name, category_id) VALUES (3, 2, 'capacity', 1, 'B', 'az-aware', TRUE, TRUE, TRUE, 'unshared/capacity', 'Capacity', 3);
+INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_quota, path, display_name, category_id) VALUES (4, 2, 'things', 1, 'piece', 'flat', TRUE, 'unshared/things', 'Things', 4);
 
 INSERT INTO services (id, type, next_scrape_at, liquid_version, display_name) VALUES (1, 'shared', 0, 1, 'Shared');
 INSERT INTO services (id, type, next_scrape_at, liquid_version, display_name) VALUES (2, 'unshared', 0, 1, 'Unshared');

--- a/internal/collector/fixtures/scandomains1.sql
+++ b/internal/collector/fixtures/scandomains1.sql
@@ -14,7 +14,9 @@ INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (8, 3,
 INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (9, 3, 'az-one', 0, 'unshared/capacity/az-one');
 
 INSERT INTO categories (id, name, display_name, service_id) VALUES (1, 'foo_category', 'Foo Category', 1);
-INSERT INTO categories (id, name, display_name, service_id) VALUES (2, 'foo_category', 'Foo Category', 2);
+INSERT INTO categories (id, name, display_name, service_id) VALUES (2, 'shared', 'Shared', 1);
+INSERT INTO categories (id, name, display_name, service_id) VALUES (3, 'foo_category', 'Foo Category', 2);
+INSERT INTO categories (id, name, display_name, service_id) VALUES (4, 'unshared', 'Unshared', 2);
 
 INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
 INSERT INTO domains (id, name, uuid) VALUES (2, 'france', 'uuid-for-france');
@@ -31,9 +33,9 @@ INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (2, 1, 'dre
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (3, 2, 'paris', 'uuid-for-paris', 'uuid-for-france');
 
 INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, needs_resource_demand, has_quota, path, display_name, category_id) VALUES (1, 1, 'capacity', 1, 'B', 'az-aware', TRUE, TRUE, TRUE, 'shared/capacity', 'Capacity', 1);
-INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_quota, path, display_name) VALUES (2, 1, 'things', 1, 'piece', 'flat', TRUE, 'shared/things', 'Things');
-INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, needs_resource_demand, has_quota, path, display_name, category_id) VALUES (3, 2, 'capacity', 1, 'B', 'az-aware', TRUE, TRUE, TRUE, 'unshared/capacity', 'Capacity', 2);
-INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_quota, path, display_name) VALUES (4, 2, 'things', 1, 'piece', 'flat', TRUE, 'unshared/things', 'Things');
+INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_quota, path, display_name, category_id) VALUES (2, 1, 'things', 1, 'piece', 'flat', TRUE, 'shared/things', 'Things', 2);
+INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, needs_resource_demand, has_quota, path, display_name, category_id) VALUES (3, 2, 'capacity', 1, 'B', 'az-aware', TRUE, TRUE, TRUE, 'unshared/capacity', 'Capacity', 3);
+INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_quota, path, display_name, category_id) VALUES (4, 2, 'things', 1, 'piece', 'flat', TRUE, 'unshared/things', 'Things', 4);
 
 INSERT INTO services (id, type, next_scrape_at, liquid_version, display_name) VALUES (1, 'shared', 0, 1, 'Shared');
 INSERT INTO services (id, type, next_scrape_at, liquid_version, display_name) VALUES (2, 'unshared', 0, 1, 'Unshared');

--- a/internal/collector/fixtures/scrape0.sql
+++ b/internal/collector/fixtures/scrape0.sql
@@ -9,6 +9,8 @@ INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (7, 2,
 INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (8, 2, 'az-two', 0, 'unittest/things/az-two');
 INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (9, 2, 'total', 0, 'unittest/things/total');
 
+INSERT INTO categories (id, name, display_name, service_id) VALUES (1, 'unittest', 'Unit Test', 1);
+
 INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
 
 INSERT INTO project_rates (id, project_id, rate_id, rate_limit, window_ns, usage_as_bigint) VALUES (1, 2, 2, 10, 1000000000, '');
@@ -20,13 +22,13 @@ INSERT INTO project_services (id, project_id, service_id, stale, next_scrape_at)
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany');
 INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (2, 1, 'dresden', 'uuid-for-dresden', 'uuid-for-berlin');
 
-INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, has_usage, path, display_name) VALUES (1, 1, 'firstrate', 1, 'piece', 'flat', TRUE, 'unittest/firstrate', 'First Rate');
-INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, path, display_name) VALUES (2, 1, 'rateWithClusterLimit', 1, 'piece', 'flat', 'unittest/rateWithClusterLimit', 'Cluster-Limited Rate');
-INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, path, display_name) VALUES (3, 1, 'rateWithProjectLimit', 1, 'piece', 'flat', 'unittest/rateWithProjectLimit', 'Project-Limited Rate');
-INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, has_usage, path, display_name) VALUES (4, 1, 'secondrate', 1, 'KiB', 'flat', TRUE, 'unittest/secondrate', 'Second Rate');
+INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, has_usage, path, display_name, category_id) VALUES (1, 1, 'firstrate', 1, 'piece', 'flat', TRUE, 'unittest/firstrate', 'First Rate', 1);
+INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, path, display_name, category_id) VALUES (2, 1, 'rateWithClusterLimit', 1, 'piece', 'flat', 'unittest/rateWithClusterLimit', 'Cluster-Limited Rate', 1);
+INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, path, display_name, category_id) VALUES (3, 1, 'rateWithProjectLimit', 1, 'piece', 'flat', 'unittest/rateWithProjectLimit', 'Project-Limited Rate', 1);
+INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, has_usage, path, display_name, category_id) VALUES (4, 1, 'secondrate', 1, 'KiB', 'flat', TRUE, 'unittest/secondrate', 'Second Rate', 1);
 INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, path, display_name) VALUES (5, 1, 'xAnotherRate', 1, 'piece', 'flat', 'unittest/xAnotherRate', 'X Another Rate');
 
-INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, needs_resource_demand, has_quota, path, display_name) VALUES (1, 1, 'capacity', 1, 'B', 'az-aware', TRUE, TRUE, TRUE, 'unittest/capacity', 'Capacity');
-INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_quota, path, display_name) VALUES (2, 1, 'things', 1, 'piece', 'az-aware', TRUE, 'unittest/things', 'Things');
+INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, needs_resource_demand, has_quota, path, display_name, category_id) VALUES (1, 1, 'capacity', 1, 'B', 'az-aware', TRUE, TRUE, TRUE, 'unittest/capacity', 'Capacity', 1);
+INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_quota, path, display_name, category_id) VALUES (2, 1, 'things', 1, 'piece', 'az-aware', TRUE, 'unittest/things', 'Things', 1);
 
 INSERT INTO services (id, type, next_scrape_at, liquid_version, usage_metric_families_json, display_name) VALUES (1, 'unittest', 0, 1, '{"limes_unittest_capacity_usage":{"type":"gauge","help":"","labelKeys":null},"limes_unittest_things_usage":{"type":"gauge","help":"","labelKeys":null}}', 'Unit Test');

--- a/internal/collector/scrape_test.go
+++ b/internal/collector/scrape_test.go
@@ -773,6 +773,7 @@ func Test_ScrapeReturnsNoUsageData(t *testing.T) {
 		INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (3, 1, 'az-two', 0, 'noop/things/az-two');
 		INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (4, 1, 'total', 0, 'noop/things/total');
 		INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (5, 1, 'unknown', 0, 'noop/things/unknown');
+		INSERT INTO categories (id, name, display_name, service_id) VALUES (1, 'noop', 'Noop', 1);
 		INSERT INTO domains (id, name, uuid) VALUES (1, 'germany', 'uuid-for-germany');
 		INSERT INTO project_az_resources (id, project_id, az_resource_id, quota, usage) VALUES (1, 1, 1, 0, 0);
 		INSERT INTO project_az_resources (id, project_id, az_resource_id, quota, usage) VALUES (2, 1, 2, 0, 0);
@@ -781,7 +782,7 @@ func Test_ScrapeReturnsNoUsageData(t *testing.T) {
 		INSERT INTO project_resources (id, project_id, resource_id, forbidden) VALUES (1, 1, 1, TRUE);
 		INSERT INTO project_services (id, project_id, service_id, scraped_at, checked_at, scrape_error_message, next_scrape_at) VALUES (1, 1, 1, 0, %[2]d, 'received ServiceUsageReport is invalid: missing value for .Resources["things"]', %[3]d);
 		INSERT INTO projects (id, domain_id, name, uuid, parent_uuid) VALUES (1, 1, 'berlin', 'uuid-for-berlin', 'uuid-for-germany');
-		INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_quota, path, display_name) VALUES (1, 1, 'things', 1, 'piece', 'az-aware', TRUE, 'noop/things', 'Things');
+		INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_quota, path, display_name, category_id) VALUES (1, 1, 'things', 1, 'piece', 'az-aware', TRUE, 'noop/things', 'Things', 1);
 		INSERT INTO services (id, type, next_scrape_at, liquid_version, display_name) VALUES (1, 'noop', %[1]d, 1, 'Noop');
 	`,
 		initialTime.Unix(), scrapedAt.Unix(), scrapedAt.Add(collector.RecheckInterval).Unix(),

--- a/internal/core/cluster.go
+++ b/internal/core/cluster.go
@@ -25,7 +25,6 @@ import (
 	"github.com/sapcc/go-bits/sqlext"
 	"go.xyrillian.de/gg/gsql"
 	. "go.xyrillian.de/gg/option"
-	"go.xyrillian.de/gg/options"
 	"go.xyrillian.de/gg/pgruntime"
 
 	"github.com/sapcc/limes/internal/db"
@@ -291,6 +290,31 @@ func SaveServiceInfoToDB(ctx context.Context, serviceType db.ServiceType, servic
 		}
 	}
 
+	// make the implicitly defined default category explicit if needed
+	defaultCategoryName := liquid.CategoryName(serviceType)
+	if usesDefaultCategory(serviceInfo) {
+		if _, exists := serviceInfo.Categories[defaultCategoryName]; !exists {
+			if serviceInfo.Categories == nil {
+				serviceInfo.Categories = make(map[liquid.CategoryName]liquid.CategoryInfo)
+			}
+			serviceInfo.Categories[defaultCategoryName] = liquid.CategoryInfo{
+				DisplayName: serviceInfo.DisplayName,
+			}
+		}
+		for resName, resInfo := range serviceInfo.Resources {
+			if resInfo.Category.IsNone() {
+				resInfo.Category = Some(defaultCategoryName)
+				serviceInfo.Resources[resName] = resInfo
+			}
+		}
+		for rateName, rateInfo := range serviceInfo.Rates {
+			if rateInfo.Category.IsNone() {
+				rateInfo.Category = Some(defaultCategoryName)
+				serviceInfo.Rates[rateName] = rateInfo
+			}
+		}
+	}
+
 	// do the whole consistency check for one connection in a transaction to avoid inconsistent DB state
 	tx, err := dbm.Begin()
 	if err != nil {
@@ -411,14 +435,11 @@ func SaveServiceInfoToDB(ctx context.Context, serviceType db.ServiceType, servic
 				logg.Info("SaveServiceInfoToDB: creating Resource %s/%s with LiquidVersion = %d", serviceType, resourceName, serviceInfo.Version)
 			}
 			resInfo := serviceInfo.Resources[resourceName]
-			categoryID := options.Map(resInfo.Category,
-				func(cn liquid.CategoryName) db.CategoryID { return categoryByName[cn].ID })
 			return db.Resource{
-				ServiceID:   srv.ID,
-				Name:        resourceName,
-				DisplayName: resInfo.DisplayName,
-				// TODO: consider serializing empty categories as serviceType here, instead at the consumers
-				CategoryID:          categoryID,
+				ServiceID:           srv.ID,
+				Name:                resourceName,
+				DisplayName:         resInfo.DisplayName,
+				CategoryID:          Some(categoryByName[resInfo.Category.UnwrapOr(defaultCategoryName)].ID),
 				Path:                db.ResourcePath{ServiceType: serviceType, ResourceName: resourceName},
 				LiquidVersion:       serviceInfo.Version,
 				Unit:                resInfo.Unit,
@@ -443,9 +464,7 @@ func SaveServiceInfoToDB(ctx context.Context, serviceType db.ServiceType, servic
 				}
 			}
 			res.DisplayName = resInfo.DisplayName
-			// TODO: consider serializing empty categories as serviceType here, instead at the consumers
-			res.CategoryID = options.Map(resInfo.Category,
-				func(cn liquid.CategoryName) db.CategoryID { return categoryByName[cn].ID })
+			res.CategoryID = Some(categoryByName[resInfo.Category.UnwrapOr(defaultCategoryName)].ID)
 			res.Unit = resInfo.Unit
 			res.Topology = resInfo.Topology
 			res.HasCapacity = resInfo.HasCapacity
@@ -612,13 +631,11 @@ func SaveServiceInfoToDB(ctx context.Context, serviceType db.ServiceType, servic
 		},
 		Create: func(rateName liquid.RateName) (db.Rate, error) {
 			rateInfo := serviceInfo.Rates[rateName]
-			categoryID := options.Map(rateInfo.Category,
-				func(cn liquid.CategoryName) db.CategoryID { return categoryByName[cn].ID })
 			return db.Rate{
 				ServiceID:     dbServices[0].ID,
 				Name:          rateName,
 				DisplayName:   rateInfo.DisplayName,
-				CategoryID:    categoryID,
+				CategoryID:    Some(categoryByName[rateInfo.Category.UnwrapOr(defaultCategoryName)].ID),
 				Path:          db.RatePath{ServiceType: serviceType, RateName: rateName},
 				LiquidVersion: serviceInfo.Version,
 				Unit:          rateInfo.Unit,
@@ -631,8 +648,7 @@ func SaveServiceInfoToDB(ctx context.Context, serviceType db.ServiceType, servic
 
 			rate.LiquidVersion = serviceInfo.Version
 			rate.DisplayName = rateInfo.DisplayName
-			rate.CategoryID = options.Map(rateInfo.Category,
-				func(cn liquid.CategoryName) db.CategoryID { return categoryByName[cn].ID })
+			rate.CategoryID = Some(categoryByName[rateInfo.Category.UnwrapOr(defaultCategoryName)].ID)
 			rate.Topology = rateInfo.Topology
 			rate.HasUsage = rateInfo.HasUsage
 
@@ -685,4 +701,18 @@ func SaveServiceInfoToDB(ctx context.Context, serviceType db.ServiceType, servic
 	}
 
 	return tx.Commit()
+}
+
+func usesDefaultCategory(serviceInfo liquid.ServiceInfo) bool {
+	for _, resInfo := range serviceInfo.Resources {
+		if resInfo.Category.IsNone() {
+			return true
+		}
+	}
+	for _, rateInfo := range serviceInfo.Rates {
+		if rateInfo.Category.IsNone() {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/core/cluster_test.go
+++ b/internal/core/cluster_test.go
@@ -100,12 +100,13 @@ func Test_ClusterSaveServiceInfo(t *testing.T) {
 		INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (14, 4, 'total', 0, 'unshared/things/total');
 		INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (8, 3, 'any', 0, 'unshared/capacity/any');
 		INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (9, 3, 'az-one', 0, 'unshared/capacity/az-one');
-		INSERT INTO categories (id, name, display_name, service_id) VALUES (2, 'foo_category', 'Foo Category', 2);
-		INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, has_usage, path, category_id) VALUES (1, 2, 'only_usage', 1, 'MiB', 'flat', TRUE, 'unshared/only_usage', 2);
-		INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, path) VALUES (2, 2, 'with_global_limit', 1, 'MiB', 'flat', 'unshared/with_global_limit');
-		INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, path) VALUES (3, 2, 'with_project_limit', 1, 'piece', 'flat', 'unshared/with_project_limit');
-		INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, needs_resource_demand, has_quota, path, display_name, category_id) VALUES (3, 2, 'capacity', 1, 'B', 'az-aware', TRUE, TRUE, TRUE, 'unshared/capacity', 'Capacity', 2);
-		INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_quota, path, display_name) VALUES (4, 2, 'things', 1, 'piece', 'flat', TRUE, 'unshared/things', 'Things');
+		INSERT INTO categories (id, name, display_name, service_id) VALUES (3, 'foo_category', 'Foo Category', 2);
+		INSERT INTO categories (id, name, display_name, service_id) VALUES (4, 'unshared', 'Unshared', 2);
+		INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, has_usage, path, category_id) VALUES (1, 2, 'only_usage', 1, 'MiB', 'flat', TRUE, 'unshared/only_usage', 3);
+		INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, path, category_id) VALUES (2, 2, 'with_global_limit', 1, 'MiB', 'flat', 'unshared/with_global_limit', 4);
+		INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, path, category_id) VALUES (3, 2, 'with_project_limit', 1, 'piece', 'flat', 'unshared/with_project_limit', 4);
+		INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, needs_resource_demand, has_quota, path, display_name, category_id) VALUES (3, 2, 'capacity', 1, 'B', 'az-aware', TRUE, TRUE, TRUE, 'unshared/capacity', 'Capacity', 3);
+		INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_quota, path, display_name, category_id) VALUES (4, 2, 'things', 1, 'piece', 'flat', TRUE, 'unshared/things', 'Things', 4);
 		INSERT INTO services (id, type, next_scrape_at, liquid_version, display_name) VALUES (2, 'unshared', 0, 1, 'Unshared');
 	`)
 
@@ -118,6 +119,7 @@ func Test_ClusterSaveServiceInfo(t *testing.T) {
 	tr.DBChanges().AssertEqual(`
 		DELETE FROM az_resources WHERE id = 6 AND resource_id = 2 AND az = 'any' AND path = 'shared/things/any';
 		DELETE FROM az_resources WHERE id = 7 AND resource_id = 2 AND az = 'total' AND path = 'shared/things/total';
+		DELETE FROM categories WHERE id = 2 AND name = 'shared' AND service_id = 1;
 		UPDATE resources SET liquid_version = 2 WHERE id = 1 AND service_id = 1 AND name = 'capacity' AND path = 'shared/capacity';
 		DELETE FROM resources WHERE id = 2 AND service_id = 1 AND name = 'things' AND path = 'shared/things';
 		DELETE FROM services WHERE id = 1 AND type = 'shared' AND liquid_version = 1;
@@ -133,8 +135,9 @@ func Test_ClusterSaveServiceInfo(t *testing.T) {
 	tr.DBChanges().AssertEqual(`
 		INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (15, 5, 'any', 0, 'shared/things/any');
 		INSERT INTO az_resources (id, resource_id, az, raw_capacity, path) VALUES (16, 5, 'total', 0, 'shared/things/total');
+		INSERT INTO categories (id, name, display_name, service_id) VALUES (5, 'shared', 'Shared', 1);
 		UPDATE resources SET liquid_version = 3 WHERE id = 1 AND service_id = 1 AND name = 'capacity' AND path = 'shared/capacity';
-		INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_quota, path, display_name) VALUES (5, 1, 'things', 3, 'piece', 'flat', TRUE, 'shared/things', 'Things');
+		INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_quota, path, display_name, category_id) VALUES (5, 1, 'things', 3, 'piece', 'flat', TRUE, 'shared/things', 'Things', 5);
 		DELETE FROM services WHERE id = 1 AND type = 'shared' AND liquid_version = 2;
 		INSERT INTO services (id, type, next_scrape_at, liquid_version, display_name) VALUES (1, 'shared', 0, 3, 'Shared');
 	`)
@@ -162,9 +165,9 @@ func Test_ClusterSaveServiceInfo(t *testing.T) {
 	})
 	generateNewClusterWithPersistingServiceInfo(t, s, true)
 	tr.DBChanges().AssertEqual(`
-		INSERT INTO categories (id, name, display_name, service_id) VALUES (3, 'bar_category', 'Bar Category', 2);
-		UPDATE rates SET liquid_version = 2, category_id = 3 WHERE id = 1 AND service_id = 2 AND name = 'only_usage' AND path = 'unshared/only_usage';
-		UPDATE rates SET liquid_version = 2, category_id = 2 WHERE id = 2 AND service_id = 2 AND name = 'with_global_limit' AND path = 'unshared/with_global_limit';
+		INSERT INTO categories (id, name, display_name, service_id) VALUES (6, 'bar_category', 'Bar Category', 2);
+		UPDATE rates SET liquid_version = 2, category_id = 6 WHERE id = 1 AND service_id = 2 AND name = 'only_usage' AND path = 'unshared/only_usage';
+		UPDATE rates SET liquid_version = 2, category_id = 3 WHERE id = 2 AND service_id = 2 AND name = 'with_global_limit' AND path = 'unshared/with_global_limit';
 		UPDATE rates SET liquid_version = 2 WHERE id = 3 AND service_id = 2 AND name = 'with_project_limit' AND path = 'unshared/with_project_limit';
 		UPDATE resources SET liquid_version = 2 WHERE id = 3 AND service_id = 2 AND name = 'capacity' AND path = 'unshared/capacity';
 		UPDATE resources SET liquid_version = 2 WHERE id = 4 AND service_id = 2 AND name = 'things' AND path = 'unshared/things';
@@ -187,9 +190,9 @@ func Test_ClusterSaveServiceInfo(t *testing.T) {
 	})
 	generateNewClusterWithPersistingServiceInfo(t, s, true)
 	tr.DBChanges().AssertEqual(`
-		DELETE FROM categories WHERE id = 3 AND name = 'bar_category' AND service_id = 2;
-		INSERT INTO categories (id, name, display_name, service_id) VALUES (4, 'bar_category_renamed', 'Bar Category', 2);
-		UPDATE rates SET liquid_version = 3, category_id = 4 WHERE id = 1 AND service_id = 2 AND name = 'only_usage' AND path = 'unshared/only_usage';
+		DELETE FROM categories WHERE id = 6 AND name = 'bar_category' AND service_id = 2;
+		INSERT INTO categories (id, name, display_name, service_id) VALUES (7, 'bar_category_renamed', 'Bar Category', 2);
+		UPDATE rates SET liquid_version = 3, category_id = 7 WHERE id = 1 AND service_id = 2 AND name = 'only_usage' AND path = 'unshared/only_usage';
 		UPDATE rates SET liquid_version = 3 WHERE id = 2 AND service_id = 2 AND name = 'with_global_limit' AND path = 'unshared/with_global_limit';
 		UPDATE rates SET liquid_version = 3 WHERE id = 3 AND service_id = 2 AND name = 'with_project_limit' AND path = 'unshared/with_project_limit';
 		UPDATE resources SET liquid_version = 3 WHERE id = 3 AND service_id = 2 AND name = 'capacity' AND path = 'unshared/capacity';

--- a/internal/core/service_info_cache_test.go
+++ b/internal/core/service_info_cache_test.go
@@ -162,8 +162,8 @@ func TestServiceInfoCache(t *testing.T) {
 	assert.Equal(t, len(must.BeOKT(sis.GetResourcesForType("second"))(t)), 2)
 	assert.Equal(t, must.BeOKT(sis.GetResourceForPath(db.ResourcePath{ServiceType: "second", ResourceName: "capacity"}))(t).Name, "capacity")
 	must.NotBeOKT(sis.GetRatesForType("second"))(t)
-	assert.Equal(t, len(sis.GetCategoriesForType("first")), 0)
-	assert.Equal(t, len(sis.GetCategoriesForType("second")), 1)
+	assert.Equal(t, len(sis.GetCategoriesForType("first")), 1)  // just default category
+	assert.Equal(t, len(sis.GetCategoriesForType("second")), 2) // default + "foo_category"
 
 	// check service update
 	assert.Equal(t, must.BeOKT(sis.GetServiceForType("first"))(t).DisplayName, "First")

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -49,7 +49,8 @@ type Resource struct {
 	ServiceID   ServiceID           `db:"service_id"`
 	Name        liquid.ResourceName `db:"name"`
 	DisplayName string              `db:"display_name"`
-	CategoryID  Option[CategoryID]  `db:"category_id"`
+	// TODO: change type to plain CategoryID and add "NOT NULL" constraint once prod has the materialized default categories
+	CategoryID Option[CategoryID] `db:"category_id"`
 	// a unique identifier for this record in the form "servicetype/resourcename"; mostly intended for manual lookup
 	Path ResourcePath `db:"path"`
 
@@ -110,11 +111,12 @@ var AZResourceByResourceIDIndex = oblast.NewRuntimeIndex(func(azr AZResource) Re
 
 // Rate contains a record from the `rates` table.
 type Rate struct {
-	ID          RateID             `db:"id,auto"`
-	ServiceID   ServiceID          `db:"service_id"`
-	Name        liquid.RateName    `db:"name"`
-	DisplayName string             `db:"display_name"`
-	CategoryID  Option[CategoryID] `db:"category_id"`
+	ID          RateID          `db:"id,auto"`
+	ServiceID   ServiceID       `db:"service_id"`
+	Name        liquid.RateName `db:"name"`
+	DisplayName string          `db:"display_name"`
+	// TODO: change type to plain CategoryID and add "NOT NULL" constraint once prod has the materialized default categories
+	CategoryID Option[CategoryID] `db:"category_id"`
 	// a unique identifier for this record in the form "servicetype/ratename"; mostly intended for manual lookup
 	Path RatePath `db:"path"`
 	// following fields get filled from liquid.ServiceInfo


### PR DESCRIPTION
To simplify the code that deals with matching on categories, e.g. in ServiceInfoSnapshot, I want to make the `resources.category_id` and `rates.category_id` NOT NULL. As the first half of this change, this commit changes SaveServiceInfoToDB to stop writing NULL into those fields. Instead, if there is a resource or rate with `info.Category.IsNone()`, a new category with the name equal to the service type is generated, and the resource or rate is linked to that category.

This is consistent with the definition of the Category field on liquid.ResourceInfo (and analogously on liquid.RateInfo):

> If None, the resource is grouped into the implicitly-defined default category.