### PR TITLE
implement complex commitment conversions

### DIFF
--- a/docs/operators/config.md
+++ b/docs/operators/config.md
@@ -266,8 +266,10 @@ Commitment behavior configuration is optional. If none is provided, commitments 
 | `commitment_behavior_per_resource[].value.durations_per_domain` | [ConfigSet](#configset) keyed on domain name | Commitments for matching resources can be created with any of the matching durations. Each value in this ConfigSet must be a list of duration strings in the same format as in the `commitments[].duration` attribute that appears on the resource API. If no value matches in this set, or if the matching value is explicitly an empty list, commitments may not be created in the matching resource and domain. |
 | `commitment_behavior_per_resource[].min_confirm_date` | timestamp in RFC 3339 format | If given, commitments for this resource will always be created with `confirm_by` no earlier than this timestamp. This can be used to plan the introduction of commitments on a specific date. Ignored if `commitment_durations` is empty. |
 | `commitment_behavior_per_resource[].until_percent` | float | If given, commitments for this resource will only be confirmed while the total of all confirmed commitments or uncommitted usage in the respective AZ is smaller than the respective percentage of the total capacity for that AZ. This is intended to provide a reserved buffer for the growth quota configured by `quota_distribution_configs[].autogrow.growth_multiplier`. Defaults to 100, i.e. all capacity is committable. |
-| `commitment_behavior_per_resource[].conversion_rule.identifier` | no | If given, must contain a string. Commitments for this resource will then be allowed to be converted into commitments for all resources that set the same conversion identifier. |
-| `commitment_behavior_per_resource[].conversion_rule.weight` | no | If given, must contain an integer. When converting commitments for this resource into another compatible resource, the ratio of the weights of both resources gives the conversion rate for the commitment amount. (Or put another way, the product of commitment amount and conversion weight must remain the same before and after the conversion.) For example, if resource `foo` has a weight of 2 and `bar` has a weight of 5, the conversion rate is 2:5, meaning that a commitment for 25 units of `foo` would be converted into a commitment for 10 units of `bar`. |
+| `commitment_behavior_per_resource[].conversion_rules` | `map[identifier]ConversionRule` (see below) | List of conversion rules that this resource can participate in. Conversions are possible between multiple conversion rules with the same `identifier`. |
+| `commitment_behavior_per_resource[].conversion_rules[].weight` | [complex unit](#complexunit) | When converting commitments for this resource into another compatible resource, the ratio of the weights of both resources multiplied with the resources unit (being a [complex unit](#complexunit), too) gives the conversion rate for the commitment amount. (Or put another way, the product of commitment amount, conversion weight and resource unit must remain the same before and after the conversion.) For example, if resource `foo` has a weight of 2, unit of `piece`, and `bar` has a weight of 5, unit of `piece`, the conversion rate is 2:5, meaning that a commitment for 25 `piece` of `foo` would be converted into a commitment for 10 `piece` of `bar`. Conversions with a weight other than `piece` only make sense, when the resource itself has unit `piece` and the conversion partner has a unit other than `piece`. For example, if resource `flavor_m480` has a weight of 480 `GiB`, unit of `piece`, and `ram` has a weight of 1 (`piece`), unit of 60 `GiB`, the conversion rate is 1:8, meaning that a commitment for 25 `piece` of `flavor_m480` would be converted into a commitment of 200 * `60 GiB` of `ram`.|
+| `commitment_behavior_per_resource[].conversion_rules[].only_source` | boolean | If set to `true`, this resource can only be a source of a conversion, but not a target. |
+| `commitment_behavior_per_resource[].conversion_rules[].allow_rounding` | boolean | If set to `true`, this rule as target of a conversion may round the resulting commitment amount down to the next integer. This is useful for conversions that would otherwise result in fractional commitments, which is not allowed and not possible to enter in the database. This does not allow cases, where the next lower integer is 0, meaning a commitment would vanish. |
 
 #### Capacity from liquid
 
@@ -362,7 +364,7 @@ For example, the following configuration can be used with [swift-health-exporter
 [prom]:   https://prometheus.io
 [she]:    https://github.com/sapcc/swift-health-exporter
 
-#### ConfigSet
+#### `ConfigSet`
 
 Every field that is documented to be "a ConfigSet keyed on some string identifier" is structured as a list of key and value pairs, like so:
 
@@ -385,6 +387,12 @@ The resource `foobar` would match the value of 23, because the first rule matche
 The value 42 would not be used, even though the second rule matches, because the first matching rule takes priority.
 The resource `unknown` would not match any value, because no rule matches.
 If you want to have a fallback value that matches if nothing else does, put a rule at the end of the list with the key `.*`.
+
+#### `complex unit`
+
+In Limes, a unit cannot only be `piece`, or multiples of `B` but also consist of a value with unit, e.g.:
+* `1 piece`
+* `480 GiB`
 
 ### Resource behavior
 

--- a/internal/api/commitment.go
+++ b/internal/api/commitment.go
@@ -1774,19 +1774,16 @@ func (p *v1Provider) GetCommitmentConversions(w http.ResponseWriter, r *http.Req
 
 	// enumerate possible conversions
 	conversions := make([]limesresources.CommitmentConversionRule, 0)
-	if sourceBehavior.ConversionRule.IsSome() {
+	if len(sourceBehavior.ConversionRules) > 0 {
 		for _, targetServiceType := range slices.Sorted(maps.Keys(sis.GetResources())) {
 			resources, _ := sis.GetResourcesForType(targetServiceType) // can have no resources
 			for targetResourceName, targetResource := range resources {
 				if sourceServiceType == targetServiceType && sourceResourceName == targetResourceName {
 					continue
 				}
-				if sourceResource.Unit != targetResource.Unit {
-					continue
-				}
 
 				targetBehavior := forTokenScope(p.Cluster.CommitmentBehaviorForResource(targetServiceType, targetResourceName))
-				if rate, ok := sourceBehavior.GetConversionRateTo(targetBehavior).Unpack(); ok {
+				if rate, ok := sourceBehavior.GetConversionRateTo(targetBehavior, sourceResource.Unit, targetResource.Unit).Unpack(); ok {
 					apiServiceType, apiResourceName, ok := nm.MapToV1API(targetServiceType, targetResourceName)
 					if ok {
 						conversions = append(conversions, limesresources.CommitmentConversionRule{
@@ -1859,8 +1856,9 @@ func (p *v1Provider) ConvertCommitment(w http.ResponseWriter, r *http.Request) {
 	sourceBehavior := p.Cluster.CommitmentBehaviorForResourcePath(sourcePath.Resource()).ForDomain(dbDomain.Name)
 
 	sis := p.Cluster.SIC.GetSnapshot()
-	sourceService, sExists := sis.GetServiceForType(sourcePath.ServiceType)
-	if !sExists {
+	sourceService, _ := sis.GetServiceForType(sourcePath.ServiceType)
+	sourceResource, rExists := sis.GetResourceForPath(sourcePath.Resource())
+	if !rExists {
 		http.Error(w, "service or resource not found", http.StatusNotFound)
 		return
 	}
@@ -1890,7 +1888,12 @@ func (p *v1Provider) ConvertCommitment(w http.ResponseWriter, r *http.Request) {
 		ResourceName:     targetResourceName,
 		AvailabilityZone: sourcePath.AvailabilityZone,
 	}
-	targetBehavior := p.Cluster.CommitmentBehaviorForResourcePath(targetPath.Resource()).ForDomain(dbDomain.Name)
+	targetResource, rExists := sis.GetResourceForPath(targetPath.Resource())
+	if !rExists {
+		http.Error(w, "service or resource not found", http.StatusNotFound)
+		return
+	}
+	targetBehavior := p.Cluster.CommitmentBehaviorForResourcePath(targetResource.Path).ForDomain(dbDomain.Name)
 	if sourcePath.ResourceName == targetResourceName && sourcePath.ServiceType == targetServiceType {
 		http.Error(w, "conversion attempt to the same resource.", http.StatusConflict)
 		return
@@ -1900,7 +1903,7 @@ func (p *v1Provider) ConvertCommitment(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, msg, http.StatusUnprocessableEntity)
 		return
 	}
-	rate, ok := sourceBehavior.GetConversionRateTo(targetBehavior).Unpack()
+	rate, ok := sourceBehavior.GetConversionRateTo(targetBehavior, sourceResource.Unit, targetResource.Unit).Unpack()
 	if !ok {
 		msg := fmt.Sprintf("commitment is not convertible into resource %s/%s", req.TargetService, req.TargetResource)
 		http.Error(w, msg, http.StatusUnprocessableEntity)
@@ -1913,11 +1916,15 @@ func (p *v1Provider) ConvertCommitment(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, msg, http.StatusConflict)
 		return
 	}
-	conversionAmount := (req.SourceAmount / rate.FromAmount) * rate.ToAmount
 	remainderAmount := req.SourceAmount % rate.FromAmount
-	if remainderAmount > 0 {
+	if remainderAmount > 0 && !rate.AllowRounding {
 		msg := fmt.Sprintf("amount: %v does not fit into conversion rate of: %v", req.SourceAmount, rate.FromAmount)
 		http.Error(w, msg, http.StatusConflict)
+		return
+	}
+	conversionAmount := (req.SourceAmount * rate.ToAmount) / rate.FromAmount
+	if conversionAmount == 0 {
+		http.Error(w, "converted amount would be zero", http.StatusConflict)
 		return
 	}
 	if conversionAmount != req.TargetAmount {
@@ -2089,7 +2096,6 @@ func (p *v1Provider) ConvertCommitment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	targetResource := must.BeOK(sis.GetResourceForPath(targetPath.Resource()))
 	c := datamodel.ConvertCommitmentToDisplayForm(convertedCommitment, targetPath.AvailabilityZone, p.Cluster.BehaviorForResourcePath(targetPath.Resource()).IdentityInV1API, datamodel.CanDeleteCommitment(token, convertedCommitment, p.timeNow), targetResource.Unit)
 
 	auditEvents := audit.CommitmentEventTarget{

--- a/internal/api/commitment_test.go
+++ b/internal/api/commitment_test.go
@@ -59,7 +59,7 @@ var testCommitmentsJSONWithoutMinConfirmDate = testCommitmentsJSON.
 	Modify("del(.liquids.first.commitment_behavior_per_resource)").
 	Modify(`.liquids.second.commitment_behavior_per_resource[0].value.durations_per_domain[0].value += ["3 hours"]`).
 	Modify("del(.liquids.second.commitment_behavior_per_resource[0].value.min_confirm_date)")
-var testConvertCommitmentsJSON = httptest.NewJQModifiableJSONString(`
+var testConvertCommitmentsJSON = httptest.NewJQModifiableJSONString(test.RemoveCommentsFromJSON(`
 	{
 		"areas": { "third": { "display_name": "Third" }, "fourth": { "display_name": "Fourth" }},
 		"liquids": {
@@ -70,35 +70,49 @@ var testConvertCommitmentsJSON = httptest.NewJQModifiableJSONString(`
 						"key": "capacity_c32",
 						"value": {
 							"durations_per_domain": [{"key": ".*", "value": ["1 hour", "2 hours"]}],
-							"conversion_rule": {"identifier": "flavor1", "weight": 32}
+							"conversion_rules": {"flavor1": { "weight": "32 GiB", "only_source": true }}
 						}
 					},
 					{
 						"key": "capacity_c48",
 						"value": {
 							"durations_per_domain": [{"key": ".*", "value": ["1 hour", "2 hours"]}],
-							"conversion_rule": {"identifier": "flavor1", "weight": 48}
+							"conversion_rules": {"flavor1": { "weight": "48 GiB" }}
 						}
 					},
 					{
 						"key": "capacity_c96",
 						"value": {
 							"durations_per_domain": [{"key": ".*", "value": ["1 hour", "2 hours"]}],
-							"conversion_rule": {"identifier": "flavor1", "weight": 96}
+							"conversion_rules": {"flavor1": { "weight": "96 GiB" }}
 						}
 					},
 					{
 						"key": "capacity_c120",
 						"value": {
 							"durations_per_domain": [{"key": ".*", "value": ["1 hour", "2 hours"]}],
-							"conversion_rule": {"identifier": "flavor1", "weight": 120}
+							"conversion_rules": {"flavor1": { "weight": "120 piece" }}
 						}
 					},
 					{
 						"key": "capacity2_c144",
 						"value": {
 							"durations_per_domain": [{"key": ".*", "value": ["1 hour", "2 hours"]}],
-							"conversion_rule": {"identifier": "flavor2", "weight": 144}
+							"conversion_rules": {"flavor2": { "weight": "144 piece" }}
+						}
+					},
+					{
+						"key": "capacity_fits",
+						"value": {
+							"durations_per_domain": [{"key": ".*", "value": ["1 hour", "2 hours"]}],
+							"conversion_rules": {"flavor1": { "weight": "1 piece" }}
+						}
+					},
+					{
+						"key": "capacity_does_not_fit",
+						"value": {
+							"durations_per_domain": [{"key": ".*", "value": ["1 hour", "2 hours"]}],
+							"conversion_rules": {"flavor1": { "weight": "1 piece", "allow_rounding": true }}
 						}
 					},
 					{
@@ -116,14 +130,14 @@ var testConvertCommitmentsJSON = httptest.NewJQModifiableJSONString(`
 						"key": "capacity_a",
 						"value": {
 							"durations_per_domain": [{"key": ".*", "value": ["1 hour", "2 hours"]}],
-							"conversion_rule": {"identifier": "flavor3", "weight": 48}
+							"conversion_rules": {"flavor3": { "weight": "48 piece" }}
 						}
 					},
 					{
 						"key": "capacity_b",
 						"value": {
 							"durations_per_domain": [{"key": ".*", "value": ["1 hour", "2 hours"]}],
-							"conversion_rule": {"identifier": "flavor3", "weight": 32}
+							"conversion_rules": {"flavor3": { "weight": "32 piece" }}
 						}
 					},
 					{
@@ -135,7 +149,7 @@ var testConvertCommitmentsJSON = httptest.NewJQModifiableJSONString(`
 				]
 			}
 		}
-	}`, "testConvertCommitmentsJSON").
+	}`), "testConvertCommitmentsJSON").
 	ModifyWithVariable(".discovery = $ref", common_fixtures.DiscoveryBerlinDresdenParis).
 	ModifyWithVariable(".availability_zones = $ref", common_fixtures.AZsOneTwo)
 
@@ -148,7 +162,17 @@ func setupCommitmentTest(t *testing.T, configJSON string) test.Setup {
 	resInfoLikeThings := test.DefaultLiquidServiceInfo("").Resources["things"]
 	resInfoLikeThings.HandlesCommitments = true
 	resInfoConvertible := liquid.ResourceInfo{
-		Unit:               liquid.UnitBytes,
+		Unit:               liquid.UnitPiece,
+		Topology:           liquid.FlatTopology,
+		HandlesCommitments: true,
+	}
+	resInfoConvertibleFits := liquid.ResourceInfo{
+		Unit:               must.Return(liquid.UnitGibibytes.MultiplyBy(16)),
+		Topology:           liquid.FlatTopology,
+		HandlesCommitments: true,
+	}
+	resInfoConvertibleDoesNotFit := liquid.ResourceInfo{
+		Unit:               must.Return(liquid.UnitGibibytes.MultiplyBy(20)),
 		Topology:           liquid.FlatTopology,
 		HandlesCommitments: true,
 	}
@@ -175,11 +199,13 @@ func setupCommitmentTest(t *testing.T, configJSON string) test.Setup {
 		Version:     1,
 		DisplayName: "Third",
 		Resources: map[liquid.ResourceName]liquid.ResourceInfo{
-			"capacity_c32":   resInfoConvertible,
-			"capacity_c48":   resInfoConvertible,
-			"capacity_c96":   resInfoConvertible,
-			"capacity_c120":  resInfoLikeThings,
-			"capacity2_c144": resInfoLikeThings,
+			"capacity_c32":          resInfoConvertible,
+			"capacity_c48":          resInfoConvertible,
+			"capacity_c96":          resInfoConvertible,
+			"capacity_c120":         resInfoLikeThings,
+			"capacity2_c144":        resInfoLikeThings,
+			"capacity_fits":         resInfoConvertibleFits,
+			"capacity_does_not_fit": resInfoConvertibleDoesNotFit,
 		},
 	}
 	srvInfoFourth := liquid.ServiceInfo{
@@ -1996,19 +2022,32 @@ func TestTransferCommitmentForbiddenResource(t *testing.T) {
 func Test_GetCommitmentConversion(t *testing.T) {
 	s := setupCommitmentTest(t, string(must.Return(testConvertCommitmentsJSON.MarshalJSON())))
 
-	// capacity_c120 uses a different Unit than the source and is therefore ignored.
+	// c32 has only_source=true so it does not appear as a target.
+	// capacity_c120 uses "piece" weight but its resource unit is also "piece" (resInfoLikeThings),
+	// so it's a pure piece-to-piece conversion which only works between same-unit resources;
+	// however c48 has GiB weight with piece unit, so no match.
+	// capacity_fits (weight=1 piece, unit=16 GiB): 48 GiB fits 3 times into 16 GiB → from=1, to=3
+	// capacity_does_not_fit (weight=1 piece, unit=20 GiB): 48 GiB fits 2.4 times into 20 GiB → from=5, to=12
 	resp1 := []oldassert.JSONObject{
 		{
-			"from":            2,
-			"to":              3,
-			"target_service":  "third",
-			"target_resource": "capacity_c32",
-		}, {
 			"from":            2,
 			"to":              1,
 			"target_service":  "third",
 			"target_resource": "capacity_c96",
-		}}
+		},
+		{
+			"from":            5, // 48 GiB / 20 GiB = 2.4 → reduced to 5:12
+			"to":              12,
+			"target_service":  "third",
+			"target_resource": "capacity_does_not_fit",
+		},
+		{
+			"from":            1, // 48 GiB / 16 GiB = 3.0 → reduced to 1:3
+			"to":              3,
+			"target_service":  "third",
+			"target_resource": "capacity_fits",
+		},
+	}
 
 	resp2 := []oldassert.JSONObject{}
 
@@ -2301,6 +2340,101 @@ func Test_ConvertCommitments(t *testing.T) {
 		ExpectStatus: http.StatusAccepted,
 	}.Check(t, s.Handler)
 	assert.Equal(t, s.LiquidClients["fourth"].LastCommitmentChangeRequest, commitmentChangeRequest)
+
+	// test conversion from capacity_c48 (piece, weight=48 GiB) to capacity_fits (16 GiB, weight=1 piece)
+	// conversion rate: from=1, to=3  (1 piece × 48 GiB = 3 × 16 GiB)
+	oldassert.HTTPRequest{
+		Method: http.MethodPost,
+		Path:   "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/new",
+		Body: oldassert.JSONObject{
+			"commitment": oldassert.JSONObject{
+				"service_type":      "third",
+				"resource_name":     "capacity_c48",
+				"availability_zone": "any",
+				"amount":            10,
+				"duration":          "1 hour",
+			},
+		},
+		ExpectStatus: http.StatusCreated,
+	}.Check(t, s.Handler)
+
+	oldassert.HTTPRequest{
+		Method:       http.MethodPost,
+		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/6/convert",
+		Body:         req("third", "capacity_fits", 3, 9),
+		ExpectStatus: http.StatusAccepted,
+	}.Check(t, s.Handler)
+
+	// check remaining amount and new commitment
+	commitmentToCheck = must.ReturnT(db.ProjectCommitmentStore.SelectOneWhere(s.Ctx, s.DB, `id = 7`))(t)
+	assert.Equal(t, commitmentToCheck.Amount, uint64(7)) // 10 - 3 = 7 remainder
+	convertedCommitment := must.ReturnT(db.ProjectCommitmentStore.SelectOneWhere(s.Ctx, s.DB, `id = 8`))(t)
+	assert.Equal(t, convertedCommitment.Amount, uint64(9)) // 3 * 3 = 9
+
+	// test conversion from capacity_c48 to capacity_does_not_fit with rounding (20 GiB, weight=1 piece, allow_rounding=true)
+	// conversion rate: from=5, to=12  (5 piece × 48 GiB = 240 GiB = 12 × 20 GiB)
+	// with sourceAmount=3: (3 * 12) / 5 = 36 / 5 = 7 (rounded down from 7.2)
+	oldassert.HTTPRequest{
+		Method:       http.MethodPost,
+		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/7/convert",
+		Body:         req("third", "capacity_does_not_fit", 3, 7),
+		ExpectStatus: http.StatusAccepted,
+	}.Check(t, s.Handler)
+
+	convertedCommitment = must.ReturnT(db.ProjectCommitmentStore.SelectOneWhere(s.Ctx, s.DB, `id = 10`))(t)
+	assert.Equal(t, convertedCommitment.Amount, uint64(7))
+
+	// test that non-fitting conversions are rejected when target has allow_rounding=false
+	// We convert capacity_does_not_fit → capacity_fits (target has allow_rounding=false)
+	// rate = from=4, to=5 (20 GiB source : 16 GiB target)
+	oldassert.HTTPRequest{
+		Method: http.MethodPost,
+		Path:   "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/new",
+		Body: oldassert.JSONObject{
+			"commitment": oldassert.JSONObject{
+				"service_type":      "third",
+				"resource_name":     "capacity_does_not_fit",
+				"availability_zone": "any",
+				"amount":            10,
+				"duration":          "1 hour",
+			},
+		},
+		ExpectStatus: http.StatusCreated,
+	}.Check(t, s.Handler)
+	// commitment 11 = capacity_does_not_fit, amount 10
+	oldassert.HTTPRequest{
+		Method:       http.MethodPost,
+		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/11/convert",
+		Body:         req("third", "capacity_fits", 3, 3),
+		ExpectBody:   oldassert.StringData("amount: 3 does not fit into conversion rate of: 4\n"),
+		ExpectStatus: http.StatusConflict,
+	}.Check(t, s.Handler)
+
+	// test that rounding to 0 is rejected even with allow_rounding=true
+	// capacity_fits → capacity_does_not_fit: rate = from=5, to=4, allow_rounding=true on target
+	// sourceAmount=1: (1 * 4) / 5 = 0 → rejected
+	oldassert.HTTPRequest{
+		Method: http.MethodPost,
+		Path:   "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/new",
+		Body: oldassert.JSONObject{
+			"commitment": oldassert.JSONObject{
+				"service_type":      "third",
+				"resource_name":     "capacity_fits",
+				"availability_zone": "any",
+				"amount":            10,
+				"duration":          "1 hour",
+			},
+		},
+		ExpectStatus: http.StatusCreated,
+	}.Check(t, s.Handler)
+	// commitment 12 = capacity_fits, amount 10
+	oldassert.HTTPRequest{
+		Method:       http.MethodPost,
+		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/12/convert",
+		Body:         req("third", "capacity_does_not_fit", 1, 0),
+		ExpectBody:   oldassert.StringData("converted amount would be zero\n"),
+		ExpectStatus: http.StatusConflict,
+	}.Check(t, s.Handler)
 }
 
 func Test_UpdateCommitmentDuration(t *testing.T) {

--- a/internal/api/commitment_test.go
+++ b/internal/api/commitment_test.go
@@ -4,6 +4,7 @@
 package api_test
 
 import (
+	"database/sql"
 	"encoding/json"
 	"maps"
 	"net/http"
@@ -59,7 +60,7 @@ var testCommitmentsJSONWithoutMinConfirmDate = testCommitmentsJSON.
 	Modify("del(.liquids.first.commitment_behavior_per_resource)").
 	Modify(`.liquids.second.commitment_behavior_per_resource[0].value.durations_per_domain[0].value += ["3 hours"]`).
 	Modify("del(.liquids.second.commitment_behavior_per_resource[0].value.min_confirm_date)")
-var testConvertCommitmentsJSON = httptest.NewJQModifiableJSONString(test.RemoveCommentsFromJSON(`
+var testConvertCommitmentsJSON = httptest.NewJQModifiableJSONString(`
 	{
 		"areas": { "third": { "display_name": "Third" }, "fourth": { "display_name": "Fourth" }},
 		"liquids": {
@@ -149,7 +150,7 @@ var testConvertCommitmentsJSON = httptest.NewJQModifiableJSONString(test.RemoveC
 				]
 			}
 		}
-	}`), "testConvertCommitmentsJSON").
+	}`, "testConvertCommitmentsJSON").
 	ModifyWithVariable(".discovery = $ref", common_fixtures.DiscoveryBerlinDresdenParis).
 	ModifyWithVariable(".availability_zones = $ref", common_fixtures.AZsOneTwo)
 
@@ -167,12 +168,12 @@ func setupCommitmentTest(t *testing.T, configJSON string) test.Setup {
 		HandlesCommitments: true,
 	}
 	resInfoConvertibleFits := liquid.ResourceInfo{
-		Unit:               must.Return(liquid.UnitGibibytes.MultiplyBy(16)),
+		Unit:               must.Return(liquid.UnitGibibytes.MultiplyBy(36)),
 		Topology:           liquid.FlatTopology,
 		HandlesCommitments: true,
 	}
 	resInfoConvertibleDoesNotFit := liquid.ResourceInfo{
-		Unit:               must.Return(liquid.UnitGibibytes.MultiplyBy(20)),
+		Unit:               must.Return(liquid.UnitGibibytes.MultiplyBy(80)),
 		Topology:           liquid.FlatTopology,
 		HandlesCommitments: true,
 	}
@@ -2026,8 +2027,8 @@ func Test_GetCommitmentConversion(t *testing.T) {
 	// capacity_c120 uses "piece" weight but its resource unit is also "piece" (resInfoLikeThings),
 	// so it's a pure piece-to-piece conversion which only works between same-unit resources;
 	// however c48 has GiB weight with piece unit, so no match.
-	// capacity_fits (weight=1 piece, unit=16 GiB): 48 GiB fits 3 times into 16 GiB → from=1, to=3
-	// capacity_does_not_fit (weight=1 piece, unit=20 GiB): 48 GiB fits 2.4 times into 20 GiB → from=5, to=12
+	// capacity_fits (weight=1 piece, unit=36 GiB): 48 GiB / 36 GiB = 4/3 → from=3, to=4
+	// capacity_does_not_fit (weight=1 piece, unit=80 GiB): 48 GiB / 80 GiB = 3/5 → from=5, to=3
 	resp1 := []oldassert.JSONObject{
 		{
 			"from":            2,
@@ -2036,14 +2037,14 @@ func Test_GetCommitmentConversion(t *testing.T) {
 			"target_resource": "capacity_c96",
 		},
 		{
-			"from":            5, // 48 GiB / 20 GiB = 2.4 → reduced to 5:12
-			"to":              12,
+			"from":            5, // 48 GiB / 80 GiB = 3/5 → reduced to 5:3
+			"to":              3,
 			"target_service":  "third",
 			"target_resource": "capacity_does_not_fit",
 		},
 		{
-			"from":            1, // 48 GiB / 16 GiB = 3.0 → reduced to 1:3
-			"to":              3,
+			"from":            3, // 48 GiB / 36 GiB = 4/3 → reduced to 3:4
+			"to":              4,
 			"target_service":  "third",
 			"target_resource": "capacity_fits",
 		},
@@ -2341,8 +2342,8 @@ func Test_ConvertCommitments(t *testing.T) {
 	}.Check(t, s.Handler)
 	assert.Equal(t, s.LiquidClients["fourth"].LastCommitmentChangeRequest, commitmentChangeRequest)
 
-	// test conversion from capacity_c48 (piece, weight=48 GiB) to capacity_fits (16 GiB, weight=1 piece)
-	// conversion rate: from=1, to=3  (1 piece × 48 GiB = 3 × 16 GiB)
+	// test conversion from capacity_c48 (piece, weight=48 GiB) to capacity_fits (36 GiB, weight=1 piece)
+	// conversion rate: from=3, to=4  (3 piece × 48 GiB = 144 GiB = 4 × 36 GiB)
 	oldassert.HTTPRequest{
 		Method: http.MethodPost,
 		Path:   "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/new",
@@ -2361,7 +2362,7 @@ func Test_ConvertCommitments(t *testing.T) {
 	oldassert.HTTPRequest{
 		Method:       http.MethodPost,
 		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/6/convert",
-		Body:         req("third", "capacity_fits", 3, 9),
+		Body:         req("third", "capacity_fits", 3, 4),
 		ExpectStatus: http.StatusAccepted,
 	}.Check(t, s.Handler)
 
@@ -2369,24 +2370,28 @@ func Test_ConvertCommitments(t *testing.T) {
 	commitmentToCheck = must.ReturnT(db.ProjectCommitmentStore.SelectOneWhere(s.Ctx, s.DB, `id = 7`))(t)
 	assert.Equal(t, commitmentToCheck.Amount, uint64(7)) // 10 - 3 = 7 remainder
 	convertedCommitment := must.ReturnT(db.ProjectCommitmentStore.SelectOneWhere(s.Ctx, s.DB, `id = 8`))(t)
-	assert.Equal(t, convertedCommitment.Amount, uint64(9)) // 3 * 3 = 9
+	assert.Equal(t, convertedCommitment.Amount, uint64(4)) // 3 * 4 / 3 = 4
 
-	// test conversion from capacity_c48 to capacity_does_not_fit with rounding (20 GiB, weight=1 piece, allow_rounding=true)
-	// conversion rate: from=5, to=12  (5 piece × 48 GiB = 240 GiB = 12 × 20 GiB)
-	// with sourceAmount=3: (3 * 12) / 5 = 36 / 5 = 7 (rounded down from 7.2)
+	// test conversion from capacity_c48 to capacity_does_not_fit with rounding (80 GiB, weight=1 piece, allow_rounding=true)
+	// conversion rate: from=5, to=3  (5 piece × 48 GiB = 240 GiB = 3 × 80 GiB)
+	// with sourceAmount=3: (3 * 3) / 5 = 9 / 5 = 1 (rounded down from 1.8)
+	// lost value: 3 × 48 GiB - 1 × 80 GiB = 144 - 80 = 64 GiB > 48 GiB (more than 1 source unit!)
+	// no leftover commitment is created for the rounded-down amount
 	oldassert.HTTPRequest{
 		Method:       http.MethodPost,
 		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/7/convert",
-		Body:         req("third", "capacity_does_not_fit", 3, 7),
+		Body:         req("third", "capacity_does_not_fit", 3, 1),
 		ExpectStatus: http.StatusAccepted,
 	}.Check(t, s.Handler)
 
 	convertedCommitment = must.ReturnT(db.ProjectCommitmentStore.SelectOneWhere(s.Ctx, s.DB, `id = 10`))(t)
-	assert.Equal(t, convertedCommitment.Amount, uint64(7))
+	assert.Equal(t, convertedCommitment.Amount, uint64(1))
+	_, err := db.ProjectCommitmentStore.SelectOneWhere(s.Ctx, s.DB, `id = 11`)
+	assert.ErrEqual(t, err, sql.ErrNoRows)
 
 	// test that non-fitting conversions are rejected when target has allow_rounding=false
 	// We convert capacity_does_not_fit → capacity_fits (target has allow_rounding=false)
-	// rate = from=4, to=5 (20 GiB source : 16 GiB target)
+	// rate = from=9, to=20 (80 GiB source / gcd(36,80)=4 : 36 GiB target / gcd(36,80)=4 → 20:9)
 	oldassert.HTTPRequest{
 		Method: http.MethodPost,
 		Path:   "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/new",
@@ -2406,13 +2411,13 @@ func Test_ConvertCommitments(t *testing.T) {
 		Method:       http.MethodPost,
 		Path:         "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/11/convert",
 		Body:         req("third", "capacity_fits", 3, 3),
-		ExpectBody:   oldassert.StringData("amount: 3 does not fit into conversion rate of: 4\n"),
+		ExpectBody:   oldassert.StringData("amount: 3 does not fit into conversion rate of: 9\n"),
 		ExpectStatus: http.StatusConflict,
 	}.Check(t, s.Handler)
 
 	// test that rounding to 0 is rejected even with allow_rounding=true
-	// capacity_fits → capacity_does_not_fit: rate = from=5, to=4, allow_rounding=true on target
-	// sourceAmount=1: (1 * 4) / 5 = 0 → rejected
+	// capacity_fits → capacity_does_not_fit: rate = from=20, to=9, allow_rounding=true on target
+	// sourceAmount=1: (1 * 9) / 20 = 0 → rejected
 	oldassert.HTTPRequest{
 		Method: http.MethodPost,
 		Path:   "/v1/domains/uuid-for-germany/projects/uuid-for-berlin/commitments/new",

--- a/internal/core/commitment_behavior.go
+++ b/internal/core/commitment_behavior.go
@@ -4,11 +4,13 @@
 package core
 
 import (
+	"maps"
 	"slices"
 	"time"
 
 	"github.com/sapcc/go-api-declarations/limes"
 	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
+	"github.com/sapcc/go-api-declarations/liquid"
 	"github.com/sapcc/go-bits/errext"
 	"github.com/sapcc/go-bits/regexpext"
 	"go.xyrillian.de/gg/is"
@@ -27,16 +29,16 @@ type CommitmentBehavior struct {
 	// If DurationsPerDomain.Pick() returns an empty slice, then commitments are entirely forbidden for that resource in the given domain.
 	DurationsPerDomain regexpext.ConfigSet[string, []limesresources.CommitmentDuration] `json:"durations_per_domain"`
 
-	MinConfirmDate Option[time.Time]                `json:"min_confirm_date"`
-	UntilPercent   Option[float64]                  `json:"until_percent"`
-	ConversionRule Option[CommitmentConversionRule] `json:"conversion_rule"`
+	MinConfirmDate  Option[time.Time]                                     `json:"min_confirm_date"`
+	UntilPercent    Option[float64]                                       `json:"until_percent"`
+	ConversionRules map[ConversionRuleIdentifier]CommitmentConversionRule `json:"conversion_rules"`
 }
 
 // Validate returns a list of all errors in this behavior configuration.
 //
 // The `path` argument denotes the location of this behavior in the
 // configuration file, and will be used when generating error messages.
-func (b CommitmentBehavior) Validate(path string, occupiedConversionIdentifiers []string) (errs errext.ErrorSet, identifier string) {
+func (b CommitmentBehavior) Validate(path string, occupiedConversionIdentifiers []ConversionRuleIdentifier) (errs errext.ErrorSet, identifiers []ConversionRuleIdentifier) {
 	if percent, ok := b.UntilPercent.Unpack(); ok {
 		if percent < 0 {
 			errs.Addf("invalid value: %s.until_percent may not be smaller than 0", path)
@@ -45,32 +47,32 @@ func (b CommitmentBehavior) Validate(path string, occupiedConversionIdentifiers 
 			errs.Addf("invalid value: %s.until_percent may not be bigger than 100", path)
 		}
 	}
-	if conversionRule, ok := b.ConversionRule.Unpack(); ok {
-		identifier = conversionRule.Identifier
-		if slices.Contains(occupiedConversionIdentifiers, conversionRule.Identifier) {
-			errs.Addf("invalid value: %s.conversion_rule.identifier values must be restricted to a single serviceType, but %q is already used by another serviceType", path, conversionRule.Identifier)
+	for identifier := range b.ConversionRules {
+		if slices.Contains(occupiedConversionIdentifiers, identifier) {
+			errs.Addf("invalid value: %[1]s.conversion_rules[%[2]q] identifier must be restricted to a single serviceType, but %[2]q is already used by another serviceType", path, identifier)
 		}
+		identifiers = append(identifiers, identifier)
 	}
 
-	return errs, identifier
+	return errs, identifiers
 }
 
 // ScopedCommitmentBehavior is a CommitmentBehavior that applies only to a certain scope (usually a specific domain).
 // It is created through the For... methods on type CommitmentBehavior.
 type ScopedCommitmentBehavior struct {
-	Durations      []limesresources.CommitmentDuration
-	MinConfirmDate Option[time.Time]
-	UntilPercent   Option[float64]
-	ConversionRule Option[CommitmentConversionRule]
+	Durations       []limesresources.CommitmentDuration
+	MinConfirmDate  Option[time.Time]
+	UntilPercent    Option[float64]
+	ConversionRules map[ConversionRuleIdentifier]CommitmentConversionRule
 }
 
 // ForDomain resolves Durations.Pick() using the provided domain name.
 func (b CommitmentBehavior) ForDomain(domainName string) ScopedCommitmentBehavior {
 	return ScopedCommitmentBehavior{
-		Durations:      b.DurationsPerDomain.Pick(domainName).UnwrapOr(nil),
-		MinConfirmDate: b.MinConfirmDate,
-		UntilPercent:   b.UntilPercent,
-		ConversionRule: b.ConversionRule,
+		Durations:       b.DurationsPerDomain.Pick(domainName).UnwrapOr(nil),
+		MinConfirmDate:  b.MinConfirmDate,
+		UntilPercent:    b.UntilPercent,
+		ConversionRules: b.ConversionRules,
 	}
 }
 
@@ -94,10 +96,10 @@ func (b CommitmentBehavior) ForCluster() ScopedCommitmentBehavior {
 	}
 
 	return ScopedCommitmentBehavior{
-		Durations:      allDurations,
-		MinConfirmDate: b.MinConfirmDate,
-		UntilPercent:   b.UntilPercent,
-		ConversionRule: b.ConversionRule,
+		Durations:       allDurations,
+		MinConfirmDate:  b.MinConfirmDate,
+		UntilPercent:    b.UntilPercent,
+		ConversionRules: b.ConversionRules,
 	}
 }
 
@@ -135,39 +137,102 @@ func (b ScopedCommitmentBehavior) ForV2API(now time.Time) Option[resourcesv2.Com
 	return Some(result)
 }
 
+// ConversionRuleIdentifier is an explicit type to increased readability of the code
+type ConversionRuleIdentifier string
+
 // CommitmentConversionRule describes how commitments for a resource may be converted
 // into commitments for other resources with the same rule identifier.
 type CommitmentConversionRule struct {
-	Identifier string `json:"identifier"`
-	Weight     uint64 `json:"weight"`
+	Weight limes.Unit `json:"weight"`
+	// if set, only allows this conversion rule as source of conversions
+	OnlySource bool `json:"only_source"`
+	// if set, this rule as target allows to round the amount down to the next integer, except when it would be 0
+	AllowRounding bool `json:"allow_rounding"`
 }
 
 // CommitmentConversionRate describes the rate for converting commitments between two compatible resources.
 type CommitmentConversionRate struct {
-	FromAmount uint64
-	ToAmount   uint64
+	FromAmount    uint64
+	ToAmount      uint64
+	AllowRounding bool
 }
 
 // GetConversionRateTo checks whether this resource can be converted into the given resource.
-// If so, the conversion rate is returned.
-func (b ScopedCommitmentBehavior) GetConversionRateTo(other ScopedCommitmentBehavior) Option[CommitmentConversionRate] {
-	sourceRule, ok := b.ConversionRule.Unpack()
-	if !ok {
+// If so, the conversion rate between the first two matching conversion rules (ordered by
+// identifier alphabetically) is returned.
+//
+// The conversion rate satisfies the invariant:
+//
+//	fromAmount × sourceWeightFactor × sourceUnitFactor = toAmount × targetWeightFactor × targetUnitFactor
+//
+// To avoid overflow when multiplying large byte-based factors, the four factors
+// are reduced pairwise (weight pair and unit pair) by their GCD before multiplying.
+func (b ScopedCommitmentBehavior) GetConversionRateTo(other ScopedCommitmentBehavior, sourceUnit, targetUnit liquid.Unit) Option[CommitmentConversionRate] {
+	sourceRules := b.ConversionRules
+	if len(sourceRules) == 0 {
 		return None[CommitmentConversionRate]()
 	}
-	targetRule, ok := other.ConversionRule.Unpack()
-	if !ok {
-		return None[CommitmentConversionRate]()
-	}
-	if sourceRule.Identifier != targetRule.Identifier {
+	targetRules := other.ConversionRules
+	if len(targetRules) == 0 {
 		return None[CommitmentConversionRate]()
 	}
 
-	divisor := getGreatestCommonDivisor(sourceRule.Weight, targetRule.Weight)
-	return Some(CommitmentConversionRate{
-		FromAmount: targetRule.Weight / divisor,
-		ToAmount:   sourceRule.Weight / divisor,
-	})
+	sourceUnitBase, sourceUnitFactor := sourceUnit.Base()
+	sourceUnitIsByte := sourceUnitBase == limes.UnitBytes
+	targetUnitBase, targetUnitFactor := targetUnit.Base()
+	targetUnitIsByte := targetUnitBase == limes.UnitBytes
+
+outer:
+	for _, sourceIdentifier := range slices.Sorted(maps.Keys(sourceRules)) {
+		sourceRule := sourceRules[sourceIdentifier]
+		for _, targetIdentifier := range slices.Sorted(maps.Keys(targetRules)) {
+			targetRule := targetRules[targetIdentifier]
+			if sourceIdentifier != targetIdentifier || targetRule.OnlySource {
+				if sourceIdentifier <= targetIdentifier {
+					continue outer
+				}
+				continue
+			}
+			sourceWeightUnitBase, sourceWeightFactor := sourceRule.Weight.Base()
+			sourceWeightIsByte := sourceWeightUnitBase == limes.UnitBytes
+			targetWeightUnitBase, targetWeightFactor := targetRule.Weight.Base()
+			targetWeightIsByte := targetWeightUnitBase == limes.UnitBytes
+
+			// we need to guard the units so that this works out:
+			// okay: all piece units
+			// okay: one of source is byte based, one of target is byte based
+			// not okay: all other cases
+			if sourceWeightIsByte && sourceUnitIsByte || targetWeightIsByte && targetUnitIsByte {
+				continue
+			}
+			if (sourceWeightIsByte || sourceUnitIsByte) && !targetWeightIsByte && !targetUnitIsByte {
+				continue
+			}
+			if (targetWeightIsByte || targetUnitIsByte) && !sourceWeightIsByte && !sourceUnitIsByte {
+				continue
+			}
+
+			// we need: fromAmount × sourceWeightFactor × sourceUnitFactor = toAmount × targetWeightFactor × targetUnitFactor
+			// therefore: fromAmount / toAmount = (targetWeightFactor × targetUnitFactor) / (sourceWeightFactor × sourceUnitFactor)
+			// to reduce before multiplying (avoiding overflow), we cancel common factors weights and units separately
+			weightDivisor := getGreatestCommonDivisor(sourceWeightFactor, targetWeightFactor)
+			unitDivisor := getGreatestCommonDivisor(sourceUnitFactor, targetUnitFactor)
+			fromAmount := (targetWeightFactor / weightDivisor) * (targetUnitFactor / unitDivisor)
+			toAmount := (sourceWeightFactor / weightDivisor) * (sourceUnitFactor / unitDivisor)
+
+			finalDivisor := getGreatestCommonDivisor(fromAmount, toAmount)
+			fromAmount /= finalDivisor
+			toAmount /= finalDivisor
+
+			return Some(CommitmentConversionRate{
+				FromAmount:    fromAmount,
+				ToAmount:      toAmount,
+				AllowRounding: targetRule.AllowRounding,
+			})
+		}
+	}
+
+	return None[CommitmentConversionRate]()
 }
 
 func getGreatestCommonDivisor(a, b uint64) uint64 {

--- a/internal/core/commitment_behavior.go
+++ b/internal/core/commitment_behavior.go
@@ -137,7 +137,8 @@ func (b ScopedCommitmentBehavior) ForV2API(now time.Time) Option[resourcesv2.Com
 	return Some(result)
 }
 
-// ConversionRuleIdentifier is an explicit type to increased readability of the code
+// ConversionRuleIdentifier is an explicit type to increase readability of the code.
+// It appears in type [CommitmentBehavior].
 type ConversionRuleIdentifier string
 
 // CommitmentConversionRule describes how commitments for a resource may be converted

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -226,7 +226,7 @@ func (cluster ClusterConfiguration) validateConfig() (errs errext.ErrorSet) {
 
 	usedAreas := make(map[string]bool)
 	// NOTE: Liquids[].FixedCapacityConfiguration and Liquids[].PrometheusCapacityConfiguration are optional
-	var occupiedConversionIdentifiers []string
+	var occupiedConversionIdentifiers []ConversionRuleIdentifier
 	// sorted for deterministic test order
 	for _, serviceType := range slices.Sorted(maps.Keys(cluster.Liquids)) {
 		l := cluster.Liquids[serviceType]
@@ -236,15 +236,15 @@ func (cluster ClusterConfiguration) validateConfig() (errs errext.ErrorSet) {
 			errs.Addf(`liquids.%s has area %s which is not defined in areas`, string(serviceType), l.Area)
 		}
 		usedAreas[l.Area] = true
-		serviceIdentifiers := make([]string, 0, len(l.CommitmentBehaviorPerResource))
+		serviceIdentifiers := make([]ConversionRuleIdentifier, 0, len(l.CommitmentBehaviorPerResource))
 		for idx2, behavior := range l.CommitmentBehaviorPerResource {
 			var (
-				validationErrs    errext.ErrorSet
-				serviceIdentifier string
+				validationErrs      errext.ErrorSet
+				resourceIdentifiers []ConversionRuleIdentifier
 			)
-			validationErrs, serviceIdentifier = behavior.Value.Validate(fmt.Sprintf("liquids.%s.commitment_behavior_per_resource[%d]", string(serviceType), idx2), occupiedConversionIdentifiers)
+			validationErrs, resourceIdentifiers = behavior.Value.Validate(fmt.Sprintf("liquids.%s.commitment_behavior_per_resource[%d]", string(serviceType), idx2), occupiedConversionIdentifiers)
 			errs.Append(validationErrs)
-			serviceIdentifiers = append(serviceIdentifiers, serviceIdentifier)
+			serviceIdentifiers = append(serviceIdentifiers, resourceIdentifiers...)
 		}
 		occupiedConversionIdentifiers = append(occupiedConversionIdentifiers, serviceIdentifiers...)
 	}

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -183,9 +183,10 @@ func TestConfigValidation(t *testing.T) {
 									"value": ["1 hour", "2 hours"]
 								}
 							],
-							"conversion_rule": {
-								"identifier": "flavor1",
-								"weight": 32
+							"conversion_rules": {
+								"flavor1" : {
+									"weight": "32 piece"
+								}
 							}
 						}
 					},
@@ -198,9 +199,10 @@ func TestConfigValidation(t *testing.T) {
 									"value": ["1 hour", "2 hours"]
 								}
 							],
-							"conversion_rule": {
-								"identifier": "flavor2",
-								"weight": 144
+							"conversion_rules": {
+								"flavor2": {
+									"weight": "144 piece"
+								}
 							}
 						}
 					}
@@ -218,9 +220,10 @@ func TestConfigValidation(t *testing.T) {
 									"value": ["1 hour", "2 hours"]
 								}
 							],
-							"conversion_rule": {
-								"identifier": "flavor2",
-								"weight": 48
+							"conversion_rules": {
+								"flavor2": {
+									"weight": "48 piece"
+								}
 							}
 						}
 					}
@@ -228,7 +231,7 @@ func TestConfigValidation(t *testing.T) {
 			}
 		}
 	}`), time.Now, nil, true)
-	assert.Equal(t, errs.Join(","), `invalid value: liquids.second.commitment_behavior_per_resource[0].conversion_rule.identifier values must be restricted to a single serviceType, but "flavor2" is already used by another serviceType`)
+	assert.Equal(t, errs.Join(","), `invalid value: liquids.second.commitment_behavior_per_resource[0].conversion_rules["flavor2"] identifier must be restricted to a single serviceType, but "flavor2" is already used by another serviceType`)
 
 	// Valid config. Empty discovery method should be allowed
 	_, errs = core.NewClusterFromJSON([]byte(`{


### PR DESCRIPTION
This branch allows for complex unit conversions. The functionality is described in the `config.md`.

tl;dr:
* per resource, multiple conversion rules are now possible
* conversion weights now get a unit. The new lemma is that when converting commitments, `weight * unit * amount = const`. Because the weight has a unit itself, conversions from a byte-based to a non-byte based unit and vise versa are possible.
* conversion direction can be limited, a rule can be set to only be source for conversion
* the old `/commitment` APIs signature is not changed, we could/should probably expose the units in the v2 API to make things more transparent