### PR TITLE
bump go-api-declarations, remove support for liquid.UnitNone

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/common v0.70.1
 	github.com/rs/cors v1.11.1
-	github.com/sapcc/go-api-declarations v1.24.0
+	github.com/sapcc/go-api-declarations v1.25.0
 	github.com/sapcc/go-bits v0.0.0-20260813170327-ea1a14435d35
 	github.com/sergi/go-diff v1.4.0
 	go.xyrillian.de/gg v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -110,8 +110,8 @@ github.com/rabbitmq/amqp091-go v1.13.0 h1:L8NA1WtF76C6KA3LAoufjfLgbist/If1UQYcsO
 github.com/rabbitmq/amqp091-go v1.13.0/go.mod h1:Hy4jKW5kQART1u+JkDTF9YYOQUHXqMuhrgxOEeS7G4o=
 github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=
 github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
-github.com/sapcc/go-api-declarations v1.24.0 h1:sGBvOMVSM1olJlyvNoQSk7NX5uatXHKkztGDBPnTWMs=
-github.com/sapcc/go-api-declarations v1.24.0/go.mod h1:ZWRTijvgF8o8aHg5stgg7u4DF6jFrd0X97le/uGlZsA=
+github.com/sapcc/go-api-declarations v1.25.0 h1:vLkSVV8oaZExoBMEkwX31AqUjZIjwxKkxXr4q2sAAOg=
+github.com/sapcc/go-api-declarations v1.25.0/go.mod h1:7NrwidCCv/MxwBpb/qqYLbQb/eY6rlnYkXwWMGx/wlI=
 github.com/sapcc/go-bits v0.0.0-20260813170327-ea1a14435d35 h1:pTo+tUdMlRJRGY+MsAPeicedx58QYdnne8uWWufHA68=
 github.com/sapcc/go-bits v0.0.0-20260813170327-ea1a14435d35/go.mod h1:oxx7AA+bHudahaXHEcg/Xk4avBckWR/rOOa0SAsuSgg=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -101,17 +101,17 @@ func setupTest(t *testing.T) test.Setup {
 
 	srvInfoShared := test.DefaultLiquidServiceInfo("Shared")
 	srvInfoShared.Rates = map[liquid.RateName]liquid.RateInfo{
-		"objects:create":    {Topology: liquid.FlatTopology, HasUsage: true},
+		"objects:create":    {Unit: liquid.UnitPiece, Topology: liquid.FlatTopology, HasUsage: true},
 		"objects:delete":    {Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: true},
-		"objects:update":    {Topology: liquid.FlatTopology, HasUsage: true},
-		"objects:read":      {Topology: liquid.FlatTopology, HasUsage: false},
+		"objects:update":    {Unit: liquid.UnitPiece, Topology: liquid.FlatTopology, HasUsage: true},
+		"objects:read":      {Unit: liquid.UnitPiece, Topology: liquid.FlatTopology, HasUsage: false},
 		"objects:unlimited": {Unit: liquid.UnitKibibytes, Topology: liquid.FlatTopology, HasUsage: true},
 	}
 	srvInfoUnshared := test.DefaultLiquidServiceInfo("Unshared")
 	srvInfoUnshared.Rates = map[liquid.RateName]liquid.RateInfo{
-		"instances:create": {Topology: liquid.FlatTopology, HasUsage: true},
-		"instances:delete": {Topology: liquid.FlatTopology, HasUsage: true},
-		"instances:update": {Topology: liquid.FlatTopology, HasUsage: true},
+		"instances:create": {Unit: liquid.UnitPiece, Topology: liquid.FlatTopology, HasUsage: true},
+		"instances:delete": {Unit: liquid.UnitPiece, Topology: liquid.FlatTopology, HasUsage: true},
+		"instances:update": {Unit: liquid.UnitPiece, Topology: liquid.FlatTopology, HasUsage: true},
 	}
 	s := test.NewSetup(t,
 		test.WithConfig(testConfigJSON),

--- a/internal/api/api_v2/cluster_test.go
+++ b/internal/api/api_v2/cluster_test.go
@@ -244,9 +244,9 @@ var rateReportConfigJSON = string(must.Return(httptest.NewJQModifiableJSONString
 func TestV2ClusterRateReport(t *testing.T) {
 	srvInfoFirst := test.DefaultLiquidServiceInfo("First")
 	srvInfoFirst.Rates = map[liquid.RateName]liquid.RateInfo{
-		"objects:create":    {DisplayName: "Object Creations", Topology: liquid.FlatTopology, HasUsage: true, Category: Some(liquid.CategoryName("foo_category"))},
+		"objects:create":    {DisplayName: "Object Creations", Unit: liquid.UnitPiece, Topology: liquid.FlatTopology, HasUsage: true, Category: Some(liquid.CategoryName("foo_category"))},
 		"objects:delete":    {DisplayName: "Object Deletions", Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: true},
-		"objects:update":    {DisplayName: "Object Updates", Topology: liquid.FlatTopology, HasUsage: false},
+		"objects:update":    {DisplayName: "Object Updates", Unit: liquid.UnitPiece, Topology: liquid.FlatTopology, HasUsage: false},
 		"objects:unlimited": {DisplayName: "Object Unlimited Operations", Unit: liquid.UnitKibibytes, Topology: liquid.FlatTopology, HasUsage: true},
 	}
 

--- a/internal/api/api_v2/domain_test.go
+++ b/internal/api/api_v2/domain_test.go
@@ -167,9 +167,9 @@ func TestV2DomainResourceReport(t *testing.T) {
 func TestV2DomainRateReport(t *testing.T) {
 	srvInfoFirst := test.DefaultLiquidServiceInfo("First")
 	srvInfoFirst.Rates = map[liquid.RateName]liquid.RateInfo{
-		"objects:create":    {DisplayName: "Object Creations", Topology: liquid.FlatTopology, HasUsage: true, Category: Some(liquid.CategoryName("foo_category"))},
+		"objects:create":    {DisplayName: "Object Creations", Unit: liquid.UnitPiece, Topology: liquid.FlatTopology, HasUsage: true, Category: Some(liquid.CategoryName("foo_category"))},
 		"objects:delete":    {DisplayName: "Object Deletions", Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: true},
-		"objects:update":    {DisplayName: "Object Updates", Topology: liquid.FlatTopology, HasUsage: false},
+		"objects:update":    {DisplayName: "Object Updates", Unit: liquid.UnitPiece, Topology: liquid.FlatTopology, HasUsage: false},
 		"objects:unlimited": {DisplayName: "Object Unlimited Operations", Unit: liquid.UnitKibibytes, Topology: liquid.FlatTopology, HasUsage: true},
 	}
 

--- a/internal/api/api_v2/info_test.go
+++ b/internal/api/api_v2/info_test.go
@@ -58,8 +58,8 @@ var infoConfigJSON = string(must.Return(httptest.NewJQModifiableJSONString(`
 func TestV2ResourcesInfoAPI(t *testing.T) {
 	srvInfoFirst := test.DefaultLiquidServiceInfo("First")
 	srvInfoFirst.Rates = map[liquid.RateName]liquid.RateInfo{
-		"objects:create": {Topology: liquid.FlatTopology, HasUsage: false},
-		"objects:update": {Topology: liquid.FlatTopology, HasUsage: false},
+		"objects:create": {Unit: liquid.UnitPiece, Topology: liquid.FlatTopology, HasUsage: false},
+		"objects:update": {Unit: liquid.UnitPiece, Topology: liquid.FlatTopology, HasUsage: false},
 	}
 
 	s := test.NewSetup(t,
@@ -139,9 +139,9 @@ func TestV2ResourcesInfoAPI(t *testing.T) {
 func TestV2RatesInfoAPI(t *testing.T) {
 	serviceInfoFirst := test.DefaultLiquidServiceInfo("First")
 	serviceInfoFirst.Rates = map[liquid.RateName]liquid.RateInfo{
-		"objects:create":    {DisplayName: "Object Creations", Topology: liquid.FlatTopology, HasUsage: true, Category: Some(liquid.CategoryName("foo_category"))},
+		"objects:create":    {DisplayName: "Object Creations", Unit: liquid.UnitPiece, Topology: liquid.FlatTopology, HasUsage: true, Category: Some(liquid.CategoryName("foo_category"))},
 		"objects:delete":    {DisplayName: "Object Deletions", Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: true},
-		"objects:update":    {DisplayName: "Object Updates", Topology: liquid.FlatTopology, HasUsage: true},
+		"objects:update":    {DisplayName: "Object Updates", Unit: liquid.UnitPiece, Topology: liquid.FlatTopology, HasUsage: true},
 		"objects:unlimited": {DisplayName: "Object Unlimited Operations", Unit: liquid.UnitKibibytes, Topology: liquid.FlatTopology, HasUsage: true},
 	}
 	serviceInfoSecond := test.DefaultLiquidServiceInfo("Second")

--- a/internal/api/api_v2/project_test.go
+++ b/internal/api/api_v2/project_test.go
@@ -258,9 +258,9 @@ func TestV2ProjectResourceReport(t *testing.T) {
 func TestV2ProjectRateReport(t *testing.T) {
 	srvInfoFirst := test.DefaultLiquidServiceInfo("First")
 	srvInfoFirst.Rates = map[liquid.RateName]liquid.RateInfo{
-		"objects:create":    {DisplayName: "Object Creations", Topology: liquid.FlatTopology, HasUsage: true, Category: Some(liquid.CategoryName("foo_category"))},
+		"objects:create":    {DisplayName: "Object Creations", Unit: liquid.UnitPiece, Topology: liquid.FlatTopology, HasUsage: true, Category: Some(liquid.CategoryName("foo_category"))},
 		"objects:delete":    {DisplayName: "Object Deletions", Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: true},
-		"objects:update":    {DisplayName: "Object Updates", Topology: liquid.FlatTopology, HasUsage: false},
+		"objects:update":    {DisplayName: "Object Updates", Unit: liquid.UnitPiece, Topology: liquid.FlatTopology, HasUsage: false},
 		"objects:unlimited": {DisplayName: "Object Unlimited Operations", Unit: liquid.UnitKibibytes, Topology: liquid.FlatTopology, HasUsage: true},
 	}
 

--- a/internal/collector/quota_overrides_test.go
+++ b/internal/collector/quota_overrides_test.go
@@ -21,8 +21,8 @@ func TestApplyQuotaOverrides(t *testing.T) {
 	// setup enough to have fully populated project_services and project_resources
 	srvInfo := test.DefaultLiquidServiceInfo("Unit Test")
 	srvInfo.Rates = map[liquid.RateName]liquid.RateInfo{
-		"rateWithClusterLimit": {Topology: liquid.FlatTopology, HasUsage: false},
-		"rateWithProjectLimit": {Topology: liquid.FlatTopology, HasUsage: false},
+		"rateWithClusterLimit": {Unit: liquid.UnitPiece, Topology: liquid.FlatTopology, HasUsage: false},
+		"rateWithProjectLimit": {Unit: liquid.UnitPiece, Topology: liquid.FlatTopology, HasUsage: false},
 	}
 	s := test.NewSetup(t,
 		test.WithConfig(testScrapeBasicConfigJSON),

--- a/internal/collector/scrape_test.go
+++ b/internal/collector/scrape_test.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/sapcc/go-api-declarations/limes"
 	limesrates "github.com/sapcc/go-api-declarations/limes/rates"
 	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
 	"github.com/sapcc/go-api-declarations/liquid"
@@ -98,10 +97,10 @@ func commonComplexScrapeTestSetup(t *testing.T) (s test.Setup, scrapeJob jobloop
 			},
 		},
 		Rates: map[liquid.RateName]liquid.RateInfo{
-			"firstrate":            {DisplayName: "First Rate", Topology: liquid.FlatTopology, HasUsage: true},
+			"firstrate":            {DisplayName: "First Rate", Unit: liquid.UnitPiece, Topology: liquid.FlatTopology, HasUsage: true},
 			"secondrate":           {DisplayName: "Second Rate", Unit: liquid.UnitKibibytes, Topology: liquid.FlatTopology, HasUsage: true},
-			"rateWithClusterLimit": {DisplayName: "Cluster-Limited Rate", Topology: liquid.FlatTopology, HasUsage: false},
-			"rateWithProjectLimit": {DisplayName: "Project-Limited Rate", Topology: liquid.FlatTopology, HasUsage: false},
+			"rateWithClusterLimit": {DisplayName: "Cluster-Limited Rate", Unit: liquid.UnitPiece, Topology: liquid.FlatTopology, HasUsage: false},
+			"rateWithProjectLimit": {DisplayName: "Project-Limited Rate", Unit: liquid.UnitPiece, Topology: liquid.FlatTopology, HasUsage: false},
 		},
 		UsageMetricFamilies: map[liquid.MetricName]liquid.MetricFamilyInfo{
 			"limes_unittest_capacity_usage": {Type: liquid.MetricTypeGauge},
@@ -744,7 +743,7 @@ func Test_ScrapeReturnsNoUsageData(t *testing.T) {
 		Version:     1,
 		DisplayName: "Noop",
 		Resources: map[liquid.ResourceName]liquid.ResourceInfo{
-			"things": {DisplayName: "Things", Unit: limes.UnitNone, HasQuota: true, Topology: liquid.AZAwareTopology},
+			"things": {DisplayName: "Things", Unit: liquid.UnitPiece, HasQuota: true, Topology: liquid.AZAwareTopology},
 		},
 	}
 	s := test.NewSetup(t,

--- a/internal/core/cluster.go
+++ b/internal/core/cluster.go
@@ -275,21 +275,6 @@ func generateDeleteFunc[T any](dbm *gsql.DB, getAZResourcePathPattern func(o T) 
 // or ScrapeCapacity or on Init from the collect-task. It does not have the LiquidConnection as receiverType,
 // so that it can be reused from the testSetup to create DB entries.
 func SaveServiceInfoToDB(ctx context.Context, serviceType db.ServiceType, serviceInfo liquid.ServiceInfo, availabilityZones []limes.AvailabilityZone, rateLimits ServiceRateLimitConfiguration, timeNow time.Time, dbm *gsql.DB) (err error) {
-	// TODO: remove this once the move from UnitNone to UnitPiece is finished
-	//       (i.e. when liquid.ValidateServiceInfo is updated to reject UnitNone)
-	for resName, resInfo := range serviceInfo.Resources {
-		if resInfo.Unit == liquid.UnitNone { //nolint:staticcheck // necessary use of deprecated symbol
-			resInfo.Unit = liquid.UnitPiece
-			serviceInfo.Resources[resName] = resInfo
-		}
-	}
-	for rateName, rateInfo := range serviceInfo.Rates {
-		if rateInfo.Unit == liquid.UnitNone { //nolint:staticcheck // necessary use of deprecated symbol
-			rateInfo.Unit = liquid.UnitPiece
-			serviceInfo.Rates[rateName] = rateInfo
-		}
-	}
-
 	// make the implicitly defined default category explicit if needed
 	defaultCategoryName := liquid.CategoryName(serviceType)
 	if usesDefaultCategory(serviceInfo) {

--- a/internal/core/cluster_test.go
+++ b/internal/core/cluster_test.go
@@ -77,7 +77,7 @@ func Test_ClusterSaveServiceInfo(t *testing.T) {
 	srvInfoUnshared.Rates = map[liquid.RateName]liquid.RateInfo{
 		"only_usage":         {Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: true, Category: Some(liquid.CategoryName("foo_category"))},
 		"with_global_limit":  {Unit: liquid.UnitMebibytes, Topology: liquid.FlatTopology, HasUsage: false},
-		"with_project_limit": {Unit: liquid.UnitNone, Topology: liquid.FlatTopology, HasUsage: false}, //nolint:staticcheck // intentionally using deprecated name UnitNone to validate the automatic rewrite into UnitPiece
+		"with_project_limit": {Unit: liquid.UnitPiece, Topology: liquid.FlatTopology, HasUsage: false},
 	}
 
 	s := test.NewSetup(t,

--- a/internal/liquids/nova/liquid.go
+++ b/internal/liquids/nova/liquid.go
@@ -317,8 +317,7 @@ func (l *Logic) SetQuota(ctx context.Context, projectUUID string, req liquid.Ser
 				}
 			}
 			sumConverted := sum
-			//nolint:staticcheck // intentionally using deprecated name UnitNone to ensure we catch all cases
-			if resInfo.Unit != liquid.UnitPiece && resInfo.Unit != liquid.UnitMebibytes && resInfo.Unit != liquid.UnitNone {
+			if resInfo.Unit != liquid.UnitPiece && resInfo.Unit != liquid.UnitMebibytes {
 				result, err := limes.ValueWithUnit{Value: sum, Unit: resInfo.Unit}.ConvertTo(liquid.UnitMebibytes)
 				if err != nil {
 					return fmt.Errorf("while converting quota for %s to MiB: %w", resName, err)

--- a/internal/test/mock_liquid_client.go
+++ b/internal/test/mock_liquid_client.go
@@ -35,7 +35,7 @@ func DefaultLiquidServiceInfo(displayName string) liquid.ServiceInfo {
 			},
 			"things": {
 				DisplayName: "Things",
-				Unit:        liquid.UnitNone, //nolint:staticcheck // intentionally using deprecated name UnitNone to validate the automatic rewrite into UnitPiece
+				Unit:        liquid.UnitPiece,
 				Topology:    liquid.FlatTopology,
 				HasCapacity: false,
 				HasQuota:    true,

--- a/vendor/github.com/sapcc/go-api-declarations/internal/units/amount.go
+++ b/vendor/github.com/sapcc/go-api-declarations/internal/units/amount.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-// TODO: BaseUnitNone, UnitNone, EmptyFormat and NumberOnlyFormat can be removed when removing support for Limes v1 (after checking that no liquids use UnitNone anymore, see TODO in liquid/validation.go)
+// TODO: BaseUnitNone, UnitNone, EmptyFormat and NumberOnlyFormat can be removed when removing support for Limes v1
 
 // Amount describes an amount of a countable or measurable resource in terms of a base unit.
 // This type provides basic serialization and deserialization for unit or amount strings,

--- a/vendor/github.com/sapcc/go-api-declarations/liquid/validation.go
+++ b/vendor/github.com/sapcc/go-api-declarations/liquid/validation.go
@@ -57,7 +57,9 @@ func validateServiceInfoImpl(srv ServiceInfo) (errs errorset.ErrorSet) {
 		if _, ok := srv.Categories[category]; hasCategory && !ok {
 			errs.Addf(".Resources[%q] has category %q, which is not declared in .Categories", resName, category)
 		}
-		// TODO: before removing UnitNone from internal/units, have a check here for a while that `res.Unit != units.UnitNone`
+		if res.Unit == UnitNone {
+			errs.Addf(`.Resources[%q] uses invalid unit "" (in your code, replace liquid.UnitNone with liquid.UnitPiece)`, resName)
+		}
 	}
 
 	for _, rateName := range slices.Sorted(maps.Keys(srv.Rates)) {
@@ -78,6 +80,9 @@ func validateServiceInfoImpl(srv ServiceInfo) (errs errorset.ErrorSet) {
 		}
 		if _, ok := srv.Categories[category]; hasCategory && !ok {
 			errs.Addf(".Rates[%q] has category %q, which is not declared in .Categories", rateName, category)
+		}
+		if rate.Unit == UnitNone {
+			errs.Addf(`.Rates[%q] uses invalid unit "" (in your code, replace liquid.UnitNone with liquid.UnitPiece)`, rateName)
 		}
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -131,7 +131,7 @@ github.com/rabbitmq/amqp091-go
 ## explicit; go 1.13
 github.com/rs/cors
 github.com/rs/cors/internal
-# github.com/sapcc/go-api-declarations v1.24.0
+# github.com/sapcc/go-api-declarations v1.25.0
 ## explicit; go 1.26
 github.com/sapcc/go-api-declarations/bininfo
 github.com/sapcc/go-api-declarations/cadf


### PR DESCRIPTION
Validation in go-api-declarations/liquid now rejects liquid.UnitNone, following my verification that all liquids have migrated to UnitPiece.

The only remaining instances of `UnitNone` in Limes are within the scope of the v1 API, where UnitPiece is not used.