### PR TITLE
replace deep cloning in ServiceInfoCache with ConstMap

### DIFF
--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"maps"
 	"net/http"
 	"slices"
 	"strings"
@@ -1775,9 +1774,10 @@ func (p *v1Provider) GetCommitmentConversions(w http.ResponseWriter, r *http.Req
 	// enumerate possible conversions
 	conversions := make([]limesresources.CommitmentConversionRule, 0)
 	if len(sourceBehavior.ConversionRules) > 0 {
-		for _, targetServiceType := range slices.Sorted(maps.Keys(sis.GetResources())) {
-			resources, _ := sis.GetResourcesForType(targetServiceType) // can have no resources
-			for targetResourceName, targetResource := range resources {
+		for _, targetServiceType := range slices.Sorted(sis.GetServices().Keys()) {
+			resources := sis.GetResourcesForType(targetServiceType) // can have no resources
+			for _, targetResourceName := range slices.Sorted(resources.Keys()) {
+				targetResource := resources.GetOrZero(targetResourceName)
 				if sourceServiceType == targetServiceType && sourceResourceName == targetResourceName {
 					continue
 				}

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -5,7 +5,6 @@ package api
 
 import (
 	"fmt"
-	"maps"
 	"net/http"
 	"slices"
 
@@ -260,7 +259,7 @@ func (p *v1Provider) PutProjectMaxQuota(w http.ResponseWriter, r *http.Request) 
 	}
 	defer sqlext.RollbackUnlessCommitted(tx)
 
-	for _, serviceType := range slices.Sorted(maps.Keys(sis.GetServices())) {
+	for _, serviceType := range slices.Sorted(sis.GetServices().Keys()) {
 		service, _ := sis.GetServiceForType(serviceType)
 		requestedInService, exists := requested[service.Type]
 		if !exists {
@@ -401,7 +400,7 @@ func (p *v1Provider) PutQuotaAutogrowth(w http.ResponseWriter, r *http.Request) 
 	}
 	defer sqlext.RollbackUnlessCommitted(tx)
 
-	for _, serviceType := range slices.Sorted(maps.Keys(sis.GetServices())) {
+	for _, serviceType := range slices.Sorted(sis.GetServices().Keys()) {
 		service, _ := sis.GetServiceForType(serviceType)
 		requestedInService, exists := requested[service.Type]
 		if !exists {

--- a/internal/api/reports_v2/filter.go
+++ b/internal/api/reports_v2/filter.go
@@ -34,17 +34,23 @@ func FilterFromResourceOpts(cluster *core.Cluster, opts common.ResourceReportOpt
 		ResourceName: opts.ResourceName,
 	})}
 	services := f.GetServices()
-	if area, ok := opts.Area.Unpack(); ok && len(services) == 0 {
+	if area, ok := opts.Area.Unpack(); ok && services.Len() == 0 {
 		return f, fmt.Errorf(`no services found for area %q`, area)
 	}
-	if serviceType, ok := opts.ServiceType.Unpack(); ok && len(services) == 0 {
+	if serviceType, ok := opts.ServiceType.Unpack(); ok && services.Len() == 0 {
 		return f, fmt.Errorf(`no services found for type %q`, serviceType)
 	}
-	resources := f.GetResources()
-	if category, ok := opts.Category.Unpack(); ok && len(resources) == 0 {
+	hasResources := false
+	for serviceType := range f.GetServices().Keys() {
+		if f.GetResourcesForType(serviceType).Len() > 0 {
+			hasResources = true
+			break
+		}
+	}
+	if category, ok := opts.Category.Unpack(); ok && !hasResources {
 		return f, fmt.Errorf(`no resources found for category %q`, category)
 	}
-	if name, ok := opts.ResourceName.Unpack(); ok && len(resources) == 0 {
+	if name, ok := opts.ResourceName.Unpack(); ok && !hasResources {
 		return f, fmt.Errorf(`no resources found for name %q`, name)
 	}
 	return f, nil
@@ -60,17 +66,23 @@ func FilterFromRateOpts(cluster *core.Cluster, opts common.RateReportOpts) (f Fi
 		RateName:    opts.RateName,
 	})}
 	services := f.GetServices()
-	if area, ok := opts.Area.Unpack(); ok && len(services) == 0 {
+	if area, ok := opts.Area.Unpack(); ok && services.Len() == 0 {
 		return f, fmt.Errorf(`no services found for area %q`, area)
 	}
-	if serviceType, ok := opts.ServiceType.Unpack(); ok && len(services) == 0 {
+	if serviceType, ok := opts.ServiceType.Unpack(); ok && services.Len() == 0 {
 		return f, fmt.Errorf(`no services found for type %q`, serviceType)
 	}
-	rates := f.GetRates()
-	if category, ok := opts.Category.Unpack(); ok && len(rates) == 0 {
+	hasRates := false
+	for serviceType := range f.GetServices().Keys() {
+		if f.GetRatesForType(serviceType).Len() > 0 {
+			hasRates = true
+			break
+		}
+	}
+	if category, ok := opts.Category.Unpack(); ok && !hasRates {
 		return f, fmt.Errorf(`no rates found for category %q`, category)
 	}
-	if name, ok := opts.RateName.Unpack(); ok && len(rates) == 0 {
+	if name, ok := opts.RateName.Unpack(); ok && !hasRates {
 		return f, fmt.Errorf(`no rates found for name %q`, name)
 	}
 	return f, nil
@@ -127,15 +139,15 @@ func (f Filter) ExpandServiceFilters(originalQuery string, originalArgs ...any) 
 }
 
 func (f Filter) getServiceIDs() (ids []db.ServiceID) {
-	for _, service := range f.GetServices() {
+	for service := range f.GetServices().Values() {
 		ids = append(ids, service.ID)
 	}
 	return ids
 }
 
 func (f Filter) getResourceIDs() (ids []db.ResourceID) {
-	for _, resources := range f.GetResources() {
-		for _, resource := range resources {
+	for serviceType := range f.GetServices().Keys() {
+		for resource := range f.GetResourcesForType(serviceType).Values() {
 			ids = append(ids, resource.ID)
 		}
 	}
@@ -143,9 +155,9 @@ func (f Filter) getResourceIDs() (ids []db.ResourceID) {
 }
 
 func (f Filter) getAZResourceIDs() (ids []db.AZResourceID) {
-	for _, azResources := range f.GetAZResources() {
-		for _, azResourcesByAZ := range azResources {
-			for _, azResource := range azResourcesByAZ {
+	for serviceType := range f.GetServices().Keys() {
+		for res := range f.GetResourcesForType(serviceType).Values() {
+			for azResource := range f.GetAZResourcesForPath(res.Path).Values() {
 				ids = append(ids, azResource.ID)
 			}
 		}
@@ -154,8 +166,8 @@ func (f Filter) getAZResourceIDs() (ids []db.AZResourceID) {
 }
 
 func (f Filter) getRateIDs() (ids []db.RateID) {
-	for _, rates := range f.GetRates() {
-		for _, rate := range rates {
+	for serviceType := range f.GetServices().Keys() {
+		for rate := range f.GetRatesForType(serviceType).Values() {
 			ids = append(ids, rate.ID)
 		}
 	}

--- a/internal/api/reports_v2/filter_test.go
+++ b/internal/api/reports_v2/filter_test.go
@@ -40,114 +40,114 @@ func TestV2FilterCreation(t *testing.T) {
 	)
 	// do some basic assertions to compare the filtered results against
 	sis := s.Cluster.SIC.GetSnapshot()
-	assert.Equal(t, len(sis.GetServices()), 2)
-	assert.Equal(t, len(must.BeOK(sis.GetResourcesForType("first"))), 2)
-	assert.Equal(t, len(must.BeOK(sis.GetResourcesForType("second"))), 2)
-	assert.Equal(t, len(must.BeOK(sis.GetRatesForType("first"))), 2)
-	assert.Equal(t, len(must.NotBeOK(sis.GetRatesForType("second"))), 0)
+	assert.Equal(t, sis.GetServices().Len(), 2)
+	assert.Equal(t, sis.GetResourcesForType("first").Len(), 2)
+	assert.Equal(t, sis.GetResourcesForType("second").Len(), 2)
+	assert.Equal(t, sis.GetRatesForType("first").Len(), 2)
+	assert.Equal(t, sis.GetRatesForType("second").Len(), 0)
 
 	// empty opts yields the same service info
 	resourceOpts := common.ResourceReportOpts{}
 	resourceFilter := must.ReturnT(reports_v2.FilterFromResourceOpts(s.Cluster, resourceOpts))(t)
-	assert.Equal(t, len(resourceFilter.GetServices()), 2)
-	assert.Equal(t, len(must.BeOK(resourceFilter.GetResourcesForType("first"))), 2)
-	assert.Equal(t, len(must.BeOK(resourceFilter.GetResourcesForType("second"))), 2)
-	assert.Equal(t, len(must.BeOK(resourceFilter.GetRatesForType("first"))), 2)
-	assert.Equal(t, len(must.NotBeOK(resourceFilter.GetRatesForType("second"))), 0)
+	assert.Equal(t, resourceFilter.GetServices().Len(), 2)
+	assert.Equal(t, resourceFilter.GetResourcesForType("first").Len(), 2)
+	assert.Equal(t, resourceFilter.GetResourcesForType("second").Len(), 2)
+	assert.Equal(t, resourceFilter.GetRatesForType("first").Len(), 2)
+	assert.Equal(t, resourceFilter.GetRatesForType("second").Len(), 0)
 
 	rateOpts := common.RateReportOpts{}
 	rateFilter := must.ReturnT(reports_v2.FilterFromRateOpts(s.Cluster, rateOpts))(t)
-	assert.Equal(t, len(rateFilter.GetServices()), 2)
-	assert.Equal(t, len(must.BeOK(rateFilter.GetResourcesForType("first"))), 2)
-	assert.Equal(t, len(must.BeOK(rateFilter.GetResourcesForType("second"))), 2)
-	assert.Equal(t, len(must.BeOK(rateFilter.GetRatesForType("first"))), 2)
-	assert.Equal(t, len(must.NotBeOK(rateFilter.GetRatesForType("second"))), 0)
+	assert.Equal(t, rateFilter.GetServices().Len(), 2)
+	assert.Equal(t, rateFilter.GetResourcesForType("first").Len(), 2)
+	assert.Equal(t, rateFilter.GetResourcesForType("second").Len(), 2)
+	assert.Equal(t, rateFilter.GetRatesForType("first").Len(), 2)
+	assert.Equal(t, rateFilter.GetRatesForType("second").Len(), 0)
 
 	// area filter
 	resourceOpts = common.ResourceReportOpts{Area: Some("second")}
 	resourceFilter = must.ReturnT(reports_v2.FilterFromResourceOpts(s.Cluster, resourceOpts))(t)
-	assert.Equal(t, len(resourceFilter.GetServices()), 1)
-	assert.Equal(t, len(must.NotBeOK(resourceFilter.GetResourcesForType("first"))), 0)
-	assert.Equal(t, len(must.BeOK(resourceFilter.GetResourcesForType("second"))), 2)
-	assert.Equal(t, len(must.NotBeOK(resourceFilter.GetRatesForType("first"))), 0)
-	assert.Equal(t, len(must.NotBeOK(resourceFilter.GetRatesForType("second"))), 0)
+	assert.Equal(t, resourceFilter.GetServices().Len(), 1)
+	assert.Equal(t, resourceFilter.GetResourcesForType("first").Len(), 0)
+	assert.Equal(t, resourceFilter.GetResourcesForType("second").Len(), 2)
+	assert.Equal(t, resourceFilter.GetRatesForType("first").Len(), 0)
+	assert.Equal(t, resourceFilter.GetRatesForType("second").Len(), 0)
 
 	rateOpts = common.RateReportOpts{Area: Some("second")}
 	rateFilter = must.ReturnT(reports_v2.FilterFromRateOpts(s.Cluster, rateOpts))(t)
-	assert.Equal(t, len(rateFilter.GetServices()), 1)
-	assert.Equal(t, len(must.NotBeOK(rateFilter.GetResourcesForType("first"))), 0)
-	assert.Equal(t, len(must.BeOK(rateFilter.GetResourcesForType("second"))), 2)
-	assert.Equal(t, len(must.NotBeOK(rateFilter.GetRatesForType("first"))), 0)
-	assert.Equal(t, len(must.NotBeOK(rateFilter.GetRatesForType("second"))), 0)
+	assert.Equal(t, rateFilter.GetServices().Len(), 1)
+	assert.Equal(t, rateFilter.GetResourcesForType("first").Len(), 0)
+	assert.Equal(t, rateFilter.GetResourcesForType("second").Len(), 2)
+	assert.Equal(t, rateFilter.GetRatesForType("first").Len(), 0)
+	assert.Equal(t, rateFilter.GetRatesForType("second").Len(), 0)
 
 	// service filter
 	resourceOpts = common.ResourceReportOpts{ServiceType: Some(db.ServiceType("second"))}
 	resourceFilter = must.ReturnT(reports_v2.FilterFromResourceOpts(s.Cluster, resourceOpts))(t)
-	assert.Equal(t, len(resourceFilter.GetServices()), 1)
-	assert.Equal(t, len(must.NotBeOK(resourceFilter.GetResourcesForType("first"))), 0)
-	assert.Equal(t, len(must.BeOK(resourceFilter.GetResourcesForType("second"))), 2)
-	assert.Equal(t, len(must.NotBeOK(resourceFilter.GetRatesForType("first"))), 0)
-	assert.Equal(t, len(must.NotBeOK(resourceFilter.GetRatesForType("second"))), 0)
+	assert.Equal(t, resourceFilter.GetServices().Len(), 1)
+	assert.Equal(t, resourceFilter.GetResourcesForType("first").Len(), 0)
+	assert.Equal(t, resourceFilter.GetResourcesForType("second").Len(), 2)
+	assert.Equal(t, resourceFilter.GetRatesForType("first").Len(), 0)
+	assert.Equal(t, resourceFilter.GetRatesForType("second").Len(), 0)
 
 	rateOpts = common.RateReportOpts{ServiceType: Some(db.ServiceType("second"))}
 	rateFilter = must.ReturnT(reports_v2.FilterFromRateOpts(s.Cluster, rateOpts))(t)
-	assert.Equal(t, len(rateFilter.GetServices()), 1)
-	assert.Equal(t, len(must.NotBeOK(rateFilter.GetResourcesForType("first"))), 0)
-	assert.Equal(t, len(must.BeOK(rateFilter.GetResourcesForType("second"))), 2)
-	assert.Equal(t, len(must.NotBeOK(rateFilter.GetRatesForType("first"))), 0)
-	assert.Equal(t, len(must.NotBeOK(rateFilter.GetRatesForType("second"))), 0)
+	assert.Equal(t, rateFilter.GetServices().Len(), 1)
+	assert.Equal(t, rateFilter.GetResourcesForType("first").Len(), 0)
+	assert.Equal(t, rateFilter.GetResourcesForType("second").Len(), 2)
+	assert.Equal(t, rateFilter.GetRatesForType("first").Len(), 0)
+	assert.Equal(t, rateFilter.GetRatesForType("second").Len(), 0)
 
 	// category filter
 	resourceOpts = common.ResourceReportOpts{Category: Some(liquid.CategoryName("foo_category"))}
 	resourceFilter = must.ReturnT(reports_v2.FilterFromResourceOpts(s.Cluster, resourceOpts))(t)
-	assert.Equal(t, len(resourceFilter.GetServices()), 2)
-	assert.Equal(t, len(must.BeOK(resourceFilter.GetResourcesForType("first"))), 1)
-	assert.Equal(t, len(must.BeOK(resourceFilter.GetResourcesForType("second"))), 1)
-	assert.Equal(t, len(must.BeOK(resourceFilter.GetRatesForType("first"))), 1)
-	assert.Equal(t, len(must.NotBeOK(resourceFilter.GetRatesForType("second"))), 0)
+	assert.Equal(t, resourceFilter.GetServices().Len(), 2)
+	assert.Equal(t, resourceFilter.GetResourcesForType("first").Len(), 1)
+	assert.Equal(t, resourceFilter.GetResourcesForType("second").Len(), 1)
+	assert.Equal(t, resourceFilter.GetRatesForType("first").Len(), 1)
+	assert.Equal(t, resourceFilter.GetRatesForType("second").Len(), 0)
 
 	rateOpts = common.RateReportOpts{Category: Some(liquid.CategoryName("foo_category"))}
 	rateFilter = must.ReturnT(reports_v2.FilterFromRateOpts(s.Cluster, rateOpts))(t)
-	assert.Equal(t, len(rateFilter.GetServices()), 2)
-	assert.Equal(t, len(must.BeOK(rateFilter.GetResourcesForType("first"))), 1)
-	assert.Equal(t, len(must.BeOK(rateFilter.GetResourcesForType("second"))), 1)
-	assert.Equal(t, len(must.BeOK(rateFilter.GetRatesForType("first"))), 1)
-	assert.Equal(t, len(must.NotBeOK(rateFilter.GetRatesForType("second"))), 0)
+	assert.Equal(t, rateFilter.GetServices().Len(), 2)
+	assert.Equal(t, rateFilter.GetResourcesForType("first").Len(), 1)
+	assert.Equal(t, rateFilter.GetResourcesForType("second").Len(), 1)
+	assert.Equal(t, rateFilter.GetRatesForType("first").Len(), 1)
+	assert.Equal(t, rateFilter.GetRatesForType("second").Len(), 0)
 
 	// category filter: using serviceType value as category to get resources/rates without explicit category
 	resourceOpts = common.ResourceReportOpts{Category: Some(liquid.CategoryName("first"))}
 	resourceFilter = must.ReturnT(reports_v2.FilterFromResourceOpts(s.Cluster, resourceOpts))(t)
-	assert.Equal(t, len(resourceFilter.GetServices()), 1)
-	assert.Equal(t, len(must.BeOK(resourceFilter.GetResourcesForType("first"))), 1)
-	assert.Equal(t, len(must.NotBeOK(resourceFilter.GetResourcesForType("second"))), 0)
-	assert.Equal(t, len(must.BeOK(resourceFilter.GetRatesForType("first"))), 1)
-	assert.Equal(t, len(must.NotBeOK(resourceFilter.GetRatesForType("second"))), 0)
+	assert.Equal(t, resourceFilter.GetServices().Len(), 1)
+	assert.Equal(t, resourceFilter.GetResourcesForType("first").Len(), 1)
+	assert.Equal(t, resourceFilter.GetResourcesForType("second").Len(), 0)
+	assert.Equal(t, resourceFilter.GetRatesForType("first").Len(), 1)
+	assert.Equal(t, resourceFilter.GetRatesForType("second").Len(), 0)
 
 	rateOpts = common.RateReportOpts{Category: Some(liquid.CategoryName("first"))}
 	rateFilter = must.ReturnT(reports_v2.FilterFromRateOpts(s.Cluster, rateOpts))(t)
-	assert.Equal(t, len(rateFilter.GetServices()), 1)
-	assert.Equal(t, len(must.BeOK(rateFilter.GetResourcesForType("first"))), 1)
-	assert.Equal(t, len(must.NotBeOK(rateFilter.GetResourcesForType("second"))), 0)
-	assert.Equal(t, len(must.BeOK(rateFilter.GetRatesForType("first"))), 1)
-	assert.Equal(t, len(must.NotBeOK(rateFilter.GetRatesForType("second"))), 0)
+	assert.Equal(t, rateFilter.GetServices().Len(), 1)
+	assert.Equal(t, rateFilter.GetResourcesForType("first").Len(), 1)
+	assert.Equal(t, rateFilter.GetResourcesForType("second").Len(), 0)
+	assert.Equal(t, rateFilter.GetRatesForType("first").Len(), 1)
+	assert.Equal(t, rateFilter.GetRatesForType("second").Len(), 0)
 
 	// resource filter
 	resourceOpts = common.ResourceReportOpts{ResourceName: Some(liquid.ResourceName("capacity"))}
 	resourceFilter = must.ReturnT(reports_v2.FilterFromResourceOpts(s.Cluster, resourceOpts))(t)
-	assert.Equal(t, len(resourceFilter.GetServices()), 2)
-	assert.Equal(t, len(must.BeOK(resourceFilter.GetResourcesForType("first"))), 1)
-	assert.Equal(t, len(must.BeOK(resourceFilter.GetResourcesForType("second"))), 1)
-	assert.Equal(t, len(must.BeOK(resourceFilter.GetRatesForType("first"))), 2)
-	assert.Equal(t, len(must.NotBeOK(resourceFilter.GetRatesForType("second"))), 0)
+	assert.Equal(t, resourceFilter.GetServices().Len(), 2)
+	assert.Equal(t, resourceFilter.GetResourcesForType("first").Len(), 1)
+	assert.Equal(t, resourceFilter.GetResourcesForType("second").Len(), 1)
+	assert.Equal(t, resourceFilter.GetRatesForType("first").Len(), 2)
+	assert.Equal(t, resourceFilter.GetRatesForType("second").Len(), 0)
 
 	// rate filter
 	rateOpts = common.RateReportOpts{RateName: Some(liquid.RateName("objects:create"))}
 	rateFilter = must.ReturnT(reports_v2.FilterFromRateOpts(s.Cluster, rateOpts))(t)
-	assert.Equal(t, len(rateFilter.GetServices()), 2)
-	assert.Equal(t, len(must.BeOK(rateFilter.GetResourcesForType("first"))), 2)
-	assert.Equal(t, len(must.BeOK(rateFilter.GetResourcesForType("second"))), 2)
-	assert.Equal(t, len(must.BeOK(rateFilter.GetRatesForType("first"))), 1)
-	assert.Equal(t, len(must.NotBeOK(rateFilter.GetRatesForType("second"))), 0)
+	assert.Equal(t, rateFilter.GetServices().Len(), 2)
+	assert.Equal(t, rateFilter.GetResourcesForType("first").Len(), 2)
+	assert.Equal(t, rateFilter.GetResourcesForType("second").Len(), 2)
+	assert.Equal(t, rateFilter.GetRatesForType("first").Len(), 1)
+	assert.Equal(t, rateFilter.GetRatesForType("second").Len(), 0)
 }
 
 func TestV2ExpandServiceFilters(t *testing.T) {

--- a/internal/api/reports_v2/info.go
+++ b/internal/api/reports_v2/info.go
@@ -6,7 +6,6 @@ package reports_v2
 import (
 	"database/sql"
 	"errors"
-	"maps"
 	"net/http"
 	"slices"
 	"time"
@@ -110,10 +109,10 @@ func GetResourcesInfo(cluster *core.Cluster, token *gopherpolicy.Token, timeNow 
 	}
 	services := sis.GetServices()
 
-	for _, serviceType := range slices.Sorted(maps.Keys(services)) {
-		service := services[serviceType]
+	for _, serviceType := range slices.Sorted(services.Keys()) {
+		service := services.GetOrZero(serviceType)
 		categories := sis.GetCategoriesForType(serviceType)
-		resources, _ := sis.GetResourcesForType(serviceType) // can have no resources
+		resources := sis.GetResourcesForType(serviceType) // can have no resources
 		// skip non-allowed resources for this user, if any
 		allowedResources, serviceTypeOK := allowedResourcesByService[serviceType]
 		if !serviceTypeOK {
@@ -144,13 +143,13 @@ func GetResourcesInfo(cluster *core.Cluster, token *gopherpolicy.Token, timeNow 
 		}
 		serviceReport := report.Areas[area].Services[serviceType]
 
-		for _, resourceName := range slices.Sorted(maps.Keys(resources)) {
-			resource := resources[resourceName]
+		for _, resourceName := range slices.Sorted(resources.Keys()) {
+			resource := resources.GetOrZero(resourceName)
 			// skip non-allowed resources for this user, if any
 			if !slices.Contains(allowedResources, resourceName) {
 				continue
 			}
-			category := categories[resource.CategoryID]
+			category := categories.GetOrZero(resource.CategoryID)
 			if _, exists := serviceReport.Categories[category.Name]; !exists {
 				serviceReport.Categories[category.Name] = resourcesv2.CategoryInfoReport{
 					DisplayName: category.DisplayName,
@@ -195,10 +194,10 @@ func GetRatesInfo(cluster *core.Cluster, token *gopherpolicy.Token, sis core.Ser
 	}
 	services := sis.GetServices()
 
-	for _, serviceType := range slices.Sorted(maps.Keys(services)) {
-		service := services[serviceType]
+	for _, serviceType := range slices.Sorted(services.Keys()) {
+		service := services.GetOrZero(serviceType)
 		categories := sis.GetCategoriesForType(serviceType)
-		rates, _ := sis.GetRatesForType(serviceType) // can have no rates
+		rates := sis.GetRatesForType(serviceType) // can have no rates
 		config := cluster.Config.Liquids[serviceType]
 		area := config.Area
 		// defense in depth: config should be in sync with serviceInfo
@@ -224,8 +223,8 @@ func GetRatesInfo(cluster *core.Cluster, token *gopherpolicy.Token, sis core.Ser
 		}
 		serviceReport := report.Areas[area].Services[serviceType]
 
-		for _, rateName := range slices.Sorted(maps.Keys(rates)) {
-			rate := rates[rateName]
+		for _, rateName := range slices.Sorted(rates.Keys()) {
+			rate := rates.GetOrZero(rateName)
 			rir := ratesv2.RateInfoReport{
 				DisplayName: rate.DisplayName,
 				Topology:    rate.Topology,
@@ -236,7 +235,7 @@ func GetRatesInfo(cluster *core.Cluster, token *gopherpolicy.Token, sis core.Ser
 				rir.ProjectDefaultLimit = rateConfig.Limit
 				rir.ProjectDefaultWindow = Some(rateConfig.Window)
 			}
-			category := categories[rate.CategoryID]
+			category := categories.GetOrZero(rate.CategoryID)
 			if _, exists := serviceReport.Categories[category.Name]; !exists {
 				serviceReport.Categories[category.Name] = ratesv2.CategoryInfoReport{
 					DisplayName: category.DisplayName,

--- a/internal/collector/capacity_scrape.go
+++ b/internal/collector/capacity_scrape.go
@@ -164,8 +164,7 @@ func (c *Collector) processCapacityScrapeTask(ctx context.Context, task capacity
 	if !sExists { // defense in depth: when we get here, the scrape was successful, so the service should be up to date
 		return fmt.Errorf("no data found in ServiceInfoCache for type %s", connection.ServiceType)
 	}
-	resources, _ := sis.GetResourcesForType(serviceType)     // might have no resources
-	azResources, _ := sis.GetAZResourcesForType(serviceType) // might have no az_resources
+	resources := sis.GetResourcesForType(serviceType) // might have no resources
 
 	task.Timing.FinishedAt = c.MeasureTimeAtEnd()
 	if err == nil {
@@ -198,7 +197,7 @@ func (c *Collector) processCapacityScrapeTask(ctx context.Context, task capacity
 	defer sqlext.RollbackUnlessCommitted(tx)
 
 	// az_resources should be there - enumerate the data and complain if they don't match (with exceptions)
-	for _, res := range resources {
+	for _, res := range resources.All() {
 		resourceData, resExists := capacityData.Resources[res.Name]
 		if !resExists {
 			logg.Error("could not find resource %s in capacity data of %s, either version was not bumped correctly or capacity configuration is incomplete", res.Name, service.Type)
@@ -206,7 +205,7 @@ func (c *Collector) processCapacityScrapeTask(ctx context.Context, task capacity
 		}
 
 		_, anyAZexists := resourceData.PerAZ[liquid.AvailabilityZoneAny]
-		for _, azRes := range azResources[res.Name] {
+		for azRes := range sis.GetAZResourcesForPath(res.Path).Values() {
 			azResourceData, azResExists := resourceData.PerAZ[azRes.AvailabilityZone]
 			// az=unknown and az=any do not have to exist
 			// specific AZs do not need capacity when az=any has capacity (sum should be correct)
@@ -255,7 +254,7 @@ func (c *Collector) processCapacityScrapeTask(ctx context.Context, task capacity
 	}
 
 	// for all resources thus updated, sync commitment status with reality
-	for _, res := range resources {
+	for _, res := range resources.All() {
 		now := c.MeasureTime()
 		_, err = c.DB.Exec(updateProjectCommitmentStatusForResourceQuery, res.Path, now)
 		if err != nil {
@@ -264,7 +263,7 @@ func (c *Collector) processCapacityScrapeTask(ctx context.Context, task capacity
 	}
 
 	// for all resources thus updated, try to confirm pending commitments
-	for _, resource := range resources {
+	for _, resource := range resources.All() {
 		err := c.confirmPendingCommitmentsIfNecessary(ctx, resource)
 		if err != nil {
 			return err
@@ -272,7 +271,7 @@ func (c *Collector) processCapacityScrapeTask(ctx context.Context, task capacity
 	}
 
 	// for all resources thus updated, recompute project quotas if necessary
-	for _, res := range resources {
+	for _, res := range resources.All() {
 		now := c.MeasureTime()
 		err := datamodel.ApplyComputedProjectQuota(service.Type, res, c.Cluster, now)
 		if err != nil {

--- a/internal/collector/metrics.go
+++ b/internal/collector/metrics.go
@@ -8,7 +8,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"maps"
 	"math/big"
 	"net/http"
 	"slices"
@@ -99,8 +98,7 @@ func (c *AggregateMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 			return err
 		}
 
-		resources, _ := c.Cluster.SIC.GetSnapshot().GetResourcesForType(serviceType) // we can ignore "ok" because the len matters
-		if len(resources) > 0 {
+		if c.Cluster.SIC.GetSnapshot().GetResourcesForType(serviceType).Len() > 0 {
 			ch <- prometheus.MustNewConstMetric(
 				minScrapedAtDesc,
 				prometheus.GaugeValue, timeAsUnixOrZero(minScrapedAt),
@@ -156,7 +154,7 @@ type CapacityCollectionMetricsInstance struct {
 // Describe implements the prometheus.Collector interface.
 func (c *CapacityCollectionMetricsCollector) Describe(ch chan<- *prometheus.Desc) {
 	capacityCollectionMetricsOkGauge.Describe(ch)
-	for _, service := range c.Cluster.SIC.GetSnapshot().GetServices() {
+	for service := range c.Cluster.SIC.GetSnapshot().GetServices().Values() {
 		capacityMetricFamilies, err := util.JSONToAny[map[liquid.MetricName]liquid.MetricFamilyInfo](service.CapacityMetricFamiliesJSON, "capacity_metric_families")
 		if err != nil {
 			ch <- prometheus.NewInvalidDesc(fmt.Errorf("error describing capacity_metric_families for %s: %w", service.Type, err))
@@ -254,7 +252,7 @@ type QuotaCollectionMetricsInstance struct {
 // Describe implements the prometheus.Collector interface.
 func (c *UsageCollectionMetricsCollector) Describe(ch chan<- *prometheus.Desc) {
 	usageCollectionMetricsOkGauge.Describe(ch)
-	for _, service := range c.Cluster.SIC.GetSnapshot().GetServices() {
+	for service := range c.Cluster.SIC.GetSnapshot().GetServices().Values() {
 		usageMetricFamilies, err := util.JSONToAny[map[liquid.MetricName]liquid.MetricFamilyInfo](service.UsageMetricFamiliesJSON, "usage_metric_families")
 		if err != nil {
 			ch <- prometheus.NewInvalidDesc(fmt.Errorf("error describing usage_metric_families for %s: %w", service.Type, err))
@@ -480,7 +478,8 @@ var (
 
 func (d *DataMetricsV1Reporter) collectMetrics(ctx context.Context, ms *microprom.MetricSet) error {
 	behaviorCache := newResourceAndRateBehaviorCache(d.Cluster)
-	resources := d.Cluster.SIC.GetSnapshot().GetResources()
+	sis := d.Cluster.SIC.GetSnapshot()
+	services := sis.GetServices()
 
 	// fetch values for cluster level
 	capacityReported := make(map[db.ServiceType]map[liquid.ResourceName]bool)
@@ -552,8 +551,8 @@ func (d *DataMetricsV1Reporter) collectMetrics(ctx context.Context, ms *micropro
 	// make sure that a cluster capacity value is reported for each resource (the
 	// corresponding time series might otherwise be missing if capacity scraping
 	// fails)
-	for _, serviceType := range slices.Sorted(maps.Keys(resources)) {
-		for resName := range resources[serviceType] {
+	for _, serviceType := range slices.Sorted(services.Keys()) {
+		for resName := range sis.GetResourcesForType(serviceType).Keys() {
 			if capacityReported[serviceType][resName] {
 				continue
 			}
@@ -708,8 +707,8 @@ func (d *DataMetricsV1Reporter) collectMetrics(ctx context.Context, ms *micropro
 	}
 
 	// fetch metadata for services/resources
-	for _, serviceType := range slices.Sorted(maps.Keys(resources)) {
-		for dbResourceName, resourceInfo := range resources[serviceType] {
+	for _, serviceType := range slices.Sorted(services.Keys()) {
+		for dbResourceName, resourceInfo := range sis.GetResourcesForType(serviceType).All() {
 			behavior := behaviorCache.Get(serviceType, dbResourceName)
 			apiIdentity := behavior.IdentityInV1API
 			labels := ms.FormatLabels(dmv1ResourceLabelNames,

--- a/internal/collector/scrape.go
+++ b/internal/collector/scrape.go
@@ -474,11 +474,7 @@ func (c *Collector) writeRateScrapeResult(ctx context.Context, task projectScrap
 	defer sqlext.RollbackUnlessCommitted(tx)
 
 	// For updating project_rates, we need to find the project_rates' rate_name
-	rateSlice := make([]db.Rate, 0, rates.Len())
-	for _, rate := range rates.All() {
-		rateSlice = append(rateSlice, rate)
-	}
-	ratesByID := db.RateByIDIndex.Index(rateSlice)
+	ratesByID := db.RateByIDIndex.Index(slices.Collect(rates.Values()))
 
 	// update existing project_rates entries
 	rateExists := make(map[liquid.RateName]bool)

--- a/internal/collector/scrape.go
+++ b/internal/collector/scrape.go
@@ -118,7 +118,7 @@ func (c *Collector) discoverScrapeTask(ctx context.Context, labels prometheus.La
 	}
 	// if the above check succeeded, this should never fail because the SIC is updated after the
 	// LiquidConnection is initialized.
-	if !c.Cluster.SIC.HasService(serviceType) {
+	if _, ok := c.Cluster.SIC.GetSnapshot().GetServiceForType(serviceType); !ok {
 		return projectScrapeTask{}, fmt.Errorf("no data found in ServiceInfoCache for type %s", serviceType)
 	}
 
@@ -253,9 +253,8 @@ func extractRateData(report liquid.ServiceUsageReport) (result map[liquid.RateNa
 
 func (c *Collector) writeResourceScrapeResult(ctx context.Context, task projectScrapeTask, serviceType db.ServiceType, dbProject db.Project, resourceData liquid.ServiceUsageReport, sis core.ServiceInfoSnapshot) error {
 	service, sExists := sis.GetServiceForType(serviceType)
-	resources, _ := sis.GetResourcesForType(serviceType)     // can have no resources
-	azResources, _ := sis.GetAZResourcesForType(serviceType) // can have no az_resources
-	if !sExists {                                            // defense in depth: this snapshot is taken immediately after saving the ServiceInfo
+	resources := sis.GetResourcesForType(serviceType) // can have no resources
+	if !sExists {                                     // defense in depth: this snapshot is taken immediately after saving the ServiceInfo
 		return fmt.Errorf("no data found in ServiceInfoCache for type %s", serviceType)
 	}
 
@@ -325,12 +324,6 @@ func (c *Collector) writeResourceScrapeResult(ctx context.Context, task projectS
 	}
 
 	// For inserting the project_az_resources, we need to find the project_az_resources availabilityZone
-	azResourcesByID := make(map[db.AZResourceID]db.AZResource)
-	for _, azResourcesByAZ := range azResources {
-		for _, azr := range azResourcesByAZ {
-			azResourcesByID[azr.ID] = azr
-		}
-	}
 	projectAZResourcesByAZResourceID, err := db.ProjectAZResourceByAZResourceIDIndex.IndexFrom(
 		db.ProjectAZResourceStore.Select(ctx, tx,
 			`SELECT pazr.* FROM project_az_resources pazr JOIN az_resources azr ON PAZR.az_resource_id = azr.id JOIN resources r ON azr.resource_id = r.id WHERE r.service_id = $1 AND pazr.project_id = $2`,
@@ -340,21 +333,20 @@ func (c *Collector) writeResourceScrapeResult(ctx context.Context, task projectS
 	if err != nil {
 		return err
 	}
-	resourceNames := slices.Sorted(maps.Keys(resources))
 
 	// update project_az_resources for each resource
 	hasBackendQuotaDrift := false
-	for _, resourceName := range resourceNames {
-		resource := resources[resourceName]
-		filteredAZResources := azResources[resourceName]
+	for _, resourceName := range slices.Sorted(resources.Keys()) {
+		resource := resources.GetOrZero(resourceName)
+		filteredAZResources := sis.GetAZResourcesForPath(db.ResourcePath{ServiceType: serviceType, ResourceName: resourceName})
 		usageData := resourceData.Resources[resourceName].PerAZ
-		projectAZResources := make([]db.ProjectAZResource, 0, len(filteredAZResources))
-		for _, azResource := range filteredAZResources {
+		projectAZResources := make([]db.ProjectAZResource, 0, filteredAZResources.Len())
+		for _, azResource := range filteredAZResources.All() {
 			projectAZResources = append(projectAZResources, projectAZResourcesByAZResourceID[azResource.ID])
 		}
 		wantedKeys := make([]db.AZResourceID, 0, len(usageData))
 		for _, az := range slices.Sorted(maps.Keys(usageData)) {
-			wantedKeys = append(wantedKeys, filteredAZResources[az].ID)
+			wantedKeys = append(wantedKeys, filteredAZResources.GetOrZero(az).ID)
 		}
 
 		setUpdate := db.SetUpdate[db.ProjectAZResource, db.AZResourceID]{
@@ -369,11 +361,15 @@ func (c *Collector) writeResourceScrapeResult(ctx context.Context, task projectS
 					AZResourceID: id,
 				}, nil
 			},
-			Update: func(azRes *db.ProjectAZResource) (err error) {
-				az := azResourcesByID[azRes.AZResourceID].AvailabilityZone
+			Update: func(projectAZRes *db.ProjectAZResource) (err error) {
+				azRes, ok := sis.GetAZResourceForID(projectAZRes.AZResourceID)
+				if !ok { // defense in depth: referential integrity
+					return fmt.Errorf("no data found in ServiceInfoCache for az_resource.id %d", projectAZRes.AZResourceID)
+				}
+				az := azRes.AvailabilityZone
 				data := usageData[az]
-				azRes.Usage = data.Usage
-				azRes.PhysicalUsage = data.PhysicalUsage
+				projectAZRes.Usage = data.Usage
+				projectAZRes.PhysicalUsage = data.PhysicalUsage
 
 				// for the quota values, we want to
 				// a) reset both to None when HasQuota is false
@@ -381,21 +377,21 @@ func (c *Collector) writeResourceScrapeResult(ctx context.Context, task projectS
 				// c) set backendQuota for the applicable cases according to topology, otherwise set None (important for topology switch)
 				// d) check for backendQuota drift
 				if !resource.HasQuota {
-					azRes.BackendQuota = None[int64]()
-					azRes.Quota = None[uint64]()
+					projectAZRes.BackendQuota = None[int64]()
+					projectAZRes.Quota = None[uint64]()
 				} else {
-					if datamodel.AZHasQuotaForTopology(resource.Topology, az) && azRes.Quota.IsNone() {
-						azRes.Quota = Some[uint64](0)
+					if datamodel.AZHasQuotaForTopology(resource.Topology, az) && projectAZRes.Quota.IsNone() {
+						projectAZRes.Quota = Some[uint64](0)
 					}
 					if datamodel.AZHasBackendQuotaForTopology(resource.Topology, az) {
-						azRes.BackendQuota = data.Quota
+						projectAZRes.BackendQuota = data.Quota
 					} else {
-						azRes.BackendQuota = None[int64]()
+						projectAZRes.BackendQuota = None[int64]()
 					}
 					if datamodel.AZHasBackendQuotaForTopology(resource.Topology, az) {
 						// check if we need to arrange for SetQuotaJob to look at this project service
-						backendQuota := azRes.BackendQuota.UnwrapOr(-1)
-						quota := azRes.Quota.UnwrapOr(0)
+						backendQuota := projectAZRes.BackendQuota.UnwrapOr(-1)
+						quota := projectAZRes.Quota.UnwrapOr(0)
 						if backendQuota < 0 || uint64(backendQuota) != quota {
 							hasBackendQuotaDrift = true
 						}
@@ -410,7 +406,7 @@ func (c *Collector) writeResourceScrapeResult(ctx context.Context, task projectS
 					)
 				}
 
-				azRes.SubresourcesJSON, err = util.RenderListToJSON("subresources", data.Subresources)
+				projectAZRes.SubresourcesJSON, err = util.RenderListToJSON("subresources", data.Subresources)
 				if err != nil {
 					return err
 				}
@@ -418,7 +414,7 @@ func (c *Collector) writeResourceScrapeResult(ctx context.Context, task projectS
 				// track historical usage if required (only required for AutogrowQuotaDistribution)
 				autogrowCfg, ok := c.Cluster.QuotaDistributionConfigForResource(service.Type, resourceName).Autogrow.Unpack()
 				if ok {
-					ts, err := util.ParseTimeSeries[uint64](azRes.HistoricalUsageJSON)
+					ts, err := util.ParseTimeSeries[uint64](projectAZRes.HistoricalUsageJSON)
 					if err != nil {
 						return fmt.Errorf("while parsing historical_usage for AZ %s: %w", az, err)
 					}
@@ -427,12 +423,12 @@ func (c *Collector) writeResourceScrapeResult(ctx context.Context, task projectS
 						return fmt.Errorf("while tracking historical_usage for AZ %s: %w", az, err)
 					}
 					ts.PruneOldValues(task.Timing.FinishedAt, autogrowCfg.UsageDataRetentionPeriod.Into())
-					azRes.HistoricalUsageJSON, err = ts.Serialize()
+					projectAZRes.HistoricalUsageJSON, err = ts.Serialize()
 					if err != nil {
 						return fmt.Errorf("while serializing historical_usage for AZ %s: %w", az, err)
 					}
 				} else {
-					azRes.HistoricalUsageJSON = ""
+					projectAZRes.HistoricalUsageJSON = ""
 				}
 
 				return nil
@@ -469,7 +465,7 @@ func (c *Collector) writeRateScrapeResult(ctx context.Context, task projectScrap
 	if !sExists { // defense in depth: this snapshot is taken immediately after saving the ServiceInfo
 		return fmt.Errorf("no data found in ServiceInfoCache for type %s", serviceType)
 	}
-	rates, _ := sis.GetRatesForType(serviceType) // can have no rates
+	rates := sis.GetRatesForType(serviceType) // can have no rates
 
 	tx, err := c.DB.Begin()
 	if err != nil {
@@ -478,7 +474,11 @@ func (c *Collector) writeRateScrapeResult(ctx context.Context, task projectScrap
 	defer sqlext.RollbackUnlessCommitted(tx)
 
 	// For updating project_rates, we need to find the project_rates' rate_name
-	ratesByID := db.RateByIDIndex.Index(slices.Collect(maps.Values(rates)))
+	rateSlice := make([]db.Rate, 0, rates.Len())
+	for _, rate := range rates.All() {
+		rateSlice = append(rateSlice, rate)
+	}
+	ratesByID := db.RateByIDIndex.Index(rateSlice)
 
 	// update existing project_rates entries
 	rateExists := make(map[liquid.RateName]bool)
@@ -515,8 +515,8 @@ func (c *Collector) writeRateScrapeResult(ctx context.Context, task projectScrap
 	}
 
 	// insert missing project_rates entries
-	for _, rateName := range slices.Sorted(maps.Keys(rates)) {
-		rate := rates[rateName]
+	for _, rateName := range slices.Sorted(rates.Keys()) {
+		rate := rates.GetOrZero(rateName)
 		if _, exists := rateExists[rateName]; exists {
 			continue
 		}
@@ -559,9 +559,8 @@ func (c *Collector) writeDummyResources(ctx context.Context, dbProject db.Projec
 	defer sqlext.RollbackUnlessCommitted(tx)
 	sis := c.Cluster.SIC.GetSnapshot()
 	service, sExists := sis.GetServiceForType(serviceType)
-	resources, _ := sis.GetResourcesForType(serviceType)     // can have no resources
-	azResources, _ := sis.GetAZResourcesForType(serviceType) // can have no az_resources
-	if !sExists {                                            // defense in depth: when we get here, the scrape never happened, so the sic must be up to date
+	resources := sis.GetResourcesForType(serviceType) // can have no resources
+	if !sExists {                                     // defense in depth: when we get here, the scrape never happened, so the sic must be up to date
 		return fmt.Errorf("no data found in ServiceInfoCache for type %s", serviceType)
 	}
 
@@ -581,11 +580,11 @@ func (c *Collector) writeDummyResources(ctx context.Context, dbProject db.Projec
 		return err
 	}
 
-	for _, resName := range slices.Sorted(maps.Keys(azResources)) {
-		resByAZ := azResources[resName]
-		resource := resources[resName]
-		for _, az := range slices.Sorted(maps.Keys(resByAZ)) {
-			azResource := resByAZ[az]
+	for _, resName := range slices.Sorted(resources.Keys()) {
+		resource := resources.GetOrZero(resName)
+		resByAZ := sis.GetAZResourcesForPath(resource.Path)
+		for _, az := range slices.Sorted(resByAZ.Keys()) {
+			azResource := resByAZ.GetOrZero(az)
 			if az == limes.AvailabilityZoneUnknown {
 				// we don't write dummy entries for unknown - this should just exist, when there is real usage
 				continue

--- a/internal/collector/scrape_test.go
+++ b/internal/collector/scrape_test.go
@@ -511,9 +511,9 @@ func Test_ScrapeSuccess(t *testing.T) {
 	}}
 
 	// run ACPQ in order to be able to test how data metrics reporters handle project quota
-	val, ok := s.Cluster.SIC.GetSnapshot().GetResourcesForType("unittest")
-	assert.Equal(t, ok, true)
-	for _, resource := range val {
+	val := s.Cluster.SIC.GetSnapshot().GetResourcesForType("unittest")
+	assert.Equal(t, val.Len(), 2)
+	for _, resource := range val.All() {
 		must.SucceedT(t, datamodel.ApplyComputedProjectQuota("unittest", resource, s.Cluster, s.Clock.Now()))
 	}
 

--- a/internal/collector/sync_quota_to_backend.go
+++ b/internal/collector/sync_quota_to_backend.go
@@ -118,8 +118,8 @@ func (c *Collector) performQuotaSync(ctx context.Context, srv db.ProjectService,
 	}
 	startedAt := c.MeasureTime()
 
-	resources, ok := c.Cluster.SIC.GetSnapshot().GetResourcesForType(serviceType)
-	if !ok {
+	sis := c.Cluster.SIC.GetSnapshot()
+	if _, sExists := sis.GetServiceForType(serviceType); !sExists {
 		return fmt.Errorf("no data found in ServiceInfoCache for %s", serviceType)
 	}
 
@@ -142,7 +142,12 @@ func (c *Collector) performQuotaSync(ctx context.Context, srv db.ProjectService,
 			return err
 		}
 
-		resource := resources[resourceName]
+		resource, ok := sis.GetResourceForPath(db.ResourcePath{ServiceType: serviceType, ResourceName: resourceName})
+		if !ok {
+			// race condition: selected projectResource while the resource got deleted
+			// other projectResources/ resources might still exist, so we don't abort!
+			return nil
+		}
 		if !resource.HasQuota {
 			return nil
 		}
@@ -186,7 +191,7 @@ func (c *Collector) performQuotaSync(ctx context.Context, srv db.ProjectService,
 	if needsApply {
 		// double-check that we only include quota values for resources that the backend currently knows about
 		targetQuotasForBackend := make(map[liquid.ResourceName]liquid.ResourceQuotaRequest)
-		for resName, resource := range resources {
+		for resName, resource := range sis.GetResourcesForType(serviceType).All() {
 			if !resource.HasQuota {
 				continue
 			}

--- a/internal/core/liquid.go
+++ b/internal/core/liquid.go
@@ -308,14 +308,14 @@ func prometheusScrapeOneResource(p PrometheusCapacityConfiguration, ctx context.
 // request for admin purposes, it does not use the LiquidConnection as receiver type.
 func BuildServiceCapacityRequest(backchannel CapacityScrapeBackchannel, allAZs []limes.AvailabilityZone, sis ServiceInfoSnapshot, serviceType db.ServiceType) (liquid.ServiceCapacityRequest, error) {
 	service := must.BeOK(sis.GetServiceForType(serviceType)) // when we get here, this is already validated
-	resources, _ := sis.GetResourcesForType(service.Type)    // can have no resources
+	resources := sis.GetResourcesForType(service.Type)       // can have no resources
 	req := liquid.ServiceCapacityRequest{
 		AllAZs:           allAZs,
-		DemandByResource: make(map[liquid.ResourceName]liquid.ResourceDemand, len(resources)),
+		DemandByResource: make(map[liquid.ResourceName]liquid.ResourceDemand, resources.Len()),
 	}
 
 	var err error
-	for resName, resource := range resources {
+	for resName, resource := range resources.All() {
 		if !resource.HasCapacity {
 			continue
 		}

--- a/internal/core/name_mapping.go
+++ b/internal/core/name_mapping.go
@@ -42,8 +42,8 @@ func BuildResourceNameMapping(cluster *Cluster, sis ServiceInfoSnapshot) Resourc
 		fromAPIToDB: make(map[ResourceRef]dbResourceRef),
 		fromDBToAPI: make(map[dbResourceRef]ResourceRef),
 	}
-	for dbServiceType, resByName := range sis.GetResources() {
-		for dbResourceName := range resByName {
+	for dbServiceType := range sis.GetServices().Keys() {
+		for dbResourceName := range sis.GetResourcesForType(dbServiceType).Keys() {
 			dbRef := dbResourceRef{dbServiceType, dbResourceName}
 			apiRef := cluster.BehaviorForResource(dbServiceType, dbResourceName).IdentityInV1API
 			nm.fromAPIToDB[apiRef] = dbRef
@@ -60,9 +60,10 @@ func BuildRateNameMapping(cluster *Cluster, sis ServiceInfoSnapshot) RateNameMap
 		fromAPIToDB: make(map[RateRef]dbRateRef),
 		fromDBToAPI: make(map[dbRateRef]RateRef),
 	}
-	for dbServiceType, rateByName := range sis.GetRates() {
+	for dbServiceType := range sis.GetServices().Keys() {
+		rateByName := sis.GetRatesForType(dbServiceType)
 		dbRateNames := make(map[liquid.RateName]struct{})
-		for dbRateName := range rateByName {
+		for dbRateName := range rateByName.All() {
 			dbRateNames[dbRateName] = struct{}{}
 		}
 		cfg, _ := cluster.Config.GetLiquidConfigurationForType(dbServiceType)

--- a/internal/core/service_info_cache.go
+++ b/internal/core/service_info_cache.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"maps"
 	"sync"
 	"time"
 
@@ -567,119 +566,125 @@ func (s *ServiceInfoCache) InvalidateService(ctx context.Context, serviceType Op
 	s.dataMutex.Lock()
 	defer s.dataMutex.Unlock()
 
-	// Build area mapping (constant, derived from config)
+	// build area mapping (constant, derived from config)
 	areaMappingPlain := make(map[db.ServiceType]string, len(s.config.Liquids))
 	for st, liquidConfiguration := range s.config.Liquids {
 		areaMappingPlain[st] = liquidConfiguration.Area
 	}
 
-	// Start with existing data (for partial invalidation) or empty maps.
-	// We always build into plain maps, then wrap with util.NewConstMap() at the end.
+	// we start with empty maps, get the data we want from the database and then possibly copy over the old values
 	services := make(map[db.ServiceType]db.Service)
-	resources := make(map[db.ServiceType]map[liquid.ResourceName]db.Resource)
-	azResources := make(map[db.ServiceType]map[liquid.ResourceName]map[limes.AvailabilityZone]db.AZResource)
-	rates := make(map[db.ServiceType]map[liquid.RateName]db.Rate)
-	categories := make(map[db.ServiceType]map[db.CategoryID]db.Category)
+	resources := make(map[db.ServiceType]util.ConstMap[liquid.ResourceName, db.Resource])
+	azResources := make(map[db.ServiceType]util.ConstMap[liquid.ResourceName, util.ConstMap[liquid.AvailabilityZone, db.AZResource]])
+	rates := make(map[db.ServiceType]util.ConstMap[liquid.RateName, db.Rate])
+	categories := make(map[db.ServiceType]util.ConstMap[db.CategoryID, db.Category])
 
-	if st, ok := serviceType.Unpack(); ok {
-		// Partial invalidation: copy all data except the invalidated service type.
-		for sType, svc := range s.data.services.All() {
-			if sType != st {
-				services[sType] = svc
-			}
-		}
-		for sType, resByName := range s.data.resources.All() {
-			if sType != st {
-				// Unwrap the inner constmap into a plain map for consistency.
-				// This is safe because we're building a new snapshot.
-				inner := maps.Collect(resByName.All())
-				resources[sType] = inner
-			}
-		}
-		for sType, azResByName := range s.data.azResources.All() {
-			if sType != st {
-				innerByName := make(map[liquid.ResourceName]map[limes.AvailabilityZone]db.AZResource, azResByName.Len())
-				for name, azResByAZ := range azResByName.All() {
-					innerByName[name] = maps.Collect(azResByAZ.All())
-				}
-				azResources[sType] = innerByName
-			}
-		}
-		for sType, rateByName := range s.data.rates.All() {
-			if sType != st {
-				rates[sType] = maps.Collect(rateByName.All())
-			}
-		}
-		for sType, catByID := range s.data.categories.All() {
-			if sType != st {
-				categories[sType] = maps.Collect(catByID.All())
-			}
-		}
-	}
-
-	// Load fresh data from DB for the affected services.
+	// load fresh data for affected services
 	dbServices, err := db.ServiceStore.SelectWhere(ctx, s.DB, `type = $1 OR $1 IS NULL`, serviceType).Collect()
 	if err != nil {
 		return fmt.Errorf("while reading services for type(s) %v: %w", serviceType, err)
 	}
+	serviceIDs := make([]db.ServiceID, 0, len(dbServices))
 	for _, dbService := range dbServices {
 		services[dbService.Type] = dbService
+		serviceIDs = append(serviceIDs, dbService.ID)
 	}
 
-	dbResources, err := db.ResourceStore.Select(ctx, s.DB, `SELECT r.* FROM resources r JOIN services s ON r.service_id = s.id WHERE s.type = $1 OR $1 IS NULL`, serviceType).Collect()
+	dbResources, err := db.ResourceStore.Select(ctx, s.DB, `SELECT r.* FROM resources r WHERE r.service_id = ANY($1) OR CARDINALITY($1) = 0 ORDER BY path`, pq.Array(serviceIDs)).Collect()
 	if err != nil {
 		return fmt.Errorf("while reading resources for type(s) %v: %w", serviceType, err)
 	}
+	var (
+		currentService               db.ServiceType
+		resourcesForCurrentService   map[liquid.ResourceName]db.Resource
+		azResourcesForCurrentService map[liquid.ResourceName]map[liquid.AvailabilityZone]db.AZResource
+		ratesForCurrentService       map[liquid.RateName]db.Rate
+		categoriesForCurrentService  map[db.CategoryID]db.Category
+	)
+	currentService = ""
 	for _, dbResource := range dbResources {
 		path := dbResource.Path
-		if resources[path.ServiceType] == nil {
-			resources[path.ServiceType] = make(map[liquid.ResourceName]db.Resource)
+		if currentService != path.ServiceType {
+			// flush
+			resources[currentService] = util.NewConstMap(resourcesForCurrentService)
+			resourcesForCurrentService = make(map[liquid.ResourceName]db.Resource)
+			currentService = path.ServiceType
 		}
-		resources[path.ServiceType][path.ResourceName] = dbResource
+		resourcesForCurrentService[path.ResourceName] = dbResource
 	}
+	resources[currentService] = util.NewConstMap(resourcesForCurrentService)
 
-	dbAZResources, err := db.AZResourceStore.Select(ctx, s.DB, `SELECT azr.* FROM az_resources azr JOIN resources r ON azr.resource_id = r.id JOIN services s ON r.service_id = s.id WHERE s.type = $1 OR $1 IS NULL`, serviceType).Collect()
+	dbAZResources, err := db.AZResourceStore.Select(ctx, s.DB, `SELECT azr.* FROM az_resources azr JOIN resources r ON azr.resource_id = r.id WHERE r.service_id = ANY($1) OR CARDINALITY($1) = 0 ORDER BY path`, pq.Array(serviceIDs)).Collect()
 	if err != nil {
 		return fmt.Errorf("while reading az_resources for type(s) %v: %w", serviceType, err)
 	}
+	currentService = ""
 	for _, dbAZResource := range dbAZResources {
 		path := dbAZResource.Path
-		if azResources[path.ServiceType] == nil {
-			azResources[path.ServiceType] = make(map[liquid.ResourceName]map[limes.AvailabilityZone]db.AZResource)
+		if currentService != path.ServiceType {
+			// flush
+			azResources[currentService] = util.New2LevelConstMap(azResourcesForCurrentService)
+			azResourcesForCurrentService = make(map[liquid.ResourceName]map[liquid.AvailabilityZone]db.AZResource)
+			currentService = path.ServiceType
 		}
-		if azResources[path.ServiceType][path.ResourceName] == nil {
-			azResources[path.ServiceType][path.ResourceName] = make(map[limes.AvailabilityZone]db.AZResource)
+		if azResourcesForCurrentService[path.ResourceName] == nil {
+			azResourcesForCurrentService[path.ResourceName] = make(map[liquid.AvailabilityZone]db.AZResource)
 		}
-		azResources[path.ServiceType][path.ResourceName][path.AvailabilityZone] = dbAZResource
+		azResourcesForCurrentService[path.ResourceName][path.AvailabilityZone] = dbAZResource
 	}
+	azResources[currentService] = util.New2LevelConstMap(azResourcesForCurrentService)
 
-	dbRates, err := db.RateStore.Select(ctx, s.DB, "SELECT ra.* FROM rates ra JOIN services s ON ra.service_id = s.id WHERE s.type = $1 OR $1 IS NULL", serviceType).Collect()
+	dbRates, err := db.RateStore.Select(ctx, s.DB, "SELECT ra.* FROM rates ra WHERE ra.service_id = ANY($1) OR CARDINALITY($1) = 0 ORDER BY path", pq.Array(serviceIDs)).Collect()
 	if err != nil {
 		return fmt.Errorf("while reading rates for type(s) %v: %w", serviceType, err)
 	}
+	currentService = ""
 	for _, dbRate := range dbRates {
 		path := dbRate.Path
-		if rates[path.ServiceType] == nil {
-			rates[path.ServiceType] = make(map[liquid.RateName]db.Rate)
+		if currentService != path.ServiceType {
+			// flush
+			rates[currentService] = util.NewConstMap(ratesForCurrentService)
+			ratesForCurrentService = make(map[liquid.RateName]db.Rate)
+			currentService = path.ServiceType
 		}
-		rates[path.ServiceType][path.RateName] = dbRate
+		ratesForCurrentService[path.RateName] = dbRate
 	}
+	rates[currentService] = util.NewConstMap(ratesForCurrentService)
 
 	type categoryRecord struct {
 		db.Category
 		ServiceType db.ServiceType `db:"service_type"`
 	}
 	categoryRecords, err := oblast.MustNewStore[categoryRecord](oblast.PostgresDialect()).Select(ctx, s.DB,
-		`SELECT c.*, s.type AS service_type FROM categories c JOIN services s ON c.service_id = s.id WHERE s.type = $1 OR $1 IS NULL`, serviceType,
+		`SELECT c.*, s.type AS service_type FROM categories c JOIN services s ON c.service_id = s.id WHERE s.id = ANY($1) OR CARDINALITY($1) = 0 ORDER BY s.type`, pq.Array(serviceIDs),
 	).Collect()
 	if err != nil {
 		return fmt.Errorf("while reading categories for type(s) %v: %w", serviceType, err)
 	}
+	currentService = ""
 	for _, record := range categoryRecords {
-		if categories[record.ServiceType] == nil {
-			categories[record.ServiceType] = make(map[db.CategoryID]db.Category)
+		if currentService != record.ServiceType {
+			// flush
+			categories[currentService] = util.NewConstMap(categoriesForCurrentService)
+			categoriesForCurrentService = make(map[db.CategoryID]db.Category)
+			currentService = record.ServiceType
 		}
-		categories[record.ServiceType][record.ID] = record.Category
+		categoriesForCurrentService[record.ID] = record.Category
+	}
+	categories[currentService] = util.NewConstMap(categoriesForCurrentService)
+
+	// copy unchanged entries, if there are any
+	if stFilter, ok := serviceType.Unpack(); ok {
+		for st, oldService := range s.data.services.All() {
+			if st == stFilter {
+				continue
+			}
+			services[st] = oldService
+			resources[st], _ = s.data.resources.Get(st)
+			azResources[st], _ = s.data.azResources.Get(st)
+			rates[st], _ = s.data.rates.Get(st)
+			categories[st], _ = s.data.categories.Get(st)
+		}
 	}
 
 	// Build ID indexes.
@@ -689,27 +694,27 @@ func (s *ServiceInfoCache) InvalidateService(ctx context.Context, serviceType Op
 	}
 	resourcesByID := make(map[db.ResourceID]db.Resource)
 	for _, resByName := range resources {
-		for _, resource := range resByName {
+		for resource := range resByName.Values() {
 			resourcesByID[resource.ID] = resource
 		}
 	}
 	azResourcesByID := make(map[db.AZResourceID]db.AZResource)
 	for _, azResByName := range azResources {
-		for _, azResByAZ := range azResByName {
-			for _, azRes := range azResByAZ {
+		for azResByAZ := range azResByName.Values() {
+			for azRes := range azResByAZ.Values() {
 				azResourcesByID[azRes.ID] = azRes
 			}
 		}
 	}
 	ratesByID := make(map[db.RateID]db.Rate)
 	for _, rateByName := range rates {
-		for _, rate := range rateByName {
+		for rate := range rateByName.Values() {
 			ratesByID[rate.ID] = rate
 		}
 	}
 	categoriesByID := make(map[db.CategoryID]db.Category)
 	for _, catByID := range categories {
-		for _, cat := range catByID {
+		for cat := range catByID.Values() {
 			categoriesByID[cat.ID] = cat
 		}
 	}
@@ -717,10 +722,10 @@ func (s *ServiceInfoCache) InvalidateService(ctx context.Context, serviceType Op
 	// Wrap nested maps and assign the new snapshot atomically.
 	s.data = ServiceInfoSnapshot{
 		services:        util.NewConstMap(services),
-		resources:       util.New2LevelConstMap(resources),
-		azResources:     util.New3LevelConstMap(azResources),
-		rates:           util.New2LevelConstMap(rates),
-		categories:      util.New2LevelConstMap(categories),
+		resources:       util.NewConstMap(resources),
+		azResources:     util.NewConstMap(azResources),
+		rates:           util.NewConstMap(rates),
+		categories:      util.NewConstMap(categories),
 		servicesByID:    util.NewConstMap(servicesByID),
 		resourcesByID:   util.NewConstMap(resourcesByID),
 		azResourcesByID: util.NewConstMap(azResourcesByID),

--- a/internal/core/service_info_cache.go
+++ b/internal/core/service_info_cache.go
@@ -50,39 +50,31 @@ func (s ServiceInfoFilter) isEmpty() bool {
 // It is implemented by types [ServiceInfoSnapshot] and [FilteredServiceInfoSnapshot].
 type ServiceInfoReader interface {
 	// GetServices returns all services.
-	GetServices() map[db.ServiceType]db.Service
+	GetServices() util.ConstMap[db.ServiceType, db.Service]
 	// GetServiceForType returns the service for the given service type.
 	GetServiceForType(serviceType db.ServiceType) (db.Service, bool)
 	// GetServiceForID returns the service for the given service ID.
 	GetServiceForID(id db.ServiceID) (db.Service, bool)
-	// GetResources returns all resources.
-	GetResources() map[db.ServiceType]map[liquid.ResourceName]db.Resource
 	// GetResourcesForType returns all resources for the given service type.
-	GetResourcesForType(serviceType db.ServiceType) (map[liquid.ResourceName]db.Resource, bool)
+	GetResourcesForType(serviceType db.ServiceType) util.ConstMap[liquid.ResourceName, db.Resource]
 	// GetResourceForPath returns the resource for the given path.
 	GetResourceForPath(path db.ResourcePath) (db.Resource, bool)
 	// GetResourceForID returns the resource for the given resource ID.
 	GetResourceForID(id db.ResourceID) (db.Resource, bool)
-	// GetAZResources returns all AZ resources.
-	GetAZResources() map[db.ServiceType]map[liquid.ResourceName]map[limes.AvailabilityZone]db.AZResource
-	// GetAZResourcesForType returns all AZ resources for the given service type.
-	GetAZResourcesForType(serviceType db.ServiceType) (map[liquid.ResourceName]map[limes.AvailabilityZone]db.AZResource, bool)
 	// GetAZResourcesForPath returns all AZ resources for the given ResourcePath.
-	GetAZResourcesForPath(path db.ResourcePath) (map[limes.AvailabilityZone]db.AZResource, bool)
+	GetAZResourcesForPath(path db.ResourcePath) util.ConstMap[limes.AvailabilityZone, db.AZResource]
 	// GetAZResourceForPath returns the AZ resource for the given AZResourcePath.
 	GetAZResourceForPath(path db.AZResourcePath) (db.AZResource, bool)
 	// GetAZResourceForID returns the AZ resource for the given AZ resource ID.
 	GetAZResourceForID(id db.AZResourceID) (db.AZResource, bool)
-	// GetRates returns all rates.
-	GetRates() map[db.ServiceType]map[liquid.RateName]db.Rate
 	// GetRatesForType returns all rates for the given service type.
-	GetRatesForType(serviceType db.ServiceType) (map[liquid.RateName]db.Rate, bool)
+	GetRatesForType(serviceType db.ServiceType) util.ConstMap[liquid.RateName, db.Rate]
 	// GetRateForPath returns the rate for the given service type and rate name.
 	GetRateForPath(path db.RatePath) (db.Rate, bool)
 	// GetRateForID returns the rate for the given rate ID.
 	GetRateForID(id db.RateID) (db.Rate, bool)
-	// GetCategories returns all categories for the given service type.
-	GetCategoriesForType(serviceType db.ServiceType) map[db.CategoryID]db.Category
+	// GetCategoriesForType returns all categories for the given service type.
+	GetCategoriesForType(serviceType db.ServiceType) util.ConstMap[db.CategoryID, db.Category]
 	// GetCategoryForID returns the category for the given ID.
 	GetCategoryForID(categoryID db.CategoryID) (db.Category, bool)
 }
@@ -95,373 +87,270 @@ var (
 
 ///////////////////////////////////////////////////////////////////////
 
-type (
-	// ServiceInfoSnapshot is the combined representation of db.Service, db.Resource
-	// db.AZResource, db.Rate and db.Category. We chose to provide this as only
-	// data structure and output of ServiceInfoCache mainly for 2 reasons:
-	// This ensures we get one consistent state from the ServiceInfoCache and
-	// not multiple outputs where the cache might have changed in between.
-	// Also, we can express filtering all entities by the same ServiceInfoFilter
-	// which makes application of the same filter to all entities easier.
-	// ServiceInfoSnapshot offers almost the same external method set for
-	// on-read access as FilteredServiceInfoSnapshot, they are defined by the
-	// ServiceInfoReader interface.
-	ServiceInfoSnapshot struct {
-		services    servicesByType
-		resources   resourcesByNameType
-		azResources azResourcesByAZNameType
-		rates       ratesByNameType
-		categories  categoriesByIDType
-		// ID-based indexes for O(1) lookup by primary key
-		servicesByID    servicesByIDIndex
-		resourcesByID   resourcesByIDIndex
-		azResourcesByID azResourcesByIDIndex
-		ratesByID       ratesByIDIndex
-		categoriesByID  categoriesByID
-		// necessary for constructing filters by area
-		areaMapping map[db.ServiceType]string
-	}
-
-	// shorthands for use within this file
-	servicesByType          = map[db.ServiceType]db.Service
-	resourcesByNameType     = map[db.ServiceType]resourcesByName
-	resourcesByName         = map[liquid.ResourceName]db.Resource
-	azResourcesByAZNameType = map[db.ServiceType]azResourcesByAZName
-	azResourcesByAZName     = map[liquid.ResourceName]azResourcesByAZ
-	azResourcesByAZ         = map[limes.AvailabilityZone]db.AZResource
-	ratesByNameType         = map[db.ServiceType]ratesByName
-	ratesByName             = map[liquid.RateName]db.Rate
-	categoriesByIDType      = map[db.ServiceType]categoriesByID
-	categoriesByID          = map[db.CategoryID]db.Category
-
-	servicesByIDIndex    = map[db.ServiceID]db.Service
-	resourcesByIDIndex   = map[db.ResourceID]db.Resource
-	azResourcesByIDIndex = map[db.AZResourceID]db.AZResource
-	ratesByIDIndex       = map[db.RateID]db.Rate
-)
-
-// removeDataForType removes all data of a given serviceType, making the cache ready
-// for populating this serviceType from scratch.
-func (s ServiceInfoSnapshot) removeDataForType(serviceType db.ServiceType) ServiceInfoSnapshot {
-	// remove ID index entries for this service type
-	if svc, ok := s.services[serviceType]; ok {
-		delete(s.servicesByID, svc.ID)
-	}
-	for _, resource := range s.resources[serviceType] {
-		delete(s.resourcesByID, resource.ID)
-	}
-	for _, azResByAZ := range s.azResources[serviceType] {
-		for _, azRes := range azResByAZ {
-			delete(s.azResourcesByID, azRes.ID)
-		}
-	}
-	for _, rate := range s.rates[serviceType] {
-		delete(s.ratesByID, rate.ID)
-	}
-	for _, category := range s.categories[serviceType] {
-		delete(s.categoriesByID, category.ID)
-	}
-	delete(s.services, serviceType)
-	delete(s.resources, serviceType)
-	delete(s.azResources, serviceType)
-	delete(s.rates, serviceType)
-	delete(s.categories, serviceType)
-	return s
-}
-
-// deepClone delivers a deep copy of the ServiceInfoSnapshot. This is used to
-// create a copy which can be altered without interfering with the original.
-// It shall only be used from ServiceInfoCache or when creating a
-// FilteredServiceInfoSnapshot.
-func (s ServiceInfoSnapshot) deepClone() ServiceInfoSnapshot {
-	return ServiceInfoSnapshot{
-		services:  maps.Clone(s.services),
-		resources: deepCloneMap(s.resources, maps.Clone),
-		azResources: deepCloneMap(s.azResources, func(inner azResourcesByAZName) azResourcesByAZName {
-			return deepCloneMap(inner, maps.Clone)
-		}),
-		rates:           deepCloneMap(s.rates, maps.Clone),
-		categories:      deepCloneMap(s.categories, maps.Clone),
-		servicesByID:    maps.Clone(s.servicesByID),
-		resourcesByID:   maps.Clone(s.resourcesByID),
-		azResourcesByID: maps.Clone(s.azResourcesByID),
-		categoriesByID:  maps.Clone(s.categoriesByID),
-		ratesByID:       maps.Clone(s.ratesByID),
-		areaMapping:     s.areaMapping, // should never get modified
-	}
+// ServiceInfoSnapshot is the combined representation of db.Service, db.Resource
+// db.AZResource, db.Rate and db.Category. We chose to provide this as only
+// data structure and output of ServiceInfoCache mainly for 2 reasons:
+// This ensures we get one consistent state from the ServiceInfoCache and
+// not multiple outputs where the cache might have changed in between.
+// Also, we can express filtering all entities by the same ServiceInfoFilter
+// which makes application of the same filter to all entities easier.
+//
+// All internal fields are util.ConstMap (read-only), which means that
+// ServiceInfoSnapshot can be shared across goroutines without deep cloning.
+type ServiceInfoSnapshot struct {
+	services    util.ConstMap[db.ServiceType, db.Service]
+	resources   util.ConstMap[db.ServiceType, util.ConstMap[liquid.ResourceName, db.Resource]]
+	azResources util.ConstMap[db.ServiceType, util.ConstMap[liquid.ResourceName, util.ConstMap[limes.AvailabilityZone, db.AZResource]]]
+	rates       util.ConstMap[db.ServiceType, util.ConstMap[liquid.RateName, db.Rate]]
+	categories  util.ConstMap[db.ServiceType, util.ConstMap[db.CategoryID, db.Category]]
+	// ID-based indexes for O(1) lookup by primary key
+	servicesByID    util.ConstMap[db.ServiceID, db.Service]
+	resourcesByID   util.ConstMap[db.ResourceID, db.Resource]
+	azResourcesByID util.ConstMap[db.AZResourceID, db.AZResource]
+	ratesByID       util.ConstMap[db.RateID, db.Rate]
+	categoriesByID  util.ConstMap[db.CategoryID, db.Category]
+	// necessary for constructing filters by area
+	areaMapping util.ConstMap[db.ServiceType, string]
 }
 
 // Filter applies the filter to the ServiceInfoSnapshot and produces an
-// eagerly filtered FilteredServiceInfoSnapshot.
+// eagerly filtered FilteredServiceInfoSnapshot using a copy-on-filter approach.
+// Only entries that pass the filter are copied into the new snapshot.
 func (s ServiceInfoSnapshot) Filter(filter ServiceInfoFilter) FilteredServiceInfoSnapshot {
-	f := FilteredServiceInfoSnapshot{
-		snapshot: s.deepClone(),
-		filter:   filter,
+	// Phase 1: determine service types which survive area and type filter
+	survivingServiceTypes := make(map[db.ServiceType]struct{})
+	for serviceType := range s.services.All() {
+		if area, ok := filter.ServiceArea.Unpack(); ok {
+			if s.areaMapping.GetOrZero(serviceType) != area {
+				continue
+			}
+		}
+		if typeFilter, ok := filter.ServiceType.Unpack(); ok {
+			if serviceType != typeFilter {
+				continue
+			}
+		}
+		survivingServiceTypes[serviceType] = struct{}{}
 	}
 
-	// filter services by area
-	if areaFilter, ok := f.filter.ServiceArea.Unpack(); ok {
-		for serviceType, area := range f.snapshot.areaMapping {
-			if area == areaFilter {
-				continue
-			}
-			delete(f.snapshot.services, serviceType)
-			delete(f.snapshot.resources, serviceType)
-			delete(f.snapshot.azResources, serviceType)
-			delete(f.snapshot.rates, serviceType)
-			delete(f.snapshot.categories, serviceType)
-		}
-	}
-	// filter services by type
-	if typeFilter, ok := f.filter.ServiceType.Unpack(); ok {
-		for serviceType := range f.snapshot.services {
-			if typeFilter == serviceType {
-				continue
-			}
-			delete(f.snapshot.services, serviceType)
-			delete(f.snapshot.azResources, serviceType)
-			delete(f.snapshot.resources, serviceType)
-			delete(f.snapshot.rates, serviceType)
-			delete(f.snapshot.categories, serviceType)
-		}
-	}
+	// Phase 2: determine categories to remove, when filtering by category
 	categoriesToRemove := make(map[db.CategoryID]struct{})
-	// find categories to remove
-	categoryFilter, categoryFilterExists := f.filter.Category.Unpack()
+	categoryFilter, categoryFilterExists := filter.Category.Unpack()
 	if categoryFilterExists {
-		for serviceType, categories := range f.snapshot.categories {
-			_ = serviceType
-			for categoryID, info := range categories {
+		for serviceType := range survivingServiceTypes {
+			categories := s.categories.GetOrZero(serviceType)
+			for categoryID, info := range categories.All() {
 				if info.Name != categoryFilter {
-					delete(categories, categoryID)
 					categoriesToRemove[categoryID] = struct{}{}
 				}
 			}
 		}
 	}
+
+	// Phase 3: build filtered resources and az_resources
+	resourceNameFilter, resourceFilterExists := filter.ResourceName.Unpack()
 	seenCategories := make(map[db.CategoryID]struct{})
-	resourceNameFilter, resourceFilterExists := f.filter.ResourceName.Unpack()
-	// filter resources/ az_resources by category or name
-	if categoryFilterExists || resourceFilterExists {
-		for serviceType, resources := range f.snapshot.resources {
-			for resourceName, resource := range resources {
-				_, inRemoveSet := categoriesToRemove[resource.CategoryID]
-				shouldRemove := (resourceFilterExists && resourceName != resourceNameFilter) ||
-					(categoryFilterExists && inRemoveSet)
-				if shouldRemove {
-					delete(f.snapshot.resources[serviceType], resourceName)
-					delete(f.snapshot.azResources[serviceType], resourceName)
-					if len(f.snapshot.resources[serviceType]) == 0 && len(f.snapshot.rates[serviceType]) == 0 {
-						delete(f.snapshot.services, serviceType)
-						delete(f.snapshot.resources, serviceType)
-						delete(f.snapshot.azResources, serviceType)
-						delete(f.snapshot.rates, serviceType)
-						delete(f.snapshot.categories, serviceType)
-					}
-				} else {
-					seenCategories[resource.CategoryID] = struct{}{}
-				}
+	newResources := make(map[db.ServiceType]util.ConstMap[liquid.ResourceName, db.Resource], len(survivingServiceTypes))
+	newAZResources := make(map[db.ServiceType]util.ConstMap[liquid.ResourceName, util.ConstMap[limes.AvailabilityZone, db.AZResource]], len(survivingServiceTypes))
+
+	for serviceType := range survivingServiceTypes {
+		resByName := s.resources.GetOrZero(serviceType)
+		azResByName := s.azResources.GetOrZero(serviceType)
+		filteredRes := make(map[liquid.ResourceName]db.Resource)
+		filteredAZRes := make(map[liquid.ResourceName]util.ConstMap[limes.AvailabilityZone, db.AZResource])
+
+		for resourceName, resource := range resByName.All() {
+			_, inRemoveSet := categoriesToRemove[resource.CategoryID]
+			if resourceFilterExists && resourceName != resourceNameFilter {
+				continue
+			}
+			if categoryFilterExists && inRemoveSet {
+				continue
+			}
+			filteredRes[resourceName] = resource
+			seenCategories[resource.CategoryID] = struct{}{}
+			if azByAZ, ok := azResByName.Get(resourceName); ok {
+				filteredAZRes[resourceName] = azByAZ
 			}
 		}
-	}
-	rateNameFilter, rateFilterExists := f.filter.RateName.Unpack()
-	// filter rates by category or name
-	if categoryFilterExists || rateFilterExists {
-		for serviceType, rates := range f.snapshot.rates {
-			for rateName, rate := range rates {
-				_, inRemoveSet := categoriesToRemove[rate.CategoryID]
-				shouldRemove := (rateFilterExists && rateName != rateNameFilter) ||
-					(categoryFilterExists && inRemoveSet)
-				if shouldRemove {
-					delete(f.snapshot.rates[serviceType], rateName)
-					if len(f.snapshot.resources[serviceType]) == 0 && len(f.snapshot.rates[serviceType]) == 0 {
-						delete(f.snapshot.services, serviceType)
-						delete(f.snapshot.resources, serviceType)
-						delete(f.snapshot.azResources, serviceType)
-						delete(f.snapshot.rates, serviceType)
-						delete(f.snapshot.categories, serviceType)
-					}
-				} else {
-					seenCategories[rate.CategoryID] = struct{}{}
-				}
-			}
+		if len(filteredRes) > 0 {
+			newResources[serviceType] = util.NewConstMap(filteredRes)
+		}
+		if len(filteredAZRes) > 0 {
+			newAZResources[serviceType] = util.NewConstMap(filteredAZRes)
 		}
 	}
 
-	// if we filtered by rate or service name, we must thin out the categories
-	if resourceFilterExists || rateFilterExists {
-		for serviceType, categories := range f.snapshot.categories {
-			for categoryID := range categories {
-				if _, ok := seenCategories[categoryID]; !ok {
-					delete(categories, categoryID)
-				}
+	// Phase 4: build filtered rates
+	rateNameFilter, rateFilterExists := filter.RateName.Unpack()
+	newRates := make(map[db.ServiceType]util.ConstMap[liquid.RateName, db.Rate], len(survivingServiceTypes))
+
+	for serviceType := range survivingServiceTypes {
+		rateByName := s.rates.GetOrZero(serviceType)
+		filteredRates := make(map[liquid.RateName]db.Rate)
+
+		for rateName, rate := range rateByName.All() {
+			_, inRemoveSet := categoriesToRemove[rate.CategoryID]
+			if rateFilterExists && rateName != rateNameFilter {
+				continue
 			}
-			if len(categories) == 0 {
-				delete(f.snapshot.categories, serviceType)
+			if categoryFilterExists && inRemoveSet {
+				continue
 			}
+			filteredRates[rateName] = rate
+			seenCategories[rate.CategoryID] = struct{}{}
+		}
+		if len(filteredRates) > 0 {
+			newRates[serviceType] = util.NewConstMap(filteredRates)
 		}
 	}
 
-	// rebuild ID indexes from the surviving path-based maps
-	f.snapshot.servicesByID = make(servicesByIDIndex, len(f.snapshot.services))
-	for _, svc := range f.snapshot.services {
-		f.snapshot.servicesByID[svc.ID] = svc
-	}
-	f.snapshot.resourcesByID = make(resourcesByIDIndex)
-	for _, resources := range f.snapshot.resources {
-		for _, resource := range resources {
-			f.snapshot.resourcesByID[resource.ID] = resource
+	// Phase 5: remove empty service types
+	newServices := make(map[db.ServiceType]db.Service, len(survivingServiceTypes))
+	for serviceType := range survivingServiceTypes {
+		if newResources[serviceType].Len() == 0 && newRates[serviceType].Len() == 0 {
+			delete(newResources, serviceType)
+			delete(newAZResources, serviceType)
+			delete(newRates, serviceType)
+			continue
 		}
+		svc, _ := s.services.Get(serviceType)
+		newServices[serviceType] = svc
 	}
-	f.snapshot.azResourcesByID = make(azResourcesByIDIndex)
-	for _, azResByAZName := range f.snapshot.azResources {
-		for _, azResByAZ := range azResByAZName {
-			for _, azRes := range azResByAZ {
-				f.snapshot.azResourcesByID[azRes.ID] = azRes
+
+	// Phase 6: build filtered categories (using seenCategories).
+	newCategories := make(map[db.ServiceType]util.ConstMap[db.CategoryID, db.Category])
+	for serviceType := range newServices {
+		cats := s.categories.GetOrZero(serviceType)
+		filteredCats := make(map[db.CategoryID]db.Category)
+		for categoryID, cat := range cats.All() {
+			if _, ok := seenCategories[categoryID]; ok {
+				filteredCats[categoryID] = cat
 			}
 		}
-	}
-	f.snapshot.ratesByID = make(ratesByIDIndex, len(f.snapshot.rates))
-	for _, rates := range f.snapshot.rates {
-		for _, rate := range rates {
-			f.snapshot.ratesByID[rate.ID] = rate
-		}
-	}
-	f.snapshot.categoriesByID = make(categoriesByID, len(f.snapshot.categories))
-	for _, categories := range f.snapshot.categories {
-		for _, category := range categories {
-			f.snapshot.categoriesByID[category.ID] = category
+		if len(filteredCats) > 0 {
+			newCategories[serviceType] = util.NewConstMap(filteredCats)
 		}
 	}
 
-	return f
+	// Phase 7: build ID indexes
+	newServicesByID := make(map[db.ServiceID]db.Service, len(newServices))
+	for _, svc := range newServices {
+		newServicesByID[svc.ID] = svc
+	}
+	newResourcesByID := make(map[db.ResourceID]db.Resource)
+	for _, resByName := range newResources {
+		for _, resource := range resByName.All() {
+			newResourcesByID[resource.ID] = resource
+		}
+	}
+	newAZResourcesByID := make(map[db.AZResourceID]db.AZResource)
+	for _, azResByName := range newAZResources {
+		for _, azResByAZ := range azResByName.All() {
+			for _, azRes := range azResByAZ.All() {
+				newAZResourcesByID[azRes.ID] = azRes
+			}
+		}
+	}
+	newRatesByID := make(map[db.RateID]db.Rate)
+	for _, rateByName := range newRates {
+		for _, rate := range rateByName.All() {
+			newRatesByID[rate.ID] = rate
+		}
+	}
+	newCategoriesByID := make(map[db.CategoryID]db.Category)
+	for _, catByID := range newCategories {
+		for _, cat := range catByID.All() {
+			newCategoriesByID[cat.ID] = cat
+		}
+	}
+
+	return FilteredServiceInfoSnapshot{
+		snapshot: ServiceInfoSnapshot{
+			services:        util.NewConstMap(newServices),
+			resources:       util.NewConstMap(newResources),
+			azResources:     util.NewConstMap(newAZResources),
+			rates:           util.NewConstMap(newRates),
+			categories:      util.NewConstMap(newCategories),
+			servicesByID:    util.NewConstMap(newServicesByID),
+			resourcesByID:   util.NewConstMap(newResourcesByID),
+			azResourcesByID: util.NewConstMap(newAZResourcesByID),
+			ratesByID:       util.NewConstMap(newRatesByID),
+			categoriesByID:  util.NewConstMap(newCategoriesByID),
+			areaMapping:     s.areaMapping, // shared, never modified
+		},
+		filter: filter,
+	}
 }
 
 // GetServices implements the [ServiceInfoReader] interface.
-func (s ServiceInfoSnapshot) GetServices() servicesByType {
-	return maps.Clone(s.services)
+func (s ServiceInfoSnapshot) GetServices() util.ConstMap[db.ServiceType, db.Service] {
+	return s.services
 }
 
 // GetServiceForType implements the [ServiceInfoReader] interface.
 func (s ServiceInfoSnapshot) GetServiceForType(serviceType db.ServiceType) (db.Service, bool) {
-	val, ok := s.services[serviceType]
-	return val, ok
+	return s.services.Get(serviceType)
 }
 
 // GetServiceForID implements the [ServiceInfoReader] interface.
 func (s ServiceInfoSnapshot) GetServiceForID(id db.ServiceID) (db.Service, bool) {
-	val, ok := s.servicesByID[id]
-	return val, ok
-}
-
-// GetResources implements the [ServiceInfoReader] interface.
-func (s ServiceInfoSnapshot) GetResources() resourcesByNameType {
-	return deepCloneMap(s.resources, maps.Clone)
+	return s.servicesByID.Get(id)
 }
 
 // GetResourcesForType implements the [ServiceInfoReader] interface.
-func (s ServiceInfoSnapshot) GetResourcesForType(serviceType db.ServiceType) (resourcesByName, bool) {
-	val, ok := s.resources[serviceType]
-	return maps.Clone(val), ok
+func (s ServiceInfoSnapshot) GetResourcesForType(serviceType db.ServiceType) util.ConstMap[liquid.ResourceName, db.Resource] {
+	return s.resources.GetOrZero(serviceType)
 }
 
 // GetResourceForPath implements the [ServiceInfoReader] interface.
 func (s ServiceInfoSnapshot) GetResourceForPath(path db.ResourcePath) (db.Resource, bool) {
-	val, ok := s.resources[path.ServiceType][path.ResourceName]
-	return val, ok
+	return s.resources.GetOrZero(path.ServiceType).Get(path.ResourceName)
 }
 
 // GetResourceForID implements the [ServiceInfoReader] interface.
 func (s ServiceInfoSnapshot) GetResourceForID(id db.ResourceID) (db.Resource, bool) {
-	val, ok := s.resourcesByID[id]
-	return val, ok
-}
-
-// GetAZResources implements the [ServiceInfoReader] interface.
-func (s ServiceInfoSnapshot) GetAZResources() azResourcesByAZNameType {
-	return deepCloneMap(s.azResources, func(inner azResourcesByAZName) azResourcesByAZName {
-		return deepCloneMap(inner, maps.Clone)
-	})
-}
-
-// GetAZResourcesForType implements the [ServiceInfoReader] interface.
-func (s ServiceInfoSnapshot) GetAZResourcesForType(serviceType db.ServiceType) (azResourcesByAZName, bool) {
-	val, ok := s.azResources[serviceType]
-	return deepCloneMap(val, maps.Clone), ok
+	return s.resourcesByID.Get(id)
 }
 
 // GetAZResourcesForPath implements the [ServiceInfoReader] interface.
-func (s ServiceInfoSnapshot) GetAZResourcesForPath(path db.ResourcePath) (azResourcesByAZ, bool) {
-	val, ok := s.azResources[path.ServiceType][path.ResourceName]
-	return maps.Clone(val), ok
+func (s ServiceInfoSnapshot) GetAZResourcesForPath(path db.ResourcePath) util.ConstMap[limes.AvailabilityZone, db.AZResource] {
+	return s.azResources.GetOrZero(path.ServiceType).GetOrZero(path.ResourceName)
 }
 
 // GetAZResourceForPath implements the [ServiceInfoReader] interface.
 func (s ServiceInfoSnapshot) GetAZResourceForPath(path db.AZResourcePath) (db.AZResource, bool) {
-	val, ok := s.azResources[path.ServiceType][path.ResourceName][path.AvailabilityZone]
-	return val, ok
+	return s.azResources.GetOrZero(path.ServiceType).GetOrZero(path.ResourceName).Get(path.AvailabilityZone)
 }
 
 // GetAZResourceForID implements the [ServiceInfoReader] interface.
 func (s ServiceInfoSnapshot) GetAZResourceForID(id db.AZResourceID) (db.AZResource, bool) {
-	val, ok := s.azResourcesByID[id]
-	return val, ok
-}
-
-// GetRates implements the [ServiceInfoReader] interface.
-func (s ServiceInfoSnapshot) GetRates() ratesByNameType {
-	return deepCloneMap(s.rates, maps.Clone)
+	return s.azResourcesByID.Get(id)
 }
 
 // GetRatesForType implements the [ServiceInfoReader] interface.
-func (s ServiceInfoSnapshot) GetRatesForType(serviceType db.ServiceType) (ratesByName, bool) {
-	val, ok := s.rates[serviceType]
-	return maps.Clone(val), ok
+func (s ServiceInfoSnapshot) GetRatesForType(serviceType db.ServiceType) util.ConstMap[liquid.RateName, db.Rate] {
+	return s.rates.GetOrZero(serviceType)
 }
 
 // GetRateForPath implements the [ServiceInfoReader] interface.
 func (s ServiceInfoSnapshot) GetRateForPath(path db.RatePath) (db.Rate, bool) {
-	val, ok := s.rates[path.ServiceType][path.RateName]
-	return val, ok
+	return s.rates.GetOrZero(path.ServiceType).Get(path.RateName)
 }
 
 // GetRateForID implements the [ServiceInfoReader] interface.
 func (s ServiceInfoSnapshot) GetRateForID(id db.RateID) (db.Rate, bool) {
-	val, ok := s.ratesByID[id]
-	return val, ok
+	return s.ratesByID.Get(id)
 }
 
 // GetCategoriesForType implements the [ServiceInfoReader] interface.
-func (s ServiceInfoSnapshot) GetCategoriesForType(serviceType db.ServiceType) categoriesByID {
-	return maps.Clone(s.categories[serviceType])
+func (s ServiceInfoSnapshot) GetCategoriesForType(serviceType db.ServiceType) util.ConstMap[db.CategoryID, db.Category] {
+	return s.categories.GetOrZero(serviceType)
 }
 
 // GetCategoryForID implements the [ServiceInfoReader] interface.
 func (s ServiceInfoSnapshot) GetCategoryForID(categoryID db.CategoryID) (db.Category, bool) {
-	val, ok := s.categoriesByID[categoryID]
-	return val, ok
-}
-
-// newEmptyServiceInfoSnapshot() returns an empty ServiceInfoSnapshot with all
-// maps initialized on their first level.
-func newEmptyServiceInfoSnapshot(config ClusterConfiguration) ServiceInfoSnapshot {
-	areaMapping := make(map[db.ServiceType]string)
-	for serviceType, liquidConfiguration := range config.Liquids {
-		areaMapping[serviceType] = liquidConfiguration.Area
-	}
-	return ServiceInfoSnapshot{
-		services:        make(servicesByType),
-		resources:       make(resourcesByNameType),
-		azResources:     make(azResourcesByAZNameType),
-		rates:           make(ratesByNameType),
-		categories:      make(categoriesByIDType),
-		servicesByID:    make(servicesByIDIndex),
-		resourcesByID:   make(resourcesByIDIndex),
-		azResourcesByID: make(azResourcesByIDIndex),
-		ratesByID:       make(ratesByIDIndex),
-		categoriesByID:  make(categoriesByID),
-		areaMapping:     areaMapping,
-	}
+	return s.categoriesByID.Get(categoryID)
 }
 
 ///////////////////////////////////////////////////////////////////////
@@ -482,7 +371,7 @@ func (f FilteredServiceInfoSnapshot) FilterIsEmpty() bool {
 }
 
 // GetServices implements the [ServiceInfoReader] interface.
-func (f FilteredServiceInfoSnapshot) GetServices() servicesByType {
+func (f FilteredServiceInfoSnapshot) GetServices() util.ConstMap[db.ServiceType, db.Service] {
 	return f.snapshot.GetServices()
 }
 
@@ -496,13 +385,8 @@ func (f FilteredServiceInfoSnapshot) GetServiceForID(id db.ServiceID) (db.Servic
 	return f.snapshot.GetServiceForID(id)
 }
 
-// GetResources implements the [ServiceInfoReader] interface.
-func (f FilteredServiceInfoSnapshot) GetResources() resourcesByNameType {
-	return f.snapshot.GetResources()
-}
-
 // GetResourcesForType implements the [ServiceInfoReader] interface.
-func (f FilteredServiceInfoSnapshot) GetResourcesForType(serviceType db.ServiceType) (resourcesByName, bool) {
+func (f FilteredServiceInfoSnapshot) GetResourcesForType(serviceType db.ServiceType) util.ConstMap[liquid.ResourceName, db.Resource] {
 	return f.snapshot.GetResourcesForType(serviceType)
 }
 
@@ -516,18 +400,8 @@ func (f FilteredServiceInfoSnapshot) GetResourceForID(id db.ResourceID) (db.Reso
 	return f.snapshot.GetResourceForID(id)
 }
 
-// GetAZResources implements the [ServiceInfoReader] interface.
-func (f FilteredServiceInfoSnapshot) GetAZResources() azResourcesByAZNameType {
-	return f.snapshot.GetAZResources()
-}
-
-// GetAZResourcesForType implements the [ServiceInfoReader] interface.
-func (f FilteredServiceInfoSnapshot) GetAZResourcesForType(serviceType db.ServiceType) (azResourcesByAZName, bool) {
-	return f.snapshot.GetAZResourcesForType(serviceType)
-}
-
 // GetAZResourcesForPath implements the [ServiceInfoReader] interface.
-func (f FilteredServiceInfoSnapshot) GetAZResourcesForPath(path db.ResourcePath) (azResourcesByAZ, bool) {
+func (f FilteredServiceInfoSnapshot) GetAZResourcesForPath(path db.ResourcePath) util.ConstMap[limes.AvailabilityZone, db.AZResource] {
 	return f.snapshot.GetAZResourcesForPath(path)
 }
 
@@ -541,13 +415,8 @@ func (f FilteredServiceInfoSnapshot) GetAZResourceForID(id db.AZResourceID) (db.
 	return f.snapshot.GetAZResourceForID(id)
 }
 
-// GetRates implements the [ServiceInfoReader] interface.
-func (f FilteredServiceInfoSnapshot) GetRates() ratesByNameType {
-	return f.snapshot.GetRates()
-}
-
 // GetRatesForType implements the [ServiceInfoReader] interface.
-func (f FilteredServiceInfoSnapshot) GetRatesForType(serviceType db.ServiceType) (ratesByName, bool) {
+func (f FilteredServiceInfoSnapshot) GetRatesForType(serviceType db.ServiceType) util.ConstMap[liquid.RateName, db.Rate] {
 	return f.snapshot.GetRatesForType(serviceType)
 }
 
@@ -562,7 +431,7 @@ func (f FilteredServiceInfoSnapshot) GetRateForID(id db.RateID) (db.Rate, bool) 
 }
 
 // GetCategoriesForType implements the [ServiceInfoReader] interface.
-func (f FilteredServiceInfoSnapshot) GetCategoriesForType(serviceType db.ServiceType) categoriesByID {
+func (f FilteredServiceInfoSnapshot) GetCategoriesForType(serviceType db.ServiceType) util.ConstMap[db.CategoryID, db.Category] {
 	return f.snapshot.GetCategoriesForType(serviceType)
 }
 
@@ -608,7 +477,6 @@ func NewServiceInfoCache(ctx context.Context, dbm *gsql.DB, config ClusterConfig
 	sic := &ServiceInfoCache{
 		DB:     dbm,
 		config: config,
-		data:   newEmptyServiceInfoSnapshot(config),
 	}
 
 	// populate all data from the DB on startup
@@ -693,71 +561,108 @@ func (s *ServiceInfoCache) signalInvalidation() {
 
 // InvalidateService will make the ServiceInfoCache reload one service (if
 // serviceType is provided) or all services (if no serviceType is provided).
+// It rebuilds the internal util.ConstMap fields from scratch for the affected
+// services so that the existing references to those maps are not affected.
 func (s *ServiceInfoCache) InvalidateService(ctx context.Context, serviceType Option[db.ServiceType]) error {
 	s.dataMutex.Lock()
 	defer s.dataMutex.Unlock()
 
-	if st, ok := serviceType.Unpack(); ok {
-		s.data = s.data.removeDataForType(st)
-	} else {
-		s.data = newEmptyServiceInfoSnapshot(s.config)
+	// Build area mapping (constant, derived from config)
+	areaMappingPlain := make(map[db.ServiceType]string, len(s.config.Liquids))
+	for st, liquidConfiguration := range s.config.Liquids {
+		areaMappingPlain[st] = liquidConfiguration.Area
 	}
 
-	// now we fill the cache for the invalidated services again
-	servicesByType, err := db.ServiceByTypeIndex.IndexFrom(db.ServiceStore.SelectWhere(ctx, s.DB, `type = $1 OR $1 IS NULL`, serviceType))
+	// Start with existing data (for partial invalidation) or empty maps.
+	// We always build into plain maps, then wrap with util.NewConstMap() at the end.
+	services := make(map[db.ServiceType]db.Service)
+	resources := make(map[db.ServiceType]map[liquid.ResourceName]db.Resource)
+	azResources := make(map[db.ServiceType]map[liquid.ResourceName]map[limes.AvailabilityZone]db.AZResource)
+	rates := make(map[db.ServiceType]map[liquid.RateName]db.Rate)
+	categories := make(map[db.ServiceType]map[db.CategoryID]db.Category)
+
+	if st, ok := serviceType.Unpack(); ok {
+		// Partial invalidation: copy all data except the invalidated service type.
+		for sType, svc := range s.data.services.All() {
+			if sType != st {
+				services[sType] = svc
+			}
+		}
+		for sType, resByName := range s.data.resources.All() {
+			if sType != st {
+				// Unwrap the inner constmap into a plain map for consistency.
+				// This is safe because we're building a new snapshot.
+				inner := maps.Collect(resByName.All())
+				resources[sType] = inner
+			}
+		}
+		for sType, azResByName := range s.data.azResources.All() {
+			if sType != st {
+				innerByName := make(map[liquid.ResourceName]map[limes.AvailabilityZone]db.AZResource, azResByName.Len())
+				for name, azResByAZ := range azResByName.All() {
+					innerByName[name] = maps.Collect(azResByAZ.All())
+				}
+				azResources[sType] = innerByName
+			}
+		}
+		for sType, rateByName := range s.data.rates.All() {
+			if sType != st {
+				rates[sType] = maps.Collect(rateByName.All())
+			}
+		}
+		for sType, catByID := range s.data.categories.All() {
+			if sType != st {
+				categories[sType] = maps.Collect(catByID.All())
+			}
+		}
+	}
+
+	// Load fresh data from DB for the affected services.
+	dbServices, err := db.ServiceStore.SelectWhere(ctx, s.DB, `type = $1 OR $1 IS NULL`, serviceType).Collect()
 	if err != nil {
 		return fmt.Errorf("while reading services for type(s) %v: %w", serviceType, err)
 	}
-	maps.Copy(s.data.services, servicesByType)
-	for _, svc := range servicesByType {
-		s.data.servicesByID[svc.ID] = svc
+	for _, dbService := range dbServices {
+		services[dbService.Type] = dbService
 	}
 
-	// TODO: simplify queries below by using the ServiceID from the record that we just pulled
-
-	resourcesByPath, err := db.ResourceByPathIndex.IndexFrom(
-		db.ResourceStore.Select(ctx, s.DB, `SELECT r.* FROM resources r JOIN services s ON r.service_id = s.id WHERE s.type = $1 OR $1 IS NULL`, serviceType),
-	)
+	dbResources, err := db.ResourceStore.Select(ctx, s.DB, `SELECT r.* FROM resources r JOIN services s ON r.service_id = s.id WHERE s.type = $1 OR $1 IS NULL`, serviceType).Collect()
 	if err != nil {
 		return fmt.Errorf("while reading resources for type(s) %v: %w", serviceType, err)
 	}
-	for path, resource := range resourcesByPath {
-		if _, sExists := s.data.resources[path.ServiceType]; !sExists {
-			s.data.resources[path.ServiceType] = make(resourcesByName)
+	for _, dbResource := range dbResources {
+		path := dbResource.Path
+		if resources[path.ServiceType] == nil {
+			resources[path.ServiceType] = make(map[liquid.ResourceName]db.Resource)
 		}
-		s.data.resources[path.ServiceType][path.ResourceName] = resource
-		s.data.resourcesByID[resource.ID] = resource
+		resources[path.ServiceType][path.ResourceName] = dbResource
 	}
 
-	azResourcesByPath, err := db.AZResourceByPathIndex.IndexFrom(
-		db.AZResourceStore.Select(ctx, s.DB, `SELECT azr.* FROM az_resources azr JOIN resources r ON azr.resource_id = r.id JOIN services s ON r.service_id = s.id WHERE s.type = $1 OR $1 IS NULL`, serviceType),
-	)
+	dbAZResources, err := db.AZResourceStore.Select(ctx, s.DB, `SELECT azr.* FROM az_resources azr JOIN resources r ON azr.resource_id = r.id JOIN services s ON r.service_id = s.id WHERE s.type = $1 OR $1 IS NULL`, serviceType).Collect()
 	if err != nil {
 		return fmt.Errorf("while reading az_resources for type(s) %v: %w", serviceType, err)
 	}
-	for path, azResource := range azResourcesByPath {
-		if _, sExists := s.data.azResources[path.ServiceType]; !sExists {
-			s.data.azResources[path.ServiceType] = make(azResourcesByAZName)
+	for _, dbAZResource := range dbAZResources {
+		path := dbAZResource.Path
+		if azResources[path.ServiceType] == nil {
+			azResources[path.ServiceType] = make(map[liquid.ResourceName]map[limes.AvailabilityZone]db.AZResource)
 		}
-		if _, rExists := s.data.azResources[path.ServiceType][path.ResourceName]; !rExists {
-			s.data.azResources[path.ServiceType][path.ResourceName] = make(azResourcesByAZ)
+		if azResources[path.ServiceType][path.ResourceName] == nil {
+			azResources[path.ServiceType][path.ResourceName] = make(map[limes.AvailabilityZone]db.AZResource)
 		}
-		s.data.azResources[path.ServiceType][path.ResourceName][path.AvailabilityZone] = azResource
-		s.data.azResourcesByID[azResource.ID] = azResource
+		azResources[path.ServiceType][path.ResourceName][path.AvailabilityZone] = dbAZResource
 	}
 
-	ratesByPath, err := db.RateByPathIndex.IndexFrom(
-		db.RateStore.Select(ctx, s.DB, "SELECT ra.* FROM rates ra JOIN services s ON ra.service_id = s.id WHERE s.type = $1 OR $1 IS NULL", serviceType),
-	)
+	dbRates, err := db.RateStore.Select(ctx, s.DB, "SELECT ra.* FROM rates ra JOIN services s ON ra.service_id = s.id WHERE s.type = $1 OR $1 IS NULL", serviceType).Collect()
 	if err != nil {
 		return fmt.Errorf("while reading rates for type(s) %v: %w", serviceType, err)
 	}
-	for path, rate := range ratesByPath {
-		if _, rExists := s.data.rates[path.ServiceType]; !rExists {
-			s.data.rates[path.ServiceType] = make(ratesByName)
+	for _, dbRate := range dbRates {
+		path := dbRate.Path
+		if rates[path.ServiceType] == nil {
+			rates[path.ServiceType] = make(map[liquid.RateName]db.Rate)
 		}
-		s.data.rates[path.ServiceType][path.RateName] = rate
-		s.data.ratesByID[rate.ID] = rate
+		rates[path.ServiceType][path.RateName] = dbRate
 	}
 
 	type categoryRecord struct {
@@ -771,35 +676,68 @@ func (s *ServiceInfoCache) InvalidateService(ctx context.Context, serviceType Op
 		return fmt.Errorf("while reading categories for type(s) %v: %w", serviceType, err)
 	}
 	for _, record := range categoryRecords {
-		if _, ok := s.data.categories[record.ServiceType]; !ok {
-			s.data.categories[record.ServiceType] = make(categoriesByID)
+		if categories[record.ServiceType] == nil {
+			categories[record.ServiceType] = make(map[db.CategoryID]db.Category)
 		}
-		s.data.categories[record.ServiceType][record.ID] = record.Category
-		s.data.categoriesByID[record.ID] = record.Category
+		categories[record.ServiceType][record.ID] = record.Category
+	}
+
+	// Build ID indexes.
+	servicesByID := make(map[db.ServiceID]db.Service, len(services))
+	for _, svc := range services {
+		servicesByID[svc.ID] = svc
+	}
+	resourcesByID := make(map[db.ResourceID]db.Resource)
+	for _, resByName := range resources {
+		for _, resource := range resByName {
+			resourcesByID[resource.ID] = resource
+		}
+	}
+	azResourcesByID := make(map[db.AZResourceID]db.AZResource)
+	for _, azResByName := range azResources {
+		for _, azResByAZ := range azResByName {
+			for _, azRes := range azResByAZ {
+				azResourcesByID[azRes.ID] = azRes
+			}
+		}
+	}
+	ratesByID := make(map[db.RateID]db.Rate)
+	for _, rateByName := range rates {
+		for _, rate := range rateByName {
+			ratesByID[rate.ID] = rate
+		}
+	}
+	categoriesByID := make(map[db.CategoryID]db.Category)
+	for _, catByID := range categories {
+		for _, cat := range catByID {
+			categoriesByID[cat.ID] = cat
+		}
+	}
+
+	// Wrap nested maps and assign the new snapshot atomically.
+	s.data = ServiceInfoSnapshot{
+		services:        util.NewConstMap(services),
+		resources:       util.New2LevelConstMap(resources),
+		azResources:     util.New3LevelConstMap(azResources),
+		rates:           util.New2LevelConstMap(rates),
+		categories:      util.New2LevelConstMap(categories),
+		servicesByID:    util.NewConstMap(servicesByID),
+		resourcesByID:   util.NewConstMap(resourcesByID),
+		azResourcesByID: util.NewConstMap(azResourcesByID),
+		ratesByID:       util.NewConstMap(ratesByID),
+		categoriesByID:  util.NewConstMap(categoriesByID),
+		areaMapping:     util.NewConstMap(areaMappingPlain),
 	}
 
 	return nil
 }
 
 // GetSnapshot returns a ServiceInfoSnapshot with the current data in the ServiceInfoCache.
+// This is a cheap O(1) operation because all internal fields are immutable util.ConstMap values.
 func (s *ServiceInfoCache) GetSnapshot() ServiceInfoSnapshot {
 	s.dataMutex.RLock()
 	defer s.dataMutex.RUnlock()
-	return s.data.deepClone()
-}
-
-// HasService is the same as the second return value of s.GetSnapshot().GetServiceForType(serviceType),
-// but avoids a costly deep clone.
-//
-// Usually, we want all access to payload in ServiceInfoCache to go through [ServiceInfoSnapshot],
-// but this particular method allows us to reduce memory allocations in the collector by 30%.
-//
-// TODO: remove this method once we rework GetSnapshot into a cheap shallow copy
-func (s *ServiceInfoCache) HasService(serviceType db.ServiceType) bool {
-	s.dataMutex.RLock()
-	defer s.dataMutex.RUnlock()
-	_, ok := s.data.services[serviceType]
-	return ok
+	return s.data
 }
 
 // GetServiceInfo should only be used when interacting with the liquid
@@ -809,9 +747,9 @@ func (s *ServiceInfoCache) GetServiceInfo(serviceType db.ServiceType) (info liqu
 	s.dataMutex.RLock()
 	defer s.dataMutex.RUnlock()
 	// we can assume the data is saved because of the call context
-	service := s.data.services[serviceType]
-	resources := s.data.resources[serviceType]
-	rates := s.data.rates[serviceType]
+	service := s.data.services.GetOrZero(serviceType)
+	resources := s.data.resources.GetOrZero(serviceType)
+	rates := s.data.rates.GetOrZero(serviceType)
 	categories := s.data.categoriesByID
 
 	capacityMetricFamilies, err := util.JSONToAny[map[liquid.MetricName]liquid.MetricFamilyInfo](service.CapacityMetricFamiliesJSON, "capacity_metric_families")
@@ -829,14 +767,14 @@ func (s *ServiceInfoCache) GetServiceInfo(serviceType db.ServiceType) (info liqu
 		UsageReportNeedsProjectMetadata:        service.UsageReportNeedsProjectMetadata,
 		QuotaUpdateNeedsProjectMetadata:        service.QuotaUpdateNeedsProjectMetadata,
 		CommitmentHandlingNeedsProjectMetadata: service.CommitmentHandlingNeedsProjectMetadata,
-		Resources:                              make(map[liquid.ResourceName]liquid.ResourceInfo, len(resources)),
-		Rates:                                  make(map[liquid.RateName]liquid.RateInfo, len(rates)),
+		Resources:                              make(map[liquid.ResourceName]liquid.ResourceInfo, resources.Len()),
+		Rates:                                  make(map[liquid.RateName]liquid.RateInfo, rates.Len()),
 		Categories:                             make(map[liquid.CategoryName]liquid.CategoryInfo),
 		CapacityMetricFamilies:                 capacityMetricFamilies,
 		UsageMetricFamilies:                    usageMetricFamilies,
 	}
 	// reconstruct resource infos
-	for name, res := range resources {
+	for name, res := range resources.All() {
 		resInfo := liquid.ResourceInfo{
 			DisplayName:         res.DisplayName,
 			Unit:                res.Unit,
@@ -849,7 +787,7 @@ func (s *ServiceInfoCache) GetServiceInfo(serviceType db.ServiceType) (info liqu
 		if res.AttributesJSON != "" {
 			resInfo.Attributes = json.RawMessage(res.AttributesJSON)
 		}
-		if cat, exists := categories[res.CategoryID]; exists {
+		if cat, exists := categories.Get(res.CategoryID); exists {
 			resInfo.Category = Some(cat.Name)
 			info.Categories[cat.Name] = liquid.CategoryInfo{
 				DisplayName: cat.DisplayName,
@@ -858,14 +796,14 @@ func (s *ServiceInfoCache) GetServiceInfo(serviceType db.ServiceType) (info liqu
 		info.Resources[name] = resInfo
 	}
 	// reconstruct rate infos
-	for name, rate := range rates {
+	for name, rate := range rates.All() {
 		rateInfo := liquid.RateInfo{
 			DisplayName: rate.DisplayName,
 			Unit:        rate.Unit,
 			Topology:    rate.Topology,
 			HasUsage:    rate.HasUsage,
 		}
-		if cat, exists := categories[rate.CategoryID]; exists {
+		if cat, exists := categories.Get(rate.CategoryID); exists {
 			rateInfo.Category = Some(cat.Name)
 			info.Categories[cat.Name] = liquid.CategoryInfo{
 				DisplayName: cat.DisplayName,
@@ -874,22 +812,4 @@ func (s *ServiceInfoCache) GetServiceInfo(serviceType db.ServiceType) (info liqu
 		info.Rates[name] = rateInfo
 	}
 	return info, nil
-}
-
-///////////////////////////////////////////////////////////////////////
-// Utility functions
-
-// deepCloneMap returns a deep copy of a map by cloning each value using the
-// provided cloneValue function. For leaf maps (where values are not maps),
-// pass maps.Clone directly. For nested maps, pass a function that itself
-// calls deepCloneMap to deepClone the next level.
-func deepCloneMap[M ~map[K]V, K comparable, V any](m M, cloneValue func(V) V) M {
-	if m == nil {
-		return nil
-	}
-	result := make(M, len(m))
-	for k, v := range m {
-		result[k] = cloneValue(v)
-	}
-	return result
 }

--- a/internal/core/service_info_cache.go
+++ b/internal/core/service_info_cache.go
@@ -575,7 +575,7 @@ func (s *ServiceInfoCache) InvalidateService(ctx context.Context, serviceType Op
 	// we start with empty maps, get the data we want from the database and then possibly copy over the old values
 	services := make(map[db.ServiceType]db.Service)
 	resources := make(map[db.ServiceType]util.ConstMap[liquid.ResourceName, db.Resource])
-	azResources := make(map[db.ServiceType]util.ConstMap[liquid.ResourceName, util.ConstMap[liquid.AvailabilityZone, db.AZResource]])
+	azResources := make(map[db.ServiceType]util.ConstMap[liquid.ResourceName, util.ConstMap[limes.AvailabilityZone, db.AZResource]])
 	rates := make(map[db.ServiceType]util.ConstMap[liquid.RateName, db.Rate])
 	categories := make(map[db.ServiceType]util.ConstMap[db.CategoryID, db.Category])
 
@@ -597,16 +597,18 @@ func (s *ServiceInfoCache) InvalidateService(ctx context.Context, serviceType Op
 	var (
 		currentService               db.ServiceType
 		resourcesForCurrentService   map[liquid.ResourceName]db.Resource
-		azResourcesForCurrentService map[liquid.ResourceName]map[liquid.AvailabilityZone]db.AZResource
+		azResourcesForCurrentService map[liquid.ResourceName]map[limes.AvailabilityZone]db.AZResource
 		ratesForCurrentService       map[liquid.RateName]db.Rate
 		categoriesForCurrentService  map[db.CategoryID]db.Category
 	)
 	currentService = ""
-	for _, dbResource := range dbResources {
+	for i, dbResource := range dbResources {
 		path := dbResource.Path
 		if currentService != path.ServiceType {
 			// flush
-			resources[currentService] = util.NewConstMap(resourcesForCurrentService)
+			if i > 0 {
+				resources[currentService] = util.NewConstMap(resourcesForCurrentService)
+			}
 			resourcesForCurrentService = make(map[liquid.ResourceName]db.Resource)
 			currentService = path.ServiceType
 		}
@@ -621,16 +623,18 @@ func (s *ServiceInfoCache) InvalidateService(ctx context.Context, serviceType Op
 		return fmt.Errorf("while reading az_resources for type(s) %v: %w", serviceType, err)
 	}
 	currentService = ""
-	for _, dbAZResource := range dbAZResources {
+	for i, dbAZResource := range dbAZResources {
 		path := dbAZResource.Path
 		if currentService != path.ServiceType {
 			// flush
-			azResources[currentService] = util.New2LevelConstMap(azResourcesForCurrentService)
-			azResourcesForCurrentService = make(map[liquid.ResourceName]map[liquid.AvailabilityZone]db.AZResource)
+			if i > 0 {
+				azResources[currentService] = util.New2LevelConstMap(azResourcesForCurrentService)
+			}
+			azResourcesForCurrentService = make(map[liquid.ResourceName]map[limes.AvailabilityZone]db.AZResource)
 			currentService = path.ServiceType
 		}
 		if azResourcesForCurrentService[path.ResourceName] == nil {
-			azResourcesForCurrentService[path.ResourceName] = make(map[liquid.AvailabilityZone]db.AZResource)
+			azResourcesForCurrentService[path.ResourceName] = make(map[limes.AvailabilityZone]db.AZResource)
 		}
 		azResourcesForCurrentService[path.ResourceName][path.AvailabilityZone] = dbAZResource
 	}
@@ -643,11 +647,13 @@ func (s *ServiceInfoCache) InvalidateService(ctx context.Context, serviceType Op
 		return fmt.Errorf("while reading rates for type(s) %v: %w", serviceType, err)
 	}
 	currentService = ""
-	for _, dbRate := range dbRates {
+	for i, dbRate := range dbRates {
 		path := dbRate.Path
 		if currentService != path.ServiceType {
 			// flush
-			rates[currentService] = util.NewConstMap(ratesForCurrentService)
+			if i > 0 {
+				rates[currentService] = util.NewConstMap(ratesForCurrentService)
+			}
 			ratesForCurrentService = make(map[liquid.RateName]db.Rate)
 			currentService = path.ServiceType
 		}
@@ -668,10 +674,12 @@ func (s *ServiceInfoCache) InvalidateService(ctx context.Context, serviceType Op
 		return fmt.Errorf("while reading categories for type(s) %v: %w", serviceType, err)
 	}
 	currentService = ""
-	for _, record := range categoryRecords {
+	for i, record := range categoryRecords {
 		if currentService != record.ServiceType {
 			// flush
-			categories[currentService] = util.NewConstMap(categoriesForCurrentService)
+			if i > 0 {
+				categories[currentService] = util.NewConstMap(categoriesForCurrentService)
+			}
 			categoriesForCurrentService = make(map[db.CategoryID]db.Category)
 			currentService = record.ServiceType
 		}

--- a/internal/core/service_info_cache.go
+++ b/internal/core/service_info_cache.go
@@ -612,7 +612,9 @@ func (s *ServiceInfoCache) InvalidateService(ctx context.Context, serviceType Op
 		}
 		resourcesForCurrentService[path.ResourceName] = dbResource
 	}
-	resources[currentService] = util.NewConstMap(resourcesForCurrentService)
+	if currentService != "" {
+		resources[currentService] = util.NewConstMap(resourcesForCurrentService)
+	}
 
 	dbAZResources, err := db.AZResourceStore.Select(ctx, s.DB, `SELECT azr.* FROM az_resources azr JOIN resources r ON azr.resource_id = r.id WHERE r.service_id = ANY($1) OR CARDINALITY($1) = 0 ORDER BY path`, pq.Array(serviceIDs)).Collect()
 	if err != nil {
@@ -632,7 +634,9 @@ func (s *ServiceInfoCache) InvalidateService(ctx context.Context, serviceType Op
 		}
 		azResourcesForCurrentService[path.ResourceName][path.AvailabilityZone] = dbAZResource
 	}
-	azResources[currentService] = util.New2LevelConstMap(azResourcesForCurrentService)
+	if currentService != "" {
+		azResources[currentService] = util.New2LevelConstMap(azResourcesForCurrentService)
+	}
 
 	dbRates, err := db.RateStore.Select(ctx, s.DB, "SELECT ra.* FROM rates ra WHERE ra.service_id = ANY($1) OR CARDINALITY($1) = 0 ORDER BY path", pq.Array(serviceIDs)).Collect()
 	if err != nil {
@@ -649,7 +653,9 @@ func (s *ServiceInfoCache) InvalidateService(ctx context.Context, serviceType Op
 		}
 		ratesForCurrentService[path.RateName] = dbRate
 	}
-	rates[currentService] = util.NewConstMap(ratesForCurrentService)
+	if currentService != "" {
+		rates[currentService] = util.NewConstMap(ratesForCurrentService)
+	}
 
 	type categoryRecord struct {
 		db.Category
@@ -671,7 +677,9 @@ func (s *ServiceInfoCache) InvalidateService(ctx context.Context, serviceType Op
 		}
 		categoriesForCurrentService[record.ID] = record.Category
 	}
-	categories[currentService] = util.NewConstMap(categoriesForCurrentService)
+	if currentService != "" {
+		categories[currentService] = util.NewConstMap(categoriesForCurrentService)
+	}
 
 	// copy unchanged entries, if there are any
 	if stFilter, ok := serviceType.Unpack(); ok {

--- a/internal/core/service_info_cache_test.go
+++ b/internal/core/service_info_cache_test.go
@@ -48,90 +48,67 @@ func TestServiceInfoSnapshotFilter(t *testing.T) {
 
 	// filter by ServiceType
 	filtered := sis.Filter(core.ServiceInfoFilter{ServiceType: Some[db.ServiceType]("second")})
-	assert.Equal(t, len(filtered.GetServices()), 1)
+	assert.Equal(t, filtered.GetServices().Len(), 1)
 	_, ok := filtered.GetServiceForType("second")
 	assert.Equal(t, ok, true)
 	_, ok = filtered.GetServiceForType("first")
 	assert.Equal(t, ok, false)
-	resources, ok := filtered.GetResourcesForType("second")
-	assert.Equal(t, ok, true)
-	assert.Equal(t, len(resources), 2)
-	_, ok = filtered.GetResourcesForType("first")
-	assert.Equal(t, ok, false)
-	_, ok = filtered.GetRatesForType("first")
-	assert.Equal(t, ok, false)
+	resources := filtered.GetResourcesForType("second")
+	assert.Equal(t, resources.Len(), 2)
+	resources = filtered.GetResourcesForType("first")
+	assert.Equal(t, resources.Len(), 0)
+	rates := filtered.GetRatesForType("first")
+	assert.Equal(t, rates.Len(), 0)
 
 	// filter by ServiceArea
 	filtered = sis.Filter(core.ServiceInfoFilter{ServiceArea: Some("first")})
-	assert.Equal(t, len(filtered.GetServices()), 1)
+	assert.Equal(t, filtered.GetServices().Len(), 1)
 	_, ok = filtered.GetServiceForType("first")
 	assert.Equal(t, ok, true)
 	_, ok = filtered.GetServiceForType("second")
 	assert.Equal(t, ok, false)
-	rates, ok := filtered.GetRatesForType("first")
-	assert.Equal(t, ok, true)
-	assert.Equal(t, len(rates), 4)
+	rates = filtered.GetRatesForType("first")
+	assert.Equal(t, rates.Len(), 4)
 
 	// filter by ResourceName
 	filtered = sis.Filter(core.ServiceInfoFilter{ResourceName: Some[liquid.ResourceName]("capacity")})
-	resources, ok = filtered.GetResourcesForType("second")
+	resources = filtered.GetResourcesForType("second")
+	assert.Equal(t, resources.Len(), 1)
+	_, ok = resources.Get("capacity")
 	assert.Equal(t, ok, true)
-	assert.Equal(t, len(resources), 1)
-	_, ok = resources["capacity"]
-	assert.Equal(t, ok, true)
-	_, ok = resources["things"]
+	_, ok = resources.Get("things")
 	assert.Equal(t, ok, false)
 
 	// filter by Category
 	filtered = sis.Filter(core.ServiceInfoFilter{Category: Some[liquid.CategoryName]("foo_category")})
-	resources, ok = filtered.GetResourcesForType("second")
+	resources = filtered.GetResourcesForType("second")
+	assert.Equal(t, resources.Len(), 1)
+	_, ok = resources.Get("capacity")
 	assert.Equal(t, ok, true)
-	_, ok = resources["capacity"]
-	assert.Equal(t, ok, true)
-	_, ok = resources["things"]
+	_, ok = resources.Get("things")
 	assert.Equal(t, ok, false)
 	_, ok = filtered.GetServiceForType("first")
 	assert.Equal(t, ok, false)
 
 	// filter by Category matching the serviceType yields entries which have no explicit category
 	filtered = sis.Filter(core.ServiceInfoFilter{Category: Some[liquid.CategoryName]("second")})
-	resources, ok = filtered.GetResourcesForType("second")
+	resources = filtered.GetResourcesForType("second")
+	assert.Equal(t, resources.Len(), 1)
+	_, ok = resources.Get("things")
 	assert.Equal(t, ok, true)
-	assert.Equal(t, len(resources), 1)
-	_, ok = resources["things"]
-	assert.Equal(t, ok, true)
-	_, ok = resources["capacity"]
+	_, ok = resources.Get("capacity")
 	assert.Equal(t, ok, false)
 
 	// filter by RateName
 	filtered = sis.Filter(core.ServiceInfoFilter{RateName: Some[liquid.RateName]("objects:create")})
-	rates, ok = filtered.GetRatesForType("first")
+	rates = filtered.GetRatesForType("first")
+	assert.Equal(t, rates.Len(), 1)
+	_, ok = rates.Get("objects:create")
 	assert.Equal(t, ok, true)
-	assert.Equal(t, len(rates), 1)
-	_, ok = rates["objects:create"]
-	assert.Equal(t, ok, true)
-
-	// snapshot immutability: mutations on returned maps don't affect snapshot
-	services := sis.GetServices()
-	services["injected"] = db.Service{DisplayName: "Injected"}
-	_, ok = sis.GetServiceForType("injected")
-	assert.Equal(t, ok, false)
-	resourcesClone := must.BeOKT(sis.GetResourcesForType("second"))(t)
-	resourcesClone["injected"] = db.Resource{DisplayName: "Injected"}
-	originalResources := must.BeOKT(sis.GetResourcesForType("second"))(t)
-	_, ok = originalResources["injected"]
-	assert.Equal(t, ok, false)
-
-	// FilteredServiceInfoSnapshot immutability
-	filtered = sis.Filter(core.ServiceInfoFilter{ServiceType: Some[db.ServiceType]("second")})
-	filteredServices := filtered.GetServices()
-	filteredServices["injected"] = db.Service{DisplayName: "Injected"}
-	_, ok = filtered.GetServiceForType("injected")
-	assert.Equal(t, ok, false)
 
 	// Filter does not affect original snapshot
 	_ = sis.Filter(core.ServiceInfoFilter{ServiceType: Some[db.ServiceType]("second")})
-	assert.Equal(t, len(sis.GetServices()), 2)
+	assert.Equal(t, sis.GetServices().Len(), 2)
 }
 
 func TestServiceInfoCache(t *testing.T) {
@@ -157,13 +134,13 @@ func TestServiceInfoCache(t *testing.T) {
 	t.Cleanup(func() { s.Cluster.SIC.Close() })
 
 	sis := s.Cluster.SIC.GetSnapshot()
-	assert.Equal(t, len(sis.GetServices()), 2)
-	must.NotBeOKT(sis.GetResourcesForType("first"))(t)
-	assert.Equal(t, len(must.BeOKT(sis.GetResourcesForType("second"))(t)), 2)
+	assert.Equal(t, sis.GetServices().Len(), 2)
+	assert.Equal(t, sis.GetResourcesForType("first").Len(), 0)
+	assert.Equal(t, sis.GetResourcesForType("second").Len(), 2)
 	assert.Equal(t, must.BeOKT(sis.GetResourceForPath(db.ResourcePath{ServiceType: "second", ResourceName: "capacity"}))(t).Name, "capacity")
-	must.NotBeOKT(sis.GetRatesForType("second"))(t)
-	assert.Equal(t, len(sis.GetCategoriesForType("first")), 1)  // just default category
-	assert.Equal(t, len(sis.GetCategoriesForType("second")), 2) // default + "foo_category"
+	assert.Equal(t, sis.GetRatesForType("second").Len(), 0)
+	assert.Equal(t, sis.GetCategoriesForType("first").Len(), 1)  // just default category
+	assert.Equal(t, sis.GetCategoriesForType("second").Len(), 2) // default + "foo_category"
 
 	// check service update
 	assert.Equal(t, must.BeOKT(sis.GetServiceForType("first"))(t).DisplayName, "First")
@@ -184,7 +161,7 @@ func TestServiceInfoCache(t *testing.T) {
 	assert.Equal(t, must.BeOKT(sis.GetResourceForPath(db.ResourcePath{ServiceType: "second", ResourceName: "things"}))(t).DisplayName, "Things")
 
 	// check az_resource insert
-	assert.Equal(t, len(must.BeOKT(sis.GetAZResourcesForPath(db.ResourcePath{ServiceType: "second", ResourceName: "capacity"}))(t)), 5) // gives out total, any and unknown, too
+	assert.Equal(t, sis.GetAZResourcesForPath(db.ResourcePath{ServiceType: "second", ResourceName: "capacity"}).Len(), 5) // gives out total, any and unknown, too
 	s.MustDBInsert(&db.AZResource{
 		ResourceID:       secondCapacity,
 		AvailabilityZone: "test",
@@ -193,14 +170,14 @@ func TestServiceInfoCache(t *testing.T) {
 	})
 	<-s.Cluster.SIC.OnInvalidate
 	sis = s.Cluster.SIC.GetSnapshot()
-	assert.Equal(t, len(must.BeOKT(sis.GetAZResourcesForPath(db.ResourcePath{ServiceType: "second", ResourceName: "capacity"}))(t)), 6)
+	assert.Equal(t, sis.GetAZResourcesForPath(db.ResourcePath{ServiceType: "second", ResourceName: "capacity"}).Len(), 6)
 
 	// check rate deletion
-	assert.Equal(t, len(must.BeOKT(sis.GetRatesForType("first"))(t)), 4)
+	assert.Equal(t, sis.GetRatesForType("first").Len(), 4)
 	s.MustDBExec("DELETE FROM rates WHERE id = $1", firstObjectsCreate)
 	<-s.Cluster.SIC.OnInvalidate
 	sis = s.Cluster.SIC.GetSnapshot()
-	assert.Equal(t, len(must.BeOKT(sis.GetRatesForType("first"))(t)), 3)
+	assert.Equal(t, sis.GetRatesForType("first").Len(), 3)
 }
 
 func TestServiceInfoCacheGetByID(t *testing.T) {

--- a/internal/core/service_info_cache_test.go
+++ b/internal/core/service_info_cache_test.go
@@ -180,6 +180,58 @@ func TestServiceInfoCache(t *testing.T) {
 	assert.Equal(t, sis.GetRatesForType("first").Len(), 3)
 }
 
+func TestServiceInfoCacheEmptyServiceInvalidation(t *testing.T) {
+	// Check that an empty list of resources, rates etc. does not
+	// break the cache invalidation.
+	emptyServiceInfo := liquid.ServiceInfo{
+		Version:     1,
+		DisplayName: "Empty",
+		Resources:   map[liquid.ResourceName]liquid.ResourceInfo{},
+		Rates:       map[liquid.RateName]liquid.RateInfo{},
+		Categories:  map[liquid.CategoryName]liquid.CategoryInfo{},
+	}
+	s := test.NewSetup(t,
+		test.WithConfig(configJSON),
+		test.WithPersistedServiceInfo("first", emptyServiceInfo),
+		test.WithPersistedServiceInfo("second", test.DefaultLiquidServiceInfo("Second")),
+	)
+	first := s.GetServiceID("first")
+	// by calling connect with a DB-URL, we register the service info listeners
+	s.Cluster.Connect(s.Ctx, nil, gophercloud.EndpointOpts{}, func(serviceType db.ServiceType) (core.LiquidClient, error) { return nil, nil }, Some(s.DBConnectionTarget))
+	t.Cleanup(func() { s.Cluster.SIC.Close() })
+
+	sis := s.Cluster.SIC.GetSnapshot()
+	assert.Equal(t, sis.GetServices().Len(), 2)
+	// "first" has nothing, "second" the usual entries
+	assert.Equal(t, sis.GetResourcesForType("first").Len(), 0)
+	assert.Equal(t, sis.GetRatesForType("first").Len(), 0)
+	assert.Equal(t, sis.GetCategoriesForType("first").Len(), 0)
+	assert.Equal(t, sis.GetResourcesForType("second").Len(), 2)
+	// verify no wrong empty-string service type leaked in
+	_, ok := sis.GetServiceForType("")
+	assert.Equal(t, ok, false)
+
+	// Trigger a pg-notify invalidation for "first" only. This calls
+	// InvalidateService(Some("first")), where all four queries (resources,
+	// az_resources, rates, categories) return zero rows for "first". Before the
+	// fix, the unguarded post-loop flush would write a "" key into the maps.
+	s.MustDBExec("UPDATE services SET display_name = 'EmptyChanged' WHERE id = $1", first)
+	<-s.Cluster.SIC.OnInvalidate
+	sis = s.Cluster.SIC.GetSnapshot()
+
+	assert.Equal(t, sis.GetServices().Len(), 2)
+	// verify the update was applied
+	assert.Equal(t, must.BeOKT(sis.GetServiceForType("first"))(t).DisplayName, "EmptyChanged")
+	// everything else should still be the same
+	assert.Equal(t, sis.GetResourcesForType("first").Len(), 0)
+	assert.Equal(t, sis.GetRatesForType("first").Len(), 0)
+	assert.Equal(t, sis.GetCategoriesForType("first").Len(), 0)
+	assert.Equal(t, sis.GetResourcesForType("second").Len(), 2)
+	// verify no wrong empty-string service type exists after invalidation
+	_, ok = sis.GetServiceForType("")
+	assert.Equal(t, ok, false)
+}
+
 func TestServiceInfoCacheGetByID(t *testing.T) {
 	serviceInfoFirst := test.DefaultLiquidServiceInfo("First")
 	serviceInfoFirst.Rates = map[liquid.RateName]liquid.RateInfo{

--- a/internal/datamodel/project_resource_update.go
+++ b/internal/datamodel/project_resource_update.go
@@ -6,7 +6,6 @@ package datamodel
 import (
 	"context"
 	"fmt"
-	"maps"
 	"reflect"
 	"slices"
 
@@ -31,7 +30,7 @@ type ProjectResourceUpdate struct {
 //     caller to update resource data as necessary.
 func (u ProjectResourceUpdate) Run(ctx context.Context, dbi db.Interface, project db.Project, sis core.ServiceInfoSnapshot, serviceType db.ServiceType) error {
 	service := must.BeOK(sis.GetServiceForType(serviceType)) // should have been checked to exist before, else no update makes sense
-	resources, _ := sis.GetResourcesForType(service.Type)
+	resources := sis.GetResourcesForType(service.Type)
 	// We will first collect all existing data into one of these structs for each
 	// resource. Then we will compute the target state of the DB record. We only
 	// need to write into the DB if `.Target` ends up different from `.Original`.
@@ -40,11 +39,9 @@ func (u ProjectResourceUpdate) Run(ctx context.Context, dbi db.Interface, projec
 		CorrespondingResource *db.Resource
 	}
 
-	resourcesByID := db.ResourceByIDIndex.Index(slices.Collect(maps.Values(resources)))
-	allResourceNames := slices.Sorted(maps.Keys(resources))
 	// collect allResources instances for this service
 	allResources := make(map[liquid.ResourceName]resourceState)
-	for resName, res := range resources {
+	for resName, res := range resources.All() {
 		allResources[resName] = resourceState{
 			Original:              nil, // might be filled in the next loop below
 			CorrespondingResource: &res,
@@ -54,7 +51,12 @@ func (u ProjectResourceUpdate) Run(ctx context.Context, dbi db.Interface, projec
 	// collect existing project_resources for this service
 	const getResourcesQuery = `SELECT pr.* FROM project_resources pr JOIN resources r ON pr.resource_id = r.id WHERE r.service_id = $1 AND pr.project_id = $2`
 	err := db.ProjectResourceStore.Select(ctx, dbi, getResourcesQuery, service.ID, project.ID).Foreach(func(res db.ProjectResource) error {
-		correspondingResource := resourcesByID[res.ResourceID]
+		correspondingResource, ok := sis.GetResourceForID(res.ResourceID)
+		if !ok {
+			// race condition: selected projectResource while the resource got deleted
+			// other projectResources/ resources might still exist, so we don't abort!
+			return nil
+		}
 		allResources[correspondingResource.Name] = resourceState{
 			Original:              &res,
 			CorrespondingResource: &correspondingResource,
@@ -66,7 +68,7 @@ func (u ProjectResourceUpdate) Run(ctx context.Context, dbi db.Interface, projec
 	}
 
 	// go through resources in a defined order (to ensure deterministic test behavior)
-	for _, resName := range allResourceNames {
+	for _, resName := range slices.Sorted(resources.Keys()) {
 		state := allResources[resName]
 
 		// setup a copy of `state.Original` (or a new resource) that we can write into

--- a/internal/reports/filter.go
+++ b/internal/reports/filter.go
@@ -35,7 +35,7 @@ type Filter struct {
 
 // ReadFilter extracts a Filter from the given Request.
 func ReadFilter(r *http.Request, cluster *core.Cluster, sis core.ServiceInfoSnapshot) Filter {
-	resources := sis.GetResources()
+	services := sis.GetServices()
 	queryValues := r.URL.Query()
 	apiServiceTypes := apiFilter(queryValues["service"])
 	apiResourceNames := apiFilter(queryValues["resource"])
@@ -43,7 +43,7 @@ func ReadFilter(r *http.Request, cluster *core.Cluster, sis core.ServiceInfoSnap
 	_, withDetail := queryValues["detail"]
 
 	f := Filter{
-		Includes:               make(map[db.ServiceType]map[liquid.ResourceName]bool, len(resources)),
+		Includes:               make(map[db.ServiceType]map[liquid.ResourceName]bool, services.Len()),
 		ServiceTypeIsFiltered:  (len(apiServiceTypes) + len(apiAreas)) > 0,
 		ResourceNameIsFiltered: len(apiResourceNames) > 0,
 		WithSubresources:       withDetail,
@@ -51,13 +51,14 @@ func ReadFilter(r *http.Request, cluster *core.Cluster, sis core.ServiceInfoSnap
 		WithAZBreakdown:        strings.Contains(r.Header.Get("X-Limes-V2-API-Preview"), "per-az"),
 	}
 
-	for _, dbServiceType := range slices.Sorted(maps.Keys(resources)) {
+	for _, dbServiceType := range slices.Sorted(services.Keys()) {
 		srvCfg, _ := cluster.Config.GetLiquidConfigurationForType(dbServiceType)
 		if !apiAreas.matches(srvCfg.Area) {
 			continue
 		}
 
-		for dbResourceName := range resources[dbServiceType] {
+		resByName := sis.GetResourcesForType(dbServiceType)
+		for dbResourceName := range resByName.Keys() {
 			apiIdentity := cluster.BehaviorForResource(dbServiceType, dbResourceName).IdentityInV1API
 
 			if !apiServiceTypes.matches(string(apiIdentity.ServiceType)) {

--- a/internal/util/constmap.go
+++ b/internal/util/constmap.go
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import "iter"
+
+// ConstMap is a read-only wrapper around a Go map. It only exposes read operations
+// (Get, GetOrZero, All, Keys, Len). Since the value type V is typically a
+// non-pointer struct, Get() returns a copy of the value, making it safe
+// for callers to modify the returned value without affecting the original.
+//
+// This is useful when sharing map data between goroutines without deep cloning:
+// callers can read but not modify the shared maps.
+type ConstMap[K comparable, V any] struct {
+	m map[K]V
+}
+
+// NewConstMap wraps an existing map into a read-only ConstMap. The caller must
+// not retain or modify the passed-in map after calling NewConstMap. This does
+// not do a deep clone.
+func NewConstMap[K comparable, V any](m map[K]V) ConstMap[K, V] {
+	return ConstMap[K, V]{m: m}
+}
+
+// New2LevelConstMap is like NewConstMap, but with V as ConstMap.
+func New2LevelConstMap[K1, K2 comparable, V any](m map[K1]map[K2]V) ConstMap[K1, ConstMap[K2, V]] {
+	wrapped := make(map[K1]ConstMap[K2, V], len(m))
+	for k, inner := range m {
+		wrapped[k] = NewConstMap(inner)
+	}
+	return NewConstMap(wrapped)
+}
+
+// New3LevelConstMap is like NewConstMap, but with V as ConstMap of ConstMap.
+func New3LevelConstMap[K1, K2, K3 comparable, V any](m map[K1]map[K2]map[K3]V) ConstMap[K1, ConstMap[K2, ConstMap[K3, V]]] {
+	wrapped := make(map[K1]ConstMap[K2, ConstMap[K3, V]], len(m))
+	for k, inner := range m {
+		wrapped[k] = New2LevelConstMap(inner)
+	}
+	return NewConstMap(wrapped)
+}
+
+// Get returns the value for the given key and whether the key was found.
+func (m ConstMap[K, V]) Get(key K) (V, bool) {
+	v, ok := m.m[key]
+	return v, ok
+}
+
+// GetOrZero returns the value for the given key, or the zero value of V if
+// the key is not present.
+func (m ConstMap[K, V]) GetOrZero(key K) V {
+	return m.m[key]
+}
+
+// All returns an iterator over all key-value pairs. Iteration order is not
+// guaranteed (same as Go's built-in map iteration).
+func (m ConstMap[K, V]) All() iter.Seq2[K, V] {
+	return func(yield func(K, V) bool) {
+		for k, v := range m.m {
+			if !yield(k, v) {
+				return
+			}
+		}
+	}
+}
+
+// Keys returns an iterator over all keys. Iteration order is not guaranteed.
+func (m ConstMap[K, V]) Keys() iter.Seq[K] {
+	return func(yield func(K) bool) {
+		for k := range m.m {
+			if !yield(k) {
+				return
+			}
+		}
+	}
+}
+
+// Values returns an iterator over all values. Iteration order is not guaranteed
+func (m ConstMap[K, V]) Values() iter.Seq[V] {
+	return func(yield func(V) bool) {
+		for _, v := range m.m {
+			if !yield(v) {
+				return
+			}
+		}
+	}
+}
+
+// Len returns the number of entries in the map.
+func (m ConstMap[K, V]) Len() int {
+	return len(m.m)
+}

--- a/internal/util/constmap.go
+++ b/internal/util/constmap.go
@@ -6,7 +6,7 @@ package util
 import "iter"
 
 // ConstMap is a read-only wrapper around a Go map. It only exposes read operations
-// (Get, GetOrZero, All, Keys, Len). Since the value type V is typically a
+// (Get, GetOrZero, All, Keys, Values, Len). Since the value type V is typically a
 // non-pointer struct, Get() returns a copy of the value, making it safe
 // for callers to modify the returned value without affecting the original.
 //

--- a/internal/util/constmap_test.go
+++ b/internal/util/constmap_test.go
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"maps"
+	"slices"
+	"testing"
+
+	"go.xyrillian.de/gg/assert"
+)
+
+func TestConstMapGet(t *testing.T) {
+	m := NewConstMap(map[string]int{"a": 1, "b": 2})
+
+	v, ok := m.Get("a")
+	assert.Equal(t, ok, true)
+	assert.Equal(t, v, 1)
+
+	v, ok = m.Get("missing")
+	assert.Equal(t, ok, false)
+	assert.Equal(t, v, 0)
+}
+
+func TestConstMapGetOrZero(t *testing.T) {
+	m := NewConstMap(map[string]int{"a": 1})
+
+	assert.Equal(t, m.GetOrZero("a"), 1)
+	assert.Equal(t, m.GetOrZero("missing"), 0)
+}
+
+func TestConstMapAll(t *testing.T) {
+	m := NewConstMap(map[string]int{"a": 1, "b": 2, "c": 3})
+
+	seen := maps.Collect(m.All())
+
+	assert.Equal(t, len(seen), 3)
+	assert.Equal(t, seen["a"], 1)
+	assert.Equal(t, seen["b"], 2)
+	assert.Equal(t, seen["c"], 3)
+}
+
+func TestConstMapKeys(t *testing.T) {
+	m := NewConstMap(map[string]int{"b": 2, "a": 1, "c": 3})
+
+	keys := slices.Sorted(m.Keys())
+	expected := []string{"a", "b", "c"}
+	assert.Equal(t, keys, expected)
+}
+
+func TestConstMapValues(t *testing.T) {
+	m := NewConstMap(map[string]int{"b": 2, "a": 1, "c": 3})
+	values := slices.Sorted(m.Values())
+	expected := []int{1, 2, 3}
+	assert.Equal(t, values, expected)
+}
+
+func TestConstMapLen(t *testing.T) {
+	m := NewConstMap(map[string]int{"a": 1, "b": 2})
+	assert.Equal(t, m.Len(), 2)
+
+	empty := NewConstMap(map[string]int{})
+	assert.Equal(t, empty.Len(), 0)
+}
+
+func TestConstMapNil(t *testing.T) {
+	m := NewConstMap[string, int](nil)
+	assert.Equal(t, m.Len(), 0)
+	assert.Equal(t, m.GetOrZero("a"), 0)
+	_, ok := m.Get("a")
+	assert.Equal(t, ok, false)
+
+	count := 0
+	for range m.All() {
+		count++
+	}
+	assert.Equal(t, count, 0)
+}
+
+func TestConstMapValueCopySemantics(t *testing.T) {
+	type val struct{ X int }
+	m := NewConstMap(map[string]val{"a": {X: 1}})
+
+	v, _ := m.Get("a")
+	v.X = 999 //nolint:govet // unused write on purpose for testing
+
+	// Original must be unchanged
+	orig, _ := m.Get("a")
+	assert.Equal(t, orig.X, 1)
+}

--- a/internal/util/constmap_test.go
+++ b/internal/util/constmap_test.go
@@ -33,12 +33,7 @@ func TestConstMapGetOrZero(t *testing.T) {
 func TestConstMapAll(t *testing.T) {
 	m := NewConstMap(map[string]int{"a": 1, "b": 2, "c": 3})
 
-	seen := maps.Collect(m.All())
-
-	assert.Equal(t, len(seen), 3)
-	assert.Equal(t, seen["a"], 1)
-	assert.Equal(t, seen["b"], 2)
-	assert.Equal(t, seen["c"], 3)
+	assert.Equal(t, maps.Collect(m.All()), map[string]int{"a": 1, "b": 2, "c": 3})
 }
 
 func TestConstMapKeys(t *testing.T) {


### PR DESCRIPTION
includes the following improvements, too:
* some missing defense-in-depth checks for race conditions where we select in project-entities and try to find the referenced service-info entity
* remove multi-level-return methods from ServiceInfoReader interface, because subsequent calls are cheap now without clones and therefore we can just chain the calls. E.g. getResources()=getServices()+getResourcesForType()
* remove unnecessary "ok" bools from signature of constMap-returning entries of ServiceInfoReader interface, because most of the time we just iterate the result, and the ok variable can be easily replaced. E.g. ok=getResourcesForType().Len()==0