### PR TITLE
collector/metrics: reduce repeated clones of ServiceInfoSnapshot

### DIFF
--- a/internal/collector/metrics.go
+++ b/internal/collector/metrics.go
@@ -278,10 +278,11 @@ func (c *UsageCollectionMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 	descCh := make(chan *prometheus.Desc, 1)
 	usageCollectionMetricsOkGauge.Describe(descCh)
 	collectionMetricsOkDesc := <-descCh
+	sis := c.Cluster.SIC.GetSnapshot()
 
 	if c.Override != nil {
 		for _, instance := range c.Override {
-			c.collectOneProjectService(ch, collectionMetricsOkDesc, instance)
+			c.collectOneProjectService(ch, collectionMetricsOkDesc, instance, sis)
 		}
 		return
 	}
@@ -293,7 +294,7 @@ func (c *UsageCollectionMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 			&i.Project.Name, &i.Project.UUID, &i.Project.ParentUUID,
 			&i.ServiceType, &i.SerializedMetrics)
 		if err == nil {
-			c.collectOneProjectService(ch, collectionMetricsOkDesc, i)
+			c.collectOneProjectService(ch, collectionMetricsOkDesc, i, sis)
 		}
 		return err
 	})
@@ -302,9 +303,9 @@ func (c *UsageCollectionMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 }
 
-func (c *UsageCollectionMetricsCollector) collectOneProjectService(ch chan<- prometheus.Metric, collectionMetricsOkDesc *prometheus.Desc, instance QuotaCollectionMetricsInstance) {
+func (c *UsageCollectionMetricsCollector) collectOneProjectService(ch chan<- prometheus.Metric, collectionMetricsOkDesc *prometheus.Desc, instance QuotaCollectionMetricsInstance, sis core.ServiceInfoSnapshot) {
 	// we ignore when a resource can't be found in the app layer yet, it will appear with default value
-	service, _ := c.Cluster.SIC.GetSnapshot().GetServiceForType(instance.ServiceType)
+	service, _ := sis.GetServiceForType(instance.ServiceType)
 	successAsFloat := 1.0
 	usageMetricFamilies, err := util.JSONToAny[map[liquid.MetricName]liquid.MetricFamilyInfo](service.UsageMetricFamiliesJSON, "usage_metric_families")
 	if err != nil {


### PR DESCRIPTION
We pulled an allocation profile for the collector, and found that the vast majority of allocations are within UsageCollectionMetricsCollector, because it calls SIC.GetSnapshot() for each individual project service.

SIC.GetSnapshot() currently does a deep clone of the snapshot, which is something that we ought to optimize, but doing so is quite involved. As a quick win, UsageCollectionMetricsCollector now reuses the same snapshot for the entire duration of a collection cycle.