### PR TITLE
Go 1.27: replace gofrs/uuid with uuid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.27
 require (
 	github.com/databus23/goslo.policy v0.0.0-20250326134918-4afc2c56a903
 	github.com/dlmiddlecote/sqlstats v1.0.2
-	github.com/gofrs/uuid/v5 v5.5.1
 	github.com/gophercloud/gophercloud/v2 v2.14.0
 	github.com/gorilla/mux v1.8.1
 	github.com/lib/pq v1.12.3
@@ -23,6 +22,7 @@ require (
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/gofrs/uuid/v5 v5.5.1 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/itchyny/gojq v0.12.19 // indirect

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -13,8 +13,8 @@ import (
 	"sort"
 	"testing"
 	"time"
+	"uuid"
 
-	"github.com/gofrs/uuid/v5"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sapcc/go-api-declarations/limes"
 	limesrates "github.com/sapcc/go-api-declarations/limes/rates"
@@ -262,7 +262,7 @@ func setupTest(t *testing.T) test.Setup {
 	makeCommitment := func(projectID db.ProjectID, azResourceID db.AZResourceID, amount uint64, status liquid.CommitmentStatus, durationStr string) *db.ProjectCommitment {
 		duration := must.Return(limesresources.ParseCommitmentDuration(durationStr))
 		c := db.ProjectCommitment{
-			UUID:                liquid.CommitmentUUID(must.Return(uuid.NewV4()).String()),
+			UUID:                liquid.CommitmentUUID(uuid.NewV4().String()),
 			ProjectID:           projectID,
 			AZResourceID:        azResourceID,
 			Amount:              amount,
@@ -925,7 +925,7 @@ func Test_LargeProjectList(t *testing.T) {
 	projectUUIDs := make([]liquid.ProjectUUID, 100)
 	projectsAsConfigured := make([]core.KeystoneProject, len(projectUUIDs))
 	for idx := range projectUUIDs {
-		projectUUID := liquid.ProjectUUID(must.Return(uuid.NewV4()).String())
+		projectUUID := liquid.ProjectUUID(uuid.NewV4().String())
 		projectUUIDs[idx] = projectUUID
 		projectsAsConfigured[idx] = core.KeystoneProject{
 			Name:       fmt.Sprintf("test-project%04d", idx),

--- a/internal/datamodel/commitment.go
+++ b/internal/datamodel/commitment.go
@@ -10,13 +10,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
+	"uuid"
 
-	"github.com/gofrs/uuid/v5"
 	"github.com/sapcc/go-api-declarations/limes"
 	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
 	"github.com/sapcc/go-api-declarations/liquid"
 	"github.com/sapcc/go-bits/gopherpolicy"
-	"github.com/sapcc/go-bits/must"
 	"go.xyrillian.de/gg/options"
 
 	"github.com/sapcc/limes/internal/core"
@@ -41,7 +40,7 @@ func GenerateTransferToken() string {
 func GenerateProjectCommitmentUUID() liquid.CommitmentUUID {
 	// UUID generation will only raise an error if reading from /dev/urandom fails,
 	// which is a wildly unexpected OS-level error and thus fine as a fatal error
-	return liquid.CommitmentUUID(must.Return(uuid.NewV4()).String())
+	return liquid.CommitmentUUID(uuid.NewV4().String())
 }
 
 // BuildSplitCommitment prepares a new commitment instance whose creation context


### PR DESCRIPTION
The dependency is not gone yet because libraries are using it, too.