### PR TITLE
add NOT NULL constraint to `{resources,rates}.category_id`

### DIFF
--- a/internal/api/reports_v2/cluster.go
+++ b/internal/api/reports_v2/cluster.go
@@ -209,14 +209,11 @@ func setInClusterResourceReport(filter Filter, cluster *core.Cluster, report *re
 	serviceReport := areaReport.Services[service.Type]
 
 	// check category level
-	category := liquid.CategoryName(service.Type)
-	if categoryID, exists := resource.CategoryID.Unpack(); exists {
-		category = must.BeOK(filter.GetCategoryForID(categoryID)).Name
+	categoryName := must.BeOK(filter.GetCategoryForID(resource.CategoryID)).Name
+	if _, exists := serviceReport.Categories[categoryName]; !exists {
+		serviceReport.Categories[categoryName] = resourcesv2.ClusterCategoryReport{Resources: make(map[liquid.ResourceName]resourcesv2.ClusterResourceReport)}
 	}
-	if _, exists := serviceReport.Categories[category]; !exists {
-		serviceReport.Categories[category] = resourcesv2.ClusterCategoryReport{Resources: make(map[liquid.ResourceName]resourcesv2.ClusterResourceReport)}
-	}
-	categoryReport := serviceReport.Categories[category]
+	categoryReport := serviceReport.Categories[categoryName]
 
 	// check resource level
 	if _, exists := categoryReport.Resources[resource.Name]; !exists {
@@ -299,14 +296,11 @@ func setInClusterRateReport(filter Filter, cluster *core.Cluster, report *ratesv
 	serviceReport := areaReport.Services[service.Type]
 
 	// check category level
-	category := liquid.CategoryName(service.Type)
-	if categoryID, exists := rate.CategoryID.Unpack(); exists {
-		category = must.BeOK(filter.GetCategoryForID(categoryID)).Name
+	categoryName := must.BeOK(filter.GetCategoryForID(rate.CategoryID)).Name
+	if _, exists := serviceReport.Categories[categoryName]; !exists {
+		serviceReport.Categories[categoryName] = ratesv2.ClusterCategoryReport{Rates: make(map[liquid.RateName]ratesv2.ClusterRateReport)}
 	}
-	if _, exists := serviceReport.Categories[category]; !exists {
-		serviceReport.Categories[category] = ratesv2.ClusterCategoryReport{Rates: make(map[liquid.RateName]ratesv2.ClusterRateReport)}
-	}
-	categoryReport := serviceReport.Categories[category]
+	categoryReport := serviceReport.Categories[categoryName]
 
 	// check rate level
 	categoryReport.Rates[rate.Name] = value

--- a/internal/api/reports_v2/domain.go
+++ b/internal/api/reports_v2/domain.go
@@ -213,14 +213,11 @@ func setInDomainResourceReport(filter Filter, cluster *core.Cluster, report *res
 	serviceReport := areaReport.Services[service.Type]
 
 	// check category level
-	category := liquid.CategoryName(service.Type)
-	if categoryID, exists := resource.CategoryID.Unpack(); exists {
-		category = must.BeOK(filter.GetCategoryForID(categoryID)).Name
+	categoryName := must.BeOK(filter.GetCategoryForID(resource.CategoryID)).Name
+	if _, exists := serviceReport.Categories[categoryName]; !exists {
+		serviceReport.Categories[categoryName] = resourcesv2.DomainCategoryReport{Resources: make(map[liquid.ResourceName]resourcesv2.DomainResourceReport)}
 	}
-	if _, exists := serviceReport.Categories[category]; !exists {
-		serviceReport.Categories[category] = resourcesv2.DomainCategoryReport{Resources: make(map[liquid.ResourceName]resourcesv2.DomainResourceReport)}
-	}
-	categoryReport := serviceReport.Categories[category]
+	categoryReport := serviceReport.Categories[categoryName]
 
 	// check resource level
 	if _, exists := categoryReport.Resources[resource.Name]; !exists {
@@ -325,14 +322,11 @@ func setInDomainRateReport(filter Filter, cluster *core.Cluster, report *ratesv2
 	serviceReport := areaReport.Services[service.Type]
 
 	// check category level
-	category := liquid.CategoryName(service.Type)
-	if categoryID, exists := rate.CategoryID.Unpack(); exists {
-		category = must.BeOK(filter.GetCategoryForID(categoryID)).Name
+	categoryName := must.BeOK(filter.GetCategoryForID(rate.CategoryID)).Name
+	if _, exists := serviceReport.Categories[categoryName]; !exists {
+		serviceReport.Categories[categoryName] = ratesv2.DomainCategoryReport{Rates: make(map[liquid.RateName]ratesv2.DomainRateReport)}
 	}
-	if _, exists := serviceReport.Categories[category]; !exists {
-		serviceReport.Categories[category] = ratesv2.DomainCategoryReport{Rates: make(map[liquid.RateName]ratesv2.DomainRateReport)}
-	}
-	categoryReport := serviceReport.Categories[category]
+	categoryReport := serviceReport.Categories[categoryName]
 
 	// check rate level
 	categoryReport.Rates[rate.Name] = value

--- a/internal/api/reports_v2/filter_test.go
+++ b/internal/api/reports_v2/filter_test.go
@@ -102,20 +102,16 @@ func TestV2FilterCreation(t *testing.T) {
 	resourceFilter = must.ReturnT(reports_v2.FilterFromResourceOpts(s.Cluster, resourceOpts))(t)
 	assert.Equal(t, len(resourceFilter.GetServices()), 2)
 	assert.Equal(t, len(must.BeOK(resourceFilter.GetResourcesForType("first"))), 1)
-	assert.Equal(t, (must.BeOK(resourceFilter.GetResourcesForType("first")))["capacity"].CategoryID.IsSome(), true)
 	assert.Equal(t, len(must.BeOK(resourceFilter.GetResourcesForType("second"))), 1)
 	assert.Equal(t, len(must.BeOK(resourceFilter.GetRatesForType("first"))), 1)
-	assert.Equal(t, (must.BeOK(resourceFilter.GetRatesForType("first")))["objects:create"].CategoryID.IsSome(), true)
 	assert.Equal(t, len(must.NotBeOK(resourceFilter.GetRatesForType("second"))), 0)
 
 	rateOpts = common.RateReportOpts{GenericReportOpts: common.GenericReportOpts{Category: Some(liquid.CategoryName("foo_category"))}}
 	rateFilter = must.ReturnT(reports_v2.FilterFromRateOpts(s.Cluster, rateOpts))(t)
 	assert.Equal(t, len(rateFilter.GetServices()), 2)
 	assert.Equal(t, len(must.BeOK(rateFilter.GetResourcesForType("first"))), 1)
-	assert.Equal(t, (must.BeOK(resourceFilter.GetResourcesForType("first")))["capacity"].CategoryID.IsSome(), true)
 	assert.Equal(t, len(must.BeOK(rateFilter.GetResourcesForType("second"))), 1)
 	assert.Equal(t, len(must.BeOK(rateFilter.GetRatesForType("first"))), 1)
-	assert.Equal(t, (must.BeOK(resourceFilter.GetRatesForType("first")))["objects:create"].CategoryID.IsSome(), true)
 	assert.Equal(t, len(must.NotBeOK(rateFilter.GetRatesForType("second"))), 0)
 
 	// category filter: using serviceType value as category to get resources/rates without explicit category
@@ -123,20 +119,16 @@ func TestV2FilterCreation(t *testing.T) {
 	resourceFilter = must.ReturnT(reports_v2.FilterFromResourceOpts(s.Cluster, resourceOpts))(t)
 	assert.Equal(t, len(resourceFilter.GetServices()), 1)
 	assert.Equal(t, len(must.BeOK(resourceFilter.GetResourcesForType("first"))), 1)
-	assert.Equal(t, (must.BeOK(resourceFilter.GetResourcesForType("first")))["things"].CategoryID.IsSome(), true) // not false anymore, refers to the materialized default category
 	assert.Equal(t, len(must.NotBeOK(resourceFilter.GetResourcesForType("second"))), 0)
 	assert.Equal(t, len(must.BeOK(resourceFilter.GetRatesForType("first"))), 1)
-	assert.Equal(t, (must.BeOK(resourceFilter.GetRatesForType("first")))["objects:update"].CategoryID.IsSome(), true) // not false anymore, refers to the materialized default category
 	assert.Equal(t, len(must.NotBeOK(resourceFilter.GetRatesForType("second"))), 0)
 
 	rateOpts = common.RateReportOpts{GenericReportOpts: common.GenericReportOpts{Category: Some(liquid.CategoryName("first"))}}
 	rateFilter = must.ReturnT(reports_v2.FilterFromRateOpts(s.Cluster, rateOpts))(t)
 	assert.Equal(t, len(rateFilter.GetServices()), 1)
 	assert.Equal(t, len(must.BeOK(rateFilter.GetResourcesForType("first"))), 1)
-	assert.Equal(t, (must.BeOK(rateFilter.GetResourcesForType("first")))["things"].CategoryID.IsSome(), true) // not false anymore, refers to the materialized default category
 	assert.Equal(t, len(must.NotBeOK(rateFilter.GetResourcesForType("second"))), 0)
 	assert.Equal(t, len(must.BeOK(rateFilter.GetRatesForType("first"))), 1)
-	assert.Equal(t, (must.BeOK(rateFilter.GetRatesForType("first")))["objects:update"].CategoryID.IsSome(), true) // not false anymore, refers to the materialized default category
 	assert.Equal(t, len(must.NotBeOK(rateFilter.GetRatesForType("second"))), 0)
 
 	// resource filter

--- a/internal/api/reports_v2/info.go
+++ b/internal/api/reports_v2/info.go
@@ -130,15 +130,10 @@ func GetResourcesInfo(cluster *core.Cluster, token *gopherpolicy.Token, timeNow 
 			if !slices.Contains(allowedResources, resourceName) {
 				continue
 			}
-			category := liquid.CategoryName(serviceType)
-			categoryDisplayName := service.DisplayName
-			if categoryID, exists := resource.CategoryID.Unpack(); exists {
-				category = categories[categoryID].Name
-				categoryDisplayName = categories[categoryID].DisplayName
-			}
-			if _, exists := serviceReport.Categories[category]; !exists {
-				serviceReport.Categories[category] = resourcesv2.CategoryInfoReport{
-					DisplayName: categoryDisplayName,
+			category := categories[resource.CategoryID]
+			if _, exists := serviceReport.Categories[category.Name]; !exists {
+				serviceReport.Categories[category.Name] = resourcesv2.CategoryInfoReport{
+					DisplayName: category.DisplayName,
 					Resources:   make(map[liquid.ResourceName]resourcesv2.ResourceInfoReport),
 				}
 			}
@@ -150,7 +145,7 @@ func GetResourcesInfo(cluster *core.Cluster, token *gopherpolicy.Token, timeNow 
 			} else {
 				scopedCommitmentBehavior = commitmentBehavior.ForDomain(domainName)
 			}
-			serviceReport.Categories[category].Resources[resourceName] = resourcesv2.ResourceInfoReport{
+			serviceReport.Categories[category.Name].Resources[resourceName] = resourcesv2.ResourceInfoReport{
 				DisplayName:      resource.DisplayName,
 				Unit:             resource.Unit,
 				Topology:         resource.Topology,
@@ -221,19 +216,14 @@ func GetRatesInfo(cluster *core.Cluster, token *gopherpolicy.Token, sis core.Ser
 				rir.ProjectDefaultLimit = rateConfig.Limit
 				rir.ProjectDefaultWindow = Some(rateConfig.Window)
 			}
-			category := liquid.CategoryName(serviceType)
-			categoryDisplayName := service.DisplayName
-			if categoryID, exists := rate.CategoryID.Unpack(); exists {
-				category = categories[categoryID].Name
-				categoryDisplayName = categories[categoryID].DisplayName
-			}
-			if _, exists := serviceReport.Categories[category]; !exists {
-				serviceReport.Categories[category] = ratesv2.CategoryInfoReport{
-					DisplayName: categoryDisplayName,
+			category := categories[rate.CategoryID]
+			if _, exists := serviceReport.Categories[category.Name]; !exists {
+				serviceReport.Categories[category.Name] = ratesv2.CategoryInfoReport{
+					DisplayName: category.DisplayName,
 					Rates:       make(map[liquid.RateName]ratesv2.RateInfoReport),
 				}
 			}
-			serviceReport.Categories[category].Rates[rateName] = rir
+			serviceReport.Categories[category.Name].Rates[rateName] = rir
 		}
 	}
 	return report, nil

--- a/internal/api/reports_v2/project.go
+++ b/internal/api/reports_v2/project.go
@@ -241,14 +241,11 @@ func setInProjectResourceReport(filter Filter, cluster *core.Cluster, report *re
 	serviceReport := areaReport.Services[service.Type]
 
 	// check category level
-	category := liquid.CategoryName(service.Type)
-	if categoryID, exists := resource.CategoryID.Unpack(); exists {
-		category = must.BeOK(filter.GetCategoryForID(categoryID)).Name
+	categoryName := must.BeOK(filter.GetCategoryForID(resource.CategoryID)).Name
+	if _, exists := serviceReport.Categories[categoryName]; !exists {
+		serviceReport.Categories[categoryName] = resourcesv2.ProjectCategoryReport{Resources: make(map[liquid.ResourceName]resourcesv2.ProjectResourceReport)}
 	}
-	if _, exists := serviceReport.Categories[category]; !exists {
-		serviceReport.Categories[category] = resourcesv2.ProjectCategoryReport{Resources: make(map[liquid.ResourceName]resourcesv2.ProjectResourceReport)}
-	}
-	categoryReport := serviceReport.Categories[category]
+	categoryReport := serviceReport.Categories[categoryName]
 
 	// check resource level
 	if _, exists := categoryReport.Resources[resource.Name]; !exists {
@@ -384,14 +381,11 @@ func setInProjectRateReport(filter Filter, cluster *core.Cluster, report *ratesv
 	serviceReport := areaReport.Services[service.Type]
 
 	// check category level
-	category := liquid.CategoryName(service.Type)
-	if categoryID, exists := rate.CategoryID.Unpack(); exists {
-		category = must.BeOK(filter.GetCategoryForID(categoryID)).Name
+	categoryName := must.BeOK(filter.GetCategoryForID(rate.CategoryID)).Name
+	if _, exists := serviceReport.Categories[categoryName]; !exists {
+		serviceReport.Categories[categoryName] = ratesv2.ProjectCategoryReport{Rates: make(map[liquid.RateName]ratesv2.ProjectRateReport)}
 	}
-	if _, exists := serviceReport.Categories[category]; !exists {
-		serviceReport.Categories[category] = ratesv2.ProjectCategoryReport{Rates: make(map[liquid.RateName]ratesv2.ProjectRateReport)}
-	}
-	categoryReport := serviceReport.Categories[category]
+	categoryReport := serviceReport.Categories[categoryName]
 
 	// check rate level
 	categoryReport.Rates[rate.Name] = value

--- a/internal/collector/capacity_scrape_test.go
+++ b/internal/collector/capacity_scrape_test.go
@@ -153,6 +153,7 @@ func Test_ScanCapacity(t *testing.T) {
 		Path:          db.ResourcePath{ServiceType: "unshared", ResourceName: "unknown"},
 		Topology:      liquid.FlatTopology,
 		LiquidVersion: 1,
+		CategoryID:    Some(s.GetCategoryID("unshared", "unshared")),
 	}
 	s.MustDBInsert(unknownRes)
 	s.MustDBInsert(&db.AZResource{

--- a/internal/collector/capacity_scrape_test.go
+++ b/internal/collector/capacity_scrape_test.go
@@ -153,7 +153,7 @@ func Test_ScanCapacity(t *testing.T) {
 		Path:          db.ResourcePath{ServiceType: "unshared", ResourceName: "unknown"},
 		Topology:      liquid.FlatTopology,
 		LiquidVersion: 1,
-		CategoryID:    Some(s.GetCategoryID("unshared", "unshared")),
+		CategoryID:    s.GetCategoryID("unshared", "unshared"),
 	}
 	s.MustDBInsert(unknownRes)
 	s.MustDBInsert(&db.AZResource{

--- a/internal/collector/fixtures/scrape0.sql
+++ b/internal/collector/fixtures/scrape0.sql
@@ -26,7 +26,7 @@ INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, has_usa
 INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, path, display_name, category_id) VALUES (2, 1, 'rateWithClusterLimit', 1, 'piece', 'flat', 'unittest/rateWithClusterLimit', 'Cluster-Limited Rate', 1);
 INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, path, display_name, category_id) VALUES (3, 1, 'rateWithProjectLimit', 1, 'piece', 'flat', 'unittest/rateWithProjectLimit', 'Project-Limited Rate', 1);
 INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, has_usage, path, display_name, category_id) VALUES (4, 1, 'secondrate', 1, 'KiB', 'flat', TRUE, 'unittest/secondrate', 'Second Rate', 1);
-INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, path, display_name) VALUES (5, 1, 'xAnotherRate', 1, 'piece', 'flat', 'unittest/xAnotherRate', 'X Another Rate');
+INSERT INTO rates (id, service_id, name, liquid_version, unit, topology, path, display_name, category_id) VALUES (5, 1, 'xAnotherRate', 1, 'piece', 'flat', 'unittest/xAnotherRate', 'X Another Rate', 1);
 
 INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_capacity, needs_resource_demand, has_quota, path, display_name, category_id) VALUES (1, 1, 'capacity', 1, 'B', 'az-aware', TRUE, TRUE, TRUE, 'unittest/capacity', 'Capacity', 1);
 INSERT INTO resources (id, service_id, name, liquid_version, unit, topology, has_quota, path, display_name, category_id) VALUES (2, 1, 'things', 1, 'piece', 'az-aware', TRUE, 'unittest/things', 'Things', 1);

--- a/internal/collector/scrape_test.go
+++ b/internal/collector/scrape_test.go
@@ -129,7 +129,7 @@ func commonComplexScrapeTestSetup(t *testing.T) (s test.Setup, scrapeJob jobloop
 		Unit:          liquid.UnitPiece,
 		Topology:      liquid.FlatTopology,
 		LiquidVersion: 1,
-		CategoryID:    Some(s.GetCategoryID("unittest", "unittest")),
+		CategoryID:    s.GetCategoryID("unittest", "unittest"),
 	})
 	must.SucceedT(t, s.Cluster.SIC.InvalidateService(s.Ctx, Some(db.ServiceType("unittest"))))
 	s.MustDBInsert(&db.ProjectRate{

--- a/internal/collector/scrape_test.go
+++ b/internal/collector/scrape_test.go
@@ -129,6 +129,7 @@ func commonComplexScrapeTestSetup(t *testing.T) (s test.Setup, scrapeJob jobloop
 		Unit:          liquid.UnitPiece,
 		Topology:      liquid.FlatTopology,
 		LiquidVersion: 1,
+		CategoryID:    Some(s.GetCategoryID("unittest", "unittest")),
 	})
 	must.SucceedT(t, s.Cluster.SIC.InvalidateService(s.Ctx, Some(db.ServiceType("unittest"))))
 	s.MustDBInsert(&db.ProjectRate{

--- a/internal/core/cluster.go
+++ b/internal/core/cluster.go
@@ -439,7 +439,7 @@ func SaveServiceInfoToDB(ctx context.Context, serviceType db.ServiceType, servic
 				ServiceID:           srv.ID,
 				Name:                resourceName,
 				DisplayName:         resInfo.DisplayName,
-				CategoryID:          Some(categoryByName[resInfo.Category.UnwrapOr(defaultCategoryName)].ID),
+				CategoryID:          categoryByName[resInfo.Category.UnwrapOr(defaultCategoryName)].ID,
 				Path:                db.ResourcePath{ServiceType: serviceType, ResourceName: resourceName},
 				LiquidVersion:       serviceInfo.Version,
 				Unit:                resInfo.Unit,
@@ -464,7 +464,7 @@ func SaveServiceInfoToDB(ctx context.Context, serviceType db.ServiceType, servic
 				}
 			}
 			res.DisplayName = resInfo.DisplayName
-			res.CategoryID = Some(categoryByName[resInfo.Category.UnwrapOr(defaultCategoryName)].ID)
+			res.CategoryID = categoryByName[resInfo.Category.UnwrapOr(defaultCategoryName)].ID
 			res.Unit = resInfo.Unit
 			res.Topology = resInfo.Topology
 			res.HasCapacity = resInfo.HasCapacity
@@ -635,7 +635,7 @@ func SaveServiceInfoToDB(ctx context.Context, serviceType db.ServiceType, servic
 				ServiceID:     dbServices[0].ID,
 				Name:          rateName,
 				DisplayName:   rateInfo.DisplayName,
-				CategoryID:    Some(categoryByName[rateInfo.Category.UnwrapOr(defaultCategoryName)].ID),
+				CategoryID:    categoryByName[rateInfo.Category.UnwrapOr(defaultCategoryName)].ID,
 				Path:          db.RatePath{ServiceType: serviceType, RateName: rateName},
 				LiquidVersion: serviceInfo.Version,
 				Unit:          rateInfo.Unit,
@@ -648,7 +648,7 @@ func SaveServiceInfoToDB(ctx context.Context, serviceType db.ServiceType, servic
 
 			rate.LiquidVersion = serviceInfo.Version
 			rate.DisplayName = rateInfo.DisplayName
-			rate.CategoryID = Some(categoryByName[rateInfo.Category.UnwrapOr(defaultCategoryName)].ID)
+			rate.CategoryID = categoryByName[rateInfo.Category.UnwrapOr(defaultCategoryName)].ID
 			rate.Topology = rateInfo.Topology
 			rate.HasUsage = rateInfo.HasUsage
 

--- a/internal/core/service_info_cache.go
+++ b/internal/core/service_info_cache.go
@@ -245,11 +245,9 @@ func (s ServiceInfoSnapshot) Filter(filter ServiceInfoFilter) FilteredServiceInf
 	if categoryFilterExists || resourceFilterExists {
 		for serviceType, resources := range f.snapshot.resources {
 			for resourceName, resource := range resources {
-				categoryID, cExists := resource.CategoryID.Unpack()
-				_, inRemoveSet := categoriesToRemove[categoryID]
+				_, inRemoveSet := categoriesToRemove[resource.CategoryID]
 				shouldRemove := (resourceFilterExists && resourceName != resourceNameFilter) ||
-					(categoryFilterExists && cExists && inRemoveSet) ||
-					(categoryFilterExists && !cExists && string(categoryFilter) != string(serviceType))
+					(categoryFilterExists && inRemoveSet)
 				if shouldRemove {
 					delete(f.snapshot.resources[serviceType], resourceName)
 					delete(f.snapshot.azResources[serviceType], resourceName)
@@ -261,7 +259,7 @@ func (s ServiceInfoSnapshot) Filter(filter ServiceInfoFilter) FilteredServiceInf
 						delete(f.snapshot.categories, serviceType)
 					}
 				} else {
-					seenCategories[categoryID] = struct{}{}
+					seenCategories[resource.CategoryID] = struct{}{}
 				}
 			}
 		}
@@ -271,11 +269,9 @@ func (s ServiceInfoSnapshot) Filter(filter ServiceInfoFilter) FilteredServiceInf
 	if categoryFilterExists || rateFilterExists {
 		for serviceType, rates := range f.snapshot.rates {
 			for rateName, rate := range rates {
-				categoryID, cExists := rate.CategoryID.Unpack()
-				_, inRemoveSet := categoriesToRemove[categoryID]
+				_, inRemoveSet := categoriesToRemove[rate.CategoryID]
 				shouldRemove := (rateFilterExists && rateName != rateNameFilter) ||
-					(categoryFilterExists && cExists && inRemoveSet) ||
-					(categoryFilterExists && !cExists && string(categoryFilter) != string(serviceType))
+					(categoryFilterExists && inRemoveSet)
 				if shouldRemove {
 					delete(f.snapshot.rates[serviceType], rateName)
 					if len(f.snapshot.resources[serviceType]) == 0 && len(f.snapshot.rates[serviceType]) == 0 {
@@ -286,7 +282,7 @@ func (s ServiceInfoSnapshot) Filter(filter ServiceInfoFilter) FilteredServiceInf
 						delete(f.snapshot.categories, serviceType)
 					}
 				} else {
-					seenCategories[categoryID] = struct{}{}
+					seenCategories[rate.CategoryID] = struct{}{}
 				}
 			}
 		}
@@ -839,12 +835,10 @@ func (s *ServiceInfoCache) GetServiceInfo(serviceType db.ServiceType) (info liqu
 		if res.AttributesJSON != "" {
 			resInfo.Attributes = json.RawMessage(res.AttributesJSON)
 		}
-		if categoryID, ok := res.CategoryID.Unpack(); ok {
-			if cat, exists := categories[categoryID]; exists {
-				resInfo.Category = Some(cat.Name)
-				info.Categories[cat.Name] = liquid.CategoryInfo{
-					DisplayName: cat.DisplayName,
-				}
+		if cat, exists := categories[res.CategoryID]; exists {
+			resInfo.Category = Some(cat.Name)
+			info.Categories[cat.Name] = liquid.CategoryInfo{
+				DisplayName: cat.DisplayName,
 			}
 		}
 		info.Resources[name] = resInfo
@@ -857,12 +851,10 @@ func (s *ServiceInfoCache) GetServiceInfo(serviceType db.ServiceType) (info liqu
 			Topology:    rate.Topology,
 			HasUsage:    rate.HasUsage,
 		}
-		if categoryID, ok := rate.CategoryID.Unpack(); ok {
-			if cat, exists := categories[categoryID]; exists {
-				rateInfo.Category = Some(cat.Name)
-				info.Categories[cat.Name] = liquid.CategoryInfo{
-					DisplayName: cat.DisplayName,
-				}
+		if cat, exists := categories[rate.CategoryID]; exists {
+			rateInfo.Category = Some(cat.Name)
+			info.Categories[cat.Name] = liquid.CategoryInfo{
+				DisplayName: cat.DisplayName,
 			}
 		}
 		info.Rates[name] = rateInfo

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -154,4 +154,8 @@ var sqlMigrations = map[int64]string{
 			AFTER INSERT OR UPDATE OR DELETE ON categories
 			FOR EACH ROW EXECUTE FUNCTION notify_service_update();
 	`,
+	85: `
+		ALTER TABLE resources ALTER COLUMN category_id SET NOT NULL;
+		ALTER TABLE rates     ALTER COLUMN category_id SET NOT NULL;
+	`,
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -49,8 +49,7 @@ type Resource struct {
 	ServiceID   ServiceID           `db:"service_id"`
 	Name        liquid.ResourceName `db:"name"`
 	DisplayName string              `db:"display_name"`
-	// TODO: change type to plain CategoryID and add "NOT NULL" constraint once prod has the materialized default categories
-	CategoryID Option[CategoryID] `db:"category_id"`
+	CategoryID  CategoryID          `db:"category_id"`
 	// a unique identifier for this record in the form "servicetype/resourcename"; mostly intended for manual lookup
 	Path ResourcePath `db:"path"`
 
@@ -115,8 +114,7 @@ type Rate struct {
 	ServiceID   ServiceID       `db:"service_id"`
 	Name        liquid.RateName `db:"name"`
 	DisplayName string          `db:"display_name"`
-	// TODO: change type to plain CategoryID and add "NOT NULL" constraint once prod has the materialized default categories
-	CategoryID Option[CategoryID] `db:"category_id"`
+	CategoryID  CategoryID      `db:"category_id"`
 	// a unique identifier for this record in the form "servicetype/ratename"; mostly intended for manual lookup
 	Path RatePath `db:"path"`
 	// following fields get filled from liquid.ServiceInfo

--- a/internal/test/setup.go
+++ b/internal/test/setup.go
@@ -389,6 +389,16 @@ func (s Setup) GetServiceID(srvType db.ServiceType) (result db.ServiceID) {
 	return result
 }
 
+// GetCategoryID is a helper function for finding the ID of a db.Category record.
+func (s Setup) GetCategoryID(srvType db.ServiceType, name liquid.CategoryName) (result db.CategoryID) {
+	s.t.Helper()
+	err := s.DB.QueryRow(`SELECT id FROM categories WHERE service_id = $1 AND name = $2`, s.GetServiceID(srvType), name).Scan(&result)
+	if err != nil {
+		s.t.Fatalf("could not find categories.id for service_type = %q and name = %q: %s", srvType, name, err.Error())
+	}
+	return result
+}
+
 // GetResourceID is a helper function for finding the ID of a db.Resource record.
 func (s Setup) GetResourceID(srvType db.ServiceType, resName liquid.ResourceName) (result db.ResourceID) {
 	s.t.Helper()


### PR DESCRIPTION
As intended by the series of changes that led to this point, this simplifies category-handling code on the report level.